### PR TITLE
Make build/cmake.sh a plain sh(1) script for better portability.

### DIFF
--- a/build/cmake.sh
+++ b/build/cmake.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
-# Editable Variables
-CMAKE_COMMAND=cmake
+# You may override these from the environment
+: ${CMAKE_COMMAND:=cmake}
 
 ###############################################################################
 
-if [ -z "$(type -p $CMAKE_COMMAND)" ] ; then
-	echo "You have to install CMake"
+if [ -z "$($CMAKE_COMMAND) --version" ] ; then
+	echo "You have to install CMake" >&2
 	exit 1
 fi
 
@@ -26,47 +26,47 @@ mecho()
 ###############################################################################
 
 if [ ! -e bin ] ; then
-	mecho --blue "Creating symlink «bin» ..."
+	mecho --blue "Creating symlink 'bin' ..."
 	ln -vs . bin
 fi
 
 if [ ! -e RTTR ] ; then
 	if [ -e "${SRCDIR}/RTTR" ] ; then
-		mecho --blue "Creating symlink «RTTR» ..."
+		mecho --blue "Creating symlink 'RTTR' ..."
 		ln -vs "${SRCDIR}/RTTR" RTTR
 	else
-		mecho --red "Directory «RTTR» missing!"
+		mecho --red "Directory 'RTTR' missing!"
 		exit 1
 	fi
 fi
 
 if [ ! -e share ] ; then
-	mecho --blue "Creating symlink «share» ..."
+	mecho --blue "Creating symlink 'share' ..."
 	ln -vs . share
 fi
 
 if [ ! -e s25rttr ] ; then
-	mecho --blue "Creating symlink «s25rttr» ..."
+	mecho --blue "Creating symlink 's25rttr' ..."
 	ln -vs . s25rttr
 fi
 
 if [ ! -e S2 ] ; then
 	if [ -e "${SRCDIR}/S2" ] ; then
-		mecho --blue "Creating symlink «S2» ..."
+		mecho --blue "Creating symlink 'S2' ..."
 		ln -vs "${SRCDIR}/S2" S2
 	else
-		mecho --red "Directory «S2» missing!"
+		mecho --red "Directory 'S2' missing!"
 		mecho --yellow "Direct debugging from this directory will not work then!"
 	fi
 fi
 
-if ( [ ! -f cleanup.sh ] && [ -f "${SRCDIR}/build/cleanup.sh" ] ) ; then
-	mecho --blue "Creating symlink «cleanup.sh» ..."
+if [ ! -f cleanup.sh ] && [ -f "${SRCDIR}/build/cleanup.sh" ] ; then
+	mecho --blue "Creating symlink 'cleanup.sh' ..."
 	ln -vs $SRCDIR/build/cleanup.sh cleanup.sh
 fi
 
-if ( [ ! -f cmake.sh ] && [ -f "${SRCDIR}/build/cmake.sh" ] ) ; then
-	mecho --blue "Creating symlink «cmake.sh» ..."
+if [ ! -f cmake.sh ] && [ -f "${SRCDIR}/build/cmake.sh" ] ; then
+	mecho --blue "Creating symlink 'cmake.sh' ..."
 	ln -vs $SRCDIR/build/cmake.sh cmake.sh
 fi
 
@@ -235,13 +235,13 @@ for I in $NOARCH ; do
 done
 
 case "$enable_debug" in
-	yes|YES|Yes)
+	[Yy][Ee][Ss])
 		mecho --magenta "Activating debug build"
 		PARAMS="$PARAMS -DCMAKE_BUILD_TYPE=Debug"
 	;;
 	*)
 		case "$enable_reldeb" in
-			yes|YES|Yes)
+			[Yy][Ee][Ss])
 				mecho --magenta "Activating release build with debug information"
 				PARAMS="$PARAMS -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 			;;
@@ -254,7 +254,7 @@ case "$enable_debug" in
 esac
 
 case "$enable_verbose" in
-	yes|YES|Yes)
+	[Yy][Ee][Ss])
 		mecho --magenta "Activating verbose build"
 		PARAMS="$PARAMS -DCMAKE_VERBOSE_MAKEFILE=On"
 	;;

--- a/build/start.sh
+++ b/build/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 export LD_LIBRARY_PATH=libsiedler2/src
 export EF_ALLOW_MALLOC_0=1
@@ -24,10 +24,10 @@ while test $# != 0 ; do
 			ac_shift=1
 			;;
 	esac
-	
+
 	case $ac_option in
-                -l | --load)
-                        BINARGS="$ac_optarg"
+		-l | --load)
+			BINARGS="$ac_optarg"
 			if [ -n "$ac_optarg" ]
 			then
 				ac_shift=2
@@ -74,7 +74,7 @@ while test $# != 0 ; do
 			exit 1
 			;;
 	esac
-	
+
 	shift $ac_shift
 done
 
@@ -84,6 +84,8 @@ if [ -f /proc/cpuinfo ] ; then
 	if test "$CPU_COUNT" -gt 1; then
 		MAKEARGS="-j $((1+$CPU_COUNT)) $MAKEARGS"
 	fi
+elif [ $(sysctl -n hw.ncpu) -gt 1 ]; then
+	MAKEARGS="-j $((1 + $(sysctl -n hw.ncpu))) $MAKEARGS"
 fi
 
 make $MAKEARGS

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,2 @@
-#!/bin/bash
-
-cd build
-
-bash -c ./start.sh $*
-
-exit $?
+#!/bin/sh
+cd build && exec ./start.sh "$@"


### PR DESCRIPTION
While here, remove 8bit chars to make it UTF-8, remove some unneeded
subshells and allow all possible spellings of 'yes'.