### PR TITLE
Fix objcopy on FreeBSD, we don't support cross-builds under FreeBSD.

### DIFF
--- a/build/postinstall.sh.cmake
+++ b/build/postinstall.sh.cmake
@@ -163,7 +163,7 @@ extract_debug_symbols()
 			objcopyTarget="-pc-linux-gnu"
 		;;
 		freebsd)
-			objcopyTarget=""
+			objcopy="objcopy"  # no cross-build support for FreeBSD
 		;;
 		*)
 			echo "$COMPILEFOR not supported" >&2
@@ -171,9 +171,10 @@ extract_debug_symbols()
 		;;
 	esac
 
-	objcopy="${objcopyArch}${objcopyTarget}-objcopy"
+	# Set if not yet set
+	: ${objcopy:=${objcopyArch}${objcopyTarget}-objcopy}
 
-	if [ ! -f ${objcopy} ]; then
+	if ! `${objcopy} -V >/dev/null 2>&1`; then
 		# Use fallback
 		case "$COMPILEFOR" in
 			windows)


### PR DESCRIPTION
The binary to use is simply objcopy, set this and don't override or
append. Fix the test for checking whether objcopy works, the file
existence test is not sufficient as we need to search in $PATH.