### PR TITLE
SerializedGameData: Use std::set's find for containment check

### DIFF
--- a/src/SerializedGameData.cpp
+++ b/src/SerializedGameData.cpp
@@ -382,7 +382,7 @@ void SerializedGameData::AddObject(GameObject* go)
 bool SerializedGameData::IsObjectSerialized(const unsigned obj_id) const
 {
     assert(!isReading);
-    return helpers::contains(writtenObjIds, obj_id);
+    return writtenObjIds.find(obj_id) != writtenObjIds.end();
 }
 
 GameObject* SerializedGameData::GetReadGameObject(const unsigned obj_id) const


### PR DESCRIPTION
SerializedGameData: Use std::set's find for containment check

std::set::find is O(log n) in the size of the container, while the
previous std::find was O(n) to find the object id.

This avoids behavior quadratic in the number of serialized ids, so it
should speed up saving of big maps.