### PR TITLE
Fix iterator error in GameClientPlayer::JobNotWanted

### DIFF
--- a/src/GameClientPlayer.cpp
+++ b/src/GameClientPlayer.cpp
@@ -800,13 +800,17 @@ void GameClientPlayer::AddJobWanted(const Job job, noRoadNode* workplace)
 
 void GameClientPlayer::JobNotWanted(noRoadNode* workplace,bool all)
 {
-    for(std::list<JobNeeded>::iterator it = jobs_wanted.begin(); it != jobs_wanted.end(); ++it)
+    for(std::list<JobNeeded>::iterator it = jobs_wanted.begin(); it != jobs_wanted.end(); )
     {
         if(it->workplace == workplace)
         {
             it = jobs_wanted.erase(it);
-			if(!all || it==jobs_wanted.end())
-				return;
+            if(!all)
+                return;
+        }
+        else
+        {
+            ++it;
         }
     }
 }


### PR DESCRIPTION
Upon erasing an element (and all == true), it would increment the
iterator twice.

Also remove the check against end, which is redundant with the loop
condition.