### PR TITLE
Fix wrong building material ordering

### DIFF
--- a/src/GameClientPlayer.cpp
+++ b/src/GameClientPlayer.cpp
@@ -1342,7 +1342,9 @@ unsigned GameClientPlayer::GetBuidingSitePriority(const noBuildingSite* building
     }
 
     LOG.lprintf("GameClientPlayer::GetBuidingSitePriority: ERROR: BuildingSite or type of it not found in the list!\n");
-    return 0xFFFFFFFF;
+    assert(false);
+    // We may want to multiply this value so don't return the absolute max value
+    return std::numeric_limits<unsigned>::max() / 1000;
 }
 
 void GameClientPlayer::ConvertTransportData(const TransportOrders& transport_data)

--- a/src/buildings/noBaseBuilding.cpp
+++ b/src/buildings/noBaseBuilding.cpp
@@ -136,7 +136,6 @@ void noBaseBuilding::Destroy_noBaseBuilding()
             // wenn Rückerstattung aktiv ist, entsprechende Prozentzahl wählen
             if(settings.isEnabled(ADDON_REFUND_MATERIALS))
                 percent_index = settings.getSelection(ADDON_REFUND_MATERIALS);
-
             // wenn Rückerstattung bei Notprogramm aktiv ist, 50% zurückerstatten
             else if(gwg->GetPlayer(player).hasEmergency() && settings.isEnabled(ADDON_REFUND_ON_EMERGENCY))
                 percent_index = 2;
@@ -156,7 +155,7 @@ void noBaseBuilding::Destroy_noBaseBuilding()
                 if( (!which && boards > 0) || (which && stones > 0))
                 {
                     // Ware erzeugen
-                    Ware* ware = new Ware(goods[which], 0, flag);
+                    Ware* ware = new Ware(goods[which], NULL, flag);
                     // Inventur anpassen
                     gwg->GetPlayer(player).IncreaseInventoryWare(goods[which], 1);
                     // Abnehmer für Ware finden

--- a/src/buildings/noBuildingSite.cpp
+++ b/src/buildings/noBuildingSite.cpp
@@ -347,7 +347,7 @@ unsigned noBuildingSite::CalcDistributionPoints(noRoadNode* start, const GoodTyp
     return points;
 }
 
-void noBuildingSite::AddWare(Ware* ware)
+void noBuildingSite::AddWare(Ware*& ware)
 {
     assert(state == STATE_BUILDING);
 
@@ -369,7 +369,7 @@ void noBuildingSite::AddWare(Ware* ware)
     // Inventur entsprechend verringern
     gwg->GetPlayer(player).DecreaseInventoryWare(ware->type, 1);
     gwg->GetPlayer(player).RemoveWare(ware);
-    delete ware;
+    deletePtr(ware);
 }
 
 void noBuildingSite::WareLost(Ware* ware)

--- a/src/buildings/noBuildingSite.h
+++ b/src/buildings/noBuildingSite.h
@@ -82,7 +82,7 @@ class noBuildingSite : public noBaseBuilding
         /// Erzeugt von ihnen selbst ein FOW Objekt als visuelle "Erinnerung" für den Fog of War
         FOWObject* CreateFOWObject() const;
 
-        void AddWare(Ware* ware);
+        void AddWare(Ware*& ware);
         void GotWorker(Job job, noFigure* worker);
 
         /// Fordert Baumaterial an

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -399,7 +399,7 @@ void nobBaseWarehouse::HandleBaseEvent(const unsigned int id)
                 if(GetFlag()->GetWareCount() < 8)
                 {
                     // Dann Ware raustragen lassen
-                    Ware* ware = *waiting_wares.begin();
+                    Ware* ware = waiting_wares.front();
                     nofWarehouseWorker* worker = new nofWarehouseWorker(pos, player, ware, 0);
                     gwg->AddFigure(worker, pos);
                     assert(goods_.goods[ConvertShields(ware->type)] > 0);
@@ -757,7 +757,7 @@ bool nobBaseWarehouse::FreePlaceAtFlag()
     }
 }
 
-void nobBaseWarehouse::AddWare(Ware* ware)
+void nobBaseWarehouse::AddWare(Ware*& ware)
 {
     // Ware nicht mehr abhängig
     RemoveDependentWare(ware);
@@ -770,7 +770,7 @@ void nobBaseWarehouse::AddWare(Ware* ware)
         type = ware->type;
 
     gwg->GetPlayer(player).RemoveWare(ware);
-    delete ware;
+    deletePtr(ware);
 
     ++real_goods.goods[type];
     ++goods_.goods[type];

--- a/src/buildings/nobBaseWarehouse.h
+++ b/src/buildings/nobBaseWarehouse.h
@@ -179,7 +179,7 @@ class nobBaseWarehouse : public nobBaseMilitary
         void DontFetchNextWare() {fetch_double_protection = true;}
 
         /// Legt eine Ware im Lagerhaus ab
-        virtual void AddWare(Ware* ware);
+        virtual void AddWare(Ware*& ware);
         /// Eine Figur geht ins Lagerhaus
         virtual void AddFigure(noFigure* figure, const bool increase_visual_counts = true);
 

--- a/src/buildings/nobHarborBuilding.h
+++ b/src/buildings/nobHarborBuilding.h
@@ -122,7 +122,7 @@ public:
         /// Eine bestellte Ware konnte doch nicht kommen
         void WareLost(Ware* ware);
         /// Legt eine Ware im Lagerhaus ab
-        void AddWare(Ware* ware);
+        void AddWare(Ware*& ware);
         /// Eine Figur geht ins Lagerhaus
         void AddFigure(noFigure* figure, const bool increase_visual_counts);
         /// Berechnet Wichtigkeit einer neuen Ware für den Hafen (Waren werden für Expeditionen
@@ -176,7 +176,7 @@ public:
         int GetNeedForShip(unsigned ships_coming) const;
 
         /// Erhält die Waren von einem Schiff und nimmt diese in den Warenbestand auf
-        void ReceiveGoodsFromShip(const std::list<noFigure*>& figures, const std::list<Ware*>& wares);
+        void ReceiveGoodsFromShip(const std::list<noFigure*>& figures, std::list<Ware*>& wares);
 
         struct SeaAttackerBuilding
         {

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -613,7 +613,7 @@ void nobMilitary::TakeWare(Ware* ware)
 }
 
 
-void nobMilitary::AddWare(Ware* ware)
+void nobMilitary::AddWare(Ware*& ware)
 {
     // Ein Golstück mehr
     ++coins;
@@ -622,7 +622,7 @@ void nobMilitary::AddWare(Ware* ware)
 
     // Ware vernichten
     gwg->GetPlayer(player).RemoveWare(ware);
-    delete ware;
+    deletePtr(ware);
 
     // Evtl. Soldaten befördern
     PrepareUpgrading();

--- a/src/buildings/nobMilitary.h
+++ b/src/buildings/nobMilitary.h
@@ -136,7 +136,7 @@ class nobMilitary : public nobBaseMilitary
         /// Wird aufgerufen, wenn eine neue Ware zum dem Gebäude geliefert wird (in dem Fall nur Goldstücke)
         void TakeWare(Ware* ware);
         /// Legt eine Ware am Objekt ab (an allen Straßenknoten (Gebäude, Baustellen und Flaggen) kann man Waren ablegen
-        void AddWare(Ware* ware);
+        void AddWare(Ware*& ware);
         /// Eine bestellte Ware konnte doch nicht kommen
         void WareLost(Ware* ware);
         /// Wird aufgerufen, wenn von der Fahne vor dem Gebäude ein Rohstoff aufgenommen wurde

--- a/src/buildings/nobUsual.cpp
+++ b/src/buildings/nobUsual.cpp
@@ -351,7 +351,7 @@ void nobUsual::HandleEvent(const unsigned int id)
  *
  *  @author OLiver
  */
-void nobUsual::AddWare(Ware* ware)
+void nobUsual::AddWare(Ware*& ware)
 
 {
     // Maximale Warenanzahlbestimmen (nur für assert unten)
@@ -376,7 +376,7 @@ void nobUsual::AddWare(Ware* ware)
 
     // Ware vernichten
     gwg->GetPlayer(player).RemoveWare(ware);
-    delete ware;
+    deletePtr(ware);
 
     // Arbeiter Bescheid sagen, dass es neue Waren gibt
     if(worker)

--- a/src/buildings/nobUsual.h
+++ b/src/buildings/nobUsual.h
@@ -78,7 +78,7 @@ protected:
         /// Event-Handler
         void HandleEvent(const unsigned int id);
         /// Legt eine Ware am Objekt ab (an allen Straßenknoten (Gebäude, Baustellen und Flaggen) kann man Waren ablegen
-        void AddWare(Ware* ware);
+        void AddWare(Ware*& ware);
         /// Wird aufgerufen, wenn von der Fahne vor dem Gebäude ein Rohstoff aufgenommen wurde
         bool FreePlaceAtFlag();
         /// Eine bestellte Ware konnte doch nicht kommen

--- a/src/defines.h
+++ b/src/defines.h
@@ -107,6 +107,14 @@ inline T max(T a, T b) { return (a < b) ? b : a; }
 template <typename T>
 inline T SafeDiff(T a, T b) { return (a > b) ? a - b : b - a; }
 
+/// Deletes the ptr and sets it to NULL
+template <typename T>
+inline void deletePtr(T*& ptr)
+{
+    delete ptr;
+    ptr = 0;
+}
+
 // Fwd decl
 namespace boost{namespace filesystem{}}
 

--- a/src/figures/nofWarehouseWorker.cpp
+++ b/src/figures/nofWarehouseWorker.cpp
@@ -143,10 +143,10 @@ void nofWarehouseWorker::GoalReached()
 void nofWarehouseWorker::Walked()
 {
     // Wieder im Schloss angekommen
-
     if(!task)
     {
-        // Bringe ich wieder ne Ware mit? Dann muss die mit zu den waiting_wares, da die Flagge evtl voll war
+        // If I still cary a ware than either the flag was full or I should not bring it there (goal=warehouse or goal destroyed -> goal=location)
+        // So re-add it to waiting wares or to inventory
         if(carried_ware)
         {
             // Ware ins Lagerhaus einlagern (falls es noch existiert und nicht abgebrannt wurde)

--- a/src/nodeObjs/noFlag.cpp
+++ b/src/nodeObjs/noFlag.cpp
@@ -221,7 +221,7 @@ FOWObject* noFlag::CreateFOWObject() const
  *
  *  @author OLiver
  */
-void noFlag::AddWare(Ware* ware)
+void noFlag::AddWare(Ware*& ware)
 {
     for(unsigned char i = 0; i < 8; ++i)
     {

--- a/src/nodeObjs/noFlag.h
+++ b/src/nodeObjs/noFlag.h
@@ -44,7 +44,7 @@ class noFlag : public noRoadNode
         /// Erzeugt von ihnen selbst ein FOW Objekt als visuelle "Erinnerung" für den Fog of War.
         FOWObject* CreateFOWObject() const;
         /// Legt eine Ware an der Flagge ab.
-        void AddWare(Ware* ware);
+        void AddWare(Ware*& ware);
         /// Gibt die Anzahl der Waren zurück, die an der Flagge liegen.
         unsigned GetWareCount() const;
         /// Wählt eine Ware von einer Flagge aus (anhand der Transportreihenfolge), entfernt sie von der Flagge und gibt sie zurück.

--- a/src/nodeObjs/noRoadNode.h
+++ b/src/nodeObjs/noRoadNode.h
@@ -84,7 +84,7 @@ class noRoadNode : public noCoordBase
         unsigned char GetPlayer() const { return player; }
 
         /// Legt eine Ware am Objekt ab (an allen Straßenknoten (Gebäude, Baustellen und Flaggen) kann man Waren ablegen
-        virtual void AddWare(Ware* ware) = 0;
+        virtual void AddWare(Ware*& ware) = 0;
 
         /// Nur für Flagge, Gebäude können 0 zurückgeben, gibt Wegstrafpunkte für das Pathfinden für Waren, die in eine bestimmte Richtung noch transportiert werden müssen
         virtual unsigned short GetPunishmentPoints(const unsigned char dir) const { return 0; }


### PR DESCRIPTION
This fixes the problem described in the discussion of #298 where a building site orders to many building materials.

This changes it in a way that those superflous materials are still carried out of the harbour but instantly carried back in. This avoids problems like deleting the Ware in AddWare and accessing it later. This can be caused when Ware->RecalcRoute is called, the ware calls WareDontWantToTravelByShip and this calls AddWare. The caller of RecalcRoute might not be aware of this

Please carefully review this!
Replay: http://www96.zippyshare.com/v/h5ekrbfg/file.html
Save: http://www96.zippyshare.com/v/DVVSu1Vz/file.html