### PR TITLE
Ware fix

### DIFF
--- a/src/GameClientPlayer.cpp
+++ b/src/GameClientPlayer.cpp
@@ -549,7 +549,7 @@ void GameClientPlayer::RoadDestroyed()
     // Alle Waren, die an Flagge liegen und in Lagerhäusern, müssen gucken, ob sie ihr Ziel noch erreichen können, jetzt wo eine Straße fehlt
     for(std::list<Ware*>::iterator it = ware_list.begin(); it != ware_list.end(); )
     {
-        if((*it)->LieAtFlag()) // Liegt die Flagge an einer Flagge, muss ihr Weg neu berechnet werden
+        if((*it)->IsWaitingAtFlag()) // Liegt die Flagge an einer Flagge, muss ihr Weg neu berechnet werden
         {
 			unsigned char last_next_dir = (*it)->GetNextDir();
 			(*it)->RecalcRoute();			
@@ -597,7 +597,7 @@ void GameClientPlayer::RoadDestroyed()
 			if((*it)->GetNextDir()!=last_next_dir)
 				(*it)->RemoveWareJobForCurrentDir(last_next_dir);
 		}
-        else if((*it)->LieInWarehouse())
+        else if((*it)->IsWaitingInWarehouse())
         {
             if(!(*it)->FindRouteFromWarehouse())
             {
@@ -612,7 +612,7 @@ void GameClientPlayer::RoadDestroyed()
                 continue;
             }
         }
-        else if((*it)->LieInHarborBuilding())
+        else if((*it)->IsWaitingForShip())
         {
             // Weg neu berechnen
             (*it)->RecalcRoute();

--- a/src/GameWorldBase.cpp
+++ b/src/GameWorldBase.cpp
@@ -1859,7 +1859,7 @@ std::vector<GameWorldBase::PotentialSeaAttacker> GameWorldBase::GetAvailableSold
         for(std::vector<nofPassiveSoldier*>::const_iterator itSoldier = tmp_soldiers.begin(); itSoldier != tmp_soldiers.end(); ++itSoldier)
         {
             assert(std::find_if(attackers.begin(), attackers.end(), PotentialSeaAttacker::CmpSoldier(*itSoldier)) == attackers.end());
-            PotentialSeaAttacker pa = { *itSoldier, it->harbor, it->distance };
+            PotentialSeaAttacker pa(*itSoldier, it->harbor, it->distance);
             attackers.push_back(pa);
         }
     }

--- a/src/GameWorldBase.h
+++ b/src/GameWorldBase.h
@@ -36,6 +36,7 @@ class nobBaseMilitary;
 class noNothing;
 class fowNothing;
 class nofPassiveSoldier;
+class nobHarborBuilding;
 class GameWorldBase;
 struct lua_State;
 
@@ -355,6 +356,8 @@ public:
         nobHarborBuilding* harbor;
         /// Entfernung Hafen-Hafen (entscheidende)
         unsigned distance;
+
+        PotentialSeaAttacker(nofPassiveSoldier* soldier, nobHarborBuilding* harbor, unsigned distance): soldier(soldier), harbor(harbor), distance(distance){}
 
         /// Komperator zum Sortieren
         bool operator<(const PotentialSeaAttacker& pa) const;

--- a/src/Ware.cpp
+++ b/src/Ware.cpp
@@ -232,6 +232,27 @@ void Ware::GoalDestroyed()
     }
 }
 
+void Ware::WaitAtFlag(noFlag* flag)
+{
+    assert(flag);
+    state = STATE_WAITATFLAG;
+    location = flag;
+}
+
+void Ware::WaitInWarehouse(nobBaseWarehouse* wh)
+{
+    assert(wh);
+    state = STATE_WAITINWAREHOUSE;
+    location = wh;
+}
+
+void Ware::Carry(noRoadNode* nextGoal)
+{
+    assert(nextGoal);
+    state = STATE_CARRIED;
+    location = nextGoal;
+}
+
 /// Gibt dem Ziel der Ware bekannt, dass diese nicht mehr kommen kann
 void Ware::NotifyGoalAboutLostWare()
 {

--- a/src/Ware.cpp
+++ b/src/Ware.cpp
@@ -139,6 +139,8 @@ void Ware::GoalDestroyed()
     if(state == STATE_WAITINWAREHOUSE)
     {
         // Ware ist noch im Lagerhaus auf der Warteliste
+        assert(false); // Should not happen. noBaseBuilding::WareNotNeeded handles this case!
+        goal = NULL; // just in case: avoid corruption although the ware itself might be lost (won't ever be carried again)
     }
     // Ist sie evtl. gerade mit dem Schiff unterwegs?
     else if(state == STATE_ONSHIP)

--- a/src/Ware.h
+++ b/src/Ware.h
@@ -26,7 +26,7 @@
 class noBaseBuilding;
 class GameWorld;
 class nobHarborBuilding;
-
+class nobBaseWarehouse;
 
 // Die Klasse Ware kennzeichnet eine Ware, die von einem Träger transportiert wird bzw gerade an einer Flagge liegt
 class Ware : public GameObject
@@ -79,17 +79,18 @@ class Ware : public GameObject
 		void SetNextDir(unsigned char newnextdir) {next_dir=newnextdir;}
         /// Wird aufgerufen, wenn es das Ziel der Ware nicht mehr gibt und sie wieder "nach Hause" getragen werden muss
         void GoalDestroyed();
-        /// Verändert den Status der Ware
-        void LieAtFlag(noRoadNode* flag) { state = STATE_WAITATFLAG; location = flag; }
-        void Carry(noRoadNode* next_flag) { state = STATE_CARRIED; location = next_flag;  }
+        /// Changes the state of the ware
+        void WaitAtFlag(noFlag* flag);
+        void WaitInWarehouse(nobBaseWarehouse* wh);
+        void Carry(noRoadNode* nextGoal);
         /// Gibt dem Ziel der Ware bekannt, dass diese nicht mehr kommen kann
         void NotifyGoalAboutLostWare();
         /// Wenn die Ware vernichtet werden muss
         void WareLost(const unsigned char player);
         /// Gibt Status der Ware zurück
-        bool LieAtFlag() const { return (state == STATE_WAITATFLAG); }
-        bool LieInWarehouse() const { return (state == STATE_WAITINWAREHOUSE); }
-        bool LieInHarborBuilding() const { return (state == STATE_WAITFORSHIP); }
+        bool IsWaitingAtFlag() const { return (state == STATE_WAITATFLAG); }
+        bool IsWaitingInWarehouse() const { return (state == STATE_WAITINWAREHOUSE); }
+        bool IsWaitingForShip() const { return (state == STATE_WAITFORSHIP); }
         /// Sagt dem Träger Bescheid, dass sie in die aktuelle (next_dir) Richtung nicht mehr getragen werden will
         void RemoveWareJobForCurrentDir(const unsigned char last_next_dir);
         /// Überprüft, ob es noch ein Weg zum Ziel gibt für Waren, die noch im Lagerhaus liegen
@@ -155,7 +156,7 @@ class Ware : public GameObject
                 case GD_WATEREMPTY: return("GD_WATEREMPTY");
                 case GD_WOOD: return("GD_WOOD");
             }
-
+            assert(false);
             return("unknown");
         }
 };

--- a/src/buildings/noBaseBuilding.cpp
+++ b/src/buildings/noBaseBuilding.cpp
@@ -164,7 +164,7 @@ void noBaseBuilding::Destroy_noBaseBuilding()
                     ware->RecalcRoute();
                     // Ware ablegen
                     flag->AddWare(ware);
-                    ware->LieAtFlag(flag);
+                    ware->WaitAtFlag(flag);
 
                     if(!which)
                         --boards;
@@ -251,7 +251,7 @@ void noBaseBuilding::WareNotNeeded(Ware* ware)
         return;
     }
 
-    if(ware->LieInWarehouse())
+    if(ware->IsWaitingInWarehouse())
     {
         // Bestellung im Lagerhaus stornieren
         static_cast<nobBaseWarehouse*>(ware->GetLocation())->CancelWare(ware);

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -91,7 +91,7 @@ void nobBaseWarehouse::Destroy_nobBaseWarehouse()
     for(std::list<noFigure*>::iterator it = dependent_figures.begin(); it != dependent_figures.end(); ++it)
         (*it)->GoHome();
 	for(std::list<Ware*>::iterator it = dependent_wares.begin(); it!=dependent_wares.end(); ++it)
-        (*it)->GoalDestroyed();
+        WareNotNeeded(*it);
 
     // ggf. Events abmelden
     em->RemoveEvent(recruiting_event);
@@ -573,7 +573,7 @@ void nobBaseWarehouse::HandleBaseEvent(const unsigned int id)
             {
                 // Ware
 
-                Ware* ware = new Ware(GoodType(selectedId), 0, this);
+                Ware* ware = new Ware(GoodType(selectedId), NULL, this);
                 ware->goal = gwg->GetPlayer(player).FindClientForWare(ware);
 
                 // Ware zur Liste hinzufügen, damit sie dann rausgetragen wird
@@ -732,6 +732,7 @@ Ware* nobBaseWarehouse::OrderWare(const GoodType good, noBaseBuilding* const goa
 void nobBaseWarehouse::AddWaitingWare(Ware* ware)
 {
     waiting_wares.push_back(ware);
+    ware->LieInWarehouse();
     // Wenn gerade keiner rausgeht, muss neues Event angemeldet werden
     AddLeavingEvent();
     // Die visuelle Warenanzahl wieder erhöhen
@@ -903,6 +904,7 @@ void nobBaseWarehouse::WareLost(Ware* ware)
 void nobBaseWarehouse::CancelWare(Ware* ware)
 {
     // Ware aus den Waiting-Wares entfernen
+    assert(helpers::contains(waiting_wares, ware));
     waiting_wares.remove(ware);
     // Anzahl davon wieder hochsetzen
     ++real_goods.goods[ConvertShields(ware->type)];

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -732,7 +732,7 @@ Ware* nobBaseWarehouse::OrderWare(const GoodType good, noBaseBuilding* const goa
 void nobBaseWarehouse::AddWaitingWare(Ware* ware)
 {
     waiting_wares.push_back(ware);
-    ware->LieInWarehouse();
+    ware->WaitInWarehouse(this);
     // Wenn gerade keiner rausgeht, muss neues Event angemeldet werden
     AddLeavingEvent();
     // Die visuelle Warenanzahl wieder erhöhen

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -1368,7 +1368,7 @@ void nobHarborBuilding::WareDontWantToTravelByShip(Ware* ware)
     wares_for_ships.remove(ware);
     // Carry out. If it would want to go back to this building, then this will be handled by the carrier
     waiting_wares.push_back(ware);
-    ware->LieInWarehouse();
+    ware->IsWaitingInWarehouse();
     AddLeavingEvent();
 }
 

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -56,8 +56,7 @@ nobHarborBuilding::ExpeditionInfo::ExpeditionInfo(SerializedGameData& sgd) :
     boards(sgd.PopUnsignedInt()),
     stones(sgd.PopUnsignedInt()),
     builder(sgd.PopBool())
-{
-}
+{}
 
 void nobHarborBuilding::ExpeditionInfo::Serialize(SerializedGameData& sgd) const
 {
@@ -78,8 +77,6 @@ void nobHarborBuilding::ExplorationExpeditionInfo::Serialize(SerializedGameData&
     sgd.PushBool(active);
     sgd.PushUnsignedInt(scouts);
 }
-
-
 
 nobHarborBuilding::nobHarborBuilding(const MapPoint pos, const unsigned char player, const Nation nation)
     : nobBaseWarehouse(BLD_HARBORBUILDING, pos, player, nation), orderware_ev(NULL)
@@ -174,8 +171,6 @@ void nobHarborBuilding::Destroy()
     }
     soldiers_for_ships.clear();
 
-
-
     Destroy_nobBaseWarehouse();
 
     // Land drumherum neu berechnen (nur wenn es schon besetzt wurde!)
@@ -207,9 +202,6 @@ void nobHarborBuilding::Serialize(SerializedGameData& sgd) const
         sgd.PushMapPoint(it->dest);
         sgd.PushObject(it->attacker, true);
     }
-
-
-
 }
 
 nobHarborBuilding::nobHarborBuilding(SerializedGameData& sgd, const unsigned obj_id)
@@ -243,7 +235,6 @@ nobHarborBuilding::nobHarborBuilding(SerializedGameData& sgd, const unsigned obj
         ffs.attacker = sgd.PopObject<nofAttacker>(GOT_NOF_ATTACKER);
         soldiers_for_ships.push_back(ffs);
     }
-
 }
 
 // Relative Position des Bauarbeiters
@@ -323,7 +314,6 @@ void nobHarborBuilding::Draw(int x, int y)
 
     }
 }
-
 
 void nobHarborBuilding::HandleEvent(const unsigned int id)
 {
@@ -426,7 +416,6 @@ void nobHarborBuilding::StartExpedition()
     // Ggf. ist jetzt alles benötigte schon da
     // Dann Schiff rufen
     CheckExpeditionReady();
-
 }
 
 /// Startet eine Erkundungs-Expedition oder stoppos sie, wenn bereits eine stattfindet
@@ -500,9 +489,7 @@ void nobHarborBuilding::StartExplorationExpedition()
 
 
     CheckExplorationExpeditionReady();
-
 }
-
 
 /// Bestellt die zusätzlichen erforderlichen Waren für eine Expedition
 void nobHarborBuilding::OrderExpeditionWares()
@@ -1145,12 +1132,9 @@ void nobHarborBuilding::ReceiveGoodsFromShip(const std::list<noFigure*>& figures
     {
         if((*it)->ShipJorneyEnded(this))
         {
-            // Oposische Warenwerte entsprechend erhöhen
-            ++goods_.goods[ConvertShields((*it)->type)];
-
             // Ware will die weitere Reise antreten, also muss sie zur Liste der rausgetragenen Waren
             // hinzugefügt werden
-            waiting_wares.push_back(*it);
+            AddWaitingWare(*it);
         }
         else
         {
@@ -1181,9 +1165,6 @@ void nobHarborBuilding::ReceiveGoodsFromShip(const std::list<noFigure*>& figures
             }
         }
     }
-
-    // Ggf. neues Rausgeh-Event anmelden, was notwendig ist, wenn z.B. nur Waren zur Liste hinzugefügt wurden
-    AddLeavingEvent();
 }
 
 /// Storniert die Bestellung für eine bestimmte Ware, die mit einem Schiff transportiert werden soll
@@ -1386,6 +1367,7 @@ void nobHarborBuilding::WareDontWantToTravelByShip(Ware* ware)
     wares_for_ships.remove(ware);
     // Carry out. If it would want to go back to this building, then this will be handled by the carrier
     waiting_wares.push_back(ware);
+    ware->LieInWarehouse();
     AddLeavingEvent();
 }
 

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -494,6 +494,7 @@ void nobHarborBuilding::StartExplorationExpedition()
 /// Bestellt die zusätzlichen erforderlichen Waren für eine Expedition
 void nobHarborBuilding::OrderExpeditionWares()
 {
+    assert(!IsBeingDestroyedNow()); // Wares should already be canceled!
     if (this->IsBeingDestroyedNow()) // don't order new stuff if we are about to be destroyed
         return;
 

--- a/src/figures/nofBuildingWorker.cpp
+++ b/src/figures/nofBuildingWorker.cpp
@@ -196,7 +196,7 @@ void nofBuildingWorker::WorkingReady()
             real_ware->RecalcRoute();
             // Ware ablegen
             flag->AddWare(real_ware);
-            real_ware->LieAtFlag(flag);
+            real_ware->WaitAtFlag(flag);
             // Warenstatistik erhöhen
             GAMECLIENT.GetPlayer(this->player).IncreaseMerchandiseStatistic(ware);
             // Tragen nun keine Ware mehr

--- a/src/figures/nofCarrier.cpp
+++ b/src/figures/nofCarrier.cpp
@@ -518,7 +518,7 @@ void nofCarrier::Walked()
                     // Ist an der Flagge noch genügend Platz (wenn wir wieder eine Ware mitnehmen, kann sie auch voll sein)
                     if(this_flag->IsSpaceForWare())
                     {
-                        carried_ware->LieAtFlag(this_flag);
+                        carried_ware->WaitAtFlag(this_flag);
 
                         // Ware soll ihren weiteren Weg berechnen
                         if (!calculated)
@@ -543,7 +543,7 @@ void nofCarrier::Walked()
                         FetchWare(true);
 
                         // alte Ware ablegen
-                        tmp_ware->LieAtFlag(this_flag);
+                        tmp_ware->WaitAtFlag(this_flag);
 
                         if (!calculated)
                         {

--- a/src/figures/nofWarehouseWorker.cpp
+++ b/src/figures/nofWarehouseWorker.cpp
@@ -111,7 +111,7 @@ void nofWarehouseWorker::GoalReached()
         // ( dann ist goal = location )
         if(gwg->GetSpecObj<noFlag>(pos)->GetWareCount() < 8 && carried_ware->goal != carried_ware->GetLocation() && carried_ware->goal != wh)
         {
-            carried_ware->LieAtFlag(gwg->GetSpecObj<noRoadNode>(pos));
+            carried_ware->WaitAtFlag(gwg->GetSpecObj<noFlag>(pos));
 
             // Ware soll ihren weiteren Weg berechnen
             carried_ware->RecalcRoute();

--- a/src/nodeObjs/noFlag.cpp
+++ b/src/nodeObjs/noFlag.cpp
@@ -363,12 +363,12 @@ unsigned short noFlag::GetWaresCountForRoad(const unsigned char dir) const
 unsigned short noFlag::GetPunishmentPoints(const unsigned char dir) const
 {
     // Waren zählen, die in diese Richtung transportiert werden müssen
-    unsigned short points = (dir) * 2;
+    unsigned short points = GetWaresCountForRoad(dir) * 2;
 
     // Wenn kein Träger auf der Straße ist, gibts nochmal extra satte Strafpunkte
     if(!routes[dir]->isOccupied())
         points += 500;
-	else if (routes[dir]->hasCarrier(0) && !routes[dir]->getCarrier(0)->GetCarrierState() && !routes[dir]->hasCarrier(1)) //no donkey and the normal carrier has been ordered from the warehouse but has not yet arrived
+	else if (routes[dir]->hasCarrier(0) && routes[dir]->getCarrier(0)->GetCarrierState() == CARRS_FIGUREWORK && !routes[dir]->hasCarrier(1)) //no donkey and the normal carrier has been ordered from the warehouse but has not yet arrived
 		points +=50;
 
     return points;

--- a/src/nodeObjs/noFlag.h
+++ b/src/nodeObjs/noFlag.h
@@ -20,7 +20,7 @@
 #include "noRoadNode.h"
 #include "RoadSegment.h"
 #include "gameTypes/MapTypes.h"
-#include "Ware.h"
+#include <boost/array.hpp>
 
 class noFlag : public noRoadNode
 {
@@ -35,7 +35,7 @@ class noFlag : public noRoadNode
         inline GO_Type GetGOT() const { return GOT_FLAG; }
         inline FlagType GetFlagType() const { return flagtype; }
         /// Gibt Auskunft darüber, ob noch Platz für eine Ware an der Flagge ist.
-        inline bool IsSpaceForWare() const { return (GetWareCount() < 8); }
+        inline bool IsSpaceForWare() const { return GetWareCount() < wares.size(); }
 
         void Draw(int x, int y);
 
@@ -50,29 +50,7 @@ class noFlag : public noRoadNode
         /// Wählt eine Ware von einer Flagge aus (anhand der Transportreihenfolge), entfernt sie von der Flagge und gibt sie zurück.
         Ware* SelectWare(const unsigned char dir, const bool swap_wares, const noFigure* const carrier);
         /// Prüft, ob es Waren gibt, die auf den Weg in Richtung dir getragen werden müssen.
-        inline unsigned short GetWaresCountForRoad(const unsigned char dir) const
-        {
-            unsigned short ret = 0;
-
-            if (wares[0] && (wares[0]->GetNextDir() == dir))
-                ret++;
-            if (wares[1] && (wares[1]->GetNextDir() == dir))
-                ret++;
-            if (wares[2] && (wares[2]->GetNextDir() == dir))
-                ret++;
-            if (wares[3] && (wares[3]->GetNextDir() == dir))
-                ret++;
-            if (wares[4] && (wares[4]->GetNextDir() == dir))
-                ret++;
-            if (wares[5] && (wares[5]->GetNextDir() == dir))
-                ret++;
-            if (wares[6] && (wares[6]->GetNextDir() == dir))
-                ret++;
-            if (wares[7] && (wares[7]->GetNextDir() == dir))
-                ret++;
-
-            return(ret);
-        }
+        unsigned short GetWaresCountForRoad(const unsigned char dir) const;
         /// Gibt Wegstrafpunkte für das Pathfinden für Waren, die in eine bestimmte Richtung noch transportiert werden müssen.
         unsigned short GetPunishmentPoints(const unsigned char dir) const;
         /// Zerstört evtl. vorhandenes Gebäude bzw. Baustelle vor der Flagge.
@@ -95,7 +73,7 @@ class noFlag : public noRoadNode
         FlagType flagtype;
 
         /// Die Waren, die an dieser Flagge liegen
-        Ware* wares[8];
+        boost::array<Ware*, 8> wares;
 
         /// Wieviele BWU-Teile es maximal geben soll, also wieviele abgebrannte Lagerhausgruppen
         /// gleichzeitig die Flagge als nicht begehbar deklarieren können.
@@ -106,7 +84,8 @@ class noFlag : public noRoadNode
         {
             unsigned int id;        ///< ID der Gruppe
             unsigned int last_gf;   ///< letzter TÜV, ob man auch nicht hinkommt, in GF
-        } bwus[MAX_BWU];
+        };
+        boost::array<BurnedWarehouseUnit, MAX_BWU> bwus;
 };
 
 #endif // !NO_FLAG_H_INCLUDED

--- a/src/nodeObjs/noRoadNode.cpp
+++ b/src/nodeObjs/noRoadNode.cpp
@@ -138,7 +138,7 @@ void noRoadNode::DestroyRoad(const unsigned char dir)
 #endif
 
         RoadSegment* tmp = routes[dir];
-        routes[dir] = 0;
+        routes[dir] = NULL;
 
         tmp->Destroy();
         delete tmp;


### PR DESCRIPTION
Closes #309 and supersedes https://github.com/Return-To-The-Roots/s25client/commit/cc15d43a09fc7ab7f962cd3d71290ada8bc3d73a
Actually there should not be any ware with goal = destroyed harbour. If there is, then it is a bug. Currently the Handling of wares that were waiting in warehouses was not correct. This is fixed now by calling `WareNotNeeded` instead of `GoalDestroyed`