### PR TITLE
Server fixes

### DIFF
--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -337,8 +337,8 @@ bool DebugInfo::SendReplay()
     return true;
 }
 
-bool DebugInfo::SendAsyncLog(std::list<RandomEntry>::iterator first_a, std::list<RandomEntry>::iterator first_b,
-                             std::list<RandomEntry> &a, std::list<RandomEntry> &b, unsigned identical)
+bool DebugInfo::SendAsyncLog(std::vector<RandomEntry>::const_iterator first_a, std::vector<RandomEntry>::const_iterator first_b,
+                             const std::vector<RandomEntry> &a, const std::vector<RandomEntry> &b, unsigned identical)
 {
     if (!SendString("AsyncLog"))
     {
@@ -349,8 +349,8 @@ bool DebugInfo::SendAsyncLog(std::list<RandomEntry>::iterator first_a, std::list
     unsigned len =  4;
     unsigned cnt = 0;
 
-    std::list<RandomEntry>::iterator it_a = first_a;
-    std::list<RandomEntry>::iterator it_b = first_b;
+    std::vector<RandomEntry>::const_iterator it_a = first_a;
+    std::vector<RandomEntry>::const_iterator it_b = first_b;
 
     // if there were any identical lines, include only the last one
     if (identical)

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -39,8 +39,8 @@ class DebugInfo : Socket
         bool SendStackTrace();
 #endif
         bool SendReplay();
-        bool SendAsyncLog(std::list<RandomEntry>::iterator first_a, std::list<RandomEntry>::iterator first_b,
-                          std::list<RandomEntry> &a, std::list<RandomEntry> &b, unsigned identical);
+        bool SendAsyncLog(std::vector<RandomEntry>::const_iterator first_a, std::vector<RandomEntry>::const_iterator first_b,
+                          const std::vector<RandomEntry> &a, const std::vector<RandomEntry> &b, unsigned identical);
 };
 
 #endif

--- a/src/FramesInfo.cpp
+++ b/src/FramesInfo.cpp
@@ -28,7 +28,8 @@ void FramesInfo::Clear()
 {
     gf_nr = 0;
     gf_length = 0;
-    gf_length_new = 0;
+    gfLenghtNew = 0;
+    gfLenghtNew2 = 0;
     nwf_length = 0;
     frameTime = 0;
     lastTime = 0;
@@ -39,7 +40,7 @@ void FramesInfo::ApplyNewGFLength()
 {
     // Current length of a NWF in ms
     unsigned nwfLenInMs = gf_length * nwf_length;
-    gf_length = gf_length_new;
+    gf_length = gfLenghtNew;
     // Time for one NWF should stay the same
     nwf_length = helpers::roundedDiv(nwfLenInMs, gf_length);
 }

--- a/src/FramesInfo.cpp
+++ b/src/FramesInfo.cpp
@@ -34,6 +34,15 @@ void FramesInfo::Clear()
     isPaused = false;
 }
 
+void FramesInfo::ApplyNewGFLength()
+{
+    gf_length = gf_length_new;
+    if(gf_length == 1)
+        nwf_length = 50;
+    else
+        nwf_length = 250 / gf_length;
+}
+
 FramesInfoClient::FramesInfoClient()
 {
     Clear();

--- a/src/FramesInfo.cpp
+++ b/src/FramesInfo.cpp
@@ -55,4 +55,5 @@ void FramesInfoClient::Clear()
     FramesInfo::Clear();
     gfNrServer = 0;
     pause_gf = 0;
+    forcePauseStart = forcePauseLen = 0;
 }

--- a/src/FramesInfo.cpp
+++ b/src/FramesInfo.cpp
@@ -17,6 +17,7 @@
 
 #include "defines.h"
 #include "FramesInfo.h"
+#include "helpers/mathFuncs.h"
 
 FramesInfo::FramesInfo()
 {
@@ -36,11 +37,11 @@ void FramesInfo::Clear()
 
 void FramesInfo::ApplyNewGFLength()
 {
+    // Current length of a NWF in ms
+    unsigned nwfLenInMs = gf_length * nwf_length;
     gf_length = gf_length_new;
-    if(gf_length == 1)
-        nwf_length = 50;
-    else
-        nwf_length = 250 / gf_length;
+    // Time for one NWF should stay the same
+    nwf_length = helpers::roundedDiv(nwfLenInMs, gf_length);
 }
 
 FramesInfoClient::FramesInfoClient()

--- a/src/FramesInfo.h
+++ b/src/FramesInfo.h
@@ -56,6 +56,8 @@ public:
     unsigned gfNrServer;
     /// GF at wich we should pause the game
     unsigned pause_gf;
+    /// Force pause the game (start TS and length) e.g. to compensate for lags
+    unsigned forcePauseStart, forcePauseLen;
 };
 
 #endif // FramesInfo_h__

--- a/src/FramesInfo.h
+++ b/src/FramesInfo.h
@@ -24,6 +24,8 @@ struct FramesInfo
 public:
     FramesInfo();
     void Clear();
+    /// Changes the GF length to GFLengthNEw and adapts the NWF length accordingly
+    void ApplyNewGFLength();
 
     /// Current GameFrame (GF) (from start of the game)
     unsigned gf_nr;

--- a/src/FramesInfo.h
+++ b/src/FramesInfo.h
@@ -32,7 +32,9 @@ public:
     /// Lenght of one GF in ms (~ 1/speed of the game)
     unsigned gf_length;
     /// New length of a GF (applied on next NWF)
-    unsigned gf_length_new;
+    unsigned gfLenghtNew;
+    /// New length of a GF (applied on second next NWF)
+    unsigned gfLenghtNew2;
     /// Length of a NWF (network frame) in GFs
     unsigned nwf_length;
     /// Time since last GF in ms (valid range: [0, gfLength) )

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -1292,7 +1292,7 @@ void GameClient::OnNMSGetAsyncLog(const GameMessage_GetAsyncLog& msg)
     // stückeln...
     std::list<RandomEntry>* async_log = RANDOM.GetAsyncLog();
 
-    std::list<RandomEntry> part;
+    std::vector<RandomEntry> part;
 
     for (std::list<RandomEntry>::iterator it = async_log->begin(); it != async_log->end(); ++it)
     {
@@ -1300,14 +1300,12 @@ void GameClient::OnNMSGetAsyncLog(const GameMessage_GetAsyncLog& msg)
 
         if (part.size() == 10)
         {
-            send_queue.push(new GameMessage_SendAsyncLog(&part, false));
+            send_queue.push(new GameMessage_SendAsyncLog(part, false));
             part.clear();
         }
     }
 
-    send_queue.push(new GameMessage_SendAsyncLog(&part, true));
-
-    part.clear();
+    send_queue.push(new GameMessage_SendAsyncLog(part, true));
 }
 
 /// Findet heraus, ob ein Spieler laggt und setzt bei diesen Spieler den entsprechenden flag

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -972,7 +972,7 @@ void GameClient::OnNMSServerAsync(const GameMessage_Server_Async& msg)
 
 //  LOG.lprintf("Async log saved at \"%s\"\n",filename);
 
-    GAMECLIENT.WriteSaveHeader(fileName);
+    GAMECLIENT.SaveToFile(fileName);
 
     // Pausieren
 
@@ -1560,7 +1560,7 @@ void GameClient::HandleAutosave()
             tmp += ".sav";
         }
 
-        WriteSaveHeader(tmp);
+        SaveToFile(tmp);
     }
 }
 
@@ -1941,7 +1941,7 @@ void GameClient::SystemChat(const std::string& text)
     ci->CI_Chat(playerId_, CD_SYSTEM, text);
 }
 
-unsigned GameClient::WriteSaveHeader(const std::string& filename)
+unsigned GameClient::SaveToFile(const std::string& filename)
 {
     // Mond malen
     LOADER.GetImageN("resource", 33)->Draw(VIDEODRIVER.GetMouseX(), VIDEODRIVER.GetMouseY() - 40, 0, 0, 0, 0, 0, 0);

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -1517,7 +1517,7 @@ void GameClient::ExecuteGameFrame(const bool skipping)
     {
         // Next GF not yet reached, just update the time in the current one for drawing
         framesinfo.frameTime = currentTime - framesinfo.lastTime;
-        assert(framesinfo.frameTime < framesinfo.gf_length);
+        assert(framesinfo.frameTime <= framesinfo.gf_length);
     }
 }
 

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -302,8 +302,8 @@ void GameClient::Stop()
 
     socket.Close();
 
-	// clear jump target
-	skiptogf=0;
+    // clear jump target
+    skiptogf=0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1204,30 +1204,30 @@ void GameClient::IncreaseSpeed()
 
 void GameClient::IncreaseReplaySpeed()
 {
-	if (replay_mode)
-	{
-		if (framesinfo.gf_length > 10)
-		{
-			framesinfo.gf_length -= 10;
-		} else if (framesinfo.gf_length == 10)
-		{
-			framesinfo.gf_length = 1;
-		}
-	}
+    if (replay_mode)
+    {
+        if (framesinfo.gf_length > 10)
+        {
+            framesinfo.gf_length -= 10;
+        } else if (framesinfo.gf_length == 10)
+        {
+            framesinfo.gf_length = 1;
+        }
+    }
 }
 
 void GameClient::DecreaseReplaySpeed()
 {
-	if (replay_mode)
-	{
-		if (framesinfo.gf_length == 1)
-		{
-			framesinfo.gf_length = 10;
-		} else if (framesinfo.gf_length < 1000)
-		{
-			framesinfo.gf_length += 10;
-		}
-	}
+    if (replay_mode)
+    {
+        if (framesinfo.gf_length == 1)
+        {
+            framesinfo.gf_length = 10;
+        } else if (framesinfo.gf_length < 1000)
+        {
+            framesinfo.gf_length += 10;
+        }
+    }
 }
 
 
@@ -1260,13 +1260,13 @@ void GameClient::OnNMSServerDone(const GameMessage_Server_NWFDone& msg)
 void GameClient::OnNMSPause(const GameMessage_Pause& msg)
 {
     //framesinfo.pause =  msg.paused;
-	if(msg.paused)
-		framesinfo.pause_gf = msg.nr;
-	else
-	{
-	    framesinfo.isPaused =  false;
-		framesinfo.pause_gf = 0;
-	}
+    if(msg.paused)
+        framesinfo.pause_gf = msg.nr;
+    else
+    {
+        framesinfo.isPaused =  false;
+        framesinfo.pause_gf = 0;
+    }
 
     LOG.write("<<< NMS_NFC_PAUSE(%u)\n", framesinfo.pause_gf);
 
@@ -1427,11 +1427,11 @@ void GameClient::StatisticStep()
 void GameClient::ExecuteGameFrame(const bool skipping)
 {
     unsigned int currentTime = VIDEODRIVER.GetTickCount();
-	if(!framesinfo.isPaused && framesinfo.pause_gf != 0 && framesinfo.gf_nr == framesinfo.pause_gf)
-	{
-		framesinfo.pause_gf = 0;
-		framesinfo.isPaused = true;
-	}
+    if(!framesinfo.isPaused && framesinfo.pause_gf != 0 && framesinfo.gf_nr == framesinfo.pause_gf)
+    {
+        framesinfo.pause_gf = 0;
+        framesinfo.isPaused = true;
+    }
 
     if(framesinfo.isPaused)
     {
@@ -1774,7 +1774,7 @@ unsigned GameClient::StartReplay(const std::string& path, GameWorldViewer*& gwv)
 
     replayinfo.replay.ReadGF(&replayinfo.next_gf);
 
-	state = CS_GAME; // zu gamestate wechseln
+    state = CS_GAME; // zu gamestate wechseln
     RealStart();
 
     gwv = gw;
@@ -1848,25 +1848,25 @@ void GameClient::SkipGF(unsigned int gf)
     unsigned start_ticks = VIDEODRIVER.GetTickCount();
 
     // Spiel entpausieren
-	if(replay_mode)
-		SetReplayPause(false);
-	if(!replay_mode)
-	{
-		//unpause before skipping
-		if(GAMESERVER.IsPaused())
-		{
-			GAMESERVER.TogglePause();
-			//return;
-		}
-		GAMESERVER.skiptogf=gf;
-		skiptogf=gf;
-		LOG.lprintf("jumping from gf %i to gf %i \n", framesinfo.gf_nr, gf);
-		return;
-	}
-	
+    if(replay_mode)
+        SetReplayPause(false);
+    if(!replay_mode)
+    {
+        //unpause before skipping
+        if(GAMESERVER.IsPaused())
+        {
+            GAMESERVER.TogglePause();
+            //return;
+        }
+        GAMESERVER.skiptogf=gf;
+        skiptogf=gf;
+        LOG.lprintf("jumping from gf %i to gf %i \n", framesinfo.gf_nr, gf);
+        return;
+    }
+    
 
     // GFs überspringen
-	for(unsigned int i = framesinfo.gf_nr; i < gf;++i)
+    for(unsigned int i = framesinfo.gf_nr; i < gf;++i)
     {
         if(i % 1000 == 0)
         {
@@ -1882,21 +1882,21 @@ void GameClient::SkipGF(unsigned int gf)
             gw->Draw(GetPlayerID(), &water_percent, false, MapPoint(0, 0), road);
 
             // text oben noch hinschreiben
-            snprintf(nwf_string, 255, _("current GF: %u - still fast forwarding: %d GFs left (%d %%)"), GetGFNumber(), gf - i, (i * 100 / gf) );			
+            snprintf(nwf_string, 255, _("current GF: %u - still fast forwarding: %d GFs left (%d %%)"), GetGFNumber(), gf - i, (i * 100 / gf) );            
             LargeFont->Draw(VIDEODRIVER.GetScreenWidth() / 2, VIDEODRIVER.GetScreenHeight() / 2, nwf_string, glArchivItem_Font::DF_CENTER, 0xFFFFFF00);
 
             VIDEODRIVER.SwapBuffers();
         }
         ExecuteGameFrame(true);
-		//LOG.lprintf("jumping: now at gf %i\n", framesinfo.nr);		
+        //LOG.lprintf("jumping: now at gf %i\n", framesinfo.nr);        
     }
-	
+    
     // Spiel pausieren & text ausgabe wie lang das jetzt gedauert hat 
     unsigned ticks = VIDEODRIVER.GetTickCount() - start_ticks;
-	char text[256];
-	snprintf(text, sizeof(text), _("Jump finished (%.3f seconds)."), (double) ticks / 1000.0);
-	ci->CI_Chat(playerId_, CD_SYSTEM, text); 
-	SetReplayPause(true);
+    char text[256];
+    snprintf(text, sizeof(text), _("Jump finished (%.3f seconds)."), (double) ticks / 1000.0);
+    ci->CI_Chat(playerId_, CD_SYSTEM, text); 
+    SetReplayPause(true);
 
 }
 

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -1261,7 +1261,7 @@ void GameClient::OnNMSServerDone(const GameMessage_Server_NWFDone& msg)
         framesinfo.gfNrServer = msg.nr + framesinfo.nwf_length;
     }
 
-    //LOG.lprintf("framesinfo.nr(%d) == framesinfo.nr_srv(%d)\n", framesinfo.nr, framesinfo.nr_srv);
+    //LOG.write("framesinfo.gf_nr(%d) == framesinfo.gfNrServer(%d)\n", framesinfo.gf_nr, framesinfo.gfNrServer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1602,9 +1602,6 @@ void GameClient::SendNothingNC(int checksum)
 {
     if(checksum == -1)
         checksum = RANDOM.GetCurrentRandomValue();
-
-    /*GameMessage nfc(NMS_NFC_COMMANDS, 5);
-    *static_cast<int*>(nfc.m_pData) = checksum;*/
 
     send_queue.push(new GameMessage_GameCommand(playerId_, checksum, std::vector<gc::GameCommandPtr>()));
 }

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -289,6 +289,7 @@ void GameClient::Stop()
     if (IsHost())
         GAMESERVER.Stop();
 
+    framesinfo.Clear();
     clientconfig.Clear();
     mapinfo.Clear();
     for(std::list<PostMsg*>::iterator it = postMessages.begin(); it != postMessages.end(); ++it)
@@ -1457,8 +1458,6 @@ void GameClient::ExecuteGameFrame(const bool skipping)
         if(replay_mode)
         {
             // In replay mode we have all commands in  the file -> Execute them
-            // Nächster Game-Frame erreicht
-            ++framesinfo.gf_nr;
             ExecuteGameFrame_Replay();
         }else
         {
@@ -1500,8 +1499,6 @@ void GameClient::ExecuteGameFrame(const bool skipping)
                 framesinfo.gfLenghtNew2 = 0;
             }
 
-            // continue the simulation
-            ++framesinfo.gf_nr;
             NextGF();
         }
 
@@ -1555,6 +1552,7 @@ void GameClient::HandleAutosave()
 /// Führt notwendige Dinge für nächsten GF aus
 void GameClient::NextGF()
 {
+    ++framesinfo.gf_nr;
     // Statistiken aktualisieren
     StatisticStep();
     //  EventManager Bescheid sagen

--- a/src/GameClient.h
+++ b/src/GameClient.h
@@ -178,7 +178,7 @@ class GameClient : public Singleton<GameClient, SingletonPolicies::WithLongevity
         /// Versucht einen neuen GameFrame auszuführen, falls die Zeit dafür gekommen ist
         void ExecuteGameFrame(const bool skipping = false);
         void ExecuteGameFrame_Replay();
-        void ExecuteGameFrame_Game();
+        void ExecuteNWF();
         /// Filtert aus einem Network-Command-Paket alle Commands aus und führt sie aus, falls ein Spielerwechsel-Command
         /// dabei ist, füllt er die übergebenen IDs entsprechend aus
         void ExecuteAllGCs(const GameMessage_GameCommand& gcs);
@@ -189,6 +189,8 @@ class GameClient : public Singleton<GameClient, SingletonPolicies::WithLongevity
 
         /// Führt notwendige Dinge für nächsten GF aus
         void NextGF();
+        /// Checks if its time for autosaving (if enabled) and does it
+        void HandleAutosave();
 
         /// Führt für alle Spieler einen Statistikschritt aus, wenn die Zeit es verlangt
         void StatisticStep();

--- a/src/GameClient.h
+++ b/src/GameClient.h
@@ -160,7 +160,7 @@ class GameClient : public Singleton<GameClient, SingletonPolicies::WithLongevity
         /// Spiel pausiert?
         bool IsPaused() const { return framesinfo.isPaused; }
         /// Schreibt Header der Save-Datei
-        unsigned WriteSaveHeader(const std::string& filename);
+        unsigned SaveToFile(const std::string& filename);
         /// Visuelle Einstellungen aus den richtigen ableiten
         void GetVisualSettings();
 

--- a/src/GameClientCommands.cpp
+++ b/src/GameClientCommands.cpp
@@ -24,7 +24,6 @@
 #include "nodeObjs/noFlag.h"
 #include "GameClientPlayer.h"
 
-#include "GameServer.h"
 #include "buildings/nobUsual.h"
 #include "buildings/nobMilitary.h"
 #include "buildings/nobBaseWarehouse.h"

--- a/src/GameClientGF_Game.cpp
+++ b/src/GameClientGF_Game.cpp
@@ -22,7 +22,7 @@
 #include "Random.h"
 #include "GameMessages.h"
 
-void GameClient::ExecuteGameFrame_Game()
+void GameClient::ExecuteNWF()
 {
     // Geschickte Network Commands der Spieler ausführen und ggf. im Replay aufzeichnen
 

--- a/src/GameClientGF_Game.cpp
+++ b/src/GameClientGF_Game.cpp
@@ -40,7 +40,7 @@ void GameClient::ExecuteNWF()
 
             // Command im Replay aufzeichnen (wenn nicht gerade eins schon läuft xD)
             // Nur Commands reinschreiben, KEINE PLATZHALTER (nc_count = 0)
-            if(msg.gcs.size() > 0 && !replay_mode)
+            if(!msg.gcs.empty() && !replay_mode)
             {
                 // Aktuelle Checksumme reinschreiben
                 GameMessage_GameCommand tmp(msg.player, checksum, msg.gcs);
@@ -56,12 +56,7 @@ void GameClient::ExecuteNWF()
         }
     }
 
-    // Frame ausführen
-    NextGF();
-
-    //LOG.lprintf("%d = %d - %d\n", framesinfo.nr / framesinfo.nwf_length, checksum, RANDOM.GetCurrentRandomValue());
-
-    // Stehen eigene Commands an, die gesendet werden müssen?
+    // Send GC message for this NWF
     send_queue.push(new GameMessage_GameCommand(playerId_, checksum, gameCommands_));
 
     // alles gesendet --> Liste löschen

--- a/src/GameClientGF_Game.cpp
+++ b/src/GameClientGF_Game.cpp
@@ -52,7 +52,6 @@ void GameClient::ExecuteNWF()
 
             // Nachricht abwerfen :)
             players[i].gc_queue.pop();
-
         }
     }
 

--- a/src/GameClientGF_Replay.cpp
+++ b/src/GameClientGF_Replay.cpp
@@ -32,6 +32,8 @@ void GameClient::ExecuteGameFrame_Replay()
 {
     randcheckinfo.rand = RANDOM.GetCurrentRandomValue();
 
+    assert(replayinfo.next_gf >= framesinfo.gf_nr || framesinfo.gf_nr > replayinfo.replay.lastGF_);
+
     // Commands alle aus der Datei lesen
     while(replayinfo.next_gf == framesinfo.gf_nr) // Schon an der Zeit?
     {

--- a/src/GameMessageInterface.cpp
+++ b/src/GameMessageInterface.cpp
@@ -60,5 +60,5 @@ void GameMessageInterface::OnNMSServerSpeed(const GameMessage_Server_Speed& msg)
 void GameMessageInterface::OnNMSGGSChange(const GameMessage_GGSChange& msg) {}
 
 void GameMessageInterface::OnNMSGetAsyncLog(const GameMessage_GetAsyncLog& msg) {}
-void GameMessageInterface::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::list<RandomEntry>* his, bool last) {}
+void GameMessageInterface::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, const std::vector<RandomEntry>& his, bool last) {}
 

--- a/src/GameMessageInterface.h
+++ b/src/GameMessageInterface.h
@@ -21,7 +21,7 @@
 
 #include "MessageInterface.h"
 #include "Random.h"
-#include <list>
+#include <vector>
 
 class GameMessage_Ping;
 class GameMessage_Pong;
@@ -108,7 +108,7 @@ class GameMessageInterface : public MessageInterface
         virtual void OnNMSGGSChange(const GameMessage_GGSChange& msg);
 
         virtual void OnNMSGetAsyncLog(const GameMessage_GetAsyncLog& msg);
-        virtual void OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::list<RandomEntry>* his, bool last);
+        virtual void OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, const std::vector<RandomEntry>& his, bool last);
 };
 
 /// Castet das allgemeine Message-Interface in ein GameMessage-Interface

--- a/src/GameMessages.h
+++ b/src/GameMessages.h
@@ -298,7 +298,7 @@ class GameMessage_Server_Async : public GameMessage
 
             PushUnsignedInt(unsigned(checksums.size()));
             for(unsigned int i = 0; i < checksums.size(); ++i)
-                PushSignedInt(checksums.at(i));
+                PushSignedInt(checksums[i]);
         }
         void Run(MessageInterface* callback)
         {

--- a/src/GameMessages.h
+++ b/src/GameMessages.h
@@ -850,17 +850,17 @@ class GameMessage_GetAsyncLog : public GameMessage
 /// eingehende SendAsyncLog-Nachricht
 class GameMessage_SendAsyncLog : public GameMessage
 {
-        std::list<RandomEntry> recved_log;
+        std::vector<RandomEntry> recved_log;
 
     public:
         GameMessage_SendAsyncLog() : GameMessage(NMS_SEND_ASYNC_LOG) {}
 
-        GameMessage_SendAsyncLog(std::list<RandomEntry>* async_log, bool last) : GameMessage(NMS_SEND_ASYNC_LOG, 0xFF)
+        GameMessage_SendAsyncLog(const std::vector<RandomEntry>& async_log, bool last) : GameMessage(NMS_SEND_ASYNC_LOG, 0xFF)
         {
             PushBool(last);
-            PushUnsignedInt(async_log->size());
+            PushUnsignedInt(async_log.size());
 
-            for(std::list<RandomEntry>::iterator it = async_log->begin(); it != async_log->end(); ++it)
+            for(std::vector<RandomEntry>::const_iterator it = async_log.begin(); it != async_log.end(); ++it)
             {
                 PushUnsignedInt(it->counter);
                 PushSignedInt(it->max);
@@ -899,7 +899,7 @@ class GameMessage_SendAsyncLog : public GameMessage
                 recved_log.push_back(RandomEntry(counter, max, value, src_name, src_line, obj_id));
             }
 
-            GetInterface(callback)->OnNMSSendAsyncLog(*this, &recved_log, last);
+            GetInterface(callback)->OnNMSSendAsyncLog(*this, recved_log, last);
         }
 };
 

--- a/src/GamePlayerInfo.cpp
+++ b/src/GamePlayerInfo.cpp
@@ -45,8 +45,6 @@ GamePlayerInfo::GamePlayerInfo(const unsigned playerid) :
     color(0),
     ping(0),
     rating(0),
-	obj_cnt(0),
-	obj_id_cnt(0),
     ready(false)
 {
 }
@@ -64,8 +62,6 @@ GamePlayerInfo::GamePlayerInfo(const unsigned playerid, Serializer* ser) :
     color(ser->PopUnsignedChar()),
     ping(ser->PopUnsignedInt()),
     rating(ser->PopUnsignedInt()),
-	obj_cnt(0),
-	obj_id_cnt(0),
     ready(ser->PopBool())
 {
 }
@@ -106,7 +102,6 @@ void GamePlayerInfo::serialize(Serializer* ser) const
 
 void GamePlayerInfo::SwapPlayer(GamePlayerInfo& two)
 {
-    /// Besiegt?
     std::swap(ps, two.ps);
     std::swap(aiInfo, two.aiInfo);
     std::swap(defeated, two.defeated);
@@ -114,7 +109,6 @@ void GamePlayerInfo::SwapPlayer(GamePlayerInfo& two)
     std::swap(is_host, two.is_host);
     std::swap(ping, two.ping);
     std::swap(rating, two.rating);
-    std::swap(checksum, two.checksum);
     std::swap(ready, two.ready);
 }
 

--- a/src/GamePlayerInfo.h
+++ b/src/GamePlayerInfo.h
@@ -111,9 +111,6 @@ class GamePlayerInfo
         unsigned ping;
         unsigned int rating;
 
-        int checksum;
-        unsigned obj_cnt;
-        unsigned obj_id_cnt;
         bool ready;
 };
 

--- a/src/GameServer.cpp
+++ b/src/GameServer.cpp
@@ -119,7 +119,7 @@ GameServer::GameServer(void): lanAnnouncer(LAN_DISCOVERY_CFG)
     serverconfig.Clear();
     mapinfo.Clear();
     countdown.Clear();
-	skiptogf=0;
+    skiptogf=0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -502,13 +502,13 @@ void GameServer::Stop(void)
 
     // laden dicht machen
     serversocket.Close();
-	// clear jump target
-	skiptogf=0;
+    // clear jump target
+    skiptogf=0;
 
     lanAnnouncer.Stop();
 
     if(status != SS_STOPPED)
-        LOG.lprintf("server state changed to stop\n");	
+        LOG.lprintf("server state changed to stop\n");    
 
     // status
     status = SS_STOPPED;
@@ -957,7 +957,7 @@ void GameServer::ClientWatchDog()
     unsigned int currentTime = VIDEODRIVER.GetTickCount();
 
     // prüfen ob GF vergangen
-	if(currentTime - framesinfo.lastTime > framesinfo.gf_length || skiptogf > framesinfo.gf_nr)
+    if(currentTime - framesinfo.lastTime > framesinfo.gf_length || skiptogf > framesinfo.gf_nr)
     {
         ++framesinfo.gf_nr;
         bool isNWF = framesinfo.gf_nr % framesinfo.nwf_length==0;
@@ -1672,10 +1672,10 @@ void GameServer::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::lis
 
 void GameServer::ChangePlayer(const unsigned char old_id, const unsigned char new_id)
 {
-	LOG.lprintf("GameServer::ChangePlayer %i - %i \n",old_id, new_id);
+    LOG.lprintf("GameServer::ChangePlayer %i - %i \n",old_id, new_id);
     // old_id muss richtiger Spieler, new_id KI sein, ansonsten geht das natürlich nicht
     if( !(players[old_id].ps == PS_OCCUPIED && players[new_id].ps == PS_KI) )
-        return;	
+        return;    
     players[old_id].ps = PS_KI;
     players[new_id].ps = PS_OCCUPIED;
     using std::swap;
@@ -1687,7 +1687,7 @@ void GameServer::ChangePlayer(const unsigned char old_id, const unsigned char ne
 
     ai_players[old_id] = GAMECLIENT.CreateAIPlayer(old_id);
 
-	//swap the gamecommand que
+    //swap the gamecommand que
     swap(players[old_id].gc_queue, players[new_id].gc_queue);
 }
 
@@ -1696,7 +1696,7 @@ void GameServer::ChangePlayer(const unsigned char old_id, const unsigned char ne
 bool GameServer::TogglePause()
 {
     framesinfo.isPaused = !framesinfo.isPaused;
-	SendToAll(GameMessage_Pause(framesinfo.isPaused, framesinfo.gf_nr + framesinfo.nwf_length));
+    SendToAll(GameMessage_Pause(framesinfo.isPaused, framesinfo.gf_nr + framesinfo.nwf_length));
 
     return framesinfo.isPaused;
 }

--- a/src/GameServer.cpp
+++ b/src/GameServer.cpp
@@ -432,6 +432,8 @@ void GameServer::Run(void)
     // auf neue Clients warten
     if(status == SS_CONFIG)
         WaitForClients();
+    else if(status == SS_GAME)
+        ExecuteGameFrame();
 
     // post zustellen
     FillPlayerQueues();
@@ -947,9 +949,11 @@ void GameServer::ClientWatchDog()
         // auf timeout prüfen
         player.doTimeout();
     }
+}
 
-    if(status != SS_GAME)
-        return;
+void GameServer::ExecuteGameFrame()
+{
+    assert(status == SS_GAME);
 
     if(framesinfo.isPaused)
         return;

--- a/src/GameServer.cpp
+++ b/src/GameServer.cpp
@@ -1679,7 +1679,7 @@ void GameServer::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, const st
 
     // write async save
     fileName = GetFilePath(FILE_PATHS[85]) + timeStr + ".sav";
-    GAMECLIENT.WriteSaveHeader(fileName);
+    GAMECLIENT.SaveToFile(fileName);
 
     KickPlayer(msg.player, NP_ASYNC, 0);
 }

--- a/src/GameServer.cpp
+++ b/src/GameServer.cpp
@@ -1534,14 +1534,11 @@ void GameServer::OnNMSGameCommand(const GameMessage_GameCommand& msg)
         SendToAll(GameMessage_GameCommand(msg.player, msg.checksum, std::vector<gc::GameCommandPtr>()));
 }
 
-void GameServer::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::list<RandomEntry>* in, bool last)
+void GameServer::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, const std::vector<RandomEntry>& in, bool last)
 {
     if (msg.player == async_player1)
     {
-        for (std::list<RandomEntry>::iterator it = in->begin(); it != in->end(); ++it)
-        {
-            async_player1_log.push_back(*it);
-        }
+        async_player1_log.insert(async_player1_log.end(), in.begin(), in.end());
 
         if (last)
         {
@@ -1551,10 +1548,7 @@ void GameServer::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::lis
     }
     else if (msg.player == async_player2)
     {
-        for (std::list<RandomEntry>::iterator it = in->begin(); it != in->end(); ++it)
-        {
-            async_player2_log.push_back(*it);
-        }
+        async_player2_log.insert(async_player2_log.end(), in.begin(), in.end());
 
         if (last)
         {
@@ -1577,8 +1571,8 @@ void GameServer::OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::lis
 
     LOG.lprintf("Async logs received completely.\n");
 
-    std::list<RandomEntry>::iterator it1 = async_player1_log.begin();
-    std::list<RandomEntry>::iterator it2 = async_player2_log.begin();
+    std::vector<RandomEntry>::const_iterator it1 = async_player1_log.begin();
+    std::vector<RandomEntry>::const_iterator it2 = async_player2_log.begin();
 
     // compare counters, adjust them so we're comparing the same counter numbers
     if (it1->counter > it2->counter)

--- a/src/GameServer.h
+++ b/src/GameServer.h
@@ -116,6 +116,8 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
 
         void OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::list<RandomEntry>* his, bool last);
 
+        void ExecuteNWF(const unsigned currentTime);
+
     private:
         enum ServerState
         {

--- a/src/GameServer.h
+++ b/src/GameServer.h
@@ -119,7 +119,14 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
 
         /// Handles advancing of GFs, actions of AI and potentially the NWF
         void ExecuteGameFrame();
+
+        void RunGF( bool isNWF );
+
         void ExecuteNWF(const unsigned currentTime);
+
+        void CheckAndKickLaggingPlayer(const unsigned char playerIdx);
+
+        unsigned char GetLaggingPlayer() const;
 
     private:
         enum ServerState

--- a/src/GameServer.h
+++ b/src/GameServer.h
@@ -115,7 +115,7 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
         void OnNMSGameCommand(const GameMessage_GameCommand& msg);
         void OnNMSServerSpeed(const GameMessage_Server_Speed& msg);
 
-        void OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::list<RandomEntry>* his, bool last);
+        void OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, const std::vector<RandomEntry>& his, bool last);
 
         /// Handles advancing of GFs, actions of AI and potentially the NWF
         void ExecuteGameFrame();
@@ -187,7 +187,7 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
         /// AsyncLogs of two async players
         int async_player1, async_player2;
         bool async_player1_done, async_player2_done;
-        std::list<RandomEntry> async_player1_log, async_player2_log;
+        std::vector<RandomEntry> async_player1_log, async_player2_log;
 
         LANDiscoveryService lanAnnouncer;
 

--- a/src/GameServer.h
+++ b/src/GameServer.h
@@ -88,6 +88,7 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
         void KickPlayer(NS_PlayerKicked npk);
 
         void ClientWatchDog(void);
+
         void WaitForClients(void);
         void FillPlayerQueues(void);
 
@@ -116,6 +117,8 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
 
         void OnNMSSendAsyncLog(const GameMessage_SendAsyncLog& msg, std::list<RandomEntry>* his, bool last);
 
+        /// Handles advancing of GFs, actions of AI and potentially the NWF
+        void ExecuteGameFrame();
         void ExecuteNWF(const unsigned currentTime);
 
     private:

--- a/src/GameServerPlayer.cpp
+++ b/src/GameServerPlayer.cpp
@@ -128,8 +128,8 @@ void GameServerPlayer::clear()
 
 unsigned GameServerPlayer::GetTimeOut() const
 {
-    // Nach 34 Sekunden kicken (34 damit ab 30 erst die Meldung kommt, sonst kommt sie andauernd)
-    const int timeout = 34 - int(TIME.CurrentTime() - last_command_timeout) / 1000;
+    // Nach 35 Sekunden kicken
+    const int timeout = 35 - int(TIME.CurrentTime() - last_command_timeout) / 1000;
     return (timeout >= 0 ? timeout : 0);
 }
 

--- a/src/GameWorldViewer.cpp
+++ b/src/GameWorldViewer.cpp
@@ -36,7 +36,6 @@
 
 #include "Settings.h"
 
-#include "GameServer.h"
 #include "driver/src/MouseCoords.h"
 
 GameWorldViewer::GameWorldViewer() : scroll(false), sx(0), sy(0), view(GameWorldView(MapPoint(0, 0), VIDEODRIVER.GetScreenWidth(), VIDEODRIVER.GetScreenHeight()))

--- a/src/helpers/mathFuncs.cpp
+++ b/src/helpers/mathFuncs.cpp
@@ -36,4 +36,13 @@ namespace helpers{
         }
         return a;
     }
+
+    unsigned roundedDiv(unsigned dividend, unsigned divisor)
+    {
+        assert(divisor > 0);
+        assert(dividend + (divisor / 2) >= dividend); // Overflow check
+        // Standard way for emulation mathematical rounding: floor(divident / divisor + 0.5)
+        // Which is the same as: floor((divident + 0.5 * divisor) / divisor) == floor((divident + divisor / 2) / divisor)
+        return (dividend + (divisor / 2)) / divisor;
+    }
 }

--- a/src/helpers/mathFuncs.h
+++ b/src/helpers/mathFuncs.h
@@ -23,6 +23,8 @@ namespace helpers{
     /// Returns the greatest common divisor of a and b
     /// That is the greatest number x with a % x == b % x == 0
     int gcd(int a, int b);
+    /// Returns the result of "divident / divisor" rounded to the nearest integer value
+    unsigned roundedDiv(unsigned dividend, unsigned divisor);
 }
 
 #endif // mathFuncs_h__

--- a/src/ingameWindows/iwSave.cpp
+++ b/src/ingameWindows/iwSave.cpp
@@ -175,7 +175,7 @@ void iwSave::SaveLoad()
     tmp += ".sav";
 
     // Speichern
-    GAMECLIENT.WriteSaveHeader(tmp);
+    GAMECLIENT.SaveToFile(tmp);
 
     // Aktualisieren
     RefreshTable();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@
 #include "Debug.h"
 
 #ifndef NDEBUG
-        #include "GameServer.h"
+    #include "GameServer.h"
     #include "ingameWindows/iwDirectIPCreate.h"
     #include "WindowManager.h"
     #include "desktops/dskGameLoader.h"

--- a/src/nodeObjs/noFlag.cpp
+++ b/src/nodeObjs/noFlag.cpp
@@ -33,7 +33,6 @@
 #include "FOWObjects.h"
 
 #include "ogl/glSmartBitmap.h"
-#include "GameServer.h"
 #include "gameData/TerrainData.h"
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Do not merge before
- [x] Merge #318

This fixes #315 with a complete overhaul of the network system. The system is analyzed and implemented as described in the new wiki entry I made: https://github.com/Return-To-The-Roots/s25client/wiki/Network-mechanics   
Key issues:

- Server waits for lagging clients and does not continue before (was a possible async cause!)
- Refactored methods: SRP applies: Especially the methods from the server were doing to much to be maintainable. Factored out e.g. NWF and GF handling from the general "do a step" function.
- The ServerDone message is now similar to the GC-Message from the KIs: Clients wont execute a NWF till the Done message is received. Although the Done-Messages could be used for the current NWF they are used for the **next** NWF, just like the GC-Messages to account for possible server and network latencies
- Game speed changes are now done at the correct time. They have to be executed on the same NWF for all clients and the server. So the `gfLengthNew` and `gfLengthNew2` variables act as a "stack" for the new speed.
- Frame time is now set correctly. It needs to stay within the length of a GF (graphical glitches otherwise)
- GF counting is now correct. The replays had to execute "a first GC" before starting due to a small issue in the counting. The GF counter is now increased in the `RunGF` method, so everything is consistent.
- Some asserts to catch possible regressions