### PR TITLE
Seafaring fixes

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -85,6 +85,7 @@ EventManager::EventPointer EventManager::AddEvent(EventPointer event)
     // Should be in the future!
     // At the current GF is allowed as long as a std::list is used for the events of one GF because it retains iterator validy even on modify
     assert(event->gf_next >= GAMECLIENT.GetGFNumber());
+    assert(!dynamic_cast<EventPointer>(event->obj)); // Why could this ever happen?
     events[event->gf_next].push_back(event);
     return event;
 }

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -72,7 +72,11 @@ void EventManager::Clear()
     events.clear();
 
     for(GameObjList::iterator it = kill_list.begin(); it != kill_list.end(); ++it)
-        delete *it;
+    {
+        GameObject* obj = *it;
+        *it = NULL;
+        delete obj;
+    }
     kill_list.clear();
 }
 

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -78,7 +78,9 @@ void EventManager::Clear()
 
 EventManager::EventPointer EventManager::AddEvent(EventPointer event)
 {
-    assert(event->gf_next > GAMECLIENT.GetGFNumber()); // Should be in the future!
+    // Should be in the future!
+    // At the current GF is allowed as long as a std::list is used for the events of one GF because it retains iterator validy even on modify
+    assert(event->gf_next >= GAMECLIENT.GetGFNumber());
     events[event->gf_next].push_back(event);
     return event;
 }
@@ -288,9 +290,12 @@ void EventManager::RemoveEvent(EventPointer& ep)
     ep = NULL;
 }
 
+#include "figures/noFigure.h"
+
 void EventManager::AddToKillList(GameObject* obj)
 {
     assert(obj);
     assert(!helpers::contains(kill_list, obj));
+    assert(!dynamic_cast<noFigure*>(obj) || static_cast<noFigure*>(obj)->HasNoGoal());
     kill_list.push_back(obj);
 }

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -462,6 +462,7 @@ void GameClient::ExitGame()
     gw = 0;
     em = 0;
 
+    deletePtr(human_ai);
     players.clear();
 }
 

--- a/src/GameClientPlayer.cpp
+++ b/src/GameClientPlayer.cpp
@@ -2085,7 +2085,6 @@ bool GameClientPlayer::OrderShip(nobHarborBuilding* hb)
         // ship already there?
         if (ship->GetPos() == dest)
         {
-            ship->AssignHarborId(hb->GetHarborPosID());
             hb->ShipArrived(ship);
             return(true);
         }
@@ -2169,7 +2168,6 @@ void GameClientPlayer::GetJobForShip(noShip* ship)
             // Evtl. sind wir schon da?
             if(ship->GetPos() == dest)
             {
-                ship->AssignHarborId((*it)->GetHarborPosID());
                 (*it)->ShipArrived(ship);
                 return;
             }

--- a/src/GameSavegame.cpp
+++ b/src/GameSavegame.cpp
@@ -25,7 +25,7 @@
 /// Kleine Signatur am Anfang "RTTRSAVE", die ein gültiges S25 RTTR Savegame kennzeichnet
 const char Savegame::SAVE_SIGNATURE[8] = {'R', 'T', 'T', 'R', 'S', 'A', 'V', 'E'};
 /// Version des Savegame-Formates
-const unsigned short Savegame::SAVE_VERSION = 27;
+const unsigned short Savegame::SAVE_VERSION = 28;
 
 ///////////////////////////////////////////////////////////////////////////////
 /**

--- a/src/GameWorldBase.cpp
+++ b/src/GameWorldBase.cpp
@@ -1350,7 +1350,7 @@ unsigned GameWorldBase::GetNextHarborPoint(const MapPoint pt,
         const unsigned char player, 
         bool (GameWorldBase::*IsPointOK)(const unsigned, const unsigned char, const unsigned short) const) const
 {
-
+    assert(origin_harbor_id);
     //unsigned char group_id = harbor_pos[origin_harbor_id-1].cps[
 
     // Herausfinden, in welcher Richtung sich dieser Punkt vom Ausgangspuknt unterscheidet

--- a/src/ai/AIJHHelper.cpp
+++ b/src/ai/AIJHHelper.cpp
@@ -412,11 +412,6 @@ void AIJH::BuildJob::TryToBuildSecondaryRoad()
         status = AIJH::JOB_FINISHED;
 }
 
-void AIJH::ExpandJob::ExecuteJob()
-{
-
-}
-
 
 void AIJH::EventJob::ExecuteJob()//for now it is assumed that all these will be finished or failed after execution (no wait or progress)
 {

--- a/src/ai/AIJHHelper.h
+++ b/src/ai/AIJHHelper.h
@@ -147,19 +147,6 @@ namespace AIJH
             void TryToBuildSecondaryRoad();
     };
 
-    class ExpandJob : public Job, public JobWithTarget
-    {
-            friend class iwAIDebug;
-        public:
-            ExpandJob(AIPlayerJH* aijh) : Job(aijh) { }
-            ~ExpandJob() { }
-            void ExecuteJob();
-        private:
-            BuildingType type;
-            std::vector<unsigned char> route;
-    };
-
-
     class ConnectJob : public Job, public JobWithTarget
     {
             friend class iwAIDebug;

--- a/src/buildings/noBuildingSite.cpp
+++ b/src/buildings/noBuildingSite.cpp
@@ -299,8 +299,8 @@ void noBuildingSite::GotWorker(Job job, noFigure* worker)
 
 void noBuildingSite::Abrogate()
 {
-    planer = 0;
-    builder = 0;
+    planer = NULL;
+    builder = NULL;
 
     gwg->GetPlayer(player).AddJobWanted((state == STATE_PLANING) ? JOB_PLANER : JOB_BUILDER, this);
 }

--- a/src/buildings/nobBaseMilitary.cpp
+++ b/src/buildings/nobBaseMilitary.cpp
@@ -77,8 +77,10 @@ void nobBaseMilitary::Destroy_nobBaseMilitary()
         (*it)->AttackedGoalDestroyed();
 
     // Verteidiger Bescheid sagen
-    if(defender_)
+    if(defender_){
         defender_->HomeDestroyed();
+        defender_ = NULL;
+    }
 
     // Warteschlangenevent vernichten
     em->RemoveEvent(leaving_event);

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -600,10 +600,6 @@ void nobBaseWarehouse::HandleBaseEvent(const unsigned int id)
                 else
                     fig->StartWandering();
 
-                // Kein Ziel gefunden, dann später gleich rumirren!
-                /*if(!wh)
-                    fig->StartWandering();*/
-
                 AddLeavingFigure(fig);
 
                 // Person aus Inventar entfernen

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -1011,11 +1011,12 @@ void nobBaseWarehouse::AddActiveSoldier(nofActiveSoldier* soldier)
     // Truppen prüfen in allen Häusern
     gwg->GetPlayer(player).RegulateAllTroops();
 
-    // und Soldat vernichten
-    em->AddToKillList(soldier);
-
     // Ggf. war er auf Mission
     troops_on_mission.remove(soldier);
+
+    // und Soldat vernichten
+    soldier->ResetHome();
+    em->AddToKillList(soldier);
 }
 
 nofDefender* nobBaseWarehouse::ProvideDefender(nofAttacker* const attacker)

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -166,7 +166,10 @@ void nobHarborBuilding::Destroy()
         nofAttacker* soldier = it->attacker;
         gwg->AddFigure(soldier, pos);
 
-        soldier->CancelAtHomeMilitaryBuilding();
+        soldier->CancelSeaAttack();
+        assert(!soldier->GetAttackedGoal());
+        assert(soldier->HasNoHome());
+        assert(soldier->HasNoGoal());
         soldier->StartWandering();
         soldier->StartWalking(RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 6));
     }
@@ -1309,9 +1312,10 @@ void nobHarborBuilding::AddSeaAttacker(nofAttacker* attacker)
     if (best_harbor_point == 0xffffffff)
     {
         // notify target about noShow, notify home that soldier wont return, add to inventory
-        attacker->InformTargetsAboutCancelling();
-        attacker->CancelAtHomeMilitaryBuilding();
         attacker->SeaAttackFailedBeforeLaunch(); //set state, remove target & home
+        assert(!attacker->GetAttackedGoal());
+        assert(attacker->HasNoHome());
+        assert(attacker->HasNoGoal());
         AddFigure(attacker, true);
         return;
     }

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -656,7 +656,7 @@ void nobHarborBuilding::ShipArrived(noShip* ship)
                 if(it->dest == dest)
                 {
                     figures.push_back(it->fig);
-                    it->fig->StartShipJourney(dest);
+                    it->fig->StartShipJourney();
                     --goods_.people[it->fig->GetJobType()];
                     it = figures_for_ships.erase(it);
                 }
@@ -1075,6 +1075,8 @@ void nobHarborBuilding::ReceiveGoodsFromShip(std::list<noFigure*>& figures, std:
     // Menschen zur Ausgehliste hinzufügen
     for(std::list<noFigure*>::const_iterator it = figures.begin(); it != figures.end(); ++it)
     {
+        (*it)->ArrivedByShip(pos);
+
         if((*it)->GetJobType() == JOB_BOATCARRIER)
         {
             ++goods_.people[JOB_HELPER];

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -592,7 +592,7 @@ void nobHarborBuilding::ShipArrived(noShip* ship)
                 ++it;
         }
 
-        ship->PrepareSeaAttack(ship_dest, attackers);
+        ship->PrepareSeaAttack(GetHarborPosID(), ship_dest, attackers);
         return;
     }
     //Expedition ready?
@@ -683,7 +683,7 @@ void nobHarborBuilding::ShipArrived(noShip* ship)
             }
 
             // Und das Schiff starten lassen
-            ship->PrepareTransport(dest, figures, wares);
+            ship->PrepareTransport(GetHarborPosID(), dest, figures, wares);
         }
     }
 }

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -1276,6 +1276,7 @@ void nobHarborBuilding::AddSeaAttacker(nofAttacker* attacker)
 {
     unsigned best_distance = 0xffffffff;
     unsigned best_harbor_point = 0xffffffff;
+    assert(attacker->GetAttackedGoal());
     std::vector<unsigned> harbor_points = gwg->GetHarborPointsAroundMilitaryBuilding(attacker->GetAttackedGoal()->GetPos());
     for(unsigned i = 0; i < harbor_points.size(); ++i)
     {

--- a/src/buildings/nobHarborBuilding.cpp
+++ b/src/buildings/nobHarborBuilding.cpp
@@ -603,7 +603,7 @@ void nobHarborBuilding::ShipArrived(noShip* ship)
         // Aufräumen am Hafen
         expedition.active = false;
         // Expedition starten
-        ship->StartExpedition();
+        ship->StartExpedition(GetHarborPosID());
         return;
     }
     // Exploration-Expedition ready?
@@ -612,7 +612,7 @@ void nobHarborBuilding::ShipArrived(noShip* ship)
         // Aufräumen am Hafen
         exploration_expedition.active = false;
         // Expedition starten
-        ship->StartExplorationExpedition();
+        ship->StartExplorationExpedition(GetHarborPosID());
         assert(goods_.people[JOB_SCOUT] >= exploration_expedition.scouts);
         goods_.people[JOB_SCOUT] -= exploration_expedition.scouts;
         return;
@@ -659,7 +659,6 @@ void nobHarborBuilding::ShipArrived(noShip* ship)
                     it->fig->StartShipJourney(dest);
                     --goods_.people[it->fig->GetJobType()];
                     it = figures_for_ships.erase(it);
-
                 }
                 else
                     ++it;

--- a/src/buildings/nobHarborBuilding.h
+++ b/src/buildings/nobHarborBuilding.h
@@ -174,7 +174,7 @@ public:
         int GetNeedForShip(unsigned ships_coming) const;
 
         /// Erhält die Waren von einem Schiff und nimmt diese in den Warenbestand auf
-        void ReceiveGoodsFromShip(const std::list<noFigure*>& figures, std::list<Ware*>& wares);
+        void ReceiveGoodsFromShip(std::list<noFigure*>& figures, std::list<Ware*>& wares);
 
         struct SeaAttackerBuilding
         {

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -662,8 +662,6 @@ void nobMilitary::CancelOrders()
 
 void nobMilitary::AddActiveSoldier(nofActiveSoldier* soldier)
 {
-
-
     // aktiver Soldat, eingetroffen werden --> dieser muss erst in einen passiven Soldaten
     // umoperiert werden (neu erzeugt und alter zerstört) werden
     nofPassiveSoldier* passive_soldier = new nofPassiveSoldier(*soldier);
@@ -671,11 +669,12 @@ void nobMilitary::AddActiveSoldier(nofActiveSoldier* soldier)
     // neuen Soldaten einhängen
     AddPassiveSoldier(passive_soldier);
 
-    // alten Soldaten später vernichten
-    em->AddToKillList(soldier);
-
     // Soldat ist wie tot, d.h. er muss aus allen Missionslisten etc. wieder rausgenommen werden
     SoldierLost(soldier);
+
+    // alten Soldaten später vernichten
+    soldier->ResetHome();
+    em->AddToKillList(soldier);
 }
 
 void nobMilitary::AddPassiveSoldier(nofPassiveSoldier* soldier)

--- a/src/figures/noFigure.cpp
+++ b/src/figures/noFigure.cpp
@@ -1214,13 +1214,19 @@ void noFigure::CalcVisibilities(const MapPoint pt)
 }
 
 /// Informiert die Figur, dass für sie eine Schiffsreise beginnt
-void noFigure::StartShipJourney(const MapPoint goal)
+void noFigure::StartShipJourney()
 {
     // remove us from where we are, so nobody will ever draw us :)
     gwg->RemoveFigure(this, this->pos);
 
-    pos = goal;
+    pos = MapPoint::Invalid();
     on_ship = true;
+}
+
+void noFigure::ArrivedByShip(const MapPoint harborPos)
+{
+    assert(on_ship);
+    pos = harborPos;
 }
 
 /// Informiert die Figur, wenn Kreuzfahrt beendet ist

--- a/src/figures/noFigure.cpp
+++ b/src/figures/noFigure.cpp
@@ -98,6 +98,7 @@ noFigure::noFigure(const Job job, const MapPoint pos, const unsigned char player
 
 void noFigure::Destroy_noFigure()
 {
+    assert(HasNoGoal());
     Destroy_noMovable();
 
     assert(!players->getElement(player)->CheckDependentFigure(this));
@@ -376,21 +377,20 @@ void noFigure::WalkToGoal()
 
         if(goal1 == pos || goal2 == pos)
         {
+            noRoadNode* goal = goal_;
+            // Zeug nullen
+            cur_rs = NULL;
+            goal_ = NULL;
+            rs_dir = 0;
+            rs_pos = 0;
             if(fs == FS_GOHOME)
             {
                 // Mann im Lagerhaus angekommen
                 gwg->RemoveFigure(this, pos);
-                static_cast<nobBaseWarehouse*>(goal_)->AddFigure(this);
+                static_cast<nobBaseWarehouse*>(goal)->AddFigure(this);
             }
             else
             {
-                // Zeug nullen
-                cur_rs = NULL;
-                rs_dir = 0;
-                rs_pos = 0;
-                goal_ = NULL;
-
-
                 // abgeleiteter Klasse sagen, dass das Ziel erreicht wurde
                 fs = FS_JOB;
                 GoalReached();

--- a/src/figures/noFigure.cpp
+++ b/src/figures/noFigure.cpp
@@ -676,6 +676,7 @@ void noFigure::GoHome(noRoadNode* goal)
                    gwg->GetNO(pos)->GetGOT() == GOT_NOB_STOREHOUSE
                    || gwg->GetNO(pos)->GetGOT() == GOT_NOB_HARBORBUILDING);
 
+            goal_ = NULL;
             gwg->GetSpecObj<nobBaseWarehouse>(pos)->CancelFigure(this);
             return;
         }

--- a/src/figures/noFigure.h
+++ b/src/figures/noFigure.h
@@ -211,7 +211,9 @@ class noFigure : public noMovable
         void Abrogate(); // beim Arbeitsplatz "kündigen" soll, man das Laufen zum Ziel unterbrechen muss (warum auch immer)
 
         /// Informiert die Figur, dass für sie eine Schiffsreise beginnt
-        void StartShipJourney(const MapPoint goal);
+        void StartShipJourney();
+        /// Tells the figure it arrived at a harbor at the given position
+        void ArrivedByShip(const MapPoint harborPos);
         /// Informiert die Figur, wenn Kreuzfahrt beendet ist
         void ShipJourneyEnded();
         /// Gibt zurück, ob die Figur kein Ziel mehr hat und damit nach einer Schifffahrt im

--- a/src/figures/nofActiveSoldier.cpp
+++ b/src/figures/nofActiveSoldier.cpp
@@ -80,7 +80,7 @@ void nofActiveSoldier::GoalReached()
         else
             LOG.lprintf("nofActiveSoldier::GoalRoached() - no valid 'building' also didnt find one at soldier's position (%i,%i) (gf: %u)\n", pos.x, pos.y,GAMECLIENT.GetGFNumber());
     }
-    static_cast<nobMilitary*>(building)->AddActiveSoldier(this);
+    building->AddActiveSoldier(this);
 
     // And remove myself from the map
     gwg->RemoveFigure(this, pos);
@@ -108,7 +108,6 @@ void nofActiveSoldier::WalkingHome()
         return;
     }
 
-
     // Walking home to our military building
 
     // Are we already at the flag?
@@ -131,13 +130,12 @@ void nofActiveSoldier::WalkingHome()
     // Or we don't find a route?
     if(dir == 0xFF)
     {
+        // Inform our home building that we're not coming anymore
+        Abrogate();
         // Start wandering around then
         StartWandering();
         state = STATE_FIGUREWORK;
         Wander();
-
-        // Inform our home building that we're not coming anymore
-        building->SoldierLost(this);
     }
     // All ok?
     else
@@ -388,7 +386,6 @@ void nofActiveSoldier::MeetingEnemy()
                 enemy = NULL;
 
                 FreeFightEnded();
-
                 Walked();
             }
             // Spot is still ok, let's wait for the enemy
@@ -451,9 +448,6 @@ void nofActiveSoldier::MeetEnemy(nofActiveSoldier* other, const MapPoint figh_sp
     {
         MeetingEnemy();
     }
-
-
-
 }
 
 /// Looks for an appropriate fighting spot between the two soldiers

--- a/src/figures/nofActiveSoldier.h
+++ b/src/figures/nofActiveSoldier.h
@@ -118,7 +118,7 @@ class nofActiveSoldier : public nofSoldier
         nofActiveSoldier(SerializedGameData& sgd, const unsigned obj_id);
 
         /// Tidy up
-    protected:  void Destroy_nofActiveSoldier() { Destroy_nofSoldier(); }
+    protected:  void Destroy_nofActiveSoldier() { assert(!enemy); Destroy_nofSoldier(); }
     public:     void Destroy() { Destroy_nofActiveSoldier(); }
 
         /// Serializer

--- a/src/figures/nofActiveSoldier.h
+++ b/src/figures/nofActiveSoldier.h
@@ -149,6 +149,8 @@ class nofActiveSoldier : public nofSoldier
 
         /// Gets the current state
         SoldierState GetState() const { return state; }
+        /// Sets the home (building) to NULL e.g. after the soldier was removed from the homes list but it was not destroyed
+        void ResetHome() { building = NULL; }
 };
 
 #endif // !NOF_ACTIVESOLDIER_H_

--- a/src/figures/nofAggressiveDefender.h
+++ b/src/figures/nofAggressiveDefender.h
@@ -76,6 +76,9 @@ class nofAggressiveDefender : public nofActiveSoldier
         void HomeDestroyed();
         /// Wenn er noch in der Warteschleife vom Ausgangsgebäude hängt und dieses zerstört wurde
         void HomeDestroyedAtBegin();
+
+        void CancelAtAttackedBld();
+
         /// Wenn ein Kampf gewonnen wurde
         void WonFighting();
         /// Wenn ein Kampf verloren wurde (Tod)

--- a/src/figures/nofAttacker.cpp
+++ b/src/figures/nofAttacker.cpp
@@ -819,8 +819,7 @@ void nofAttacker::CapturingWalking()
         attacked_goal->AddActiveSoldier(this);
 
         // Ein erobernder Soldat weniger
-        if(attacked_goal->GetBuildingType() >= BLD_BARRACKS &&
-                attacked_goal->GetBuildingType() <= BLD_FORTRESS)
+        if(attacked_goal->GetBuildingType() >= BLD_BARRACKS && attacked_goal->GetBuildingType() <= BLD_FORTRESS)
             static_cast<nobMilitary*>(attacked_goal)->CapturingSoldierArrived();
 
         // außerdem aus der Angreiferliste entfernen

--- a/src/figures/nofAttacker.cpp
+++ b/src/figures/nofAttacker.cpp
@@ -1106,7 +1106,7 @@ void nofAttacker::HandleState_SeaAttack_ReturnToShip()
                 // Und von der Landkarte tilgen
                 gwg->RemoveFigure(this, pos);
                 // Uns zum Schiff hinzufügen
-                ship->AddAttacker(this);
+                ship->AddReturnedAttacker(this);
 
                 state = STATE_FIGUREWORK;
                 fs = FS_GOTOGOAL;

--- a/src/figures/nofAttacker.cpp
+++ b/src/figures/nofAttacker.cpp
@@ -375,6 +375,7 @@ void nofAttacker::HomeDestroyed()
             // Hier muss sofort reagiert werden, da man steht
 
             // Angreifer muss zusätzlich seinem Ziel Bescheid sagen
+            nobBaseMilitary* curGoal = attacked_goal; // attacked_goal gets reset
             RemoveFromAttackedGoal();
 
             // Ggf. Schiff Bescheid sagen (Schiffs-Angreifer)
@@ -388,7 +389,7 @@ void nofAttacker::HomeDestroyed()
             Wander();
 
             // und evtl einen Nachrücker für diesen Platz suchen
-            attacked_goal->SendSuccessor(pos, radius, GetCurMoveDir());
+            curGoal->SendSuccessor(pos, radius, GetCurMoveDir());
         } break;
 
         default:

--- a/src/figures/nofAttacker.cpp
+++ b/src/figures/nofAttacker.cpp
@@ -1119,7 +1119,7 @@ void nofAttacker::HandleState_SeaAttack_ReturnToShip()
 void nofAttacker::CancelSeaAttack()
 {
     InformTargetsAboutCancelling();
-    AbrogateWorkplace();
+    Abrogate();
 }
 
 /// The derived classes regain control after a fight of nofActiveSoldier

--- a/src/figures/nofAttacker.cpp
+++ b/src/figures/nofAttacker.cpp
@@ -1037,27 +1037,31 @@ void nofAttacker::StartAttackOnOtherIsland(const MapPoint shipPos, const unsigne
 /// Sea attacker enters harbor and finds no shipping route or no longer has a valid target: set state,target,goal,building to 0 to avoid future problems (and add to harbor inventory)
 void nofAttacker::SeaAttackFailedBeforeLaunch()
 {
-    attacked_goal = 0;
-    goal_ = 0;
-    building = 0;
+    attacked_goal = NULL;
+    goal_ = NULL;
+    building = NULL;
     state = STATE_FIGUREWORK;
 }
 
 /// Sagt Schiffsangreifern, dass sie mit dem Schiff zurück fahren
-void nofAttacker::StartReturnViaShip()
+void nofAttacker::StartReturnViaShip(noShip& ship)
 {
     // remove us from where we are, so nobody will ever draw us :)
-    gwg->RemoveFigure(this, this->pos);
+    gwg->RemoveFigure(this, pos);
+    pos = MapPoint::Invalid(); // Similar to start ship journey
+    // Uns zum Schiff hinzufügen
+    ship.AddReturnedAttacker(this);
 
     goal_ = building;
     state = STATE_FIGUREWORK;
+    fs = FS_GOTOGOAL;
     on_ship = true;
 }
 
 /// notify sea attackers that they wont return home
 void nofAttacker::HomeHarborLost()
 {
-    goal_ = 0; //this in combination with telling the home building that the soldier is lost should work just fine
+    goal_ = NULL; //this in combination with telling the home building that the soldier is lost should work just fine
 }
 
 /// Für Schiffsangreifer: Sagt dem Schiff Bescheid, dass wir nicht mehr kommen
@@ -1102,15 +1106,7 @@ void nofAttacker::HandleState_SeaAttack_ReturnToShip()
         {
             if((*it)->GetObjId() == ship_obj_id)
             {
-                noShip* ship = static_cast<noShip*>(*it);
-                // Und von der Landkarte tilgen
-                gwg->RemoveFigure(this, pos);
-                // Uns zum Schiff hinzufügen
-                ship->AddReturnedAttacker(this);
-
-                state = STATE_FIGUREWORK;
-                fs = FS_GOTOGOAL;
-                StartReturnViaShip();
+                StartReturnViaShip(static_cast<noShip&>(**it));
                 return;
             }
         }

--- a/src/figures/nofAttacker.cpp
+++ b/src/figures/nofAttacker.cpp
@@ -260,14 +260,14 @@ void nofAttacker::Walked()
                         CancelAtShip();
                     // Gebäude einnehmen
                     static_cast<nobMilitary*>(attacked_goal)->Capture(player);
-                    // Das ist nun mein neues zu Hause
-                    building = attacked_goal;
+                    // This is the new home. Store also in temporary if the new home wants to destroy/convert the soldier
+                    nobBaseMilitary* newHome = building = attacked_goal;
                     RemoveFromAttackedGoal();
                     // mich zum Gebäude hinzufügen und von der Karte entfernen
-                    building->AddActiveSoldier(this);
+                    newHome->AddActiveSoldier(this);
                     gwg->RemoveFigure(this, pos);
                     // ggf. weitere Soldaten rufen, damit das Gebäude voll wird
-                    static_cast<nobMilitary*>(building)->NeedOccupyingTroops(player);
+                    static_cast<nobMilitary*>(newHome)->NeedOccupyingTroops(player);
                 }
                 // oder ein Hauptquartier oder Hafen?
                 else

--- a/src/figures/nofAttacker.h
+++ b/src/figures/nofAttacker.h
@@ -24,6 +24,7 @@ class nofAggressiveDefender;
 class nofPassiveSoldier;
 class nobHarborBuilding;
 class nobMilitary;
+class noShip;
 
 /// Angreifender Soldat
 class nofAttacker : public nofActiveSoldier
@@ -153,14 +154,13 @@ class nofAttacker : public nofActiveSoldier
         /// Startet den Angriff am Landungspunkt vom Schiff
         void StartAttackOnOtherIsland(const MapPoint shipPos, const unsigned ship_id);
         /// Sagt Schiffsangreifern, dass sie mit dem Schiff zurück fahren
-        void StartReturnViaShip();
+        void StartReturnViaShip(noShip& ship);
         /// Sea attacker enters harbor and finds no shipping route or no longer has a valid target: return home soon on a road
         void SeaAttackFailedBeforeLaunch();
         /// notify sea attackers that they wont return home
         void HomeHarborLost();
         /// Sagt Bescheid, dass sich die Angreifer nun auf dem Schiff befinden
-        void SeaAttackStarted()
-        { state = STATE_SEAATTACKING_ONSHIP; }
+        void SeaAttackStarted() { state = STATE_SEAATTACKING_ONSHIP; }
         /// Fragt einen Schiffs-Angreifer auf dem Schiff, ob er schon einmal
         /// draußen war und gekämpft hat
         bool IsSeaAttackCompleted() const { return (state != STATE_SEAATTACKING_ONSHIP); }

--- a/src/figures/nofAttacker.h
+++ b/src/figures/nofAttacker.h
@@ -82,6 +82,9 @@ class nofAttacker : public nofActiveSoldier
     public:
         /// Sagt den verschiedenen Zielen Bescheid, dass wir doch nicht mehr kommen können
         void InformTargetsAboutCancelling();
+
+        void RemoveFromAttackedGoal();
+
         /// Normaler Konstruktor für Angreifer
         nofAttacker(nofPassiveSoldier* other, nobBaseMilitary* const attacked_goal);
         /// Konstruktor für Schiffs-Angreifer, die zuerst einmal zu einem Hafen laufen müssen

--- a/src/figures/nofAttacker.h
+++ b/src/figures/nofAttacker.h
@@ -111,8 +111,6 @@ class nofAttacker : public nofActiveSoldier
         void HomeDestroyed();
         /// Wenn er noch in der Warteschleife vom Ausgangsgebäude hängt und dieses zerstört wurde
         void HomeDestroyedAtBegin();
-        /// Sagt dem Heimatgebäude Bescheid, dass er nicht mehr nach Hause kommen wird
-        void CancelAtHomeMilitaryBuilding();
 
         /// Wenn ein Kampf gewonnen wurde
         void WonFighting();

--- a/src/figures/nofBuilder.cpp
+++ b/src/figures/nofBuilder.cpp
@@ -83,8 +83,8 @@ nofBuilder::nofBuilder(SerializedGameData& sgd, const unsigned obj_id) : noFigur
 
 void nofBuilder::GoalReached()
 {
-
-    // Ansonsten an der Baustelle normal anfangen zu arbeiten
+    goal_ = NULL;
+    // an der Baustelle normal anfangen zu arbeiten
     state = STATE_WAITINGFREEWALK;
 
     // Sind jetzt an der Baustelle
@@ -92,7 +92,6 @@ void nofBuilder::GoalReached()
 
     // Anfangen um die Baustelle herumzulaufen
     StartFreewalk();
-
 }
 
 void nofBuilder::Walked()
@@ -101,19 +100,17 @@ void nofBuilder::Walked()
 
 void nofBuilder::AbrogateWorkplace()
 {
-
     if(building_site)
     {
         state = STATE_FIGUREWORK;
         building_site->Abrogate();
-        building_site = 0;
+        building_site = NULL;
     }
 }
 
 void nofBuilder::LostWork()
 {
-    building_site = 0;
-
+    building_site = NULL;
 
     if(state == STATE_FIGUREWORK)
         GoHome();
@@ -207,11 +204,10 @@ void nofBuilder::HandleDerivedEvent(const unsigned int id)
                 rs_pos = 0;
                 rs_dir = true;
                 cur_rs = gwg->GetSpecObj<noRoadNode>(pos)->routes[4];
-                building_site = 0;
+                building_site = NULL;
 
                 GoHome();
                 StartWalking(4);
-
             }
             else
             {

--- a/src/figures/nofBuildingWorker.cpp
+++ b/src/figures/nofBuildingWorker.cpp
@@ -93,8 +93,10 @@ nofBuildingWorker::nofBuildingWorker(SerializedGameData& sgd, const unsigned obj
 void nofBuildingWorker::AbrogateWorkplace()
 {
     if(workplace)
+    {
         workplace->WorkerLost();
-    workplace = 0;
+        workplace = NULL;
+    }
 }
 
 void nofBuildingWorker::Draw(int x, int y)

--- a/src/figures/nofCarrier.cpp
+++ b/src/figures/nofCarrier.cpp
@@ -724,13 +724,12 @@ void nofCarrier::AbrogateWorkplace()
         }
 
         workplace->CarrierAbrogated(this);
-        workplace = 0;
+        workplace = NULL;
         // Wenn ich noch ne Ware in der Hand habe, muss die gelöscht werden
         if(carried_ware)
         {
             carried_ware->WareLost(player);
-            delete carried_ware;
-            carried_ware = 0;
+            deletePtr(carried_ware);
         }
 
         state = CARRS_FIGUREWORK;

--- a/src/figures/nofDefender.cpp
+++ b/src/figures/nofDefender.cpp
@@ -106,10 +106,10 @@ void nofDefender::Walked()
             {
                 // mich von der Landkarte tilgen
                 gwg->RemoveFigure(this, pos);
-                // mich zum Gebäude wieder hinzufügen
-                building->AddActiveSoldier(this);
                 // Gebäude Bescheid sagen, dass es nun keinen Verteidiger mehr gibt
                 building->NoDefender();
+                // mich zum Gebäude wieder hinzufügen
+                building->AddActiveSoldier(this);
             }
 
         } break;

--- a/src/figures/nofDefender.cpp
+++ b/src/figures/nofDefender.cpp
@@ -211,7 +211,7 @@ void nofDefender::WonFighting()
 /// Wenn ein Kampf verloren wurde (Tod)
 void nofDefender::LostFighting()
 {
-    attacker = 0;
+    attacker = NULL;
 
     // Gebäude Bescheid sagen, falls es noch existiert
     if(building)
@@ -224,6 +224,7 @@ void nofDefender::LostFighting()
             if(static_cast<nobMilitary*>(building)->GetTroopsCount())
                 static_cast<nobMilitary*>(building)->RegulateTroops();
         }
+        building = NULL;
     }
 }
 

--- a/src/figures/nofDefender.cpp
+++ b/src/figures/nofDefender.cpp
@@ -179,7 +179,7 @@ void nofDefender::WonFighting()
 	if(GAMECLIENT.GetGGS().isEnabled(ADDON_BATTLEFIELD_PROMOTION))
 		IncreaseRank();
     // Angreifer tot
-    attacker = 0;
+    attacker = NULL;
 
     // Ist evtl. unser Heimatgebäude zerstört?
     if(!building)

--- a/src/figures/nofDefender.h
+++ b/src/figures/nofDefender.h
@@ -51,7 +51,7 @@ class nofDefender : public nofActiveSoldier
         nofDefender(SerializedGameData& sgd, const unsigned obj_id);
 
         /// Aufräummethoden
-    protected:  void Destroy_nofDefender() { Destroy_nofActiveSoldier(); }
+    protected:  void Destroy_nofDefender() { assert(!attacker); Destroy_nofActiveSoldier(); }
     public:     void Destroy() { Destroy_nofDefender(); }
 
         /// Serialisierungsfunktionen
@@ -76,12 +76,10 @@ class nofDefender : public nofActiveSoldier
         void LostFighting();
 
         /// Is the defender waiting at the flag for an attacker?
-        bool IsWaitingAtFlag() const
-        { return (state == STATE_DEFENDING_WAITING); }
+        bool IsWaitingAtFlag() const { return (state == STATE_DEFENDING_WAITING); }
         bool IsFightingAtFlag() const {return (state == STATE_FIGHTING);}
         /// Informs the defender that a fight between him and an attacker has started
-        void FightStarted()
-        { state = STATE_FIGHTING; }
+        void FightStarted() { state = STATE_FIGHTING; }
 
 
 };

--- a/src/figures/nofFlagWorker.cpp
+++ b/src/figures/nofFlagWorker.cpp
@@ -72,7 +72,7 @@ void nofFlagWorker::Destroy_nofFlagWorker()
 
 void nofFlagWorker::AbrogateWorkplace()
 {
-    flag = 0;
+    flag = NULL;
     /// uns entfernen, da wir wieder umdrehen müssen
     gwg->GetPlayer(player).RemoveFlagWorker(this);
 }
@@ -109,7 +109,7 @@ void nofFlagWorker::GoToFlag()
 
         state = STATE_FIGUREWORK;
 
-        flag = 0;
+        flag = NULL;
 
     }
     else
@@ -125,7 +125,7 @@ void nofFlagWorker::GoToFlag()
             Wander();
             state = STATE_FIGUREWORK;
 
-            flag = 0;
+            flag = NULL;
         }
         else
         {

--- a/src/figures/nofPlaner.cpp
+++ b/src/figures/nofPlaner.cpp
@@ -103,7 +103,7 @@ void nofPlaner::AbrogateWorkplace()
     {
         state = STATE_FIGUREWORK;
         building_site->Abrogate();
-        building_site = 0;
+        building_site = NULL;
     }
 }
 

--- a/src/figures/nofSoldier.cpp
+++ b/src/figures/nofSoldier.cpp
@@ -80,7 +80,7 @@ void nofSoldier::AbrogateWorkplace()
     if(building)
     {
         static_cast<nobMilitary*>(building)->SoldierLost(this);
-        building = 0;
+        building = NULL;
     }
 }
 

--- a/src/figures/nofSoldier.cpp
+++ b/src/figures/nofSoldier.cpp
@@ -79,7 +79,7 @@ void nofSoldier::AbrogateWorkplace()
     // Militärgebäude Bescheid sagen, dass ich nicht kommen kann
     if(building)
     {
-        static_cast<nobMilitary*>(building)->SoldierLost(this);
+        building->SoldierLost(this);
         building = NULL;
     }
 }

--- a/src/figures/nofSoldier.h
+++ b/src/figures/nofSoldier.h
@@ -38,7 +38,6 @@ class nofSoldier : public noFigure
         /// Zeichnet den Soldaten beim ganz normalen Laufen
         void DrawSoldierWalking(int x, int y, bool waitingsoldier = false);
 
-    private:
         /// wenn man beim Arbeitsplatz "kündigen" soll, man das Laufen zum Ziel unterbrechen muss (warum auch immer)
         void AbrogateWorkplace();
 

--- a/src/figures/nofSoldier.h
+++ b/src/figures/nofSoldier.h
@@ -51,7 +51,7 @@ class nofSoldier : public noFigure
         nofSoldier(SerializedGameData& sgd, const unsigned obj_id);
 
         /// Aufräummethoden
-    protected:  void Destroy_nofSoldier() { Destroy_noFigure(); }
+    protected:  void Destroy_nofSoldier() { assert(HasNoHome()); Destroy_noFigure(); }
     public:     void Destroy() { Destroy_nofSoldier(); }
 
         /// Serialisierungsfunktionen
@@ -60,8 +60,8 @@ class nofSoldier : public noFigure
 
         /// Liefert Rang des Soldaten
         unsigned char GetRank() const;
-
         unsigned char GetHitpoints() const;
+        bool HasNoHome() const { return building == NULL; }
 };
 
 /// Comparator to sort soldiers by rank (and ID for ties)

--- a/src/figures/nofWarehouseWorker.cpp
+++ b/src/figures/nofWarehouseWorker.cpp
@@ -165,7 +165,7 @@ void nofWarehouseWorker::Walked()
                 delete carried_ware;
             }
             // Ich trage keine Ware mehr
-            carried_ware = 0;
+            carried_ware = NULL;
         }
     }
     else
@@ -182,7 +182,7 @@ void nofWarehouseWorker::Walked()
                 delete carried_ware;
             }
             // Ich trage keine Ware mehr
-            carried_ware = 0;
+            carried_ware = NULL;
         }
     }
 
@@ -200,8 +200,7 @@ void nofWarehouseWorker::AbrogateWorkplace()
     if(carried_ware)
     {
         carried_ware->WareLost(player);
-        delete carried_ware;
-        carried_ware = 0;
+        deletePtr(carried_ware);
     }
 
     StartWandering();

--- a/src/helpers/containerUtils.h
+++ b/src/helpers/containerUtils.h
@@ -37,9 +37,6 @@ namespace helpers{
             static iterator erase(T& container, iterator it) {
                 return container.erase(it);
             }
-            static const_iterator erase(T& container, const_iterator it) {
-                return container.erase(it);
-            }
         };
         template<class T>
         struct EraseImpl<T, EEraseIterValidy::NextValid>
@@ -49,10 +46,6 @@ namespace helpers{
             typedef typename T::iterator iterator;
             typedef typename T::const_iterator const_iterator;
             static iterator erase(T& container, iterator it) {
-                container.erase(it++);
-                return it;
-            }
-            static const_iterator erase(T& container, const_iterator it) {
                 container.erase(it++);
                 return it;
             }
@@ -67,18 +60,6 @@ namespace helpers{
                 // If only previous iterators remain valid, store the predecessor
                 // and return this after incrementing it after the erase
                 // Corner case: If we erase the first element there is no previous one and we return begin()
-                bool isBegin = it == container.begin();
-                iterator tmp = it;
-                if(!isBegin)
-                    --tmp;
-                container.erase(it);
-                if(isBegin)
-                    tmp = container.begin();
-                else
-                    ++tmp;
-                return tmp;
-            }
-            static const_iterator erase(T& container, const_iterator it) {
                 bool isBegin = it == container.begin();
                 iterator tmp = it;
                 if(!isBegin)
@@ -144,25 +125,12 @@ namespace helpers{
         return detail::EraseImpl<T>::erase(container, it);
     }
 
-    /*template<typename T>
-    inline typename T::const_iterator erase(T& container, typename T::const_iterator it)
-    {
-        return EraseFromContainer<T>::erase(it);
-    }*/
-
     template<typename T>
     inline typename T::reverse_iterator erase(T& container, typename T::reverse_iterator it)
     {
         typename T::reverse_iterator tmp = it;
         return typename T::reverse_iterator(erase(container, (++tmp).base()));
     }
-
-    /*template<typename T>
-    inline typename T::const_reverse_iterator erase(T& container, typename T::const_reverse_iterator it)
-    {
-        typename std::set<T>::const_reverse_iterator tmp = it;
-        return typename T::const_reverse_iterator(erase(container, (++tmp).base()));
-    }*/
 
     /// Removes the first element in a container
     template<typename T>

--- a/src/nodeObjs/noMovable.cpp
+++ b/src/nodeObjs/noMovable.cpp
@@ -106,7 +106,7 @@ void noMovable::StartMoving(const unsigned char newDir, unsigned gf_length)
     // runter natürlich nich so viel schneller werden wie langsamer hoch
     switch(int(gwg->GetNodeAround(pos, newDir).altitude) - int(gwg->GetNode(pos).altitude))
     {
-        default: ascent = 3; // gerade
+        default: ascent = 3; break; // gerade
         case 1: ascent = 4; gf_length+=(gf_length/2); break; // leicht hoch
         case 2: case 3: ascent = 5; gf_length*=2;  break; // mittelsteil hoch
         case 4: case 5: ascent = 6; gf_length*=3;  break; // steil hoch

--- a/src/nodeObjs/noMovable.cpp
+++ b/src/nodeObjs/noMovable.cpp
@@ -78,22 +78,6 @@ void noMovable::Walk()
 	{
 		pos = gwg->GetNeighbour(pos, curMoveDir);
 	}
-/*
-    int tx = x, ty = y;
-    
-            inline void GetPointA(MapPoint& pos, unsigned dir) const {x = GetXA(pos, dir); y = GetYA(pos, dir);}
-    
-    x = gwg->GetXA(t, dir);
-    y = gwg->GetYA(t, dir);
-
-
-    // Auf der jeweiligen Stelle mich suchen und dort entfernen...
-    if(dir != 1 && dir != 2)
-        gwg->RemoveFigure(this, tx, ty);
-
-    // und an der anderen Stelle wieder hinzufgen
-    if(dir != 1 && dir != 2)
-        gwg->AddFigure(this, pos);*/
 }
 
 void noMovable::FaceDir(unsigned char newDir)

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -289,9 +289,6 @@ void noShip::HandleEvent(const unsigned int id)
             GAMECLIENT.SendAIEvent(new AIEvent::Location(AIEvent::ExpeditionWaiting, pos), player);
             break;
         case STATE_EXPLORATIONEXPEDITION_LOADING:
-            // Schiff ist nun bereit und Expedition kann beginnen
-            ContinueExplorationExpedition();
-            break;
         case STATE_EXPLORATIONEXPEDITION_WAITING:
             // Schiff ist nun bereit und Expedition kann beginnen
             ContinueExplorationExpedition();
@@ -766,17 +763,10 @@ void noShip::HandleState_ExplorationExpeditionDriving()
 
         } break;
         case NO_ROUTE_FOUND:
-        {
-            unsigned old_visual_range = GetVisualRange();
-            // Nichts machen und idlen
-            StartIdling();
-            // Sichtbarkeiten neu berechnen
-            gwg->RecalcVisibilitiesAroundPoint(pos, old_visual_range, player, NULL);
-        } break;
         case HARBOR_DOESNT_EXIST:
-        {
-            FindUnloadGoal(STATE_TRANSPORT_DRIVING); // Go back anywhere
-        } break;
+            gwg->RecalcVisibilitiesAroundPoint(pos, GetVisualRange(), player, NULL);
+            StartIdling();
+            break;
     }
 }
 
@@ -844,7 +834,7 @@ void noShip::HandleState_SeaAttackDriving()
             state = STATE_SEAATTACK_RETURN_DRIVING;
             HandleState_SeaAttackReturn();
         }else
-        AbortSeaAttack();
+            AbortSeaAttack();
         break;
     }
 }
@@ -962,7 +952,7 @@ void noShip::StartSeaAttack()
 
 void noShip::AbortSeaAttack()
 {
-    assert(!STATE_SEAATTACK_WAITING); // figures are not aboard if this fails!
+    assert(state != STATE_SEAATTACK_WAITING); // figures are not aboard if this fails!
     assert(remaining_sea_attackers == 0); // Some soldiers are still not aboard
 
     // Dann müssen alle Angreifer ihren Heimatgebäuden Bescheid geben, dass sie nun nicht mehr kommen

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -1000,40 +1000,41 @@ void noShip::StartTransport()
 void noShip::HarborDestroyed(nobHarborBuilding* hb)
 {
     // Ist unser Ziel betroffen?
-    if(hb->GetHarborPosID() == goal_harbor_id)
-    {
-        // Laden wir gerade ein?
-        if(state == STATE_TRANSPORT_LOADING)
-        {
-            // Dann einfach wieder ausladen
-            state = STATE_TRANSPORT_UNLOADING;
-            // Zielpunkt wieder auf Starthafen setzen
-            goal_harbor_id = home_harbor;
+    if(hb->GetHarborPosID() != goal_harbor_id)
+        return;
 
-            // Waren und Figure über verändertes Ziel informieren
-            for(std::list<noFigure*>::iterator it = figures.begin(); it != figures.end(); ++it)
-            {
-                (*it)->Abrogate();
-                (*it)->SetGoalToNULL();
-            }
-            for(std::list<Ware*>::iterator it = wares.begin(); it != wares.end(); ++it)
-            {
-                (*it)->NotifyGoalAboutLostWare();
-                (*it)->goal = NULL;
-            }
-        }
-        else
+    // Laden wir gerade ein?
+    if(state == STATE_TRANSPORT_LOADING)
+    {
+        // Dann einfach wieder ausladen
+        state = STATE_TRANSPORT_UNLOADING;
+        // Zielpunkt wieder auf Starthafen setzen
+        goal_harbor_id = home_harbor;
+
+        // Waren und Figure über verändertes Ziel informieren
+        for(std::list<noFigure*>::iterator it = figures.begin(); it != figures.end(); ++it)
         {
-            if(state == STATE_TRANSPORT_UNLOADING)
-            {
-                // Event zum Abladen abmelden
-                em->RemoveEvent(current_ev);
-                current_ev = NULL;
-                state = STATE_TRANSPORT_DRIVING;
-                HandleState_TransportDriving(); //finds our goal harbor doesnt exist anymore picks a new one if available etc
-            }
+            (*it)->Abrogate();
+            (*it)->SetGoalToNULL();
+        }
+        for(std::list<Ware*>::iterator it = wares.begin(); it != wares.end(); ++it)
+        {
+            (*it)->NotifyGoalAboutLostWare();
+            (*it)->goal = NULL;
         }
     }
+    else
+    {
+        if(state == STATE_TRANSPORT_UNLOADING)
+        {
+            // Event zum Abladen abmelden
+            em->RemoveEvent(current_ev);
+            current_ev = NULL;
+            state = STATE_TRANSPORT_DRIVING;
+            HandleState_TransportDriving(); //finds our goal harbor doesnt exist anymore picks a new one if available etc
+        }
+    }
+
 }
 
 /// Fängt an mit idlen und setzt nötigen Sachen auf NULL

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -577,8 +577,6 @@ unsigned noShip::GetCurrentHarbor() const
 /// Weist das Schiff an, in einer bestimmten Richtung die Expedition fortzusetzen
 void noShip::ContinueExpedition(const unsigned char dir)
 {
-    assert(state == STATE_EXPEDITION_WAITING);
-
     if(state != STATE_EXPEDITION_WAITING)
         return;
 

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -487,6 +487,7 @@ void noShip::StartExpedition(unsigned homeHarborId)
     assert(homeHarborId);
     assert(pos == gwg->GetCoastalPoint(homeHarborId, seaId_));
     home_harbor = homeHarborId;
+    goal_harbor_id = homeHarborId; // This is current goal (commands are relative to current goal)
 }
 
 /// Startet eine Erkundungs-Expedition
@@ -499,6 +500,7 @@ void noShip::StartExplorationExpedition(unsigned homeHarborId)
     assert(homeHarborId);
     assert(pos == gwg->GetCoastalPoint(homeHarborId, seaId_));
     home_harbor = homeHarborId;
+    goal_harbor_id = homeHarborId; // This is current goal (commands are relative to current goal)
     // Sichtbarkeiten neu berechnen
     gwg->SetVisibilitiesAroundPoint(pos, GetVisualRange(), player);
 }
@@ -578,10 +580,10 @@ unsigned noShip::GetCurrentHarbor() const
 /// Weist das Schiff an, in einer bestimmten Richtung die Expedition fortzusetzen
 void noShip::ContinueExpedition(const unsigned char dir)
 {
+    assert(state == STATE_EXPEDITION_WAITING);
+
     if(state != STATE_EXPEDITION_WAITING)
         return;
-
-    assert(state == STATE_EXPEDITION_WAITING);
 
     // Nächsten Hafenpunkt in dieser Richtung suchen
     unsigned new_goal = gwg->GetNextFreeHarborPoint(pos, goal_harbor_id, dir, player);

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -324,7 +324,7 @@ void noShip::HandleEvent(const unsigned int id)
         case STATE_EXPLORATIONEXPEDITION_UNLOADING:
         {
             // Hafen herausfinden
-            noBase* hb = goal_harbor_id ? gwg->GetNO(gwg->GetHarborPoint(goal_harbor_id)) : NULL;
+            noBase* hb = goal_harbor_id ? gwg->GetNO(gwg->GetHarborPoint(goal_harbor_id)): NULL;
 
             unsigned old_visual_range = GetVisualRange();
 
@@ -479,22 +479,26 @@ void noShip::GoToHarbor(nobHarborBuilding* hb, const std::vector<unsigned char>&
 }
 
 /// Startet eine Expedition
-void noShip::StartExpedition()
+void noShip::StartExpedition(unsigned homeHarborId)
 {
     /// Schiff wird "beladen", also kurze Zeit am Hafen stehen, bevor wir bereit sind
     state = STATE_EXPEDITION_LOADING;
     current_ev = em->AddEvent(this, LOADING_TIME, 1);
-    home_harbor = goal_harbor_id;
+    assert(homeHarborId);
+    assert(pos == gwg->GetCoastalPoint(homeHarborId, seaId_));
+    home_harbor = homeHarborId;
 }
 
 /// Startet eine Erkundungs-Expedition
-void noShip::StartExplorationExpedition()
+void noShip::StartExplorationExpedition(unsigned homeHarborId)
 {
     /// Schiff wird "beladen", also kurze Zeit am Hafen stehen, bevor wir bereit sind
     state = STATE_EXPLORATIONEXPEDITION_LOADING;
     current_ev = em->AddEvent(this, LOADING_TIME, 1);
     covered_distance = 0;
-    home_harbor = goal_harbor_id;
+    assert(homeHarborId);
+    assert(pos == gwg->GetCoastalPoint(homeHarborId, seaId_));
+    home_harbor = homeHarborId;
     // Sichtbarkeiten neu berechnen
     gwg->SetVisibilitiesAroundPoint(pos, GetVisualRange(), player);
 }
@@ -896,10 +900,10 @@ bool noShip::IsGoingToHarbor(nobHarborBuilding* hb) const
     case noShip::STATE_SEAATTACK_LOADING:
     case noShip::STATE_SEAATTACK_DRIVINGTODESTINATION:
     case noShip::STATE_SEAATTACK_WAITING:
-    case noShip::STATE_TRANSPORT_LOADING:   // Almost gone, so don't consider this
         return false;
     case noShip::STATE_GOTOHARBOR:
     case noShip::STATE_TRANSPORT_DRIVING:   // Driving to this harbor
+    case noShip::STATE_TRANSPORT_LOADING:   // Loading at home harbor and going to goal
     case noShip::STATE_TRANSPORT_UNLOADING: // Unloading at this harbor
     case noShip::STATE_SEAATTACK_UNLOADING: // Unloading attackers at this harbor
     case noShip::STATE_SEAATTACK_RETURN_DRIVING:    // Returning attackers to this harbor

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -818,7 +818,7 @@ void noShip::HandleState_SeaAttackDriving()
         return; // OK
     case GOAL_REACHED:
         {
-        // Ziel erreicht, dann stellen wir das Schiff hier hin und die Soldaten laufen nacheinander raus zum Ziel
+            // Ziel erreicht, dann stellen wir das Schiff hier hin und die Soldaten laufen nacheinander raus zum Ziel
             state = STATE_SEAATTACK_WAITING;
             current_ev = em->AddEvent(this, 15, 1);
             remaining_sea_attackers = figures.size();
@@ -935,7 +935,7 @@ void noShip::PrepareSeaAttack(unsigned homeHarborId, MapPoint goal, const std::l
     this->figures = figures;
     for(std::list<noFigure*>::iterator it = this->figures.begin(); it != this->figures.end(); ++it)
     {
-        static_cast<nofAttacker*>(*it)->StartShipJourney(goal);
+        static_cast<nofAttacker*>(*it)->StartShipJourney();
         static_cast<nofAttacker*>(*it)->SeaAttackStarted();
     }
     state = STATE_SEAATTACK_LOADING;
@@ -1121,11 +1121,8 @@ void noShip::SeaAttackerWishesNoReturn()
         em->RemoveEvent(current_ev);
         if(!figures.empty())
         {
-            // Wieder nach Hause fahren
+            // Go back home. Note: home_harbor can be 0 if it was destroyed, allow this and let the state handlers handle that case later
             goal_harbor_id = home_harbor;
-            MapPoint harborPoint = gwg->GetHarborPoint(goal_harbor_id);
-            for(std::list<noFigure*>::iterator it = figures.begin(); it != figures.end(); ++it)
-                (*it)->StartShipJourney(harborPoint);
             state = STATE_SEAATTACK_RETURN_DRIVING;
             StartDrivingToHarborPlace();
             HandleState_SeaAttackReturn();

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -957,7 +957,7 @@ void noShip::AbortSeaAttack()
 
     // Dann müssen alle Angreifer ihren Heimatgebäuden Bescheid geben, dass sie nun nicht mehr kommen
     for(std::list<noFigure*>::iterator it = figures.begin(); it != figures.end(); ++it)
-        static_cast<nofAttacker*>(*it)->CancelAtHomeMilitaryBuilding();
+        static_cast<nofAttacker*>(*it)->CancelSeaAttack();
 
     // Das Schiff muss einen Notlandeplatz ansteuern
     FindUnloadGoal(STATE_SEAATTACK_RETURN_DRIVING);

--- a/src/nodeObjs/noShip.h
+++ b/src/nodeObjs/noShip.h
@@ -58,7 +58,7 @@ class noShip : public noMovable
             STATE_SEAATTACK_UNLOADING,
             STATE_SEAATTACK_DRIVINGTODESTINATION, /// Fährt mit den Soldaten zum Zielhafenpunkt
             STATE_SEAATTACK_WAITING, /// wartet an der Küste, während die Soldaten was schönes machen
-            STATE_SEAATTACK_RETURN /// fährt mit den Soldaten wieder zurück zum Heimathafen
+            STATE_SEAATTACK_RETURN_DRIVING /// fährt mit den Soldaten wieder zurück zum Heimathafen
 
         } state;
 
@@ -81,7 +81,6 @@ class noShip : public noMovable
         bool lost;
         /// Bei Schiffen im STATE_SEAATTACK_WAITING:
         /// Anzahl der Soldaten, die noch kommen müssten
-        /// For ships in STATE_TRANSPORT_x a 1 indicates that the ship is carrying returning soldiers from a sea attack
         unsigned remaining_sea_attackers;
         /// Heimathafen der Schiffs-Angreifer
         unsigned home_harbor;
@@ -136,7 +135,7 @@ class noShip : public noMovable
         void StartDrivingToHarborPlace();
 
         /// Looks for a harbour to unload the goods (e.g if old one was destroyed)
-        void FindUnloadGoal(bool isExpedition);
+        void FindUnloadGoal(State newState);
         /// Aborts a sea attack (in case harbor was not found anymore)
         void AbortSeaAttack();
 
@@ -223,7 +222,7 @@ class noShip : public noMovable
         /// Sagt Bescheid, dass ein Schiffsangreifer nicht mehr mit nach Hause fahren will
         void SeaAttackerWishesNoReturn();
         /// Schiffs-Angreifer sind nach dem Angriff wieder zurückgekehrt
-        void AddAttacker(nofAttacker* attacker);
+        void AddReturnedAttacker(nofAttacker* attacker);
 
         /// Sagt dem Schiff, das ein bestimmter Hafen zerstört wurde
         void HarborDestroyed(nobHarborBuilding* hb);

--- a/src/nodeObjs/noShip.h
+++ b/src/nodeObjs/noShip.h
@@ -215,10 +215,10 @@ class noShip : public noMovable
         bool IsGoingToHarbor(nobHarborBuilding* hb) const;
 
         /// Belädt das Schiff mit Waren und Figuren, um eine Transportfahrt zu starten
-        void PrepareTransport(MapPoint goal, const std::list<noFigure*>& figures, const std::list<Ware*>& wares);
+        void PrepareTransport(unsigned homeHarborId, MapPoint goal, const std::list<noFigure*>& figures, const std::list<Ware*>& wares);
 
         /// Belädt das Schiff mit Schiffs-Angreifern
-        void PrepareSeaAttack(MapPoint goal, const std::list<noFigure*>& figures);
+        void PrepareSeaAttack(unsigned homeHarborId, MapPoint goal, const std::list<noFigure*>& figures);
         /// Sagt Bescheid, dass ein Schiffsangreifer nicht mehr mit nach Hause fahren will
         void SeaAttackerWishesNoReturn();
         /// Schiffs-Angreifer sind nach dem Angriff wieder zurückgekehrt

--- a/src/nodeObjs/noShip.h
+++ b/src/nodeObjs/noShip.h
@@ -135,6 +135,11 @@ class noShip : public noMovable
         /// Fängt an zu einem Hafen zu fahren (berechnet Route usw.)
         void StartDrivingToHarborPlace();
 
+        /// Looks for a harbour to unload the goods (e.g if old one was destroyed)
+        void FindUnloadGoal(bool isExpedition);
+        /// Aborts a sea attack (in case harbor was not found anymore)
+        void AbortSeaAttack();
+
     public:
 
         /// Konstruktor
@@ -224,11 +229,6 @@ class noShip : public noMovable
         void HarborDestroyed(nobHarborBuilding* hb);
         /// Sagt dem Schiff, dass ein neuer Hafen erbaut wurde
         void NewHarborBuilt(nobHarborBuilding* hb);
-
-
-
-
-
 };
 
 

--- a/src/nodeObjs/noShip.h
+++ b/src/nodeObjs/noShip.h
@@ -190,16 +190,12 @@ class noShip : public noMovable
         /// Beim Warten bei der Expedition: Gibt die Hafenpunkt-ID zurück, wo es sich gerade befindet
         unsigned GetCurrentHarbor() const;
 
-        /// Sagt dem Schiff, an welchem Hafenpunkt es gerade ankert, wenn es das selber noch nicht weiß
-        void AssignHarborId(const unsigned harbor_id)
-        { this->goal_harbor_id = harbor_id; }
-
         /// Fährt zum Hafen, um dort eine Mission (Expedition) zu erledigen
         void GoToHarbor(nobHarborBuilding* hb, const std::vector<unsigned char>& route);
         /// Startet eine Expedition
-        void StartExpedition();
+        void StartExpedition(unsigned homeHarborId);
         /// Startet eine Erkundungs-Expedition
-        void StartExplorationExpedition();
+        void StartExplorationExpedition(unsigned homeHarborId);
         /// Weist das Schiff an, in einer bestimmten Richtung die Expedition fortzusetzen
         void ContinueExpedition(const unsigned char dir);
         /// Weist das Schiff an, eine Expedition abzubrechen (nur wenn es steht) und zum


### PR DESCRIPTION
This refactores the seafaring system to solve a couple of bugs:

- #313 
- Loosing of wares because of calling idle for lost ships
- Wrong states for sea attacks

Tested with a (smallish) replay that includes transports, expeditions and attacks and did not async

However we should bump the savegame version before merging this as the changed use of states might lead to invalid situations with old saves (e.g. attack considered transport)

- [x] Roughly validated by @jhkl If anyone wants to double check please leave a message
- [x] Test for mem-error (see below)