### PR TITLE
Fix memory checks

### DIFF
--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -162,6 +162,11 @@ void GameManager::Stop()
  */
 bool GameManager::Run()
 {
+#if defined _WIN32 && defined _DEBUG && defined _MSC_VER && !defined NOCRTDBG
+    // Check for heap corruption
+    _ASSERTE(_CrtCheckMemory());
+#endif // _WIN32 && _DEBUG && !NOCRTDBG
+
     // Nachrichtenschleife
     if(!VIDEODRIVER.Run())
         GLOBALVARS.notdone = false;

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -162,11 +162,6 @@ void GameManager::Stop()
  */
 bool GameManager::Run()
 {
-#if defined _WIN32 && defined _DEBUG && defined _MSC_VER && !defined NOCRTDBG
-    // Check for heap corruption
-    _ASSERTE(_CrtCheckMemory());
-#endif // _WIN32 && _DEBUG && !NOCRTDBG
-
     // Nachrichtenschleife
     if(!VIDEODRIVER.Run())
         GLOBALVARS.notdone = false;

--- a/src/defines.h
+++ b/src/defines.h
@@ -31,6 +31,7 @@
 #ifdef _WIN32
 #    define WIN32_LEAN_AND_MEAN
 #    ifdef _MSC_VER
+#        include <stdlib.h> // Required for crtdbg.h
 #        include <crtdbg.h>
 #        if !defined(snprintf) && _MSC_VER < 1900
 #            define snprintf _snprintf

--- a/src/macros.h
+++ b/src/macros.h
@@ -66,4 +66,12 @@
 #   define SUPPRESS_UNUSED
 #endif
 
+#if defined _WIN32 && defined _DEBUG && defined _MSC_VER && !defined NOCRTDBG
+    // Check for heap corruption
+#   define CHECK_HEAP_CORRUPTION _ASSERTE(_CrtCheckMemory());
+#else
+#   define CHECK_HEAP_CORRUPTION
+#endif // _WIN32 && _DEBUG && !NOCRTDBG
+
+
 #endif // !MACROS_H_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
 
 #if defined _WIN32 && defined _DEBUG && defined _MSC_VER && !defined NOCRTDBG
     // Enable Memory-Leak-Detection
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_CHECK_ALWAYS_DF | _CRTDBG_LEAK_CHECK_DF /*| _CRTDBG_CHECK_CRT_DF*/);
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF | _CRTDBG_CHECK_EVERY_128_DF);
 #endif // _WIN32 && _DEBUG && !NOCRTDBG
 
     // Signal-Handler setzen

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
 
 #if defined _WIN32 && defined _DEBUG && defined _MSC_VER && !defined NOCRTDBG
     // Enable Memory-Leak-Detection
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF | _CRTDBG_CHECK_EVERY_128_DF);
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF | _CRTDBG_CHECK_EVERY_1024_DF);
 #endif // _WIN32 && _DEBUG && !NOCRTDBG
 
     // Signal-Handler setzen


### PR DESCRIPTION
This adds a missing include (according to MS docu) and makes the Debug check run every Game-Cycle and every 128 Heap operations. Using it on every heap op will render the game unusable.