### PR TITLE
Add LAN option

### DIFF
--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -1599,10 +1599,6 @@ void GameClient::ExecuteGameFrame(const bool skipping)
 /// Führt notwendige Dinge für nächsten GF aus
 void GameClient::NextGF()
 {
-    if(framesinfo.nr == 83831)
-    {
-        _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF | _CRTDBG_CHECK_ALWAYS_DF);
-    }
     // Statistiken aktualisieren
     StatisticStep();
     //  EventManager Bescheid sagen

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -78,7 +78,6 @@ void GameClient::ClientConfig::Clear()
     password.clear();
     mapfile.clear();
     mapfilepath.clear();
-    servertyp = 0;
     port = 0;
     host = false;
 }
@@ -189,7 +188,7 @@ GameClient::~GameClient(void)
  *  @author OLiver
  *  @author FloSoft
  */
-bool GameClient::Connect(const std::string& server, const std::string& password, unsigned char servertyp, unsigned short port, bool host, bool use_ipv6)
+bool GameClient::Connect(const std::string& server, const std::string& password, ServerType servertyp, unsigned short port, bool host, bool use_ipv6)
 {
     Stop();
     ggs.LoadSettings();
@@ -1600,6 +1599,10 @@ void GameClient::ExecuteGameFrame(const bool skipping)
 /// Führt notwendige Dinge für nächsten GF aus
 void GameClient::NextGF()
 {
+    if(framesinfo.nr == 83831)
+    {
+        _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF | _CRTDBG_CHECK_ALWAYS_DF);
+    }
     // Statistiken aktualisieren
     StatisticStep();
     //  EventManager Bescheid sagen

--- a/src/GameClient.h
+++ b/src/GameClient.h
@@ -81,7 +81,7 @@ class GameClient : public Singleton<GameClient, SingletonPolicies::WithLongevity
         const GlobalGameSettings& GetGGS() const { return ggs; }
         void LoadGGS();
 
-        bool Connect(const std::string& server, const std::string& password, unsigned char servertyp, unsigned short port, bool host, bool use_ipv6);
+        bool Connect(const std::string& server, const std::string& password, ServerType servertyp, unsigned short port, bool host, bool use_ipv6);
         void Run();
         void Stop();
 
@@ -300,7 +300,7 @@ class GameClient : public Singleton<GameClient, SingletonPolicies::WithLongevity
                 std::string password;
                 std::string mapfile;
                 std::string mapfilepath;
-                unsigned char servertyp;
+                ServerType servertyp;
                 unsigned short port;
                 bool host;
         } clientconfig;

--- a/src/GameMessages.h
+++ b/src/GameMessages.h
@@ -73,17 +73,17 @@ class GameMessage_Pong : public GameMessage
 class GameMessage_Server_Type: public GameMessage
 {
     public:
-        unsigned short type;
+        ServerType type;
         std::string version;
 
     public:
         GameMessage_Server_Type(void) : GameMessage(NMS_SERVER_TYPE) { }
-        GameMessage_Server_Type(const unsigned short type,
+        GameMessage_Server_Type(const ServerType type,
                                 const std::string& version) : GameMessage(NMS_SERVER_TYPE, 0xFF)
         {
             LOG.write(">>> NMS_SERVER_Type(%d, %s)\n", type, version.c_str());
 
-            PushUnsignedShort(type);
+            PushUnsignedShort(boost::underlying_cast<unsigned short>(type));
             PushString(version);
         }
         GameMessage_Server_Type(const unsigned short& type)
@@ -94,7 +94,7 @@ class GameMessage_Server_Type: public GameMessage
         }
         void Run(MessageInterface* callback)
         {
-            type = PopUnsignedShort();
+            type = static_cast<ServerType>(PopUnsignedShort());
 
             if(GetLength() > sizeof(unsigned short))
             {
@@ -105,7 +105,7 @@ class GameMessage_Server_Type: public GameMessage
             }
             else
             {
-                LOG.write("<<< NMS_SERVER_Type(%s)\n", (type == 1 ? "true" : "false"));
+                LOG.write("<<< NMS_SERVER_Type(%s)\n", (type == ServerType::DIRECT ? "true" : "false"));
                 GetInterface(callback)->OnNMSServerType(*this);
             }
         }

--- a/src/GameProtocol.h
+++ b/src/GameProtocol.h
@@ -14,12 +14,12 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+#pragma once
 #ifndef GAMEPROTOCOL_H_INCLUDED
 #define GAMEPROTOCOL_H_INCLUDED
 
 #include "Protocol.h"
-
-#pragma once
+#include "gameTypes/ServerType.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Netzwerk Messages                       // client> | <server
@@ -161,14 +161,6 @@ enum
     NP_WRONGPASSWORD, // falsches passwort
     NP_WRONGCHECKSUM, // falsche Checksumme
     NP_ASYNC // asynchron
-};
-
-// Servertypen
-enum
-{
-    NP_LOBBY = 0,
-    NP_DIRECT,
-    NP_LOCAL
 };
 
 // Wie lange maximal warten, bis Rausschmiss des Spielers (in milliseconds)

--- a/src/desktops/dskDirectIP.cpp
+++ b/src/desktops/dskDirectIP.cpp
@@ -77,11 +77,11 @@ void dskDirectIP::Msg_ButtonClick(const unsigned int ctrl_id)
             if(SETTINGS.proxy.typ != 0)
                 WINDOWMANAGER.Show(new iwMsgbox(_("Sorry!"), _("You can't create a game while a proxy server is active\nDisable the use of a proxy server first!"), this, MSB_OK, MSB_EXCLAMATIONGREEN, 1));
             else
-                WINDOWMANAGER.Show(new iwDirectIPCreate(NP_DIRECT));
+                WINDOWMANAGER.Show(new iwDirectIPCreate(ServerType::DIRECT));
         } break;
         case 4: // "Verbinden"
         {
-            WINDOWMANAGER.Show(new iwDirectIPConnect(NP_DIRECT));
+            WINDOWMANAGER.Show(new iwDirectIPConnect(ServerType::DIRECT));
         } break;
         case 5: // "Zurück"
         {

--- a/src/desktops/dskHostGame.cpp
+++ b/src/desktops/dskHostGame.cpp
@@ -55,8 +55,8 @@ static char THIS_FILE[] = __FILE__;
  *  @author Devil
  *  @author FloSoft
  */
-dskHostGame::dskHostGame(ServerType serverType) :
-    Desktop(LOADER.GetImageN("setup015", 0)), temppunkte_(0), hasCountdown_(false), serverType(serverType)
+dskHostGame::dskHostGame(const ServerType serverType) :
+    Desktop(LOADER.GetImageN("setup015", 0)), hasCountdown_(false), serverType(serverType)
 {
     const bool readonlySettings = !GAMECLIENT.IsHost() || GAMECLIENT.IsSavegame();
 

--- a/src/desktops/dskHostGame.cpp
+++ b/src/desktops/dskHostGame.cpp
@@ -74,7 +74,7 @@ dskHostGame::dskHostGame(const ServerType serverType) :
     // "Team"
     AddText(14, 405, 40, _("Team"), COLOR_YELLOW, glArchivItem_Font::DF_CENTER, NormalFont);
 
-    if (serverType != ServerType::LOCAL)
+    if (!IsSinglePlayer())
     {
         // "Bereit"
         AddText(15, 465, 40, _("Ready?"), COLOR_YELLOW, glArchivItem_Font::DF_CENTER, NormalFont);
@@ -88,7 +88,7 @@ dskHostGame::dskHostGame(const ServerType serverType) :
     if(GAMECLIENT.IsSavegame())
         AddText(17, 645, 40, _("Past player"), COLOR_YELLOW, glArchivItem_Font::DF_CENTER, NormalFont);
 
-    if (serverType != ServerType::LOCAL)
+    if (!IsSinglePlayer())
     {
         // Chatfenster
         AddChatCtrl(1, 20, 320, 360, 218, TC_GREY, NormalFont);
@@ -178,7 +178,7 @@ dskHostGame::dskHostGame(const ServerType serverType) :
         }
     }
 
-    if (serverType == ServerType::LOCAL && !GAMECLIENT.IsSavegame())
+    if (IsSinglePlayer() && !GAMECLIENT.IsSavegame())
     {
         // Setze initial auf KI
         for (unsigned char i = 0; i < GAMECLIENT.GetPlayerCount(); i++)
@@ -369,7 +369,7 @@ void dskHostGame::UpdatePlayerRow(const unsigned row)
 void dskHostGame::Msg_PaintBefore()
 {
     // Chatfenster Fokus geben
-    if (serverType != ServerType::LOCAL)
+    if (!IsSinglePlayer())
     {
         GetCtrl<ctrlEdit>(4)->SetFocus();
     }
@@ -528,7 +528,7 @@ void dskHostGame::Msg_Group_ComboSelectItem(const unsigned int group_id, const u
 
 void dskHostGame::GoBack()
 {
-    if (serverType == ServerType::LOCAL)
+    if (IsSinglePlayer())
         WINDOWMANAGER.Switch(new dskSinglePlayer);
     else if (serverType == ServerType::LAN)
         WINDOWMANAGER.Switch(new dskLAN);
@@ -647,7 +647,7 @@ void dskHostGame::CI_Countdown(int countdown)
 {
     hasCountdown_ = true;
 
-    if (serverType == ServerType::LOCAL)
+    if (IsSinglePlayer())
         return;
 
     std::stringstream message;
@@ -675,7 +675,7 @@ void dskHostGame::CI_Countdown(int countdown)
  */
 void dskHostGame::CI_CancelCountdown()
 {
-    if (serverType == ServerType::LOCAL)
+    if (IsSinglePlayer())
         return;
 
     GetCtrl<ctrlChat>(1)->AddMessage("", "", 0xFFCC2222, _("Start aborted"), 0xFFFFCC00);
@@ -936,7 +936,7 @@ void dskHostGame::CI_GameStarted(GameWorldViewer* gwv)
  */
 void dskHostGame::CI_PSChanged(const unsigned player_id, const PlayerState ps)
 {
-    if ((serverType == ServerType::LOCAL) && (ps == PS_FREE))
+    if (IsSinglePlayer() && (ps == PS_FREE))
         GAMESERVER.TogglePlayerState(player_id);
 
     UpdatePlayerRow(player_id);
@@ -1046,7 +1046,7 @@ void dskHostGame::CI_GGSChanged(const GlobalGameSettings& ggs)
  */
 void dskHostGame::CI_Chat(const unsigned player_id, const ChatDestination cd, const std::string& msg)
 {
-    if ((player_id != 0xFFFFFFFF) && serverType != ServerType::LOCAL)
+    if ((player_id != 0xFFFFFFFF) && !IsSinglePlayer())
     {
         std::string time = TIME.FormatTime("(%H:%i:%s)");
 

--- a/src/desktops/dskHostGame.cpp
+++ b/src/desktops/dskHostGame.cpp
@@ -28,9 +28,10 @@
 #include "controls/controls.h"
 #include "LobbyClient.h"
 
-#include "dskDirectIP.h"
-#include "dskLobby.h"
-#include "dskSinglePlayer.h"
+#include "desktops/dskDirectIP.h"
+#include "desktops/dskLobby.h"
+#include "desktops/dskSinglePlayer.h"
+#include "desktops/dskLAN.h"
 #include "ingameWindows/iwMsgbox.h"
 #include "ingameWindows/iwAddons.h"
 #include "gameData/GameConsts.h"
@@ -54,8 +55,8 @@ static char THIS_FILE[] = __FILE__;
  *  @author Devil
  *  @author FloSoft
  */
-dskHostGame::dskHostGame(bool single_player) :
-    Desktop(LOADER.GetImageN("setup015", 0)), temppunkte_(0), hasCountdown_(false), isSinglePlayer_(single_player)
+dskHostGame::dskHostGame(ServerType serverType) :
+    Desktop(LOADER.GetImageN("setup015", 0)), temppunkte_(0), hasCountdown_(false), serverType(serverType)
 {
     const bool readonlySettings = !GAMECLIENT.IsHost() || GAMECLIENT.IsSavegame();
 
@@ -73,7 +74,7 @@ dskHostGame::dskHostGame(bool single_player) :
     // "Team"
     AddText(14, 405, 40, _("Team"), COLOR_YELLOW, glArchivItem_Font::DF_CENTER, NormalFont);
 
-    if (!single_player)
+    if (serverType != ServerType::LOCAL)
     {
         // "Bereit"
         AddText(15, 465, 40, _("Ready?"), COLOR_YELLOW, glArchivItem_Font::DF_CENTER, NormalFont);
@@ -87,7 +88,7 @@ dskHostGame::dskHostGame(bool single_player) :
     if(GAMECLIENT.IsSavegame())
         AddText(17, 645, 40, _("Past player"), COLOR_YELLOW, glArchivItem_Font::DF_CENTER, NormalFont);
 
-    if (!single_player)
+    if (serverType != ServerType::LOCAL)
     {
         // Chatfenster
         AddChatCtrl(1, 20, 320, 360, 218, TC_GREY, NormalFont);
@@ -177,7 +178,7 @@ dskHostGame::dskHostGame(bool single_player) :
         }
     }
 
-    if (single_player && !GAMECLIENT.IsSavegame())
+    if (serverType == ServerType::LOCAL && !GAMECLIENT.IsSavegame())
     {
         // Setze initial auf KI
         for (unsigned char i = 0; i < GAMECLIENT.GetPlayerCount(); i++)
@@ -201,7 +202,7 @@ dskHostGame::dskHostGame(bool single_player) :
     this->CI_GGSChanged(GAMECLIENT.GetGGS());
 
     LOBBYCLIENT.SetInterface(this);
-    if(LOBBYCLIENT.LoggedIn())
+    if(serverType == ServerType::LOBBY && LOBBYCLIENT.LoggedIn())
     {
         LOBBYCLIENT.SendServerJoinRequest();
         LOBBYCLIENT.SendRankingInfoRequest(GAMECLIENT.GetPlayer(GAMECLIENT.GetPlayerID()).name);
@@ -368,7 +369,7 @@ void dskHostGame::UpdatePlayerRow(const unsigned row)
 void dskHostGame::Msg_PaintBefore()
 {
     // Chatfenster Fokus geben
-    if (!isSinglePlayer_)
+    if (serverType != ServerType::LOCAL)
     {
         GetCtrl<ctrlEdit>(4)->SetFocus();
     }
@@ -524,6 +525,19 @@ void dskHostGame::Msg_Group_ComboSelectItem(const unsigned int group_id, const u
     GAMESERVER.SwapPlayer(player_id, player2);
 }
 
+
+void dskHostGame::GoBack()
+{
+    if (serverType == ServerType::LOCAL)
+        WINDOWMANAGER.Switch(new dskSinglePlayer);
+    else if (serverType == ServerType::LAN)
+        WINDOWMANAGER.Switch(new dskLAN);
+    else if (serverType == ServerType::LOBBY && LOBBYCLIENT.LoggedIn())
+        WINDOWMANAGER.Switch(new dskLobby);
+    else
+        WINDOWMANAGER.Switch(new dskDirectIP);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 /**
  *
@@ -572,19 +586,9 @@ void dskHostGame::Msg_ButtonClick(const unsigned int ctrl_id)
         {
             if(GAMECLIENT.IsHost())
                 GAMESERVER.Stop();
-
             GAMECLIENT.Stop();
 
-            if (isSinglePlayer_)
-            {
-                WINDOWMANAGER.Switch(new dskSinglePlayer);
-            }
-            else if(LOBBYCLIENT.LoggedIn())
-                WINDOWMANAGER.Switch(new dskLobby);
-            else
-                // Hauptmenü zeigen
-                WINDOWMANAGER.Switch(new dskDirectIP);
-
+            GoBack();
         } break;
 
         case 2: // Starten
@@ -643,10 +647,8 @@ void dskHostGame::CI_Countdown(int countdown)
 {
     hasCountdown_ = true;
 
-    if (isSinglePlayer_)
-    {
+    if (serverType == ServerType::LOCAL)
         return;
-    }
 
     std::stringstream message;
 
@@ -673,10 +675,8 @@ void dskHostGame::CI_Countdown(int countdown)
  */
 void dskHostGame::CI_CancelCountdown()
 {
-    if (isSinglePlayer_)
-    {
+    if (serverType == ServerType::LOCAL)
         return;
-    }
 
     GetCtrl<ctrlChat>(1)->AddMessage("", "", 0xFFCC2222, _("Start aborted"), 0xFFFFCC00);
 
@@ -700,14 +700,7 @@ void dskHostGame::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult 
         {
             GAMECLIENT.Stop();
 
-            if (isSinglePlayer_)
-            {
-                WINDOWMANAGER.Switch(new dskSinglePlayer);
-            }
-            else if(LOBBYCLIENT.LoggedIn())   // steht die Lobbyverbindung noch?
-                WINDOWMANAGER.Switch(new dskLobby);
-            else
-                WINDOWMANAGER.Switch(new dskDirectIP);
+            GoBack();
         } break;
         case CGI_ADDONS: // addon-window applied settings?
         {
@@ -943,7 +936,7 @@ void dskHostGame::CI_GameStarted(GameWorldViewer* gwv)
  */
 void dskHostGame::CI_PSChanged(const unsigned player_id, const PlayerState ps)
 {
-    if ((isSinglePlayer_) && (ps == PS_FREE))
+    if ((serverType == ServerType::LOCAL) && (ps == PS_FREE))
         GAMESERVER.TogglePlayerState(player_id);
 
     UpdatePlayerRow(player_id);
@@ -1053,7 +1046,7 @@ void dskHostGame::CI_GGSChanged(const GlobalGameSettings& ggs)
  */
 void dskHostGame::CI_Chat(const unsigned player_id, const ChatDestination cd, const std::string& msg)
 {
-    if ((player_id != 0xFFFFFFFF) && !isSinglePlayer_) // Keine Lobby-Nachrichten anzeigen
+    if ((player_id != 0xFFFFFFFF) && serverType != ServerType::LOCAL)
     {
         std::string time = TIME.FormatTime("(%H:%i:%s)");
 

--- a/src/desktops/dskHostGame.h
+++ b/src/desktops/dskHostGame.h
@@ -89,6 +89,7 @@ class dskHostGame :
         void LC_Status_Error(const std::string& error);
 
         void GoBack();
+        bool IsSinglePlayer(){ return serverType == ServerType::LOCAL; }
     private:
         GlobalGameSettings ggs_;
         bool hasCountdown_;

--- a/src/desktops/dskHostGame.h
+++ b/src/desktops/dskHostGame.h
@@ -35,7 +35,7 @@ class dskHostGame :
     public:
 
         /// Map übergeben, damit die Kartenvorschau erstellt werden kann
-        dskHostGame(ServerType serverType);
+        dskHostGame(const ServerType serverType);
 
         /// Größe ändern-Reaktionen die nicht vom Skaling-Mechanismus erfasst werden.
         void Resize_(unsigned short width, unsigned short height);
@@ -90,10 +90,9 @@ class dskHostGame :
 
         void GoBack();
     private:
-        int temppunkte_; // TODO - wegmachen und durch korrekte punkte ersetzen!
         GlobalGameSettings ggs_;
         bool hasCountdown_;
-        ServerType serverType;
+        const ServerType serverType;
 };
 
 

--- a/src/desktops/dskHostGame.h
+++ b/src/desktops/dskHostGame.h
@@ -26,8 +26,6 @@
 #include "LobbyInterface.h"
 #include "ClientInterface.h"
 
-#include "ogl/glArchivItem_Bitmap_Raw.h"
-
 /// Desktop für das Hosten-eines-Spiels-Fenster
 class dskHostGame :
     public Desktop,
@@ -37,7 +35,7 @@ class dskHostGame :
     public:
 
         /// Map übergeben, damit die Kartenvorschau erstellt werden kann
-        dskHostGame(bool single_player = false);
+        dskHostGame(ServerType serverType);
 
         /// Größe ändern-Reaktionen die nicht vom Skaling-Mechanismus erfasst werden.
         void Resize_(unsigned short width, unsigned short height);
@@ -90,11 +88,12 @@ class dskHostGame :
 
         void LC_Status_Error(const std::string& error);
 
+        void GoBack();
     private:
         int temppunkte_; // TODO - wegmachen und durch korrekte punkte ersetzen!
         GlobalGameSettings ggs_;
         bool hasCountdown_;
-        bool isSinglePlayer_;
+        ServerType serverType;
 };
 
 

--- a/src/desktops/dskLAN.cpp
+++ b/src/desktops/dskLAN.cpp
@@ -1,0 +1,190 @@
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+///////////////////////////////////////////////////////////////////////////////
+// Header
+#include "defines.h"
+#include <build_version.h>
+#include "dskLAN.h"
+
+#include "WindowManager.h"
+#include "Loader.h"
+#include "Settings.h"
+#include "controls/controls.h"
+#include "ingameWindows/iwDirectIPCreate.h"
+#include "ingameWindows/iwDirectIPConnect.h"
+#include "ingameWindows/iwMsgbox.h"
+#include "desktops/dskMultiPlayer.h"
+#include "gameData/LanDiscoveryCfg.h"
+
+#include <Serializer.h>
+#include <Log.h>
+#include <boost/lexical_cast.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+// Makros / Defines
+#if defined _WIN32 && defined _DEBUG && defined _MSC_VER
+#define new new(_NORMAL_BLOCK, THIS_FILE, __LINE__)
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#endif
+
+namespace {
+    const unsigned btBackId = 3;
+    const unsigned btConnectId = 4;
+    const unsigned btAddServerId = 5;
+    const unsigned tblServerId = 6;
+    const unsigned tmrRefreshServersId = 7;
+    const unsigned tmrRefreshListId = 8;
+}
+
+dskLAN::dskLAN() : Desktop(LOADER.GetImageN("setup013", 0)), discovery(LAN_DISCOVERY_CFG)
+{
+    // Version
+    AddVarText(0, 0, 600, _("Return To The Roots - v%s-%s"), COLOR_YELLOW, 0 | glArchivItem_Font::DF_BOTTOM, NormalFont, 2, GetWindowVersion(), GetWindowRevisionShort());
+    // URL
+    AddText(1, 400, 600, _("http://www.siedler25.org"), COLOR_GREEN, glArchivItem_Font::DF_CENTER | glArchivItem_Font::DF_BOTTOM, NormalFont);
+    // Copyright
+    AddVarText(2, 800, 600, _("© 2005 - %s Settlers Freaks"), COLOR_YELLOW, glArchivItem_Font::DF_RIGHT | glArchivItem_Font::DF_BOTTOM, NormalFont, 1, GetCurrentYear());
+
+    // "Server hinzufügen"
+    AddTextButton(btAddServerId, 530, 250, 250, 22, TC_GREEN2, _("Add Server"), NormalFont);
+    // "Verbinden"
+    AddTextButton(btConnectId, 530, 280, 250, 22, TC_GREEN2, _("Connect"), NormalFont);
+    // "Zurück"
+    AddTextButton(btBackId, 530, 530, 250, 22, TC_RED1, _("Back"), NormalFont);
+
+    // Gameserver-Tabelle - "ID", "Server", "Karte", "Spieler", "Version"
+    AddTable(tblServerId, 20, 20, 500, 530, TC_GREY, NormalFont, 5, _("ID"), 0, ctrlTable::SRT_NUMBER, _("Server"), 300, ctrlTable::SRT_STRING, _("Map"), 300, ctrlTable::SRT_STRING, _("Player"), 200, ctrlTable::SRT_STRING, _("Version"), 100, ctrlTable::SRT_STRING);
+
+    discovery.Start();
+
+    AddTimer(tmrRefreshServersId, 60000); // Servers broadcast changes, so force a full update only once a minute
+    AddTimer(tmrRefreshListId, 2000);
+}
+
+void dskLAN::Msg_Timer(const unsigned int ctrl_id)
+{
+    if (ctrl_id == tmrRefreshServersId)
+        discovery.Refresh();
+    else if (ctrl_id == tmrRefreshListId)
+        UpdateServerList();
+    else
+        assert(false);
+}
+
+void dskLAN::Msg_PaintBefore()
+{
+    discovery.Run();
+}
+
+void dskLAN::Msg_ButtonClick(const unsigned int ctrl_id)
+{
+    switch(ctrl_id)
+    {
+    case btBackId:
+        WINDOWMANAGER.Switch(new dskMultiPlayer);
+        break;
+    case btConnectId:
+        ConnectToSelectedGame();
+        break;
+    case btAddServerId:
+        if(SETTINGS.proxy.typ != 0)
+            WINDOWMANAGER.Show(new iwMsgbox(_("Sorry!"), _("You can't create a game while a proxy server is active\nDisable the use of a proxy server first!"), this, MSB_OK, MSB_EXCLAMATIONGREEN, 1));
+        else
+        {
+            iwDirectIPCreate* servercreate = new iwDirectIPCreate(ServerType::LAN);
+            servercreate->SetParent(this);
+            WINDOWMANAGER.Show(servercreate, true);
+        }
+    }
+}
+
+void dskLAN::Msg_TableChooseItem(const unsigned ctrl_id, const unsigned short selection)
+{
+    if(ctrl_id == tblServerId && selection != 0xFFFF) // Server list
+        ConnectToSelectedGame();
+}
+
+void dskLAN::ReadOpenGames()
+{
+    openGames.clear();
+    const LANDiscoveryClient::ServiceMap& services = discovery.GetServices();
+    for (LANDiscoveryClient::ServiceMap::const_iterator it = services.begin(); it != services.end(); ++it)
+    {
+        Serializer ser(&it->second.info.GetPayload().front(), it->second.info.GetPayload().size());
+        GameInfo info;
+        info.ip = it->second.ip;
+        info.info.Deserialize(ser);
+        openGames.push_back(info);
+    }
+}
+
+void dskLAN::UpdateServerList()
+{
+    ReadOpenGames();
+
+    ctrlTable* servertable = GetCtrl<ctrlTable>(tblServerId);
+
+    unsigned int selection = servertable->GetSelection();
+    if(selection == 0xFFFF)
+        selection = 0;
+    unsigned short column = servertable->GetSortColumn();
+    if(column == 0xFFFF)
+        column = 0;
+    bool direction = servertable->GetSortDirection();
+    servertable->DeleteAllItems();
+
+    unsigned curId = 0;
+    for(std::vector<GameInfo>::const_iterator it = openGames.begin(); it != openGames.end(); ++it)
+    {
+        std::string id = boost::lexical_cast<std::string>(curId++);
+        std::string name = (it->info.hasPwd ? "(pwd) " : "") + it->info.name;
+        std::string player = boost::lexical_cast<std::string>(static_cast<unsigned>(it->info.curPlayer)) + "/"+
+                             boost::lexical_cast<std::string>(static_cast<unsigned>(it->info.maxPlayer));
+        servertable->AddRow(0, id.c_str(), name.c_str(), it->info.map.c_str(), player.c_str(), it->info.version.c_str());
+    }
+    
+    servertable->SortRows(column, &direction);
+    servertable->SetSelection(selection);
+}
+
+bool dskLAN::ConnectToSelectedGame()
+{
+    if(openGames.empty())
+        return false;
+
+    ctrlTable* table = GetCtrl<ctrlTable>(tblServerId);
+    unsigned int selection = atoi(table->GetItemText(table->GetSelection(), 0).c_str());
+    if (selection >= openGames.size())
+        return false;
+
+    GameInfo game = openGames[selection];
+    if(game.info.version == std::string(GetWindowVersion()))
+    {
+        iwDirectIPConnect* connect = new iwDirectIPConnect(ServerType::LAN);
+        connect->SetHost(game.ip);
+        connect->SetPort(game.info.port);
+        WINDOWMANAGER.Show(connect);
+        return true;
+    }
+    else
+    {
+        WINDOWMANAGER.Show(new iwMsgbox(_("Sorry!"), _("You can't join that game with your version!"), this, MSB_OK, MSB_EXCLAMATIONRED, 1));
+        return false;
+    }
+
+}

--- a/src/desktops/dskLAN.h
+++ b/src/desktops/dskLAN.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+#ifndef dskLAN_H_INCLUDED
+#define dskLAN_H_INCLUDED
+
+#pragma once
+
+#include "Desktop.h"
+#include "LANDiscoveryClient.h"
+#include "gameTypes/LanGameInfo.h"
+#include <vector>
+
+class dskLAN : public Desktop
+{
+public:
+    struct GameInfo {
+        std::string ip;
+        LanGameInfo info;
+    };
+    dskLAN();
+
+
+protected:
+    void Msg_Timer(const unsigned int ctrl_id);
+    void Msg_PaintBefore();
+    void Msg_ButtonClick(const unsigned int ctrl_id);
+    void Msg_TableChooseItem(const unsigned ctrl_id, const unsigned short selection);
+
+    /**
+        * Connects to the currently selected game and returns true on success
+        */
+    bool ConnectToSelectedGame();
+
+private:
+    LANDiscoveryClient discovery;
+    std::vector<GameInfo> openGames;
+
+    void UpdateServerList();
+    void ReadOpenGames();
+};
+
+#endif // dskLAN_H_INCLUDED

--- a/src/desktops/dskLobby.cpp
+++ b/src/desktops/dskLobby.cpp
@@ -75,7 +75,7 @@ dskLobby::dskLobby() : Desktop(LOADER.GetImageN("setup013", 0)), serverinfo(NULL
     AddTextButton(6, 530, 440, 250, 22, TC_GREEN2, _("Add Server"), NormalFont);
 
     // Gameserver-Tabelle - "ID", "Server", "Karte", "Spieler", "Version", "Ping"
-    AddTable(10, 20, 20, 500, 262, TC_GREY, NormalFont, 6, _("ID"), 0, ctrlTable::SRT_NUMBER, _("Server"), 300, ctrlTable::SRT_STRING, _("Map"), 300, ctrlTable::SRT_STRING, _("Player"), 200, ctrlTable::SRT_NUMBER, _("Version"), 100, ctrlTable::SRT_STRING, _("Ping"), 100, ctrlTable::SRT_NUMBER);
+    AddTable(10, 20, 20, 500, 262, TC_GREY, NormalFont, 6, _("ID"), 0, ctrlTable::SRT_NUMBER, _("Server"), 300, ctrlTable::SRT_STRING, _("Map"), 300, ctrlTable::SRT_STRING, _("Player"), 200, ctrlTable::SRT_STRING, _("Version"), 100, ctrlTable::SRT_STRING, _("Ping"), 100, ctrlTable::SRT_NUMBER);
     // Spieler-Tabelle - "Name", "Punkte", "Version"
     AddTable(11, 530, 20, 250, 410, TC_GREY, NormalFont, 3, _("Name"), 500, ctrlTable::SRT_STRING, _("Points"), 250, ctrlTable::SRT_STRING, _("Version"), 250, ctrlTable::SRT_STRING);
 
@@ -138,7 +138,7 @@ void dskLobby::Msg_ButtonClick(const unsigned int ctrl_id)
                 WINDOWMANAGER.Show(new iwMsgbox(_("Sorry!"), _("You can't create a game while a proxy server is active\nDisable the use of a proxy server first!"), this, MSB_OK, MSB_EXCLAMATIONGREEN, 1));
             else
             {
-                servercreate = new iwDirectIPCreate(NP_LOBBY);
+                servercreate = new iwDirectIPCreate(ServerType::LOBBY);
                 servercreate->SetParent(this);
                 WINDOWMANAGER.Show(servercreate, true);
             }
@@ -309,7 +309,7 @@ bool dskLobby::ConnectToSelectedGame()
 
         if(it->getVersion() == std::string(GetWindowVersion()))
         {
-            iwDirectIPConnect* connect = new iwDirectIPConnect(NP_LOBBY);
+            iwDirectIPConnect* connect = new iwDirectIPConnect(ServerType::LOBBY);
             connect->SetHost(it->getHost().c_str());
             connect->SetPort(it->getPort());
             WINDOWMANAGER.Show(connect);
@@ -364,7 +364,7 @@ void dskLobby::LC_Status_Error(const std::string& error)
  */
 void dskLobby::LC_Connected(void)
 {
-    WINDOWMANAGER.Switch(new dskHostGame);
+    WINDOWMANAGER.Switch(new dskHostGame(ServerType::LOBBY));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/desktops/dskMultiPlayer.cpp
+++ b/src/desktops/dskMultiPlayer.cpp
@@ -24,8 +24,9 @@
 #include "WindowManager.h"
 #include "Loader.h"
 
-#include "dskMainMenu.h"
-#include "dskDirectIP.h"
+#include "desktops/dskMainMenu.h"
+#include "desktops/dskDirectIP.h"
+#include "desktops/dskLAN.h"
 #include "ingameWindows/iwLobbyConnect.h"
 #include "ogl/glArchivItem_Font.h"
 
@@ -80,19 +81,16 @@ void dskMultiPlayer::Msg_ButtonClick(const unsigned int ctrl_id)
     switch(ctrl_id)
     {
         case 3: // Lobby
-        {
             WINDOWMANAGER.Show(new iwLobbyConnect, true);
-        } break;
+            break;
         case 4: // Local Area Network
-        {
-        } break;
+            WINDOWMANAGER.Switch(new dskLAN);
+            break;
         case 5: // Direct IP
-        {
             WINDOWMANAGER.Switch(new dskDirectIP);
-        } break;
+            break;
         case 6: // Zurück
-        {
             WINDOWMANAGER.Switch(new dskMainMenu);
-        } break;
+            break;
     }
 }

--- a/src/desktops/dskSelectMap.h
+++ b/src/desktops/dskSelectMap.h
@@ -58,6 +58,7 @@ class dskSelectMap :
 
         /// Startet das Spiel mit einer bestimmten Auswahl in der Tabelle
         void StartServer();
+        void GoBack();
 
     private:
         CreateServerInfo csi;

--- a/src/desktops/dskSinglePlayer.cpp
+++ b/src/desktops/dskSinglePlayer.cpp
@@ -133,7 +133,7 @@ void dskSinglePlayer::Msg_ButtonClick(const unsigned int ctrl_id)
                 csi.gamename = fileName.string();
                 csi.password = "localgame";
                 csi.port = 3665;
-                csi.type = NP_LOCAL;
+                csi.type = ServerType::LOCAL;
                 csi.ipv6 = false;
                 csi.use_upnp = false;
 
@@ -185,7 +185,7 @@ void dskSinglePlayer::PrepareSinglePlayerServer()
     csi.gamename = _("Unlimited Play");
     csi.password = "localgame";
     csi.port = 3665;
-    csi.type = NP_LOCAL;
+    csi.type = ServerType::LOCAL;
     csi.ipv6 = false;
     csi.use_upnp = false;
 
@@ -198,7 +198,7 @@ void dskSinglePlayer::PrepareLoadGame()
     csi.gamename = _("Unlimited Play");
     csi.password = "localgame";
     csi.port = 3665;
-    csi.type = NP_LOCAL;
+    csi.type = ServerType::LOCAL;
     csi.ipv6 = false;
     csi.use_upnp = false;
 

--- a/src/gameData/LanDiscoveryCfg.cpp
+++ b/src/gameData/LanDiscoveryCfg.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "defines.h"
+#include "LANDiscoveryCfg.h"
+
+static LANDiscoveryBase::Config makeDiscoveryConfig()
+{
+    LANDiscoveryBase::Config cfg;
+    cfg.magicQuery = cfg.MakeMagic("RTTRQRY");
+    cfg.magicResponse = cfg.MakeMagic("RTTRRES");
+    cfg.version = 1;
+    cfg.portQuery = 3666;
+    cfg.portResponse = 3667;
+    return cfg;
+}
+
+const LANDiscoveryBase::Config LAN_DISCOVERY_CFG = makeDiscoveryConfig();
+

--- a/src/gameData/LanDiscoveryCfg.h
+++ b/src/gameData/LanDiscoveryCfg.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef LAN_DISCOVERY_CFG_H_INCLUDED
+#define LAN_DISCOVERY_CFG_H_INCLUDED
+
+#include "LANDiscovery.h"
+
+extern const LANDiscoveryBase::Config LAN_DISCOVERY_CFG;
+
+#endif // !LAN_DISCOVERY_CFG_H_INCLUDED

--- a/src/gameTypes/LanGameInfo.cpp
+++ b/src/gameTypes/LanGameInfo.cpp
@@ -1,0 +1,49 @@
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "defines.h"
+#include "LanGameInfo.h"
+#include "Serializer.h"
+
+bool LanGameInfo::Serialize(Serializer& serializer)
+{
+    if (name.size() > 64)
+        name.resize(64);
+    if (map.size() > 64)
+        map.resize(64);
+    if (version.size() > 16)
+        version.resize(16);
+    serializer.PushString(name);
+    serializer.PushBool(hasPwd);
+    serializer.PushString(map);
+    serializer.PushUnsignedChar(curPlayer);
+    serializer.PushUnsignedChar(maxPlayer);
+    serializer.PushUnsignedShort(port);
+    serializer.PushString(version);
+    return true;
+}
+
+bool LanGameInfo::Deserialize(Serializer& serializer)
+{
+    name = serializer.PopString();
+    hasPwd = serializer.PopBool();
+    map = serializer.PopString();
+    curPlayer = serializer.PopUnsignedChar();
+    maxPlayer = serializer.PopUnsignedChar();
+    port = serializer.PopUnsignedShort();
+    version = serializer.PopString();
+    return true;
+}

--- a/src/gameTypes/LanGameInfo.h
+++ b/src/gameTypes/LanGameInfo.h
@@ -1,0 +1,38 @@
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef LAN_GAME_INFO_H_INCLUDED
+#define LAN_GAME_INFO_H_INCLUDED
+
+#include <cstdint>
+#include <string>
+
+class Serializer;
+
+struct LanGameInfo
+{
+    std::string name;
+    bool hasPwd;
+    std::string map;
+    uint8_t curPlayer, maxPlayer;
+    uint16_t port;
+    std::string version;
+
+    bool Serialize(Serializer& serializer);
+    bool Deserialize(Serializer& serializer);
+};
+
+#endif // !LAN_GAME_INFO_H_INCLUDED

--- a/src/gameTypes/ServerType.h
+++ b/src/gameTypes/ServerType.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef ServerType_h__
+#define ServerType_h__
+
+#include <boost/detail/scoped_enum_emulation.hpp>
+
+// Servertypen
+BOOST_SCOPED_ENUM_START(ServerType)
+{
+    LOBBY = 0,
+    DIRECT,
+    LOCAL,
+    LAN
+};
+BOOST_SCOPED_ENUM_END
+
+#endif // ServerType_h__

--- a/src/ingameWindows/iwDirectIPConnect.cpp
+++ b/src/ingameWindows/iwDirectIPConnect.cpp
@@ -43,7 +43,7 @@ static char THIS_FILE[] = __FILE__;
  *  @author OLiver
  *  @author FloSoft
  */
-iwDirectIPConnect::iwDirectIPConnect(unsigned int server_type)
+iwDirectIPConnect::iwDirectIPConnect(ServerType server_type)
     : IngameWindow(CGI_DIRECTIPCONNECT, 0xFFFF, 0xFFFF, 300, 285, _("Join Game"), LOADER.GetImageN("resource", 41), true),
       server_type(server_type)
 {
@@ -51,11 +51,11 @@ iwDirectIPConnect::iwDirectIPConnect(unsigned int server_type)
 
     // "IP - Adresse vom Host"
     AddText(0, 20, 30, _("IP Address of Host:"), COLOR_YELLOW, 0, NormalFont);
-    host = AddEdit(1, 20, 45, 260, 22, TC_GREEN2, NormalFont, 0, false, (server_type == NP_LOBBY),  true);
+    host = AddEdit(1, 20, 45, 260, 22, TC_GREEN2, NormalFont, 0, false, (server_type != ServerType::DIRECT),  true);
 
     // "Server-Port"
     AddText(2, 20, 80, _("Server-Port:"), COLOR_YELLOW, 0, NormalFont);
-    port = AddEdit(3, 20, 95, 260, 22, TC_GREEN2, NormalFont, 0, false, (server_type == NP_LOBBY),  true);
+    port = AddEdit(3, 20, 95, 260, 22, TC_GREEN2, NormalFont, 0, false, (server_type != ServerType::DIRECT),  true);
 
     // "Passwort (falls vorhanden)"
     AddText(4, 20, 130, _("Password (if needed):"), COLOR_YELLOW, 0, NormalFont);
@@ -220,13 +220,10 @@ void iwDirectIPConnect::SetText(const std::string& text, unsigned int color, boo
  *
  *  @author FloSoft
  */
-void iwDirectIPConnect::SetHost(const char* text)
+void iwDirectIPConnect::SetHost(const std::string& hostIp)
 {
-    static char h[256];
-    snprintf(h, 256, "%s", text);
-
     ctrlEdit* host = GetCtrl<ctrlEdit>(1);
-    host->SetText(h);
+    host->SetText(hostIp);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -282,7 +279,7 @@ void iwDirectIPConnect::CI_NextConnectState(const ConnectState cs)
 
         case CS_FINISHED: // Wir wurden verbunden
         {
-            WINDOWMANAGER.Switch(new dskHostGame);
+            WINDOWMANAGER.Switch(new dskHostGame(server_type));
         } break;
         default: break;
     }

--- a/src/ingameWindows/iwDirectIPConnect.h
+++ b/src/ingameWindows/iwDirectIPConnect.h
@@ -25,11 +25,11 @@
 class iwDirectIPConnect : public IngameWindow, public ClientInterface
 {
     private:
-        unsigned int server_type;
+        ServerType server_type;
 
     public:
-        iwDirectIPConnect(unsigned int server_type);
-        void SetHost(const char* text);
+        iwDirectIPConnect(ServerType server_type);
+        void SetHost(const std::string& host);
         void SetPort(unsigned short port);
 
     private:

--- a/src/ingameWindows/iwDirectIPCreate.cpp
+++ b/src/ingameWindows/iwDirectIPCreate.cpp
@@ -44,7 +44,7 @@ static char THIS_FILE[] = __FILE__;
  *
  *  @author OLiver
  */
-iwDirectIPCreate::iwDirectIPCreate(unsigned int server_type)
+iwDirectIPCreate::iwDirectIPCreate(ServerType server_type)
     : IngameWindow(CGI_DIRECTIPCREATE, 0xFFFF, 0xFFFF, 300, 285, _("Create Game"), LOADER.GetImageN("resource", 41), true),
       server_type(server_type)
 {

--- a/src/ingameWindows/iwDirectIPCreate.h
+++ b/src/ingameWindows/iwDirectIPCreate.h
@@ -21,11 +21,12 @@
 
 #include "IngameWindow.h"
 #include "LobbyInterface.h"
+#include "gameTypes/ServerType.h"
 
 /// Struktur zur Weitergabe der Spiel-Eröffnungsdaten
 struct CreateServerInfo
 {
-    unsigned char type;    ///< Typ des Servers.
+    ServerType type;    ///< Typ des Servers.
     unsigned short port;   ///< Port des Servers
     std::string gamename;  ///< Name des Servers.
     std::string password;  ///< Passwort des Servers.
@@ -36,7 +37,7 @@ struct CreateServerInfo
 class iwDirectIPCreate : public IngameWindow, public LobbyInterface
 {
     public:
-        iwDirectIPCreate(unsigned int server_type);
+        iwDirectIPCreate(ServerType server_type);
 
         void LC_Status_Error(const std::string& error);
 
@@ -50,7 +51,7 @@ class iwDirectIPCreate : public IngameWindow, public LobbyInterface
         void SetText(const std::string& text, unsigned int color, bool button);
 
     private:
-        unsigned int server_type;
+        ServerType server_type;
 };
 
 #endif // !iwDIRECTIPCREATE_H_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,7 @@ int main(int argc, char* argv[])
         csi.gamename = _("Unlimited Play");
         csi.password = "localgame";
         csi.port = 3665;
-        csi.type = NP_LOCAL;
+        csi.type = ServerType::LOCAL;
         csi.ipv6 = false;
         csi.use_upnp = false;
 


### PR DESCRIPTION
Closes #327 

- [x] Requires rebase after https://github.com/Return-To-The-Roots/libutil/pull/16 is merged!

Adds a LAN mode with automatic server discovery through UDP. New desktop is added for the long existing LAN button!

To catch call issues the `ServerType` enum was factored out to a new file, transformed to a boost scoped enum (type safety) and all usages fixed accordingly.

2 Small fixes slipped in: Datatype for lobby list was wrong and passing the host now as a string instead of a char*

Ports are constant and choose right after the regular RTTR ports. Maybe other ports are better?