### PR TITLE
Fix aggressive defender

### DIFF
--- a/src/GameSavegame.cpp
+++ b/src/GameSavegame.cpp
@@ -26,7 +26,7 @@
 /// Kleine Signatur am Anfang "RTTRSAVE", die ein gültiges S25 RTTR Savegame kennzeichnet
 const char Savegame::SAVE_SIGNATURE[8] = {'R', 'T', 'T', 'R', 'S', 'A', 'V', 'E'};
 /// Version des Savegame-Formates
-const unsigned short Savegame::SAVE_VERSION = 28;
+const unsigned short Savegame::SAVE_VERSION = 29;
 
 ///////////////////////////////////////////////////////////////////////////////
 /**

--- a/src/SerializedGameData.cpp
+++ b/src/SerializedGameData.cpp
@@ -244,7 +244,7 @@ void SerializedGameData::ReadFromFile(BinaryFile& file)
     Serializer::ReadFromFile(file);
 }
 
-void SerializedGameData::PushObject(const GameObject* go, const bool known)
+void SerializedGameData::PushObject_(const GameObject* go, const bool known)
 {
     RTTR_Assert(!isReading);
 

--- a/src/SerializedGameData.cpp
+++ b/src/SerializedGameData.cpp
@@ -94,6 +94,7 @@
 #include "buildings/BurnedWarehouse.h"
 
 #include "helpers/containerUtils.h"
+#include "helpers/converters.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Makros / Defines
@@ -107,7 +108,6 @@ GameObject* SerializedGameData::Create_GameObject(const GO_Type got, const unsig
 {
     switch(got)
     {
-        default: return NULL;
         case GOT_NOB_HQ: return new nobHQ(*this, obj_id);
         case GOT_NOB_MILITARY: return new nobMilitary(*this, obj_id);
         case GOT_NOB_STOREHOUSE: return new nobStorehouse(*this, obj_id);
@@ -172,8 +172,12 @@ GameObject* SerializedGameData::Create_GameObject(const GO_Type got, const unsig
         case GOT_SHIP: return new noShip(*this, obj_id);
         case GOT_SHIPBUILDINGSITE: return new noShipBuildingSite(*this, obj_id);
         case GOT_CHARBURNERPILE: return new noCharburnerPile(*this, obj_id);
-
+        case GOT_NOTHING:
+        case GOT_UNKNOWN:
+            RTTR_Assert(false);
+            break;
     }
+    throw Error("Invalid GameObjectType " + helpers::toString(got) + " for objId=" + helpers::toString(obj_id) + " found!");
 }
 
 FOWObject* SerializedGameData::Create_FOWObject(const FOW_Type fowtype)
@@ -295,7 +299,7 @@ void SerializedGameData::PushObject_(const GameObject* go, const bool known)
     go->Serialize(*this);
 
     // Sicherheitscode reinschreiben
-    PushUnsignedShort(0xFFFF);
+    PushUnsignedShort(GetSafetyCode(*go));
 }
 
 /// FoW-Objekt
@@ -333,13 +337,13 @@ GameObject* SerializedGameData::PopObject_(GO_Type got)
 {
     RTTR_Assert(isReading);
     // Obj-ID holen
-    unsigned obj_id = PopUnsignedInt();
+    const unsigned objId = PopUnsignedInt();
 
     // Obj-ID = 0 ? Dann Null-Pointer zurueckgeben
-    if(!obj_id)
+    if(!objId)
         return NULL;
 
-    GameObject* go = GetReadGameObject(obj_id);
+    GameObject* go = GetReadGameObject(objId);
 
     // Schon vorhanden?
     if(go)
@@ -351,18 +355,23 @@ GameObject* SerializedGameData::PopObject_(GO_Type got)
         got = GO_Type(PopUnsignedShort());
 
     // und erzeugen
-    go = Create_GameObject(got, obj_id);
+    go = Create_GameObject(got, objId);
 
     // Sicherheitscode auslesen
     unsigned short safety_code = PopUnsignedShort();
 
-    if(safety_code != 0xFFFF)
+    if(safety_code != GetSafetyCode(*go))
     {
-        LOG.lprintf("SerializedGameData::PopObject_: ERROR: After loading Object(obj_id = %u, got = %u); Code is wrong!\n", obj_id, got);
+        LOG.lprintf("SerializedGameData::PopObject_: ERROR: After loading Object(obj_id = %u, got = %u); Code is wrong!\n", objId, got);
         throw Error("Invalid safety code after PopObject");
     }
 
     return go;
+}
+
+unsigned short SerializedGameData::GetSafetyCode(const GameObject& go)
+{
+    return 0xFFFF ^ go.GetGOT() ^ go.GetObjId();
 }
 
 void SerializedGameData::PushMapPoint(const MapPoint p)

--- a/src/SerializedGameData.h
+++ b/src/SerializedGameData.h
@@ -60,7 +60,15 @@ public:
     //////////////////////////////////////////////////////////////////////////
 
     /// Objekt(referenzen) kopieren
-    void PushObject(const GameObject* go, const bool known);
+    template<class T>
+    void PushObject(const T* go, const bool known)
+    {
+        /* The assert below basically checks the virtual function table.
+           If the dynamic_cast failes, we tried to push an object of another type or it was deleted */
+        const GameObject* goTmp = static_cast<const GameObject*>(go);
+        RTTR_Assert(dynamic_cast<const T*>(goTmp) == go);
+        PushObject_(goTmp, known);
+    }
 
     /// Copies a container of GameObjects
     template <typename T>
@@ -120,6 +128,7 @@ private:
     /// Erzeugt FOWObject
     FOWObject* Create_FOWObject(const FOW_Type fowtype);
 
+    void PushObject_(const GameObject* go, const bool known);
     /// Objekt(referenzen) lesen
     GameObject* PopObject_(GO_Type got);
 

--- a/src/SerializedGameData.h
+++ b/src/SerializedGameData.h
@@ -107,6 +107,8 @@ public:
     bool debugMode;
 
 private:
+    static unsigned short GetSafetyCode(const GameObject& go);
+
     /// Stores the ids of all written objects (-> only valid during writing)
     std::set<unsigned> writtenObjIds;
     /// Maps already read object ids to GameObjects (-> only valid during reading)

--- a/src/buildings/nobBaseMilitary.cpp
+++ b/src/buildings/nobBaseMilitary.cpp
@@ -366,17 +366,17 @@ bool nobBaseMilitary::SendSuccessor(const MapPoint pt, const unsigned short radi
 }
 
 
-bool nobBaseMilitary::IsAggressor(nofAttacker* attacker)
+bool nobBaseMilitary::IsAggressor(nofAttacker* attacker) const
 {
     return helpers::contains(aggressors, attacker);
 }
 
-bool nobBaseMilitary::IsAggressiveDefender(nofAggressiveDefender* soldier)
+bool nobBaseMilitary::IsAggressiveDefender(nofAggressiveDefender* soldier) const
 {
     return helpers::contains(aggressive_defenders, soldier);
 }
 
-bool nobBaseMilitary::IsOnMission(nofActiveSoldier* soldier)
+bool nobBaseMilitary::IsOnMission(nofActiveSoldier* soldier) const
 {
     return helpers::contains(troops_on_mission, soldier);
 }

--- a/src/buildings/nobBaseMilitary.cpp
+++ b/src/buildings/nobBaseMilitary.cpp
@@ -166,10 +166,11 @@ void nobBaseMilitary::AddLeavingFigure(noFigure* fig)
 
 nofAttacker* nobBaseMilitary::FindAggressor(nofAggressiveDefender* defender)
 {
-    // Look for other attackers on this building that are clos and ready to fight
+    // Look for other attackers on this building that are close and ready to fight
     for(std::list<nofAttacker*>::iterator it = aggressors.begin(); it != aggressors.end(); ++it)
     {
-        if(!(*it)->IsReadyForFight())
+        // The attacker must be ready to fight and must not already have another hunting defender
+        if(!(*it)->IsReadyForFight() || (*it)->GetHuntingDefender())
             continue;
 
         const MapPoint attackerPos = (*it)->GetPos();
@@ -181,7 +182,7 @@ nofAttacker* nobBaseMilitary::FindAggressor(nofAggressiveDefender* defender)
             return (*it);
         }
         // Check roughly the distance
-        if(gwg->CalcDistance((*it)->GetPos(), defender->GetPos()) < 5)
+        if(gwg->CalcDistance((*it)->GetPos(), defender->GetPos()) <= 5)
         {
             // Check it further (e.g. if they have to walk around a river...)
             if(gwg->FindHumanPath((*it)->GetPos(), defender->GetPos(), 5) != 0xFF)

--- a/src/buildings/nobBaseMilitary.h
+++ b/src/buildings/nobBaseMilitary.h
@@ -137,9 +137,10 @@ class nobBaseMilitary : public noBuilding
         bool IsUnderAttack() const {return(aggressors.size() > 0);};
 
         /// Debugging
-        bool IsAggressor(nofAttacker* attacker);
-        bool IsAggressiveDefender(nofAggressiveDefender* soldier);
-        bool IsOnMission(nofActiveSoldier* soldier);
+        bool IsAggressor(nofAttacker* attacker) const;
+        bool IsAggressiveDefender(nofAggressiveDefender* soldier) const;
+        bool IsOnMission(nofActiveSoldier* soldier) const;
+        const std::list<nofAggressiveDefender*>& GetAggresiveDefenders() const { return aggressive_defenders; }
 
         // Vergleicht Gebäude anhand ihrer Bauzeit, um eine geordnete Reihenfolge hinzubekommen
         struct Comparer{

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -1003,7 +1003,7 @@ nofAggressiveDefender* nobBaseWarehouse::SendDefender(nofAttacker* attacker)
 
     // Wenn kein Soldat mehr da ist --> 0 zurückgeben
     if(!rank)
-        return 0;
+        return NULL;
 
     // Dann den Stärksten rausschicken
     nofAggressiveDefender* soldier = new nofAggressiveDefender(pos, player, this, rank - 1, attacker);

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -816,7 +816,7 @@ nofAggressiveDefender* nobMilitary::SendDefender(nofAttacker* attacker)
         return defender;
     }
     else
-        return 0;
+        return NULL;
 }
 
 /// Gibt die Anzahl der Soldaten zurück, die für einen Angriff auf ein bestimmtes Ziel zur Verfügung stehen

--- a/src/figures/nofActiveSoldier.cpp
+++ b/src/figures/nofActiveSoldier.cpp
@@ -67,8 +67,6 @@ nofActiveSoldier::nofActiveSoldier(SerializedGameData& sgd, const unsigned obj_i
     fightSpot_ = sgd.PopMapPoint();
 }
 
-
-
 void nofActiveSoldier::GoalReached()
 {
     // We reached the military building

--- a/src/figures/nofActiveSoldier.h
+++ b/src/figures/nofActiveSoldier.h
@@ -151,6 +151,10 @@ class nofActiveSoldier : public nofSoldier
         SoldierState GetState() const { return state; }
         /// Sets the home (building) to NULL e.g. after the soldier was removed from the homes list but it was not destroyed
         void ResetHome() { building = NULL; }
+        void FightVsDefenderStarted() { state = STATE_ATTACKING_FIGHTINGVSDEFENDER; }
+
+        // For debugging
+        const nofActiveSoldier* GetEnemy() const { return enemy; }
 };
 
 #endif // !NOF_ACTIVESOLDIER_H_

--- a/src/figures/nofAggressiveDefender.h
+++ b/src/figures/nofAggressiveDefender.h
@@ -25,17 +25,10 @@ class nofPassiveSoldier;
 /// Aggressiv-verteidigender Soldat (jemand, der den Angreifer auf offenem Feld entgegenläuft)
 class nofAggressiveDefender : public nofActiveSoldier
 {
-        // Unser Feind-Freund ;)
-        friend class nofAttacker;
-
-    private:
-
         /// Soldaten, der er entgegenrennen soll
         nofAttacker* attacker;
         /// Militärgebäude, das angegriffen wird
         nobBaseMilitary* attacked_goal;
-
-    private:
 
         /// wenn man gelaufen ist
         void Walked();
@@ -59,8 +52,6 @@ class nofAggressiveDefender : public nofActiveSoldier
         nofAggressiveDefender(SerializedGameData& sgd, const unsigned obj_id);
 
         ~nofAggressiveDefender();
-
-
 
         /// Aufräummethoden
     protected:  void Destroy_nofAggressiveDefender();
@@ -95,6 +86,8 @@ class nofAggressiveDefender : public nofActiveSoldier
         /// Mission muss also abgebrochen werden
         void NeedForHomeDefence();
 
+        //Debugging
+        const nofAttacker* GetAttacker() const { return attacker; }
 };
 
 

--- a/src/figures/nofAggressiveDefender.h
+++ b/src/figures/nofAggressiveDefender.h
@@ -41,6 +41,8 @@ class nofAggressiveDefender : public nofActiveSoldier
         /// Sagt den verschiedenen Zielen Bescheid, dass wir doch nicht mehr kommen können
         void InformTargetsAboutCancelling();
 
+        void CancelAtAttacker();
+
         /// The derived classes regain control after a fight of nofActiveSoldier
         void FreeFightEnded();
 

--- a/src/figures/nofAttacker.cpp
+++ b/src/figures/nofAttacker.cpp
@@ -1007,6 +1007,12 @@ void nofAttacker::InformTargetsAboutCancelling()
 
 void nofAttacker::RemoveFromAttackedGoal()
 {
+    // If state == STATE_ATTACKING_FIGHTINGVSDEFENDER then we probably just lost the fight against the defender, otherwise there must either be no defender or he is not waiting for us
+    RTTR_Assert(state == STATE_ATTACKING_FIGHTINGVSDEFENDER || !attacked_goal->GetDefender() ||
+        (attacked_goal->GetDefender()->GetAttacker() != this && attacked_goal->GetDefender()->GetEnemy() != this));
+    // No defender should be chasing us at this point
+    for(std::list<nofAggressiveDefender*>::const_iterator it = attacked_goal->GetAggresiveDefenders().begin(); it != attacked_goal->GetAggresiveDefenders().end(); ++it)
+        RTTR_Assert((*it)->GetAttacker() != this);
     attacked_goal->UnlinkAggressor(this);
     attacked_goal = NULL;
 }

--- a/src/figures/nofAttacker.h
+++ b/src/figures/nofAttacker.h
@@ -34,6 +34,8 @@ class nofAttacker : public nofActiveSoldier
         /// Soll er von nem Verteidiger gejagt werden? (wenn nicht wurde er schon gejagt oder er soll
         /// wegen den Militäreinstellungen nicht gejagt werden
         bool should_haunted;
+        /// Defender who is currently chasing after this soldier
+        nofAggressiveDefender* huntingDefender;
         /// In welchem Radius steht der Soldat, wenn er um eine Fahne herum wartet?
         unsigned short radius;
         /// Nach einer bestimmten Zeit, in der der Angreifer an der Flagge des Gebäudes steht, blockt er den Weg
@@ -65,6 +67,7 @@ class nofAttacker : public nofActiveSoldier
 
         /// Für Schiffsangreifer: Sagt dem Schiff Bescheid, dass wir nicht mehr kommen
         void CancelAtShip();
+        void CancelAtHuntingDefender();
         /// Behandelt das Laufen zurück zum Schiff
         void HandleState_SeaAttack_ReturnToShip();
 
@@ -80,8 +83,7 @@ class nofAttacker : public nofActiveSoldier
         /// Normaler Konstruktor für Angreifer
         nofAttacker(nofPassiveSoldier* other, nobBaseMilitary* const attacked_goal);
         /// Konstruktor für Schiffs-Angreifer, die zuerst einmal zu einem Hafen laufen müssen
-        nofAttacker(nofPassiveSoldier* other, nobBaseMilitary* const attacked_goal,
-                    const nobHarborBuilding* const harbor);
+        nofAttacker(nofPassiveSoldier* other, nobBaseMilitary* const attacked_goal, const nobHarborBuilding* const harbor);
         nofAttacker(SerializedGameData& sgd, const unsigned obj_id);
         ~nofAttacker();
 
@@ -94,6 +96,7 @@ class nofAttacker : public nofActiveSoldier
     public:     void Serialize(SerializedGameData& sgd) const { Serialize_nofAttacker(sgd); }
 
         GO_Type GetGOT() const { return GOT_NOF_ATTACKER; }
+        const nofAggressiveDefender* GetHuntingDefender() const { return huntingDefender; }
 
         void HandleDerivedEvent(const unsigned int id);
         /// Blockt der Angreifer noch?

--- a/src/figures/nofAttacker.h
+++ b/src/figures/nofAttacker.h
@@ -29,12 +29,6 @@ class noShip;
 /// Angreifender Soldat
 class nofAttacker : public nofActiveSoldier
 {
-        // Unsere Feind-Freunde ;)
-        friend class nofAggressiveDefender;
-        friend class nofDefender;
-
-    private:
-
         /// Building which is attacked by the soldier
         nobBaseMilitary* attacked_goal;
         /// Soll er von nem Verteidiger gejagt werden? (wenn nicht wurde er schon gejagt oder er soll
@@ -52,8 +46,6 @@ class nofAttacker : public nofActiveSoldier
         /// ggf. wieder nach Hause fahren kann
         MapPoint shipPos;
         unsigned ship_obj_id;
-
-    private:
 
         /// wenn man gelaufen ist
         void Walked();
@@ -167,8 +159,6 @@ class nofAttacker : public nofActiveSoldier
         bool IsSeaAttackCompleted() const { return (state != STATE_SEAATTACKING_ONSHIP); }
         /// Bricht einen Seeangriff ab
         void CancelSeaAttack();
-
-
 };
 
 

--- a/src/figures/nofDefender.cpp
+++ b/src/figures/nofDefender.cpp
@@ -76,7 +76,7 @@ void nofDefender::Walked()
             // Mit Angreifer den Kampf beginnen
             gwg->AddFigure(new noFighting(attacker, this), pos);
             state = STATE_FIGHTING;
-            attacker->state = STATE_ATTACKING_FIGHTINGVSDEFENDER;
+            attacker->FightVsDefenderStarted();
 
         } break;
         case STATE_DEFENDING_WALKINGFROM:

--- a/src/figures/nofDefender.h
+++ b/src/figures/nofDefender.h
@@ -25,15 +25,8 @@ class nofPassiveSoldier;
 /// Verteidiger, der rauskommt, wenn ein Angreifer an die Flagge kommt
 class nofDefender : public nofActiveSoldier
 {
-        // Unser Feind-Freund ;)
-        friend class nofAttacker;
-
-    private:
-
         /// angreifender Soldat an der Flagge
         nofAttacker* attacker;
-
-    private:
 
         /// wenn man gelaufen ist
         void Walked();
@@ -79,7 +72,8 @@ class nofDefender : public nofActiveSoldier
         /// Informs the defender that a fight between him and an attacker has started
         void FightStarted() { state = STATE_FIGHTING; }
 
-
+        //Debugging
+        const nofAttacker* GetAttacker() const { return attacker; }
 };
 
 

--- a/src/nodeObjs/noRoadNode.cpp
+++ b/src/nodeObjs/noRoadNode.cpp
@@ -68,7 +68,7 @@ void noRoadNode::Serialize_noRoadNode(SerializedGameData& sgd) const
         // -> RoadSegment will set these later
         for (unsigned i = 0; i < 6; ++i)
         {
-            sgd.PushObject(NULL, true);
+            sgd.PushObject(static_cast<GameObject*>(NULL), true);
         }
     }
     else


### PR DESCRIPTION
**DO NOT MERGE**
Please just tell me, if this is ready to merge. As this changes the savegame version and I have 2 other changes that do that too I want to merge all 3 of them at once, so users won't loose their savegames multiple times.

This fixes #355:   
Bug is found. The reason for this is that the system for the AggressiveDefender is completely broken. nofAggressiveDefender::AttackerLost()/nofAttacker::AggressiveDefenderLost should have been used to unlink an attacker from an AggressiveDefender and nofAttacker::LetsFight should have been used to link them. However this is not the case and AttackerLost is never called by anyone.
Bug was introduced here (before git history): http://bazaar.launchpad.net/~flamefire/s25rttr/s25rttr/revision/6559
Normally the defender would have been stored directly in the enemy member.

As far as I can see the only thing missing here is a member for the AggressiveDefender the attacker is hunted by and the corresponding link/unlink calls. The savegame cannot be rescued by this as it will be invalidated by that change and already contains the bug (attacker is walking home, still chased by the defender ^^). However this bug will then be completely avoided.

The conditional nature of the bug stems from the fact, that the memory of the deleted attacker may or may not be overwritten. If it isn't, the attacker still seems to be "valid" and "ready to fight" and will be chased further. If it is, the attacker will be found as "busy" and we stop chasing him.

Fix is implemented as discussed in #355:
>Yep, each defender should pursuit one attacker. When other enemies get into close range with a defender, they are also getting engaged. Once the hunted attacker is killed (or unavailable for fighting when being close), the defender returns home. While returning home the defender still engages enemies when getting close to them.

I also added some more checks to detect invalid states