### PR TITLE
Player switch

### DIFF
--- a/src/GameClient.h
+++ b/src/GameClient.h
@@ -150,11 +150,11 @@ class GameClient : public Singleton<GameClient, SingletonPolicies::WithLongevity
 
         void SkipGF(unsigned int gf);
 
-        /// Wechselt den aktuellen Spieler (nur zu Debugzwecken !!)
-        void ChangePlayer(const unsigned char old_id, const unsigned char new_id);
+        /// Changes the player ingame (for replay or debugging)
+        void ChangePlayerIngame(const unsigned char player1, const unsigned char player2);
+        /// Sends a request to swap places with the requested player. Only for debugging!
+        void RequestSwapToPlayer(const unsigned char newId);
 
-        /// Wechselt den aktuellen Spieler im Replaymodus
-        void ChangeReplayPlayer(const unsigned new_id);
         /// Laggt ein bestimmter Spieler gerade?
         bool IsLagging(const unsigned int id) { return GetPlayer(id).is_lagging; }
         /// Spiel pausiert?
@@ -162,7 +162,7 @@ class GameClient : public Singleton<GameClient, SingletonPolicies::WithLongevity
         /// Schreibt Header der Save-Datei
         unsigned SaveToFile(const std::string& filename);
         /// Visuelle Einstellungen aus den richtigen ableiten
-        void GetVisualSettings();
+        void ResetVisualSettings();
 
         /// Schreibt ggf. Pathfinding-Results in das Replay, falls erforderlich
         void AddPathfindingResult(const unsigned char dir, const unsigned* const length, const MapPoint* const next_harbor);

--- a/src/GameClientGF_Game.cpp
+++ b/src/GameClientGF_Game.cpp
@@ -26,10 +26,6 @@ void GameClient::ExecuteNWF()
 {
     // Geschickte Network Commands der Spieler ausführen und ggf. im Replay aufzeichnen
 
-    // Bei evtl. Spielerwechsel die IDs speichern, die "gewechselt" werden sollen
-    gw->switchedPlayers.oldPlayer = 0xFF;
-    gw->switchedPlayers.newPlayer = 0xFF;
-
     int checksum = RANDOM.GetCurrentRandomValue();
 
     for(unsigned char i = 0; i < players.getCount(); ++i)
@@ -57,16 +53,9 @@ void GameClient::ExecuteNWF()
         }
     }
 
-    // Evtl Spieler wechseln?
-    if(gw->switchedPlayers.newPlayer != 0xFF)
-    {
-        if(gw->switchedPlayers.oldPlayer == playerId_)
-            gameCommands_.clear(); // If we were switched, don't execute our GCs
-        ChangePlayer(gw->switchedPlayers.oldPlayer, gw->switchedPlayers.newPlayer);
-    }
-
     // Send GC message for this NWF
     send_queue.push(new GameMessage_GameCommand(playerId_, checksum, gameCommands_));
+    LOG.write("CLIENT >>> GC %u\n", playerId_);
 
     // alles gesendet --> Liste löschen
     gameCommands_.clear();

--- a/src/GameClientPlayer.cpp
+++ b/src/GameClientPlayer.cpp
@@ -458,16 +458,6 @@ void GameClientPlayer::Deserialize(SerializedGameData& sgd)
     emergency = sgd.PopBool();
 }
 
-void GameClientPlayer::SwapPlayer(GameClientPlayer& two)
-{
-    GamePlayerInfo::SwapPlayer(two);
-
-    using std::swap;
-
-    swap(this->is_lagging, two.is_lagging);
-    swap(this->gc_queue, two.gc_queue);
-}
-
 nobBaseWarehouse* GameClientPlayer::FindWarehouse(const noRoadNode& start, bool (*IsWarehouseGood)(nobBaseWarehouse*, const void*),
         const RoadSegment* const forbidden, const bool to_wh, const void* param, const bool use_boat_roads, unsigned* const length, bool record) const
 {

--- a/src/GameClientPlayer.h
+++ b/src/GameClientPlayer.h
@@ -201,9 +201,6 @@ class GameClientPlayer : public GamePlayerInfo
         // Deserialisieren
         void Deserialize(SerializedGameData& sgd);
 
-        /// Tauscht Spieler
-        void SwapPlayer(GameClientPlayer& two);
-
         /// Setzt GameWorld
         void SetGameWorldPointer(GameWorldGame* const gwg) { this->gwg = gwg; }
 

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -43,7 +43,6 @@ GameCommand* GameCommand::Deserialize(const Type gst, Serializer& ser)
     case CALLSCOUT: return new CallScout(ser);
     case ATTACK: return new Attack(ser);
     case SEAATTACK: return new SeaAttack(ser);
-    case SWITCHPLAYER: return new SwitchPlayer(ser);
     case TOGGLECOINS: return new ToggleCoins(ser);
     case TOGGLEPRODUCTION: return new ToggleProduction(ser);
     case CHANGEINVENTORYSETTING: return new ChangeInventorySetting(ser);

--- a/src/GameCommand.h
+++ b/src/GameCommand.h
@@ -59,7 +59,7 @@ namespace gc
         CALLGEOLOGIST,
         CALLSCOUT,
         ATTACK,
-        SWITCHPLAYER,
+        UNUSED,
         TOGGLECOINS,
         TOGGLEPRODUCTION,
         CHANGEINVENTORYSETTING,

--- a/src/GameCommands.cpp
+++ b/src/GameCommands.cpp
@@ -122,12 +122,6 @@ namespace gc{
         gwg.AttackViaSea(playerid, pt_, soldiers_count, strong_soldiers);
     }
 
-    void SwitchPlayer::Execute(GameWorldGame& gwg, GameClientPlayer& player, const unsigned char playerid)
-    {
-        gwg.switchedPlayers.oldPlayer = playerid;
-        gwg.switchedPlayers.newPlayer = new_player_id;
-    }
-
     void ToggleCoins::Execute(GameWorldGame& gwg, GameClientPlayer& player, const unsigned char playerid)
     {
         if(gwg.GetNO(pt_)->GetGOT() == GOT_NOB_MILITARY)

--- a/src/GameCommands.h
+++ b/src/GameCommands.h
@@ -475,31 +475,6 @@ namespace gc{
             void Execute(GameWorldGame& gwg, GameClientPlayer& player, const unsigned char playerid);
     };
 
-/// Spielerwechsel
-    class SwitchPlayer : public GameCommand
-    {
-        GC_FRIEND_DECL;
-            friend class GameServer;
-            /// ID des Spielers, zu den hingewechselt werden soll
-            const unsigned new_player_id;
-
-        protected:
-            SwitchPlayer(const unsigned char new_player_id)
-                : GameCommand(SWITCHPLAYER), new_player_id(new_player_id) {}
-            SwitchPlayer(Serializer& ser)
-                : GameCommand(SWITCHPLAYER), new_player_id(ser.PopUnsignedChar()) {}
-        public:
-            virtual void Serialize(Serializer& ser) const
-            {
-                ser.PushUnsignedChar(new_player_id);
-            }
-
-            unsigned GetNewPlayerId() const { return new_player_id; }
-
-            /// Führt das GameCommand aus
-            void Execute(GameWorldGame& gwg, GameClientPlayer& player, const unsigned char playerid);
-    };
-
 /// Goldzufuhr in einem Gebäude stoppen/erlauben
     class ToggleCoins : public Coords
     {

--- a/src/GamePlayerInfo.cpp
+++ b/src/GamePlayerInfo.cpp
@@ -99,7 +99,7 @@ void GamePlayerInfo::serialize(Serializer& ser) const
     ser.PushBool(ready);
 }
 
-void GamePlayerInfo::SwapPlayer(GamePlayerInfo& two)
+void GamePlayerInfo::SwapInfo(GamePlayerInfo& two)
 {
     using std::swap;
     swap(ps, two.ps);

--- a/src/GamePlayerInfo.h
+++ b/src/GamePlayerInfo.h
@@ -81,9 +81,8 @@ class GamePlayerInfo
 
         unsigned getPlayerID() const { return playerid; }
 
-    protected:
         /// Wechselt Spieler
-        void SwapPlayer(GamePlayerInfo& two);
+        void SwapInfo(GamePlayerInfo& two);
 
     protected:
         /// Player-ID

--- a/src/GameReplay.cpp
+++ b/src/GameReplay.cpp
@@ -26,7 +26,7 @@
 /// Kleine Signatur am Anfang "RTTRRP", die ein gültiges S25 RTTR Replay kennzeichnet
 const char Replay::REPLAY_SIGNATURE[6] = {'R', 'T', 'T', 'R', 'R', 'P'};
 /// Version des Replay-Formates
-const unsigned short Replay::REPLAY_VERSION = 26;
+const unsigned short Replay::REPLAY_VERSION = 27;
 
 ///////////////////////////////////////////////////////////////////////////////
 /**

--- a/src/GameSavegame.cpp
+++ b/src/GameSavegame.cpp
@@ -26,7 +26,7 @@
 /// Kleine Signatur am Anfang "RTTRSAVE", die ein gültiges S25 RTTR Savegame kennzeichnet
 const char Savegame::SAVE_SIGNATURE[8] = {'R', 'T', 'T', 'R', 'S', 'A', 'V', 'E'};
 /// Version des Savegame-Formates
-const unsigned short Savegame::SAVE_VERSION = 28;
+const unsigned short Savegame::SAVE_VERSION = 29;
 
 ///////////////////////////////////////////////////////////////////////////////
 /**

--- a/src/GameServer.h
+++ b/src/GameServer.h
@@ -69,9 +69,6 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
         void TogglePlayerState(unsigned char client);
         void ChangeGlobalGameSettings(const GlobalGameSettings& ggs);
 
-        /// Lässt einen Spieler wechseln (nur zu Debugzwecken)
-        void ChangePlayer(const unsigned char old_id, const unsigned char new_id);
-
         /// Tauscht Spieler(positionen) bei Savegames in dskHostGame
         void SwapPlayer(const unsigned char player1, const unsigned char player2);
 
@@ -82,6 +79,9 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
         unsigned short GetPort() const { return serverconfig.port; }
 
     protected:
+
+        /// Lässt einen Spieler wechseln (nur zu Debugzwecken)
+        void ChangePlayer(const unsigned char old_id, const unsigned char new_id);
 
         void SendToAll(const GameMessage& msg);
         void KickPlayer(unsigned char playerid, unsigned char cause, unsigned short param);
@@ -112,6 +112,7 @@ class GameServer : public Singleton<GameServer, SingletonPolicies::WithLongevity
         void OnNMSPlayerToggleTeam(const GameMessage_Player_Toggle_Team& msg) override;
         void OnNMSPlayerToggleColor(const GameMessage_Player_Toggle_Color& msg) override;
         void OnNMSPlayerReady(const GameMessage_Player_Ready& msg) override;
+        void OnNMSPlayerSwap(const GameMessage_Player_Swap& msg) override;
         void OnNMSMapChecksum(const GameMessage_Map_Checksum& msg) override;
         void OnNMSGameCommand(const GameMessage_GameCommand& msg) override;
         void OnNMSServerSpeed(const GameMessage_Server_Speed& msg) override;

--- a/src/GameServerPlayer.cpp
+++ b/src/GameServerPlayer.cpp
@@ -134,10 +134,10 @@ unsigned GameServerPlayer::GetTimeOut() const
 }
 
 /// Tauscht Spieler
-void GameServerPlayer::SwapPlayer(GameServerPlayer& two)
+void GameServerPlayer::SwapInfo(GameServerPlayer& two)
 {
     using std::swap;
-    GamePlayerInfo::SwapPlayer(two);
+    GamePlayerInfo::SwapInfo(two);
 
     swap(this->connecttime, two.connecttime);
     swap(this->last_command_timeout, two.last_command_timeout);

--- a/src/GameServerPlayer.h
+++ b/src/GameServerPlayer.h
@@ -45,7 +45,7 @@ class GameServerPlayer : public GamePlayerInfo
         void clear();
 
         /// Tauscht Spieler
-        void SwapPlayer(GameServerPlayer& two);
+        void SwapInfo(GameServerPlayer& two);
 
         /// Spieler laggt
         void Lagging();

--- a/src/GameWorldGame.h
+++ b/src/GameWorldGame.h
@@ -75,11 +75,6 @@ public:
 
     virtual ~GameWorldGame();
 
-    /// Set by the playerSwitch GC
-    struct{
-        unsigned char oldPlayer, newPlayer;
-    } switchedPlayers;
-
     /// Stellt anderen Spielern/Spielobjekten das Game-GUI-Interface zur Verfüung
     inline GameInterface* GetGameInterface() const { return gi; }
 

--- a/src/controls/ctrlTable.cpp
+++ b/src/controls/ctrlTable.cpp
@@ -337,9 +337,6 @@ bool ctrlTable::Msg_LeftDown(const MouseCoords& mc)
         SetSelection((mc.y - header_height - GetY()) / font->getHeight() + GetCtrl<ctrlScrollBar>(0)->GetPos());
         if(parent_)
             parent_->Msg_TableLeftButton(this->id_, row_l_selection);
-        // Doppelklick? Dann noch einen extra Eventhandler aufrufen
-        if(mc.dbl_click && parent_)
-            parent_->Msg_TableChooseItem(this->id_, row_l_selection);
 
         return true;
     }
@@ -413,7 +410,15 @@ bool ctrlTable::Msg_WheelDown(const MouseCoords& mc)
  */
 bool ctrlTable::Msg_LeftUp(const MouseCoords& mc)
 {
-    return RelayMouseMessage(&Window::Msg_LeftUp, mc);
+    if(Coll(mc.x, mc.y, GetX(), GetY() + header_height, width_ - 20, height_ - header_height))
+    {
+        if(mc.dbl_click && parent_)
+            parent_->Msg_TableChooseItem(this->id_, row_l_selection);
+
+        return true;
+    }
+    else
+        return RelayMouseMessage(&Window::Msg_LeftUp, mc);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/factories/GameCommandFactory.cpp
+++ b/src/factories/GameCommandFactory.cpp
@@ -133,12 +133,6 @@ bool GameCommandFactory<T_Handler>::SeaAttack(const MapPoint pt, const unsigned 
 }
 
 template<class T_Handler>
-bool GameCommandFactory<T_Handler>::SwitchPlayer(const unsigned char new_player_id)
-{
-    return AddGC_Virt( new gc::SwitchPlayer(new_player_id) );
-}
-
-template<class T_Handler>
 bool GameCommandFactory<T_Handler>::ToggleCoins(const MapPoint pt)
 {
     return AddGC_Virt( new gc::ToggleCoins(pt) );

--- a/src/factories/GameCommandFactory.h
+++ b/src/factories/GameCommandFactory.h
@@ -68,7 +68,6 @@ public:
     bool Attack(const MapPoint pt, const unsigned soldiers_count, const bool strong_soldiers);
     /// Sea-Attacks an enemy building
     bool SeaAttack(const MapPoint pt, const unsigned soldiers_count, const bool strong_soldiers);
-    bool SwitchPlayer(const unsigned char new_player_id);
     /// Toggles coin delivery on/off for a military building
     bool ToggleCoins(const MapPoint pt);
     /// Stops/starts production of a producer


### PR DESCRIPTION
**DO NOT MERGE**
I'll merge this with #370 and #360 as those all change the savegame version

This fixes #357 

It basically replaces the gamecommand for switching with a regular message. As ordering of messages is consistent we know, that after we received the swap from the server all future messages are already swapped. This way no GC-Messages get confused and freeze is fixed.