### PR TITLE
Utf8 improvements

### DIFF
--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -1097,7 +1097,7 @@ inline void GameClient::OnNMSMapData(const GameMessage_Map_Data& msg)
                 for(unsigned i = 0; i < header->getPlayer(); ++i)
                     players.push_back(GameClientPlayer(i));
 
-                mapinfo.title = header->getName();
+                mapinfo.title = cvStringToUTF8(header->getName());
 
             } break;
             case MAPTYPE_SAVEGAME:

--- a/src/GameReplay.cpp
+++ b/src/GameReplay.cpp
@@ -206,7 +206,7 @@ bool Replay::LoadHeader(const std::string& filename, const bool load_extended_he
             } break;
         }
 
-        file.ReadShortString(map_name);
+        map_name = file.ReadShortString();
 
         // Try to open precalculated pathfinding results
         pathfinding_results = pf_file.Open(filename + "_res", OFM_READ);
@@ -361,7 +361,7 @@ void Replay::ReadChatCommand(unsigned char* player, unsigned char*   dest, std::
 {
     *player = file.ReadUnsignedChar();
     *dest = file.ReadUnsignedChar();
-    file.ReadLongString(str);
+    str = file.ReadLongString();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/GameSavedFile.cpp
+++ b/src/GameSavedFile.cpp
@@ -134,7 +134,7 @@ void SavedFile::ReadPlayerData(BinaryFile& file)
 
         if(it->ps != PS_LOCKED)
         {
-            file.ReadShortString(it->name);
+            it->name = file.ReadShortString();
             it->nation = Nation(file.ReadUnsignedChar());
             it->color = file.ReadUnsignedChar();
             it->team = file.ReadUnsignedChar();

--- a/src/GameSavegame.cpp
+++ b/src/GameSavegame.cpp
@@ -149,7 +149,7 @@ bool Savegame::Load(BinaryFile& file, const bool load_players, const bool load_s
     save_time = libendian::ConvertEndianess<false>::toNative(save_time);
 
     // Map-Name
-    file.ReadShortString(map_name);
+    map_name = file.ReadShortString();
 
     // Anzahl Spieler
     SetPlayerCount(file.ReadUnsignedChar());

--- a/src/GameServer.cpp
+++ b/src/GameServer.cpp
@@ -54,6 +54,7 @@
 #include "libsiedler2/src/prototypen.h"
 #include "libsiedler2/src/ArchivItem_Map_Header.h"
 #include "libutil/src/colors.h"
+#include "libutil/src/ucString.h"
 
 #include "files.h"
 #include <boost/filesystem.hpp>
@@ -161,7 +162,7 @@ bool GameServer::TryToStart(const CreateServerInfo& csi, const std::string& map_
             RTTR_Assert(header);
 
             serverconfig.playercount = header->getPlayer();
-            mapinfo.title = header->getName();
+            mapinfo.title = cvStringToUTF8(header->getName());
         } break;
         // Gespeichertes Spiel
         case MAPTYPE_SAVEGAME:

--- a/src/controls/ctrlEdit.cpp
+++ b/src/controls/ctrlEdit.cpp
@@ -24,6 +24,7 @@
 #include "ogl/glArchivItem_Font.h"
 #include "driver/src/MouseCoords.h"
 #include "CollisionDetection.h"
+#include "helpers/converters.h"
 #include <sstream>
 
 // Include last!
@@ -68,31 +69,27 @@ void ctrlEdit::SetText(const std::string& text)
     viewStart_ = 0;
 
     text_.clear();
+    ucString tmp = cvUTF8ToUnicode(text);
 
-    for(unsigned i = 0; i < unsigned(text.length()); ++i)
-        AddChar(text.at(i));
+    for(ucString::const_iterator it = tmp.begin(); it != tmp.end(); ++it)
+        AddChar(*it);
 }
 
 void ctrlEdit::SetText(const unsigned int text)
 {
-    std::stringstream textt;
-    textt << text;
-
     cursorPos_ = 0;
     viewStart_ = 0;
 
     text_.clear();
 
-    for(unsigned i = 0; i < unsigned(textt.str().length()); ++i)
-        AddChar(textt.str().at(i));
+    std::string tmp = helpers::toString(text);
+    for(std::string::const_iterator it = tmp.begin(); it != tmp.end(); ++it)
+        AddChar(*it);
 }
 
 std::string ctrlEdit::GetText() const
 {
-    std::string t;
-    for(unsigned int i = 0; i < text_.length(); ++i)
-        t += font_->Unicode_to_Utf8(text_[i]);
-    return t;
+    return cvUnicodeToUTF8(text_);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -108,11 +105,11 @@ bool ctrlEdit::Draw_()
     // Box malen
     Draw3D(GetX(), GetY(), width_, height_, texColor_, 2);
 
-    std::wstring dtext;
+    ucString dtext;
 
     // Text zeichnen
     if(isPassword_)
-        dtext = std::wstring(text_.length(), '*');
+        dtext = ucString(text_.length(), '*');
     else
         dtext = text_;
 

--- a/src/controls/ctrlEdit.h
+++ b/src/controls/ctrlEdit.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Window.h"
+#include "libutil/src/ucString.h"
 class MouseCoords;
 class glArchivItem_Font;
 struct KeyEvent;
@@ -34,7 +35,6 @@ class ctrlEdit : public Window
         void SetText(const unsigned int text);
 
         std::string GetText() const;
-        const std::wstring& GetWText() const { return text_; }
         void SetFocus(bool focus = true) { newFocus_ = focus; }
         void SetDisabled(bool disabled = true) { this->isDisabled_ = disabled; }
         void SetNotify(bool notify = true) { this->notify_ = notify; }
@@ -67,7 +67,7 @@ class ctrlEdit : public Window
         bool newFocus_;
         bool notify_;
 
-        std::wstring text_;
+        ucString text_;
         unsigned cursorPos_;
         unsigned viewStart_;
 

--- a/src/desktops/dskDirectIP.cpp
+++ b/src/desktops/dskDirectIP.cpp
@@ -50,7 +50,7 @@ dskDirectIP::dskDirectIP() : Desktop(LOADER.GetImageN("menu", 0))
     AddText(1, 400, 600, _("http://www.siedler25.org"), COLOR_GREEN, glArchivItem_Font::DF_CENTER | glArchivItem_Font::DF_BOTTOM, NormalFont);
 
     // Copyright
-    AddVarText(2, 800, 600, _("\xA9 2005 - %s Settlers Freaks"), COLOR_YELLOW, glArchivItem_Font::DF_RIGHT | glArchivItem_Font::DF_BOTTOM, NormalFont, 1, GetCurrentYear());
+    AddVarText(2, 800, 600, _("© 2005 - %s Settlers Freaks"), COLOR_YELLOW, glArchivItem_Font::DF_RIGHT | glArchivItem_Font::DF_BOTTOM, NormalFont, 1, GetCurrentYear());
 
     AddTextButton(3, 115, 180, 220, 22, TC_GREEN2, _("Create Game"), NormalFont);
     AddTextButton(4, 115, 210, 220, 22, TC_GREEN2, _("Join Game"), NormalFont);

--- a/src/desktops/dskSelectMap.cpp
+++ b/src/desktops/dskSelectMap.cpp
@@ -46,6 +46,7 @@
 #include "ogl/glArchivItem_Map.h"
 #include "libsiedler2/src/ArchivItem_Map_Header.h"
 #include "libsiedler2/src/prototypen.h"
+#include "libutil/src/ucString.h"
 
 // Include last!
 #include "DebugNew.h" // IWYU pragma: keep
@@ -208,7 +209,7 @@ void dskSelectMap::Msg_TableSelectItem(const unsigned int ctrl_id, const unsigne
                         preview->SetMap(map);
 
                         ctrlText* text = GetCtrl<ctrlText>(12);
-                        text->SetText(std::string(map->getHeader().getName()) );
+                        text->SetText(cvStringToUTF8(map->getHeader().getName()) );
                         text->Move(preview->GetX(true) + preview->GetWidth() + 10, text->GetY(true), true);
 
                         text = GetCtrl<ctrlText>(13);
@@ -406,7 +407,10 @@ void dskSelectMap::FillTable(const std::vector<std::string>& files)
             _("Winter world")
         };
 
-        table->AddRow(0, header->getName().c_str(), header->getAuthor().c_str(), players, landscapes[header->getGfxSet()].c_str(), size, it->c_str());
+        std::string name = cvStringToUTF8(header->getName());
+        std::string author = cvStringToUTF8(header->getAuthor());
+
+        table->AddRow(0, name.c_str(), author.c_str(), players, landscapes[header->getGfxSet()].c_str(), size, it->c_str());
     }
 }
 

--- a/src/ingameWindows/iwSave.cpp
+++ b/src/ingameWindows/iwSave.cpp
@@ -134,10 +134,11 @@ void iwSaveLoad::RefreshTable()
         RTTR_Assert(fileName.has_extension());
         fileName.replace_extension();
 
+        std::string fileNameStr = cvWideStringToUTF8(fileName.wstring());
         std::string startGF = helpers::toString(save.start_gf);
 
         // Und das Zeug zur Tabelle hinzufügen
-        GetCtrl<ctrlTable>(0)->AddRow(0, fileName.string().c_str(), save.map_name.c_str(), dateStr.c_str(), startGF.c_str(), it->c_str());
+        GetCtrl<ctrlTable>(0)->AddRow(0, fileNameStr.c_str(), save.map_name.c_str(), dateStr.c_str(), startGF.c_str(), it->c_str());
     }
 
     // Nach Zeit Sortieren

--- a/src/ogl/glArchivItem_Font.cpp
+++ b/src/ogl/glArchivItem_Font.cpp
@@ -467,11 +467,11 @@ glArchivItem_Font::WrapInfo glArchivItem_Font::GetWrapInfo(const std::string& te
     wi.positions.push_back(0);
 
     utf8Iterator it(text.begin(), text.begin(), text.end());
-    utf8Iterator itEnd(text.begin(), text.begin(), text.end());
+    utf8Iterator itEnd(text.end(), text.begin(), text.end());
     utf8Iterator itWordStart = it;
 
     uint32_t curChar = 1;
-    for(; curChar != 0; ++it)
+    for(;; ++it)
     {
         curChar = (it != itEnd) ? *it : 0;
         // Word ended
@@ -549,7 +549,8 @@ glArchivItem_Font::WrapInfo glArchivItem_Font::GetWrapInfo(const std::string& te
                 word_width = 0;
                 line_width = 0;
                 wi.positions.push_back(static_cast<unsigned>(itWordStart.base() - text.begin()));
-            }
+            } else if(curChar == 0)
+                break;
         }
         else
         {

--- a/src/ogl/glArchivItem_Font.cpp
+++ b/src/ogl/glArchivItem_Font.cpp
@@ -39,6 +39,57 @@
 
 typedef utf8::iterator<std::string::const_iterator> utf8Iterator;
 
+
+template<typename T>
+struct GetNextCharAndIncIt;
+
+template<>
+struct GetNextCharAndIncIt<uint32_t>
+{
+    template<class T_Iterator>
+    uint32_t operator()(T_Iterator& it, const T_Iterator& itEnd) const
+    {
+        return *it++;
+    }
+};
+
+template<>
+struct GetNextCharAndIncIt<char>
+{
+    template<class T_Iterator>
+    uint32_t operator()(T_Iterator& it, const T_Iterator& itEnd) const
+    {
+        return utf8::next(it, itEnd);
+    }
+};
+
+template<class T_Iterator>
+struct Distance
+{
+    size_t operator()(const T_Iterator& first, const T_Iterator& last) const
+    {
+        return std::distance(first, last);
+    }
+};
+
+template<class T_Iterator>
+struct Distance<utf8::iterator<T_Iterator> >
+{
+    size_t operator()(const utf8::iterator<T_Iterator>& first, const utf8::iterator<T_Iterator>& last) const
+    {
+        return std::distance(first.base(), last.base());
+    }
+};
+
+template<class T_Iterator>
+T_Iterator nextIt(T_Iterator it, typename std::iterator_traits<T_Iterator>::difference_type n = 1)
+{
+    std::advance(it, n);
+    return it;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
 glArchivItem_Font::glArchivItem_Font(const glArchivItem_Font& obj): ArchivItem_Font(obj), utf8_mapping(obj.utf8_mapping)
 {
     if(obj.fontNoOutline)
@@ -295,47 +346,6 @@ void glArchivItem_Font::Draw(short x,
     glDrawArrays(GL_QUADS, 0, texList.size());
 }
 
-template<typename T>
-struct GetNextCharAndIncIt;
-
-template<>
-struct GetNextCharAndIncIt<uint32_t>
-{
-    template<class T_Iterator>
-    uint32_t operator()(T_Iterator& it, const T_Iterator& itEnd) const
-    {
-        return *it++;
-    }
-};
-
-template<>
-struct GetNextCharAndIncIt<char>
-{
-    template<class T_Iterator>
-    uint32_t operator()(T_Iterator& it, const T_Iterator& itEnd) const
-    {
-        return utf8::next(it, itEnd);
-    }
-};
-
-template<class T_Iterator>
-struct Distance
-{
-    size_t operator()(const T_Iterator& first, const T_Iterator& last) const
-    {
-        return std::distance(first, last);
-    }
-};
-
-template<class T_Iterator>
-struct Distance<utf8::iterator<T_Iterator> >
-{
-    size_t operator()(const utf8::iterator<T_Iterator>& first, const utf8::iterator<T_Iterator>& last) const
-    {
-        return std::distance(first.base(), last.base());
-    }
-};
-
 template<class T_Iterator>
 unsigned glArchivItem_Font::getWidthInternal(const T_Iterator& begin, const T_Iterator& end, unsigned maxWidth, unsigned* maxNumChars) const
 {
@@ -427,13 +437,6 @@ std::vector<std::string> glArchivItem_Font::WrapInfo::CreateSingleStrings(const 
     /* Push last part */
     destStrings.push_back(text.substr(curStart));
     return destStrings;
-}
-
-template<class T_Iterator>
-T_Iterator nextIt(T_Iterator it, typename std::iterator_traits<T_Iterator>::difference_type n = 1)
-{
-    std::advance(it, n);
-    return it;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ogl/glArchivItem_Font.h
+++ b/src/ogl/glArchivItem_Font.h
@@ -122,9 +122,9 @@ class glArchivItem_Font : public libsiedler2::ArchivItem_Font
         CharInfo placeHolder; /// Placeholder if glyph is missing
 
         /// Get width of the sequence defined by the begin/end pair of iterators (returning Unicode chars)
-        /// The width will be <= maxWidth. The number of chars (actually codepoints) is returned in maxNumChars (if specified)
+        /// The width will be <= maxWidth. The number of chars (or the iterator distance) is returned in maxNumChars (if specified)
         template<class T_Iterator>
-        unsigned getWidthInternal(T_Iterator begin, const T_Iterator end, unsigned maxWidth = 0xffffffff, unsigned* maxNumChars = NULL) const;
+        unsigned getWidthInternal(const T_Iterator& begin, const T_Iterator& end, unsigned maxWidth = 0xffffffff, unsigned* maxNumChars = NULL) const;
 };
 
 #endif // !GLARCHIVITEM_FONT_H_INCLUDED

--- a/src/ogl/glArchivItem_Font.h
+++ b/src/ogl/glArchivItem_Font.h
@@ -24,6 +24,7 @@
 #include "colors.h"
 #include "ogl/oglIncludes.h"
 #include "helpers/containerUtils.h"
+#include "libutil/src/ucString.h"
 #include <boost/smart_ptr/scoped_ptr.hpp>
 #include <map>
 #include <vector>
@@ -41,11 +42,11 @@ class glArchivItem_Font : public libsiedler2::ArchivItem_Font
         glArchivItem_Font& operator=(const glArchivItem_Font& obj);
 
         /// Zeichnet einen Text.
-        void Draw(short x, short y, const std::wstring& wtext, unsigned int format, unsigned int color = COLOR_WHITE, unsigned short length = 0, unsigned short max = 0xFFFF, const std::wstring& wend = L"...", unsigned short end_length = 0);
-        void Draw(short x, short y, const std::string& text,   unsigned int format, unsigned int color = COLOR_WHITE, unsigned short length = 0, unsigned short max = 0xFFFF, const std::string& end   = "...",  unsigned short end_length = 0);
+        void Draw(short x, short y, const ucString& wtext,   unsigned int format, unsigned int color = COLOR_WHITE, unsigned short length = 0, unsigned short max = 0xFFFF, const ucString& wend = cvWideStringToUnicode(L"..."));
+        void Draw(short x, short y, const std::string& text, unsigned int format, unsigned int color = COLOR_WHITE, unsigned short length = 0, unsigned short max = 0xFFFF, const std::string& end = "...");
 
         /// liefert die Länge einer Zeichenkette.
-        unsigned short getWidth(const std::wstring& text, unsigned length = 0, unsigned max_width = 0xffffffff, unsigned* max = NULL) const;
+        unsigned short getWidth(const ucString& text, unsigned length = 0, unsigned max_width = 0xffffffff, unsigned* max = NULL) const;
         unsigned short getWidth(const std::string& text, unsigned length = 0, unsigned max_width = 0xffffffff, unsigned* max = NULL) const;
         /// liefert die Höhe des Textes ( entspricht @p getDy()+1 )
         inline unsigned short getHeight() const { return dy + 1; }
@@ -101,9 +102,6 @@ class glArchivItem_Font : public libsiedler2::ArchivItem_Font
         inline unsigned int CharWidth(unsigned int c) const { return GetCharInfo(c).width; }
         inline unsigned int CharWidth(CharInfo ci) const { return ci.width; }
 
-        std::string Unicode_to_Utf8(unsigned int c) const;
-        unsigned int Utf8_to_Unicode(const std::string& text, unsigned int& i) const;
-
     private:
 
         struct GL_T2F_V3F_Struct
@@ -115,13 +113,18 @@ class glArchivItem_Font : public libsiedler2::ArchivItem_Font
         void initFont();
         /// liefert das Char-Info eines Zeichens
         const CharInfo& GetCharInfo(unsigned int c) const;
-        void DrawChar(const std::string& text, unsigned int& i, std::vector<GL_T2F_V3F_Struct>& vertices, short& cx, short& cy, float tw, float th);
+        void DrawChar(const unsigned c, std::vector<GL_T2F_V3F_Struct>& vertices, short& cx, short& cy, float tw, float th) const;
 
         boost::scoped_ptr<glArchivItem_Bitmap> fontNoOutline;
         boost::scoped_ptr<glArchivItem_Bitmap> fontWithOutline;
 
         std::map<unsigned int, CharInfo> utf8_mapping;
         CharInfo placeHolder; /// Placeholder if glyph is missing
+
+        /// Get width of the sequence defined by the begin/end pair of iterators (returning Unicode chars)
+        /// The width will be <= maxWidth. The number of chars (actually codepoints) is returned in maxNumChars (if specified)
+        template<class T_Iterator>
+        unsigned getWidthInternal(T_Iterator begin, const T_Iterator end, unsigned maxWidth = 0xffffffff, unsigned* maxNumChars = NULL) const;
 };
 
 #endif // !GLARCHIVITEM_FONT_H_INCLUDED


### PR DESCRIPTION
This introduces a new UTF8 library and detects non-UTF8 strings in Font.draw instead of silently doing "something" with them.
Further fixes include minor refactoring for clarity and speed and also conversion S2 map names and authors to UTF-8 before using.
There were also some small bugs in SplitSingleStrings when text was partially drawn and contained newlines