### PR TITLE
Speed indicator

### DIFF
--- a/src/FramesInfo.h
+++ b/src/FramesInfo.h
@@ -24,7 +24,7 @@ struct FramesInfo
 public:
     FramesInfo();
     void Clear();
-    /// Changes the GF length to GFLengthNEw and adapts the NWF length accordingly
+    /// Changes the GF length to GFLengthNew and adapts the NWF length accordingly
     void ApplyNewGFLength();
 
     /// Current GameFrame (GF) (from start of the game)
@@ -45,13 +45,15 @@ public:
     bool isPaused;
 };
 
-/// Same as FramesInfo but with additional data that is only meaningfull for the server
+/// Same as FramesInfo but with additional data that is only meaningfull for the client
 struct FramesInfoClient: public FramesInfo
 {
 public:
     FramesInfoClient();
     void Clear();
 
+    /// Requested length of GF (for multiple changes between a NWF)
+    unsigned gfLengthReq;
     /// Number of the GF that the server acknoledged -> Run only to this one -> gfNr <= gfNrServer
     unsigned gfNrServer;
     /// GF at wich we should pause the game

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -327,6 +327,7 @@ void GameClient::StartGame(const unsigned int random_init)
 
     // Je nach Geschwindigkeit GF-Länge einstellen
     framesinfo.gf_length = SPEED_GF_LENGTHS[ggs.game_speed];
+    framesinfo.gfLengthReq = framesinfo.gf_length;
 
     // Random-Generator initialisieren
     RANDOM.Init(random_init);
@@ -1185,19 +1186,18 @@ void GameClient::OnNMSServerSpeed(const GameMessage_Server_Speed&  /*msg*/)
 
 void GameClient::IncreaseSpeed()
 {
-    int gf_length = framesinfo.gf_length;
-    if(gf_length > 10)
-        gf_length -= 10;
+    if(framesinfo.gfLengthReq > 10)
+        framesinfo.gfLengthReq -= 10;
 
 #ifndef NDEBUG
-    else if (gf_length == 10)
-        gf_length = 1;
+    else if (framesinfo.gfLengthReq == 10)
+        framesinfo.gfLengthReq = 1;
 #endif
 
     else
-        gf_length = 70;
+        framesinfo.gfLengthReq = 70;
 
-    send_queue.push(new GameMessage_Server_Speed(gf_length));
+    send_queue.push(new GameMessage_Server_Speed(framesinfo.gfLengthReq));
 }
 
 void GameClient::IncreaseReplaySpeed()
@@ -1447,10 +1447,7 @@ void GameClient::ExecuteGameFrame(const bool skipping)
     }
 
     if(framesinfo.isPaused)
-    {
-        // pause machen ;)
-        return;
-    }
+        return; // Pause
 
     if(framesinfo.forcePauseLen)
     {
@@ -1497,6 +1494,7 @@ void GameClient::ExecuteGameFrame(const bool skipping)
                     unsigned oldGfLen = framesinfo.gf_length;
                     int oldNwfLen = framesinfo.nwf_length;
                     framesinfo.ApplyNewGFLength();
+                    framesinfo.gfLengthReq = framesinfo.gf_length;
 
                     // Adjust next confirmation for next NWF (if we have it already)
                     if(framesinfo.gfNrServer != framesinfo.gf_nr)

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -40,6 +40,7 @@
 #include "Loader.h"
 #include "MusicPlayer.h"
 #include "helpers/win32_nanosleep.h" // IWYU pragma: keep
+#include "helpers/converters.h"
 #include "Log.h"
 #include "libutil/src/error.h"
 #include "libutil/src/colors.h"
@@ -209,8 +210,22 @@ bool GameManager::Run()
             }
         }
 		WINDOWMANAGER.Draw();
-		if ((GAMECLIENT.GetState() == GameClient::CS_GAME) && (GAMECLIENT.GetGFLength() < 30))
-			LOADER.GetImageN("io", 164)->Draw(VIDEODRIVER.GetScreenWidth() - 55, 35, 0, 0, 0, 0);
+        if(GAMECLIENT.GetState() == GameClient::CS_GAME)
+        {
+            const int speedStep = (30 - static_cast<int>(GAMECLIENT.GetGFLength())) / 10;
+            if(speedStep != 0)
+            {
+                glArchivItem_Bitmap* runnerImg = LOADER.GetImageN("io", 164);
+                const short x = VIDEODRIVER.GetScreenWidth() - 55;
+                const short y = 35;
+                runnerImg->Draw(x, y, 0, 0, 0, 0);
+                if(speedStep != 1)
+                {
+                    std::string multiplier = helpers::toString(std::abs(speedStep));
+                    SmallFont->Draw(x - runnerImg->getNx() + 19, y - runnerImg->getNy() + 9, multiplier, glArchivItem_Font::DF_LEFT, speedStep > 0 ? COLOR_YELLOW : COLOR_RED);
+                }
+            }
+        }
 
 		DrawCursor();
     } else if(GAMECLIENT.GetGFNumber() % 5000 == 0)

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -39,6 +39,7 @@
 #include "ogl/glArchivItem_Font.h"
 #include "Loader.h"
 #include "MusicPlayer.h"
+#include "gameData/GameConsts.h"
 #include "helpers/win32_nanosleep.h" // IWYU pragma: keep
 #include "helpers/converters.h"
 #include "Log.h"
@@ -212,7 +213,8 @@ bool GameManager::Run()
 		WINDOWMANAGER.Draw();
         if(GAMECLIENT.GetState() == GameClient::CS_GAME)
         {
-            const int speedStep = (30 - static_cast<int>(GAMECLIENT.GetGFLength())) / 10;
+            const int startSpeed = SPEED_GF_LENGTHS[GAMECLIENT.GetGGS().game_speed];
+            const int speedStep = startSpeed / 10 - static_cast<int>(GAMECLIENT.GetGFLength()) / 10;
             if(speedStep != 0)
             {
                 glArchivItem_Bitmap* runnerImg = LOADER.GetImageN("io", 164);
@@ -222,7 +224,7 @@ bool GameManager::Run()
                 if(speedStep != 1)
                 {
                     std::string multiplier = helpers::toString(std::abs(speedStep));
-                    SmallFont->Draw(x - runnerImg->getNx() + 19, y - runnerImg->getNy() + 9, multiplier, glArchivItem_Font::DF_LEFT, speedStep > 0 ? COLOR_YELLOW : COLOR_RED);
+                    NormalFont->Draw(x - runnerImg->getNx() + 19, y - runnerImg->getNy() + 6, multiplier, glArchivItem_Font::DF_LEFT, speedStep > 0 ? COLOR_YELLOW : COLOR_RED);
                 }
             }
         }


### PR DESCRIPTION
This allows multiple speed changes during 1 NWF (pressing 'v' multiple times by now only accepts the first one)

It also adds a little number indicating the current speed stepping. Scheme is simple: Show difference to 30 ms in steps of 10 ms with negative (slower) values red and faster ones yellow. Nothing for 30ms and no number for 20ms.

This closes #406

![speed](https://cloud.githubusercontent.com/assets/309017/13757069/0b172b04-ea23-11e5-958a-58e94049c959.png)
