### PR TITLE
Fix template deduction error (for GCC >= 5.3)

### DIFF
--- a/src/world/MapGeometry.cpp
+++ b/src/world/MapGeometry.cpp
@@ -22,7 +22,7 @@
 // Include last!
 #include "DebugNew.h" // IWYU pragma: keep
 
-Point<int> GetNeighbour(const Point<int>& p, const Direction dir)
+Point<int> GetNeighbour(const Point<int>& p, const Direction::Type dir)
 {
     /*  Note that every 2nd row is shifted by half a triangle to the left, therefore:
     Modifications for the dirs:

--- a/src/world/MapGeometry.h
+++ b/src/world/MapGeometry.h
@@ -20,7 +20,7 @@
 #include "Point.h"
 #include "gameTypes/Direction.h"
 
-Point<int> GetNeighbour(const Point<int>& pt, const Direction dir);
+Point<int> GetNeighbour(const Point<int>& pt, const Direction::Type dir);
 Point<int> GetNeighbour2(Point<int> pt, unsigned dir);
 Point<unsigned short> MakeMapPoint(Point<int> pt, const unsigned short width, const unsigned short height);
 


### PR DESCRIPTION
without specifying `::Type` default template deduction fails in newer versions of GCC (5.3 in my case)