### PR TITLE
Addon text improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,27 +53,10 @@ AddDirectory(world)
 
 ################################################################################
 
+FILE(GLOB RTTR_PO_FILES ../RTTR/languages/*.po)
+
 GETTEXT_CREATE_TRANSLATIONS(../RTTR/languages/rttr.pot ALL
-							../RTTR/languages/rttr-de.po
-							../RTTR/languages/rttr-es.po
-							../RTTR/languages/rttr-sv.po
-							../RTTR/languages/rttr-fi.po
-							../RTTR/languages/rttr-fr.po
-							../RTTR/languages/rttr-ru.po
-							../RTTR/languages/rttr-nl.po
-							../RTTR/languages/rttr-et.po
-							../RTTR/languages/rttr-en_GB.po
-							../RTTR/languages/rttr-sk.po
-							../RTTR/languages/rttr-nds.po
-							../RTTR/languages/rttr-tr.po
-							../RTTR/languages/rttr-pl.po
-							../RTTR/languages/rttr-pt.po
-							../RTTR/languages/rttr-he.po
-							../RTTR/languages/rttr-cs.po
-							../RTTR/languages/rttr-hu.po
-							../RTTR/languages/rttr-it.po
-							../RTTR/languages/rttr-sl.po
-							../RTTR/languages/rttr-nb.po
+							${RTTR_PO_FILES}
 						   )
 
 ################################################################################

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -498,19 +498,8 @@ void GameClient::OnNMSPlayerList(const GameMessage_Player_List& msg)
         player.ping = msgPlayer.ping;
         player.rating = msgPlayer.rating;
         player.ps = msgPlayer.ps;
-        if(player.ps == PS_KI)
-        {
-            if(!strncmp(player.name.c_str(), "Computer", 7))
-            {
-                player.aiInfo = AI::Info(AI::DEFAULT, AI::EASY);
-                player.rating = 666;
-            }
-            else
-            {
-                player.aiInfo = AI::Info(AI::DUMMY, AI::EASY);
-                player.rating = 0;
-            }
-        }
+        player.aiInfo = msgPlayer.aiInfo;
+        player.rating = msgPlayer.rating;
 
         if(ci)
             ci->CI_PSChanged(i, player.ps);

--- a/src/GamePlayerInfo.cpp
+++ b/src/GamePlayerInfo.cpp
@@ -25,6 +25,19 @@
 // Include last!
 #include "DebugNew.h" // IWYU pragma: keep
 
+namespace AI{
+    Info::Info(Serializer& ser):
+                    type(static_cast<Type>(ser.PopUnsignedChar())),
+                    level(static_cast<Level>(ser.PopUnsignedChar()))
+    {}
+
+    void Info::serialize(Serializer& ser) const
+    {
+        ser.PushUnsignedChar(static_cast<unsigned char>(type));
+        ser.PushUnsignedChar(static_cast<unsigned char>(level));
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Konstruktor
 GamePlayerInfo::GamePlayerInfo(const unsigned playerid) :
@@ -47,7 +60,7 @@ GamePlayerInfo::GamePlayerInfo(const unsigned playerid, Serializer& ser) :
     playerid(playerid),
     defeated(false),
     ps(PlayerState(ser.PopUnsignedChar())),
-    aiInfo(),
+    aiInfo(ser),
     name(ser.PopString()),
     origin_name(ser.PopString()),
     is_host(ser.PopBool()),
@@ -58,6 +71,7 @@ GamePlayerInfo::GamePlayerInfo(const unsigned playerid, Serializer& ser) :
     rating(ser.PopUnsignedInt()),
     ready(ser.PopBool())
 {
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -82,6 +96,7 @@ void GamePlayerInfo::clear()
 void GamePlayerInfo::serialize(Serializer& ser) const
 {
     ser.PushUnsignedChar(static_cast<unsigned char>(ps));
+    aiInfo.serialize(ser);
     ser.PushString(name);
     ser.PushString(origin_name);
     ser.PushBool(is_host);

--- a/src/GamePlayerInfo.h
+++ b/src/GamePlayerInfo.h
@@ -52,6 +52,8 @@ namespace AI
         Type type;
         Level level;
         Info(Type t = DUMMY, Level l = EASY) : type(t), level(l) { }
+        Info(Serializer& ser);
+        void serialize(Serializer& ser) const;
     };
 }
 

--- a/src/PostMsg.cpp
+++ b/src/PostMsg.cpp
@@ -126,7 +126,7 @@ DiplomacyPostQuestion::DiplomacyPostQuestion(const unsigned id, const unsigned c
     type = PMT_DIPLOMACYQUESTION;
 
     char msg[512];
-    sprintf(msg, _("The player '%s' want to cancel the '%s' between you both primaturely. Do you agree?"), GAMECLIENT.GetPlayer(player).name.c_str(),
+    sprintf(msg, _("The player '%s' want to cancel the '%s' between you both prematurely. Do you agree?"), GAMECLIENT.GetPlayer(player).name.c_str(),
             _(PACT_TITLES[pt]));
 
     text = msg;

--- a/src/addons/AddonAIDebugWindow.h
+++ b/src/addons/AddonAIDebugWindow.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -34,9 +34,8 @@ class AddonAIDebugWindow : public AddonBool
     public:
         AddonAIDebugWindow() : AddonBool(ADDON_AI_DEBUG_WINDOW,
                                              ADDONGROUP_OTHER,
-                                             gettext_noop("AI Debugging Window"),
-                                             gettext_noop("Enable AI Debugging Window\n"
-                                                     "(possible cheating)"),
+                                             _("AI Debugging Window"),
+                                             _("Enable AI Debugging Window\n(possible cheating)"),
                                              0
                                             )
         {

--- a/src/addons/AddonAIDebugWindow.h
+++ b/src/addons/AddonAIDebugWindow.h
@@ -35,7 +35,8 @@ class AddonAIDebugWindow : public AddonBool
         AddonAIDebugWindow() : AddonBool(ADDON_AI_DEBUG_WINDOW,
                                              ADDONGROUP_OTHER,
                                              _("AI Debugging Window"),
-                                             _("Enable AI Debugging Window\n(possible cheating)"),
+                                             _("Enable AI Debugging Window\n"
+                                                     "(possible cheating)"),
                                              0
                                             )
         {

--- a/src/addons/AddonAdjustMilitaryStrength.h
+++ b/src/addons/AddonAdjustMilitaryStrength.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -45,14 +45,13 @@ class AddonAdjustMilitaryStrength : public AddonList
     public:
         AddonAdjustMilitaryStrength() : AddonList(ADDON_ADJUST_MILITARY_STRENGTH,
                     ADDONGROUP_MILITARY,
-                    gettext_noop("Adjust military strength"),
-                    gettext_noop("Allows you to modify the strength increase of military ranks\n\n"),
-                    1
-                                                     )
+                    _("Adjust military strength"),
+                    _("Allows you to modify the strength increase of military ranks"),
+                    1)
         {
-            addOption(gettext_noop("Maximum strength"));
-            addOption(gettext_noop("Medium strength"));
-            addOption(gettext_noop("Minimum strength"));
+            addOption(_("Maximum strength"));
+            addOption(_("Medium strength"));
+            addOption(_("Minimum strength"));
         }
 };
 

--- a/src/addons/AddonAdjustMilitaryStrength.h
+++ b/src/addons/AddonAdjustMilitaryStrength.h
@@ -46,7 +46,7 @@ class AddonAdjustMilitaryStrength : public AddonList
         AddonAdjustMilitaryStrength() : AddonList(ADDON_ADJUST_MILITARY_STRENGTH,
                     ADDONGROUP_MILITARY,
                     _("Adjust military strength"),
-                    _("Allows you to modify the strength increase of military ranks"),
+                    _("Modify the strength increase of military ranks"),
                     1)
         {
             addOption(_("Maximum strength"));

--- a/src/addons/AddonAsyncDebug.h
+++ b/src/addons/AddonAsyncDebug.h
@@ -31,8 +31,8 @@ class AddonAsyncDebug : public AddonBool
     public:
         AddonAsyncDebug() : AddonBool(ADDON_ASYNC_DEBUG,
                                           ADDONGROUP_OTHER,
-                                          gettext_noop("Async debugging (REALLY SLOW!)"),
-                                          gettext_noop("Enables extra stuff to debug asyncs. Do not enable unless you know what you are doing!"),
+                                          _("Async debugging (REALLY SLOW!)"),
+                                          _("Enables extra stuff to debug asyncs. Do not enable unless you know what you are doing!"),
                                           0
                                          )
         {

--- a/src/addons/AddonBattlefieldPromotion.h
+++ b/src/addons/AddonBattlefieldPromotion.h
@@ -31,8 +31,8 @@ class AddonBattlefieldPromotion : public AddonBool
     public:
         AddonBattlefieldPromotion() : AddonBool(ADDON_BATTLEFIELD_PROMOTION,
                                           ADDONGROUP_MILITARY,
-                                          gettext_noop("Enable battlefield promotions"),
-                                          gettext_noop("Soldiers winning a fight increase in rank."),
+                                          _("Enable battlefield promotions"),
+                                          _("Soldiers winning a fight increase in rank."),
                                           0
                                          )
         {

--- a/src/addons/AddonBurnDuration.h
+++ b/src/addons/AddonBurnDuration.h
@@ -32,8 +32,8 @@ class AddonBurnDuration : public AddonList
     public:
         AddonBurnDuration() : AddonList(ADDON_BURN_DURATION,
                                                  ADDONGROUP_GAMEPLAY,
-                                                 gettext_noop("Set duration fires burn"),
-                                                 gettext_noop("adjusts how long a building will burn for when it is destroyed.\n\n"
+                                                 _("Set duration fires burn"),
+                                                 _("adjusts how long a building will burn for when it is destroyed.\n\n"
                                                          "Possible values are:\n"
 														 "Default\n"
 														 "Reduced by 25%\n"
@@ -41,11 +41,11 @@ class AddonBurnDuration : public AddonList
                                                          "Reduced by 75%\n"
                                                          "Reduced by 90%\n"
 														 "Increased by 50%\n"
-														 "Increased by 100%\n"),
+														 "Increased by 100%"),
                                                  0
                                                 )
         {
-            addOption(gettext_noop("Default"));
+            addOption(_("Default"));
             addOption(gettext_noop("-25%"));
             addOption(gettext_noop("-50%"));
             addOption(gettext_noop("-75%"));

--- a/src/addons/AddonBurnDuration.h
+++ b/src/addons/AddonBurnDuration.h
@@ -33,15 +33,7 @@ class AddonBurnDuration : public AddonList
         AddonBurnDuration() : AddonList(ADDON_BURN_DURATION,
                                                  ADDONGROUP_GAMEPLAY,
                                                  _("Set duration fires burn"),
-                                                 _("adjusts how long a building will burn for when it is destroyed.\n\n"
-                                                         "Possible values are:\n"
-														 "Default\n"
-														 "Reduced by 25%\n"
-                                                         "Reduced by 50%\n"
-                                                         "Reduced by 75%\n"
-                                                         "Reduced by 90%\n"
-														 "Increased by 50%\n"
-														 "Increased by 100%"),
+                                                 _("Adjusts how long a building will burn for when it is destroyed"),
                                                  0
                                                 )
         {

--- a/src/addons/AddonBurnDuration.h
+++ b/src/addons/AddonBurnDuration.h
@@ -38,12 +38,12 @@ class AddonBurnDuration : public AddonList
                                                 )
         {
             addOption(_("Default"));
-            addOption(gettext_noop("-25%"));
-            addOption(gettext_noop("-50%"));
-            addOption(gettext_noop("-75%"));
-            addOption(gettext_noop("-90%"));            
-			addOption(gettext_noop("+50%"));
-			addOption(gettext_noop("+100%"));
+            addOption(_("-25%"));
+            addOption(_("-50%"));
+            addOption(_("-75%"));
+            addOption(_("-90%"));
+			addOption(_("+50%"));
+			addOption(_("+100%"));
         }
 };
 

--- a/src/addons/AddonCatapultGraphics.h
+++ b/src/addons/AddonCatapultGraphics.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -35,8 +35,8 @@ class AddonCatapultGraphics : public AddonBool
     public:
         AddonCatapultGraphics() : AddonBool(ADDON_CATAPULT_GRAPHICS,
                                                 ADDONGROUP_GAMEPLAY,
-                                                gettext_noop("Race specific catapult graphics"),
-                                                gettext_noop("Adds new graphics for catapults to the game."),
+                                                _("Race specific catapult graphics"),
+                                                _("Adds new graphics for catapults to the game."),
                                                 0
                                                )
         {

--- a/src/addons/AddonCatapultGraphics.h
+++ b/src/addons/AddonCatapultGraphics.h
@@ -36,7 +36,7 @@ class AddonCatapultGraphics : public AddonBool
         AddonCatapultGraphics() : AddonBool(ADDON_CATAPULT_GRAPHICS,
                                                 ADDONGROUP_GAMEPLAY,
                                                 _("Race specific catapult graphics"),
-                                                _("Adds new graphics for catapults to the game."),
+                                                _("Adds new race-specific graphics for catapults to the game."),
                                                 0
                                                )
         {

--- a/src/addons/AddonChangeGoldDeposits.h
+++ b/src/addons/AddonChangeGoldDeposits.h
@@ -35,9 +35,7 @@ class AddonChangeGoldDeposits : public AddonList
         AddonChangeGoldDeposits() : AddonList(ADDON_CHANGE_GOLD_DEPOSITS,
                                                   ADDONGROUP_MILITARY | ADDONGROUP_ECONOMY,
                                                   _("Change gold deposits"),
-                                                  _("Allows to play games without gold.\n\n"
-                                                          "You can choose to remove gold resources completely,\n"
-                                                          "to convert them into iron ore, coal or granite.\n\n"
+                                                  _("You can remove gold resources completely or convert them into iron ore, coal or granite.\n\n"
                                                           "You'll probably want to convert gold to iron ore, as this (on most maps)\n"
                                                           "allows you to utilize the additional coal not needed for minting anymore."),
                                                   0

--- a/src/addons/AddonChangeGoldDeposits.h
+++ b/src/addons/AddonChangeGoldDeposits.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -34,8 +34,8 @@ class AddonChangeGoldDeposits : public AddonList
     public:
         AddonChangeGoldDeposits() : AddonList(ADDON_CHANGE_GOLD_DEPOSITS,
                                                   ADDONGROUP_MILITARY | ADDONGROUP_ECONOMY,
-                                                  gettext_noop("Change gold deposits"),
-                                                  gettext_noop("Allows to play games without gold.\n\n"
+                                                  _("Change gold deposits"),
+                                                  _("Allows to play games without gold.\n\n"
                                                           "You can choose to remove gold resources completely,\n"
                                                           "to convert them into iron ore, coal or granite.\n\n"
                                                           "You'll probably want to convert gold to iron ore, as this (on most maps)\n"
@@ -43,11 +43,11 @@ class AddonChangeGoldDeposits : public AddonList
                                                   0
                                                  )
         {
-            addOption(gettext_noop("No change"));
-            addOption(gettext_noop("Remove gold completely"));
-            addOption(gettext_noop("Convert to iron ore"));
-            addOption(gettext_noop("Convert to coal"));
-            addOption(gettext_noop("Convert to granite"));
+            addOption(_("No change"));
+            addOption(_("Remove gold completely"));
+            addOption(_("Convert to iron ore"));
+            addOption(_("Convert to coal"));
+            addOption(_("Convert to granite"));
         }
 };
 

--- a/src/addons/AddonCharburner.h
+++ b/src/addons/AddonCharburner.h
@@ -19,7 +19,7 @@
 
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -32,8 +32,8 @@ class AddonCharburner : public AddonBool
     public:
         AddonCharburner() : AddonBool(ADDON_CHARBURNER,
                                           ADDONGROUP_ECONOMY,
-                                          gettext_noop("Enable charburner"),
-                                          gettext_noop("Allows to build the charburner."),
+                                          _("Enable charburner"),
+                                          _("Allows to build the charburner."),
                                           0
                                          )
         {

--- a/src/addons/AddonCustomBuildSequence.h
+++ b/src/addons/AddonCustomBuildSequence.h
@@ -34,9 +34,8 @@ class AddonCustomBuildSequence : public AddonBool
         AddonCustomBuildSequence() : AddonBool(ADDON_CUSTOM_BUILD_SEQUENCE,
                                                    ADDONGROUP_ECONOMY | ADDONGROUP_GAMEPLAY,
                                                    _("Custom build sequence"),
-                                                   _("Allows every player to control whether building sites\n"
-                                                           "should be supplied in sequence of given order or in a definable\n"
-                                                           "sequence based on the building type."),
+                                                   _("Allows every player to control whether building sites should be supplied "
+                                                           "in sequence of given order or in a definable sequence based on the building type."),
                                                    0
                                                   )
         {

--- a/src/addons/AddonCustomBuildSequence.h
+++ b/src/addons/AddonCustomBuildSequence.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,8 +33,8 @@ class AddonCustomBuildSequence : public AddonBool
     public:
         AddonCustomBuildSequence() : AddonBool(ADDON_CUSTOM_BUILD_SEQUENCE,
                                                    ADDONGROUP_ECONOMY | ADDONGROUP_GAMEPLAY,
-                                                   gettext_noop("Custom build sequence"),
-                                                   gettext_noop("Allows every player to control whether building sites\n"
+                                                   _("Custom build sequence"),
+                                                   _("Allows every player to control whether building sites\n"
                                                            "should be supplied in sequence of given order or in a definable\n"
                                                            "sequence based on the building type."),
                                                    0

--- a/src/addons/AddonDefenderBehavior.h
+++ b/src/addons/AddonDefenderBehavior.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -34,17 +34,17 @@ class AddonDefenderBehavior : public AddonList
     public:
         AddonDefenderBehavior() : AddonList(ADDON_DEFENDER_BEHAVIOR,
                                                 ADDONGROUP_MILITARY,
-                                                gettext_noop("Change defender behavior"),
-                                                gettext_noop("Allows to change the military setting 'defender'.\n\n"
+                                                _("Change defender behavior"),
+                                                _("Allows to change the military setting 'defender'.\n\n"
                                                         "You can choose to disallow any changes to that setting\n"
                                                         "or you can limit the amount of reoccupying troops\n"
                                                         "(during an attack) according to the defender setting."),
                                                 0
                                                )
         {
-            addOption(gettext_noop("No change"));
-            addOption(gettext_noop("Disallow change"));
-            addOption(gettext_noop("Reduce reoccupying troops accordingly"));
+            addOption(_("No change"));
+            addOption(_("Disallow change"));
+            addOption(_("Reduce reoccupying troops accordingly"));
         }
 };
 

--- a/src/addons/AddonDefenderBehavior.h
+++ b/src/addons/AddonDefenderBehavior.h
@@ -35,9 +35,9 @@ class AddonDefenderBehavior : public AddonList
         AddonDefenderBehavior() : AddonList(ADDON_DEFENDER_BEHAVIOR,
                                                 ADDONGROUP_MILITARY,
                                                 _("Change defender behavior"),
-                                                _("Allows to change the military setting 'defender'.\n\n"
-                                                        "You can choose to disallow any changes to that setting\n"
-                                                        "or you can limit the amount of reoccupying troops\n"
+                                                _("Change the military setting 'defender'.\n\n"
+                                                        "You can choose to disallow any changes to that setting "
+                                                        "or you can limit the amount of reoccupying troops "
                                                         "(during an attack) according to the defender setting."),
                                                 0
                                                )

--- a/src/addons/AddonDemolitionProhibition.h
+++ b/src/addons/AddonDemolitionProhibition.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,14 +33,14 @@ class AddonDemolitionProhibition : public AddonList
     public:
         AddonDemolitionProhibition() : AddonList(ADDON_DEMOLITION_PROHIBITION,
                     ADDONGROUP_MILITARY,
-                    gettext_noop("Disable Demolition of military buildings"),
-                    gettext_noop("Allows to disable the demolition of military buildings under attack or near frontiers."),
+                    _("Disable Demolition of military buildings"),
+                    _("Allows to disable the demolition of military buildings under attack or near frontiers."),
                     0
                                                     )
         {
-            addOption(gettext_noop("Off"));
-            addOption(gettext_noop("Active if attacked"));
-            addOption(gettext_noop("Active near frontiers"));
+            addOption(_("Off"));
+            addOption(_("Active if attacked"));
+            addOption(_("Active near frontiers"));
         }
 };
 

--- a/src/addons/AddonDemolitionProhibition.h
+++ b/src/addons/AddonDemolitionProhibition.h
@@ -34,9 +34,9 @@ class AddonDemolitionProhibition : public AddonList
         AddonDemolitionProhibition() : AddonList(ADDON_DEMOLITION_PROHIBITION,
                     ADDONGROUP_MILITARY,
                     _("Disable Demolition of military buildings"),
-                    _("Allows to disable the demolition of military buildings under attack or near frontiers."),
+                    _("Disable the demolition of military buildings under attack or near frontiers."),
                     0
-                                                    )
+                    )
         {
             addOption(_("Off"));
             addOption(_("Active if attacked"));

--- a/src/addons/AddonExhaustibleWells.h
+++ b/src/addons/AddonExhaustibleWells.h
@@ -34,8 +34,7 @@ class AddonExhaustibleWells : public AddonBool
         AddonExhaustibleWells() : AddonBool(ADDON_EXHAUSTIBLE_WELLS,
                                                 ADDONGROUP_ECONOMY,
                                                 _("Exhaustible Wells"),
-                                                _("Allows to have limited water.\n\n"
-                                                        "Wells will now dry out."),
+                                                _("Wells will now dry out, limiting the available water"),
                                                 0
                                                )
         {

--- a/src/addons/AddonExhaustibleWells.h
+++ b/src/addons/AddonExhaustibleWells.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,8 +33,8 @@ class AddonExhaustibleWells : public AddonBool
     public:
         AddonExhaustibleWells() : AddonBool(ADDON_EXHAUSTIBLE_WELLS,
                                                 ADDONGROUP_ECONOMY,
-                                                gettext_noop("Exhaustible Wells"),
-                                                gettext_noop("Allows to have limited water.\n\n"
+                                                _("Exhaustible Wells"),
+                                                _("Allows to have limited water.\n\n"
                                                         "Wells will now dry out."),
                                                 0
                                                )

--- a/src/addons/AddonHalfCostMilEquip.h
+++ b/src/addons/AddonHalfCostMilEquip.h
@@ -33,7 +33,7 @@ class AddonHalfCostMilEquip : public AddonBool
         AddonHalfCostMilEquip() : AddonBool(ADDON_HALF_COST_MIL_EQUIP,
                                                   ADDONGROUP_ECONOMY,
                                                   _("Half cost recruits"),
-                                                  _("Allows a smith to create 1 shield & 1 sword\n\n"
+                                                  _("Smith can create 1 shield & 1 sword "
                                                           "for 1 iron + 1 coal instead of 2 iron + 2 coal"),
                                                   0
                                                  )

--- a/src/addons/AddonHalfCostMilEquip.h
+++ b/src/addons/AddonHalfCostMilEquip.h
@@ -32,8 +32,8 @@ class AddonHalfCostMilEquip : public AddonBool
     public:
         AddonHalfCostMilEquip() : AddonBool(ADDON_HALF_COST_MIL_EQUIP,
                                                   ADDONGROUP_ECONOMY,
-                                                  gettext_noop("Half cost recruits"),
-                                                  gettext_noop("Allows a smith to create 1 shield & 1 sword\n\n"
+                                                  _("Half cost recruits"),
+                                                  _("Allows a smith to create 1 shield & 1 sword\n\n"
                                                           "for 1 iron + 1 coal instead of 2 iron + 2 coal"),
                                                   0
                                                  )

--- a/src/addons/AddonInexhaustibleFish.h
+++ b/src/addons/AddonInexhaustibleFish.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -17,8 +17,8 @@ class AddonInexhaustibleFish : public AddonBool
     public:
         AddonInexhaustibleFish() : AddonBool(ADDON_INEXHAUSTIBLE_FISH,
                                                  ADDONGROUP_ECONOMY,
-                                                 gettext_noop("Inexhaustible Fish"),
-                                                 gettext_noop("Deactivates reduction of fish population.\n"),
+                                                 _("Inexhaustible Fish"),
+                                                 _("Deactivates reduction of fish population."),
                                                  0
                                                 )
         {

--- a/src/addons/AddonInexhaustibleGraniteMines.h
+++ b/src/addons/AddonInexhaustibleGraniteMines.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -17,8 +17,8 @@ class AddonInexhaustibleGraniteMines : public AddonBool
     public:
         AddonInexhaustibleGraniteMines() : AddonBool(ADDON_INEXHAUSTIBLE_GRANITEMINES,
                     ADDONGROUP_ECONOMY,
-                    gettext_noop("Inexhaustible Granite Mines"),
-                    gettext_noop("Allows to have unlimited Granite resources.\n\n"
+                    _("Inexhaustible Granite Mines"),
+                    _("Allows to have unlimited Granite resources.\n\n"
                                  "Granite mines will never be depleted."),
                     0
                                                         )

--- a/src/addons/AddonInexhaustibleGraniteMines.h
+++ b/src/addons/AddonInexhaustibleGraniteMines.h
@@ -18,8 +18,7 @@ class AddonInexhaustibleGraniteMines : public AddonBool
         AddonInexhaustibleGraniteMines() : AddonBool(ADDON_INEXHAUSTIBLE_GRANITEMINES,
                     ADDONGROUP_ECONOMY,
                     _("Inexhaustible Granite Mines"),
-                    _("Allows to have unlimited Granite resources.\n\n"
-                                 "Granite mines will never be depleted."),
+                    _("Granite mines will never be depleted."),
                     0
                                                         )
         {

--- a/src/addons/AddonInexhaustibleMines.h
+++ b/src/addons/AddonInexhaustibleMines.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,8 +33,8 @@ class AddonInexhaustibleMines : public AddonBool
     public:
         AddonInexhaustibleMines() : AddonBool(ADDON_INEXHAUSTIBLE_MINES,
                                                   ADDONGROUP_ECONOMY,
-                                                  gettext_noop("Inexhaustible Mines"),
-                                                  gettext_noop("Allows to have unlimited resources.\n\n"
+                                                  _("Inexhaustible Mines"),
+                                                  _("Allows to have unlimited resources.\n\n"
                                                           "Mines will never be depleted."),
                                                   0
                                                  )

--- a/src/addons/AddonInexhaustibleMines.h
+++ b/src/addons/AddonInexhaustibleMines.h
@@ -34,8 +34,7 @@ class AddonInexhaustibleMines : public AddonBool
         AddonInexhaustibleMines() : AddonBool(ADDON_INEXHAUSTIBLE_MINES,
                                                   ADDONGROUP_ECONOMY,
                                                   _("Inexhaustible Mines"),
-                                                  _("Allows to have unlimited resources.\n\n"
-                                                          "Mines will never be depleted."),
+                                                  _("Mines will never be depleted."),
                                                   0
                                                  )
         {

--- a/src/addons/AddonLimitCatapults.h
+++ b/src/addons/AddonLimitCatapults.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,23 +33,23 @@ class AddonLimitCatapults : public AddonList
     public:
         AddonLimitCatapults() : AddonList(ADDON_LIMIT_CATAPULTS,
                                               ADDONGROUP_MILITARY,
-                                              gettext_noop("Limit count of catapults"),
-                                              gettext_noop("Limits the count of catapults per player.\n\n"
+                                              _("Limit count of catapults"),
+                                              _("Limits the count of catapults per player.\n\n"
                                                       "Proportional uses 0.125 catapult per barrack (you need 8 baracks for one catapult)\n"
                                                       "                  0.25           per guardhouse (4 guardhouses per catapult)\n"
                                                       "                  0.5            per watchtower (2 watchtower per catapult)\n"
-                                                      "                  1              per fortress (1 fortress per catapult)\n"),
+                                                      "                  1              per fortress (1 fortress per catapult)"),
                                               0
                                              )
         {
-            addOption(gettext_noop("Unlimited"));
-            addOption(gettext_noop("Proportional"));
-            addOption(gettext_noop("No catapults"));
-            addOption(gettext_noop("3 catapults"));
-            addOption(gettext_noop("5 catapults"));
-            addOption(gettext_noop("10 catapults"));
-            addOption(gettext_noop("20 catapults"));
-            addOption(gettext_noop("30 catapults"));
+            addOption(_("Unlimited"));
+            addOption(_("Proportional"));
+            addOption(_("No catapults"));
+            addOption(_("3 catapults"));
+            addOption(_("5 catapults"));
+            addOption(_("10 catapults"));
+            addOption(_("20 catapults"));
+            addOption(_("30 catapults"));
         }
 };
 

--- a/src/addons/AddonLimitCatapults.h
+++ b/src/addons/AddonLimitCatapults.h
@@ -33,12 +33,13 @@ class AddonLimitCatapults : public AddonList
     public:
         AddonLimitCatapults() : AddonList(ADDON_LIMIT_CATAPULTS,
                                               ADDONGROUP_MILITARY,
-                                              _("Limit count of catapults"),
-                                              _("Limits the count of catapults per player.\n\n"
-                                                      "Proportional uses 0.125 catapult per barrack (you need 8 baracks for one catapult)\n"
-                                                      "                  0.25           per guardhouse (4 guardhouses per catapult)\n"
-                                                      "                  0.5            per watchtower (2 watchtower per catapult)\n"
-                                                      "                  1              per fortress (1 fortress per catapult)"),
+                                              _("Limit number of catapults"),
+                                              _("Limits the number of catapults per player.\n\n"
+                                                      "Proportional uses the following ratios of military buildings to catapults:\n"
+                                                      "Barracks: 8\n"
+                                                      "Guardhouse: 4\n"
+                                                      "Watchtower: 2\n"
+                                                      "Fortress: 1"),
                                               0
                                              )
         {

--- a/src/addons/AddonManualRoadEnlargement.h
+++ b/src/addons/AddonManualRoadEnlargement.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,8 +33,8 @@ class AddonManualRoadEnlargement : public AddonBool
     public:
         AddonManualRoadEnlargement() : AddonBool(ADDON_MANUAL_ROAD_ENLARGEMENT,
                     ADDONGROUP_ECONOMY,
-                    gettext_noop("Manual road enlargement"),
-                    gettext_noop("Allows you to manually upgrade your roads\n"
+                    _("Manual road enlargement"),
+                    _("Allows you to manually upgrade your roads\n"
                                  "and build donkey roads directly."),
                     0
                                                     )

--- a/src/addons/AddonManualRoadEnlargement.h
+++ b/src/addons/AddonManualRoadEnlargement.h
@@ -34,10 +34,9 @@ class AddonManualRoadEnlargement : public AddonBool
         AddonManualRoadEnlargement() : AddonBool(ADDON_MANUAL_ROAD_ENLARGEMENT,
                     ADDONGROUP_ECONOMY,
                     _("Manual road enlargement"),
-                    _("Allows you to manually upgrade your roads\n"
-                                 "and build donkey roads directly."),
+                    _("Manually upgrade your roads and directly build donkey roads."),
                     0
-                                                    )
+                    )
         {
         }
 };

--- a/src/addons/AddonMaxRank.h
+++ b/src/addons/AddonMaxRank.h
@@ -44,7 +44,7 @@ class AddonMaxRank : public AddonList
         AddonMaxRank() : AddonList(ADDON_MAX_RANK,
                                        ADDONGROUP_MILITARY,
                                        _("Set max rank"),
-                                       _("Allows you to select the highest rank for soldiers"),
+                                       _("Limit the rank for soldiers"),
                                        0
                                       )
         {

--- a/src/addons/AddonMaxRank.h
+++ b/src/addons/AddonMaxRank.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -43,16 +43,16 @@ class AddonMaxRank : public AddonList
     public:
         AddonMaxRank() : AddonList(ADDON_MAX_RANK,
                                        ADDONGROUP_MILITARY,
-                                       gettext_noop("Set max rank"),
-                                       gettext_noop("Allows you to select the highest rank for soldiers\n\n"),
+                                       _("Set max rank"),
+                                       _("Allows you to select the highest rank for soldiers"),
                                        0
                                       )
         {
-            addOption(gettext_noop("General (4)"));
-            addOption(gettext_noop("Officer (3)"));
-            addOption(gettext_noop("Sergeant (2)"));
-            addOption(gettext_noop("Privatefc (1)"));
-            addOption(gettext_noop("Private (0)"));
+            addOption(_("General (4)"));
+            addOption(_("Officer (3)"));
+            addOption(_("Sergeant (2)"));
+            addOption(_("Privatefc (1)"));
+            addOption(_("Private (0)"));
         }
 };
 

--- a/src/addons/AddonMaxWaterwayLength.h
+++ b/src/addons/AddonMaxWaterwayLength.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,8 +33,8 @@ class AddonMaxWaterwayLength : public AddonList
     public:
         AddonMaxWaterwayLength() : AddonList(ADDON_MAX_WATERWAY_LENGTH,
                                                  ADDONGROUP_GAMEPLAY,
-                                                 gettext_noop("Set maximum waterway length"),
-                                                 gettext_noop("Limits the distance settlers may travel per boat.\n\n"
+                                                 _("Set maximum waterway length"),
+                                                 _("Limits the distance settlers may travel per boat.\n\n"
                                                          "Possible values are:\n"
                                                          "Short: 3 tiles\n"
                                                          "Default: 5 tiles\n"
@@ -45,12 +45,12 @@ class AddonMaxWaterwayLength : public AddonList
                                                  1
                                                 )
         {
-            addOption(gettext_noop("Short"));
-            addOption(gettext_noop("Default"));
-            addOption(gettext_noop("Long"));
-            addOption(gettext_noop("Longer"));
-            addOption(gettext_noop("Very long"));
-            addOption(gettext_noop("Unlimited"));
+            addOption(_("Short"));
+            addOption(_("Default"));
+            addOption(_("Long"));
+            addOption(_("Longer"));
+            addOption(_("Very long"));
+            addOption(_("Unlimited"));
         }
 };
 

--- a/src/addons/AddonMetalworksBehaviorOnZero.h
+++ b/src/addons/AddonMetalworksBehaviorOnZero.h
@@ -8,15 +8,15 @@ class AddonMetalworksBehaviorOnZero : public AddonList
 public:
 	AddonMetalworksBehaviorOnZero() : AddonList(ADDON_METALWORKSBEHAVIORONZERO,
 		ADDONGROUP_GAMEPLAY,
-		gettext_noop("Change metalworks behavior on zero"),
-		gettext_noop("Change the working behavior of metalworks if all sliders in the tools window are set to zero.\n"
+		_("Change metalworks behavior on zero"),
+		_("Change the working behavior of metalworks if all sliders in the tools window are set to zero.\n"
 		             "Produce random ware: S2-Default\n"
 		             "Produce nothing: RttR-Default"),
 		0
 		)
 	{
-		addOption(gettext_noop("Produce random ware"));
-		addOption(gettext_noop("Produce nothing"));
+		addOption(_("Produce random ware"));
+		addOption(_("Produce nothing"));
 	}
 };
 

--- a/src/addons/AddonMilitaryAid.h
+++ b/src/addons/AddonMilitaryAid.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -35,8 +35,8 @@ class AddonMilitaryAid : public AddonBool
     public:
         AddonMilitaryAid() : AddonBool(ADDON_MILITARY_AID,
                                            ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY,
-                                           gettext_noop("Military Aid"),
-                                           gettext_noop("Adds military building indicators in construction aid mode."),
+                                           _("Military Aid"),
+                                           _("Adds military building indicators in construction aid mode."),
                                            0
                                           )
         {

--- a/src/addons/AddonMilitaryControl.h
+++ b/src/addons/AddonMilitaryControl.h
@@ -35,7 +35,8 @@ class AddonMilitaryControl : public AddonBool
         AddonMilitaryControl() : AddonBool(ADDON_MILITARY_CONTROL,
                                            ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY,
                                            _("Military Control"),
-                                           _("Adds the 'send home' button to military buildings.\n Pressing this button will send all soldiers of the highest available rank to a warehouse \n (at least 1 Soldier will remain in the building)"),
+                                           _("Adds the 'send home' button to military buildings.\n"
+                                             "Pressing this button will send all soldiers of the highest available rank to a warehouse (at least 1 Soldier will remain in the building)"),
                                            0
                                           )
         {

--- a/src/addons/AddonMilitaryControl.h
+++ b/src/addons/AddonMilitaryControl.h
@@ -34,8 +34,8 @@ class AddonMilitaryControl : public AddonBool
     public:
         AddonMilitaryControl() : AddonBool(ADDON_MILITARY_CONTROL,
                                            ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY,
-                                           gettext_noop("Military Control"),
-                                           gettext_noop("Adds the 'send home' button to military buildings.\n Pressing this button will send all soldiers of the highest available rank to a warehouse \n (at least 1 Soldier will remain in the building)"),
+                                           _("Military Control"),
+                                           _("Adds the 'send home' button to military buildings.\n Pressing this button will send all soldiers of the highest available rank to a warehouse \n (at least 1 Soldier will remain in the building)"),
                                            0
                                           )
         {

--- a/src/addons/AddonMilitaryHitpoints.h
+++ b/src/addons/AddonMilitaryHitpoints.h
@@ -32,8 +32,8 @@ class AddonMilitaryHitpoints : public AddonBool
 public:
 	AddonMilitaryHitpoints() : AddonBool(ADDON_MILITARY_HITPOINTS,
 		ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY,
-		gettext_noop("Military Hitpoints"),
-		gettext_noop("Allows you to see the hitpoints of units in military buildings."),
+		_("Military Hitpoints"),
+		_("Allows you to see the hitpoints of units in military buildings."),
 		0
 		)
 	{

--- a/src/addons/AddonMilitaryHitpoints.h
+++ b/src/addons/AddonMilitaryHitpoints.h
@@ -33,7 +33,7 @@ public:
 	AddonMilitaryHitpoints() : AddonBool(ADDON_MILITARY_HITPOINTS,
 		ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY,
 		_("Military Hitpoints"),
-		_("Allows you to see the hitpoints of units in military buildings."),
+		_("Display the hitpoints of units in military buildings."),
 		0
 		)
 	{

--- a/src/addons/AddonMoreAnimals.h
+++ b/src/addons/AddonMoreAnimals.h
@@ -34,7 +34,7 @@ class AddonMoreAnimals : public AddonList
         AddonMoreAnimals() : AddonList(ADDON_MORE_ANIMALS,
                                                ADDONGROUP_ECONOMY,
                                                _("More trees spawn animals"),
-                                               _("Allows you to adjust the percentage of trees that spawn animals."),
+                                               _("Adjust the fraction of trees that spawn animals."),
                                                0
                                               )
         {

--- a/src/addons/AddonMoreAnimals.h
+++ b/src/addons/AddonMoreAnimals.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,17 +33,17 @@ class AddonMoreAnimals : public AddonList
     public:
         AddonMoreAnimals() : AddonList(ADDON_MORE_ANIMALS,
                                                ADDONGROUP_ECONOMY,
-                                               gettext_noop("More trees spawn animals"),
-                                               gettext_noop("Allows you to adjust the percentage of trees that spawn animals."),
+                                               _("More trees spawn animals"),
+                                               _("Allows you to adjust the percentage of trees that spawn animals."),
                                                0
                                               )
         {
-            addOption(gettext_noop("default"));
-            addOption(gettext_noop("Increase 50%"));
-            addOption(gettext_noop("Increase 100%"));
-            addOption(gettext_noop("Increase 200%"));
-			addOption(gettext_noop("Increase 500%"));
-            addOption(gettext_noop("Increase 1000%"));
+            addOption(_("default"));
+            addOption(gettext_noop("+50%"));
+            addOption(gettext_noop("+100%"));
+            addOption(gettext_noop("+200%"));
+			addOption(gettext_noop("+500%"));
+            addOption(gettext_noop("+1000%"));
         }
 };
 

--- a/src/addons/AddonMoreAnimals.h
+++ b/src/addons/AddonMoreAnimals.h
@@ -39,11 +39,11 @@ class AddonMoreAnimals : public AddonList
                                               )
         {
             addOption(_("default"));
-            addOption(gettext_noop("+50%"));
-            addOption(gettext_noop("+100%"));
-            addOption(gettext_noop("+200%"));
-			addOption(gettext_noop("+500%"));
-            addOption(gettext_noop("+1000%"));
+            addOption(_("+50%"));
+            addOption(_("+100%"));
+            addOption(_("+200%"));
+			addOption(_("+500%"));
+            addOption(_("+1000%"));
         }
 };
 

--- a/src/addons/AddonNoAlliedPush.h
+++ b/src/addons/AddonNoAlliedPush.h
@@ -17,8 +17,7 @@ class AddonNoAlliedPush : public AddonBool
         AddonNoAlliedPush() : AddonBool(ADDON_NO_ALLIED_PUSH,
                                               ADDONGROUP_MILITARY,
                                               _("Improved Alliance"),
-                                              _("Allied players can no longer push\n"
-                                                      "your borders back with new buildings."),
+                                              _("Allied players can no longer push your borders back with new buildings."),
                                               0
                                              )
         {

--- a/src/addons/AddonNoAlliedPush.h
+++ b/src/addons/AddonNoAlliedPush.h
@@ -16,8 +16,8 @@ class AddonNoAlliedPush : public AddonBool
     public:
         AddonNoAlliedPush() : AddonBool(ADDON_NO_ALLIED_PUSH,
                                               ADDONGROUP_MILITARY,
-                                              gettext_noop("Improved Alliance"),
-                                              gettext_noop("Allied players can no longer push\n"
+                                              _("Improved Alliance"),
+                                              _("Allied players can no longer push\n"
                                                       "your borders back with new buildings."),
                                               0
                                              )

--- a/src/addons/AddonNoCoinsDefault.h
+++ b/src/addons/AddonNoCoinsDefault.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -17,8 +17,8 @@ class AddonNoCoinsDefault : public AddonBool
     public:
         AddonNoCoinsDefault() : AddonBool(ADDON_NO_COINS_DEFAULT,
                                               ADDONGROUP_MILITARY,
-                                              gettext_noop("Disable coins by default"),
-                                              gettext_noop("Receiving coins is disabled\n"
+                                              _("Disable coins by default"),
+                                              _("Receiving coins is disabled\n"
                                                       "for military buildings by default."),
                                               0
                                              )

--- a/src/addons/AddonNoCoinsDefault.h
+++ b/src/addons/AddonNoCoinsDefault.h
@@ -18,8 +18,7 @@ class AddonNoCoinsDefault : public AddonBool
         AddonNoCoinsDefault() : AddonBool(ADDON_NO_COINS_DEFAULT,
                                               ADDONGROUP_MILITARY,
                                               _("Disable coins by default"),
-                                              _("Receiving coins is disabled\n"
-                                                      "for military buildings by default."),
+                                              _("Receiving coins is disabled for military buildings by default."),
                                               0
                                              )
         {

--- a/src/addons/AddonNumScoutsExploration.h
+++ b/src/addons/AddonNumScoutsExploration.h
@@ -34,7 +34,8 @@ class AddonNumScoutsExploration: public AddonList
             AddonList(ADDON_NUM_SCOUTS_EXPLORATION,
                       ADDONGROUP_ECONOMY,
                       _("Number of scouts required for exploration expedition"),
-                      _("Allows to change the required number of scouts for an exploration via ship\nNote: Setting this to low might make some maps imbalanced!"),
+                      _("Change the required number of scouts for an exploration via ship\n"
+                        "Note: Setting this to low might make some maps imbalanced!"),
                       2)
         {
             addOption(_("Minimal"));

--- a/src/addons/AddonNumScoutsExploration.h
+++ b/src/addons/AddonNumScoutsExploration.h
@@ -34,7 +34,7 @@ class AddonNumScoutsExploration: public AddonList
             AddonList(ADDON_NUM_SCOUTS_EXPLORATION,
                       ADDONGROUP_ECONOMY,
                       _("Number of scouts required for exploration expedition"),
-                      _("Allows to change the required number of scouts for an exploration via ship\nNote: Setting this to low might make some maps imbalanced!\n"),
+                      _("Allows to change the required number of scouts for an exploration via ship\nNote: Setting this to low might make some maps imbalanced!"),
                       2)
         {
             addOption(_("Minimal"));

--- a/src/addons/AddonRefundMaterials.h
+++ b/src/addons/AddonRefundMaterials.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,16 +33,16 @@ class AddonRefundMaterials : public AddonList
     public:
         AddonRefundMaterials() : AddonList(ADDON_REFUND_MATERIALS,
                                                ADDONGROUP_ECONOMY,
-                                               gettext_noop("Refund materials when building is destroyed"),
-                                               gettext_noop("Allows you to get building materials back if the building is destroyed."),
+                                               _("Refund materials when building is destroyed"),
+                                               _("Allows you to get building materials back if the building is destroyed."),
                                                0
                                               )
         {
-            addOption(gettext_noop("No refund"));
-            addOption(gettext_noop("Refund 25%"));
-            addOption(gettext_noop("Refund 50%"));
-            addOption(gettext_noop("Refund 75%"));
-            addOption(gettext_noop("Get all back"));
+            addOption(_("No refund"));
+            addOption(_("Refund 25%"));
+            addOption(_("Refund 50%"));
+            addOption(_("Refund 75%"));
+            addOption(_("Get all back"));
         }
 };
 

--- a/src/addons/AddonRefundMaterials.h
+++ b/src/addons/AddonRefundMaterials.h
@@ -33,8 +33,8 @@ class AddonRefundMaterials : public AddonList
     public:
         AddonRefundMaterials() : AddonList(ADDON_REFUND_MATERIALS,
                                                ADDONGROUP_ECONOMY,
-                                               _("Refund materials when building is destroyed"),
-                                               _("Allows you to get building materials back if the building is destroyed."),
+                                               _("Refund materials for destroyed buildings"),
+                                               _("Get building materials back when a building is destroyed."),
                                                0
                                               )
         {

--- a/src/addons/AddonRefundOnEmergency.h
+++ b/src/addons/AddonRefundOnEmergency.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -34,8 +34,8 @@ class AddonRefundOnEmergency : public AddonBool
     public:
         AddonRefundOnEmergency() : AddonBool(ADDON_REFUND_ON_EMERGENCY,
                                                  ADDONGROUP_ECONOMY,
-                                                 gettext_noop("Refund materials when emergency program is active"),
-                                                 gettext_noop("Allows you to get building materials back if the building is destroyed\n"
+                                                 _("Refund materials when emergency program is active"),
+                                                 _("Allows you to get building materials back if the building is destroyed\n"
                                                          "and your emergency program is active."),
                                                  0
                                                 )

--- a/src/addons/AddonRefundOnEmergency.h
+++ b/src/addons/AddonRefundOnEmergency.h
@@ -34,8 +34,8 @@ class AddonRefundOnEmergency : public AddonBool
     public:
         AddonRefundOnEmergency() : AddonBool(ADDON_REFUND_ON_EMERGENCY,
                                                  ADDONGROUP_ECONOMY,
-                                                 _("Refund materials when emergency program is active"),
-                                                 _("Allows you to get building materials back if the building is destroyed\n"
+                                                 _("Refund materials in emergency program"),
+                                                 _("Get building materials back when a building is destroyed "
                                                          "and your emergency program is active."),
                                                  0
                                                 )

--- a/src/addons/AddonSeaAttack.h
+++ b/src/addons/AddonSeaAttack.h
@@ -40,13 +40,13 @@ class AddonSeaAttack : public AddonList
         AddonSeaAttack() : AddonList(ADDON_SEA_ATTACK,
                                          ADDONGROUP_MILITARY,
                                          _("Sea attack settings"),
-                                         _("set restriction level for sea attacks"),
+                                         _("Set restriction level for sea attacks"),
                                          2
                                         )
         {
-            addOption(_("enemy harbors don't block"));
-            addOption(_("enemy harbors block"));
-            addOption(_("no sea attacks"));
+            addOption(_("Enemy harbors don't block"));
+            addOption(_("Enemy harbors block"));
+            addOption(_("No sea attacks"));
         }
 };
 

--- a/src/addons/AddonSeaAttack.h
+++ b/src/addons/AddonSeaAttack.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -39,14 +39,14 @@ class AddonSeaAttack : public AddonList
     public:
         AddonSeaAttack() : AddonList(ADDON_SEA_ATTACK,
                                          ADDONGROUP_MILITARY,
-                                         gettext_noop("Sea attack settings"),
-                                         gettext_noop("set restriction level for sea attacks\n\n"),
+                                         _("Sea attack settings"),
+                                         _("set restriction level for sea attacks"),
                                          2
                                         )
         {
-            addOption(gettext_noop("enemy harbors don't block"));
-            addOption(gettext_noop("enemy harbors block"));
-            addOption(gettext_noop("no sea attacks"));
+            addOption(_("enemy harbors don't block"));
+            addOption(_("enemy harbors block"));
+            addOption(_("no sea attacks"));
         }
 };
 

--- a/src/addons/AddonShipSpeed.h
+++ b/src/addons/AddonShipSpeed.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,16 +33,16 @@ class AddonShipSpeed : public AddonList
     public:
         AddonShipSpeed() : AddonList(ADDON_SHIP_SPEED,
                                          ADDONGROUP_ECONOMY,
-                                         gettext_noop("Set ship speed"),
-                                         gettext_noop("Allows you to set ship movement speed\n\n"),
+                                         _("Set ship speed"),
+                                         _("Allows you to set ship movement speed"),
                                          2
                                         )
         {
-            addOption(gettext_noop("Very slow"));
-            addOption(gettext_noop("Slow"));
-            addOption(gettext_noop("Normal"));
-            addOption(gettext_noop("Fast"));
-            addOption(gettext_noop("Very fast"));
+            addOption(_("Very slow"));
+            addOption(_("Slow"));
+            addOption(_("Normal"));
+            addOption(_("Fast"));
+            addOption(_("Very fast"));
         }
 };
 

--- a/src/addons/AddonShipSpeed.h
+++ b/src/addons/AddonShipSpeed.h
@@ -34,7 +34,7 @@ class AddonShipSpeed : public AddonList
         AddonShipSpeed() : AddonList(ADDON_SHIP_SPEED,
                                          ADDONGROUP_ECONOMY,
                                          _("Set ship speed"),
-                                         _("Allows you to set ship movement speed"),
+                                         _("Changes the ship movement speed"),
                                          2
                                         )
         {

--- a/src/addons/AddonStatisticsVisibility.h
+++ b/src/addons/AddonStatisticsVisibility.h
@@ -34,9 +34,8 @@ class AddonStatisticsVisibility : public AddonList
         AddonStatisticsVisibility() : AddonList(ADDON_STATISTICS_VISIBILITY,
                                                     ADDONGROUP_OTHER,
                                                     _("Change the visibility of your ingame statistics"),
-                                                    _("Decides to whom your statistics is visible.\n\n"
-                                                            "\"Allies\" applies to team members as well as "
-                                                            "to allies by treaty."),
+                                                    _("Decides to whom your statistics are visible.\n\n"
+                                                            "\"Allies\" applies to team members as well as to allies by treaty."),
                                                     0
                                                    )
         {

--- a/src/addons/AddonStatisticsVisibility.h
+++ b/src/addons/AddonStatisticsVisibility.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 /**
@@ -33,16 +33,16 @@ class AddonStatisticsVisibility : public AddonList
     public:
         AddonStatisticsVisibility() : AddonList(ADDON_STATISTICS_VISIBILITY,
                                                     ADDONGROUP_OTHER,
-                                                    gettext_noop("Change the visibility of your ingame statistics"),
-                                                    gettext_noop("Decides to whom your statistics is visible.\n\n"
+                                                    _("Change the visibility of your ingame statistics"),
+                                                    _("Decides to whom your statistics is visible.\n\n"
                                                             "\"Allies\" applies to team members as well as "
                                                             "to allies by treaty."),
                                                     0
                                                    )
         {
-            addOption(gettext_noop("Everyone"));
-            addOption(gettext_noop("Allies"));
-            addOption(gettext_noop("Nobody else but you"));
+            addOption(_("Everyone"));
+            addOption(_("Allies"));
+            addOption(_("Nobody else but you"));
         }
 };
 

--- a/src/addons/AddonToolOrdering.h
+++ b/src/addons/AddonToolOrdering.h
@@ -8,8 +8,8 @@ class AddonToolOrdering : public AddonBool
     public:
         AddonToolOrdering() : AddonBool(ADDON_TOOL_ORDERING,
                                             ADDONGROUP_GAMEPLAY,
-                                            gettext_noop("Tool ordering"),
-                                            gettext_noop("Allows to order a specific amount of tools for priority production."),
+                                            _("Tool ordering"),
+                                            _("Allows to order a specific amount of tools for priority production."),
                                             0
                                            )
         {

--- a/src/addons/AddonTrade.h
+++ b/src/addons/AddonTrade.h
@@ -19,7 +19,7 @@
 
 
 #include "Addons.h"
-#include "../mygettext/src/mygettext.h"
+#include "mygettext/src/mygettext.h"
 
 ///////////////////////////S////////////////////////////////////////////////////
 /**
@@ -32,8 +32,8 @@ class AddonTrade : public AddonBool
     public:
         AddonTrade() : AddonBool(ADDON_TRADE,
                                      ADDONGROUP_ECONOMY,
-                                     gettext_noop("Trade"),
-                                     gettext_noop("Allows to send wares/figures to allied warehouses"),
+                                     _("Trade"),
+                                     _("Allows to send wares/figures to allied warehouses"),
                                      0
                                     )
         {

--- a/src/addons/Addons.cpp
+++ b/src/addons/Addons.cpp
@@ -58,14 +58,14 @@ void Addon::createGui(Window* window, unsigned int id, unsigned short& y, bool  
 {
     ctrlText* text = window->GetCtrl<ctrlText>(id);
     if(!text)
-        text = window->AddText(id, 52, y + 4, _(name_), COLOR_YELLOW, 0, NormalFont);
+        text = window->AddText(id, 52, y + 4, name_, COLOR_YELLOW, 0, NormalFont);
 
     text->SetVisible(true);
     text->Move(52, y + 4);
 
     ctrlImageButton* button = window->GetCtrl<ctrlImageButton>(id + 1);
     if(!button)
-        button = window->AddImageButton(id + 1, 20, y, 22, 22, TC_GREY, LOADER.GetImageN("io", 21), _(description_));
+        button = window->AddImageButton(id + 1, 20, y, 22, 22, TC_GREY, LOADER.GetImageN("io", 21), description_);
 
     button->SetVisible(true);
     button->Move(20, y);
@@ -101,7 +101,7 @@ void AddonList::createGui(Window* window, unsigned int id, unsigned short& y, bo
     {
         combo = window->AddComboBox(id + 2, 450, y, 220, 20,  TC_GREY, NormalFont, 100, readonly );
         for(std::vector<std::string>::const_iterator it = options.begin(); it != options.end(); ++it)
-            combo->AddString(_(*it));
+            combo->AddString(*it);
 
         setGuiStatus(window, id, status);
     }

--- a/src/defines.h
+++ b/src/defines.h
@@ -71,12 +71,6 @@
 #   include <build_paths.h>
 #endif
 
-#ifdef _MSC_VER
-#   define FORCE_INLINE __forceinline
-#else
-#   define FORCE_INLINE inline __attribute__((__always_inline__))
-#endif // _MSC_VER
-
 #include "macros.h"
 #include "RTTR_Assert.h"
 

--- a/src/figures/nofBuildingWorker.cpp
+++ b/src/figures/nofBuildingWorker.cpp
@@ -414,7 +414,7 @@ bool nofBuildingWorker::GetResources(unsigned char type)
             else
                 error = _("This mine is exhausted");
 
-            GAMECLIENT.SendPostMessage(new ImagePostMsgWithLocation(_(error), PMC_GENERAL, pos, workplace->GetBuildingType(), workplace->GetNation()));
+            GAMECLIENT.SendPostMessage(new ImagePostMsgWithLocation(error, PMC_GENERAL, pos, workplace->GetBuildingType(), workplace->GetNation()));
         }
 
         outOfRessourcesMsgSent = true;

--- a/src/gameData/NationConsts.h
+++ b/src/gameData/NationConsts.h
@@ -20,8 +20,8 @@
 #ifndef NationConsts_h__
 #define NationConsts_h__
 
+#include "mygettext/src/mygettext.h"
 #include <boost/array.hpp>
-#include <string>
 
 /// Völker (dont forget to change shield-count in iwWares too ...)
 enum Nation
@@ -35,7 +35,13 @@ enum Nation
 	NAT_INVALID = 0xFFFFFFFF
 };
 
-const boost::array<std::string, NAT_COUNT> SUPPRESS_UNUSED NationNames = {{ std::string("Africans"), std::string("Japanese"), std::string("Romans"), std::string("Vikings"), std::string("Babylonians") }};
+const boost::array<const char*, NAT_COUNT> SUPPRESS_UNUSED NationNames = {{
+        gettext_noop("Africans"),
+        gettext_noop("Japanese"),
+        gettext_noop("Romans"),
+        gettext_noop("Vikings"),
+        gettext_noop("Babylonians")
+}};
 
 #define NATIVE_NAT_COUNT 4
 

--- a/src/ingameWindows/iwAIDebug.cpp
+++ b/src/ingameWindows/iwAIDebug.cpp
@@ -68,7 +68,7 @@ iwAIDebug::iwAIDebug(GameWorldViewer* const gwv)
 	ctrlComboBox* players = AddComboBox(1, 15, 30, 250, 20, TC_GREY, NormalFont, 100);
     for (std::vector<AIPlayerJH*>::iterator it = ais.begin(); it != ais.end(); ++it)
     {
-        players->AddString(_((*it)->GetPlayerName()));
+        players->AddString((*it)->GetPlayerName());
     }
 
     selection = 0;

--- a/src/macros.h
+++ b/src/macros.h
@@ -55,6 +55,12 @@
 #   define GetTxtItem(type, nr) ( dynamic_cast<libsiedler2::ArchivItem_Text*>( LOADER.type.get(nr) ) )
 #endif // !_WIN32 || !_MSC_VER
 
+#ifdef _MSC_VER
+#   define FORCE_INLINE __forceinline
+#else
+#   define FORCE_INLINE inline __attribute__((__always_inline__))
+#endif // _MSC_VER
+
 // Macro that can be used to suppress unused warnings. Required e.g. for const boost::arrays defined in headers
 // Don't use this if not absolutely necessary!
 #ifdef __GNUC__


### PR DESCRIPTION
This makes the addon texts translatable and also shortens them a bit. No need for "Allows you to change..." in the tooltips. Lengthy tooltips are hard to read especially as we got many settings.