### PR TITLE
Implement zoom for observation windows

### DIFF
--- a/RTTR/texte/de_DE/keyboardlayout.txt
+++ b/RTTR/texte/de_DE/keyboardlayout.txt
@@ -7,7 +7,7 @@ Eingeklammerte Belegungen funktionieren noch nicht.
 P:.................... Pause
 
 H:.................... Zum Hauptquartier springen
-B:.................... Zur Ausgangsposition zur�ckspringen
+B:.................... Zur Ausgangsposition zurückspringen
 
 N:.................... Nachrichtenfenster
 L:.................... Landkarte
@@ -15,13 +15,13 @@ M:.................... Hauptauswahl
 I:..................... Inventar
 
 SPACE:............ Haus-Bau-Hilfe an-/ausschalten
-C:.................... Bezeichnungen der H�user zeigen
-S:.................... Status der H�user zeigen
+C:.................... Bezeichnungen der Häuser zeigen
+S:.................... Status der Häuser zeigen
 
 Z:.................... (Zoomt das aktuelle Fenster)
 V:.................... (Spielgeschwindigkeit verstellen)
 
-Alt-W, Esc:...... Schlie�t aktives Fenster
+Alt-W, Esc:...... Schließt aktives Fenster
 Alt-Q:.............. Spiel verlassen
 
 F1:................... (Spiel laden)
@@ -33,13 +33,13 @@ F12:.................. Kontrollfenster
 
 Im Nachrichten Fenster:
 
-DEL:................ (Nachricht l�schen)
+DEL:................ (Nachricht lï¿½schen)
 G:.................... (Zum Ort der Nachricht gehen)
-+/-:.................. (N�chste/Vorherige Nachricht)
++/-:.................. (Nï¿½chste/Vorherige Nachricht)
 
 Cursortasten: Kartenausschnitt scrollen
 
-Im Replay Modus zus�tzlich:
+Im Replay Modus zusätzlich:
 
 D:.................... Karte auf- und zudecken
 J:.................... Zu einem bestimmten GF springen

--- a/RTTR/texte/de_DE/readme.txt
+++ b/RTTR/texte/de_DE/readme.txt
@@ -10,17 +10,17 @@ C. Spiel
    2. Multiplayer-Spiele
    3. Replays
    4. Optionen
-D. Abstürze und Fehler
-E. Übersicht: Updates und Änderungen
+D. AbstÃ¼rze und Fehler
+E. Ãœbersicht: Updates und Ã„nderungen
 
 --------------------------------------------------------------------------------
 
 A. Allgemeine Hinweise
 
-   Das Spiel benötigt eine OpenGL-fähige Grafikkarte mit schätzungsweise
+   Das Spiel benÃ¶tigt eine OpenGL-fÃ¤hige Grafikkarte mit schÃ¤tzungsweise
    mindestens 64 MiB Grafikspeicher. Ein Prozessor mit 800 MHz reicht aus.
 
-   Weiterhin benötigt man eine installierte "Siedler 2 Gold-Edition" oder die
+   Weiterhin benÃ¶tigt man eine installierte "Siedler 2 Gold-Edition" oder die
    Originalversion + Missions-CD.
 
 --------------------------------------------------------------------------------
@@ -29,7 +29,7 @@ B. Installation
 
    1. Windows
 
-      Windows 95/98/ME/Vista ist nicht offiziell unterstützt. Vista sollte
+      Windows 95/98/ME/Vista ist nicht offiziell unterstÃ¼tzt. Vista sollte
       aber eigentlich funktionieren.
 
       a) Zip-Archive
@@ -39,28 +39,28 @@ B. Installation
          der selben Ebene wie S2.EXE befindet).
 
          Darin kann man dann s25client.exe zum Spielen von Siedler II.5 RTTR
-         ausführen.
+         ausfÃ¼hren.
          
          (In Nightlies kann man mit RTTR.BAT updaten.)
 
       b) Setup
-         Setup ausführen und als Installationsverzeichnis die installierte
-         "Siedler 2 Gold-Edition" auswählen.
-         Alternativ kann man natürlich nachtäglich den Inhalt der
+         Setup ausfÃ¼hren und als Installationsverzeichnis die installierte
+         "Siedler 2 Gold-Edition" auswÃ¤hlen.
+         Alternativ kann man natÃ¼rlich nachtÃ¤glich den Inhalt der
          Gold-Edition in den Installationsordner von S25rttr kopieren.
 
          Das Spiel kann man dann bequem mit der installierten
-         Desktopverknüpfung starten.
+         DesktopverknÃ¼pfung starten.
 
-      Es werden KEINE originalen Spieldateien verändert. Man kann
-      weiterhin das Original ohne Beeinträchtigung spielen.
+      Es werden KEINE originalen Spieldateien verÃ¤ndert. Man kann
+      weiterhin das Original ohne BeeintrÃ¤chtigung spielen.
       
    -------------------------------------------------------------------------
 
    2. Linux
 
-      Zunächst benötigt man folgende Pakete
-      (ggf über Paketmanager/per Hand installieren):
+      ZunÃ¤chst benÃ¶tigt man folgende Pakete
+      (ggf Ã¼ber Paketmanager/per Hand installieren):
 
       libsndfile libsamplerate libsdl1.2 libsdl-mixer1.2 gettext timidity
 
@@ -89,7 +89,7 @@ B. Installation
       /opt/s25rttr/bin/rttr.sh
       
       (Nightly Versionen updaten sich selber. Wenn man rttr.sh mit der
-      Option noupdate startet, wird kein Update durchgeführt.)
+      Option noupdate startet, wird kein Update durchgefÃ¼hrt.)
 
 --------------------------------------------------------------------------------
 
@@ -98,25 +98,25 @@ C. Spiel
    1. Erstellen eines Spiels
 
       Einen richtigen Einzelspielermodus gibt es in dem Sinne noch nicht, man
-      kann aber trotzdem folgendermaßen alleine im Multiplayermodus siedeln:
+      kann aber trotzdem folgendermaÃŸen alleine im Multiplayermodus siedeln:
 
-      1. Im Hauptmenü auf Mehrspieler gehen
+      1. Im HauptmenÃ¼ auf Mehrspieler gehen
       2. Direkte IP
       3. Spiel erstellen
-      4. Im folgenden Fenster einen Namen für das Spiel eingeben (Passwort
+      4. Im folgenden Fenster einen Namen fÃ¼r das Spiel eingeben (Passwort
          kann weggelassen werden).
-      5. Im Kartenauswahl-Fenster kann oben eine Kategorie ausgewählt
-         werden, ähnlich wie im Original.
-         Alternativ kann unten über "Spiel laden" ein Spielstand geladen
+      5. Im Kartenauswahl-Fenster kann oben eine Kategorie ausgewÃ¤hlt
+         werden, Ã¤hnlich wie im Original.
+         Alternativ kann unten Ã¼ber "Spiel laden" ein Spielstand geladen
          werden.
       6. Nach der Auswahl der Karte und einem Klick auf "Weiter" gelangt man
-         ins Host-Menü, wo im oberen Teil die einzelnen Spieler samt ihrer
+         ins Host-MenÃ¼, wo im oberen Teil die einzelnen Spieler samt ihrer
          Eigenschaften aufgelistet sind.
-         Spielziel, Aufklärung und Teams sperren sind bisher noch ohne
+         Spielziel, AufklÃ¤rung und Teams sperren sind bisher noch ohne
          Bedeutung.
-         Achtung: Um das Spiel starten zu können, müssen entweder alle Plätze
+         Achtung: Um das Spiel starten zu kÃ¶nnen, mÃ¼ssen entweder alle PlÃ¤tze
          mit menschlichen oder KI-Spielern besetzt werden, oder die Slots
-         müssen geschlossen werden (mit Klick auf die Buttons unter
+         mÃ¼ssen geschlossen werden (mit Klick auf die Buttons unter
          "Spielername").
 
          Die KI-Spieler sind zur Zeit noch nicht lebendig.
@@ -128,95 +128,95 @@ C. Spiel
          weiteren Spieler gehen bei "Direkte IP" unter "Spiel beitreten" und
          geben die IP oder den Hostnamen des Spielerstellers (Host) ein.
 
-      b) Spielen über integrierte Lobby
-         Über die eingebaute Lobby kann man vorhandene Spiele einsehen,
-         diese eröffnen und auch beitreten. Weiterhin kann man sich hier
+      b) Spielen Ã¼ber integrierte Lobby
+         Ãœber die eingebaute Lobby kann man vorhandene Spiele einsehen,
+         diese erÃ¶ffnen und auch beitreten. Weiterhin kann man sich hier
          mit anderen Spielern direkt unterhalten.
 
-         Der Funktionsumfang der Lobby ist momentan noch sehr beschränkt
+         Der Funktionsumfang der Lobby ist momentan noch sehr beschrÃ¤nkt
          und es kann zeitweise zu Datenbank-Problemen kommen.
          Ein Punktesystem ist vorgesehen, aber noch nicht implementiert.
 
          Alle eingegebenen Daten werden nicht weitergegeben und dienen rein
          zur Identifikation des Spielers. Die zur Registrierung notwendige
          Emailadresse ist momentan nur ggf. zum Zusenden eines neuen
-         Passworts gedacht und ist nicht öffentlich einsehbar.
+         Passworts gedacht und ist nicht Ã¶ffentlich einsehbar.
 
-      Für das Spiel wird Port 3665 (TCP) genutzt. Dieser muss, falls man selbst
-      das Spiel eröffnen möchte, u.a. bei Verwendung eines Routers, einer
+      FÃ¼r das Spiel wird Port 3665 (TCP) genutzt. Dieser muss, falls man selbst
+      das Spiel erÃ¶ffnen mÃ¶chte, u.a. bei Verwendung eines Routers, einer
       Firewall usw. freigegeben werden!
       Router nennen diese Einstellung "Virtual Server" oder einfach nur
       "Port Forwarding". Dort ist dann Port 3665 vom Typ TCP auf die interne IP
       des Spiel-PCs weiterzuleiten.
 
-      Die Schneckensymbole im oberen Teil stehen für Lags der jeweiligen
+      Die Schneckensymbole im oberen Teil stehen fÃ¼r Lags der jeweiligen
       Spieler.
 
-      Wenn der Host das Spiel verlässt, können die übrigen Spieler noch nicht
-      das Spiel weiter fortführen.
+      Wenn der Host das Spiel verlÃ¤sst, kÃ¶nnen die Ã¼brigen Spieler noch nicht
+      das Spiel weiter fortfÃ¼hren.
 
-      Es sind sowohl Spiele über das Internet als auch über LAN möglich, wenn
+      Es sind sowohl Spiele Ã¼ber das Internet als auch Ã¼ber LAN mÃ¶glich, wenn
       die jeweilige IP bekannt ist.
 
-      Das Übertragen der Karte geschieht immer automatisch (auch wenn die
+      Das Ãœbertragen der Karte geschieht immer automatisch (auch wenn die
       Spielteilnehmer die Karte des Hosts schon besitzen).
 
-      Drücken der Taste "P" pausiert das Spiel (dies kann nur der Host tun),
-      weiteres Drücken von "P" lässt das spiel fortführen.
+      DrÃ¼cken der Taste "P" pausiert das Spiel (dies kann nur der Host tun),
+      weiteres DrÃ¼cken von "P" lÃ¤sst das spiel fortfÃ¼hren.
 
-      Zum Chatten muss man "Enter" drücken, dann kommt ein Chatfenster.
+      Zum Chatten muss man "Enter" drÃ¼cken, dann kommt ein Chatfenster.
 
    3. Replays
 
-      Replays sind Aufzeichnungen von gespielten Partien. Sie können unter
+      Replays sind Aufzeichnungen von gespielten Partien. Sie kÃ¶nnen unter
       "Einzelspieler", "Replay abspielen" angesehen werden.
 
-      Mit den Tasten [+] und [-] kann die Geschwindigkeit erhöht bzw.
-      verringert werden. Mit der Taste "J" ist es möglich, Abschnitte im
-      Replay zu überspringen.
+      Mit den Tasten [+] und [-] kann die Geschwindigkeit erhÃ¶ht bzw.
+      verringert werden. Mit der Taste "J" ist es mÃ¶glich, Abschnitte im
+      Replay zu Ã¼berspringen.
 
       Replays werden aufgezeichnet und im Verzeichnis RTTR/REPLAYS
       abgespeichert.
 
    4. Speichern
 
-      Speichern ist im Spielmenü an der "originalen" Stelle möglich.
-      Speichern ist auch aus dem Replaymodus an beliebiger Stelle möglich.
+      Speichern ist im SpielmenÃ¼ an der "originalen" Stelle mÃ¶glich.
+      Speichern ist auch aus dem Replaymodus an beliebiger Stelle mÃ¶glich.
       Laden von Spielen kann man nur aus dem Kartenauswahlbildschirm.
-      Mitspieler benötigen kein eigenes Savegame, dieses wird automatisch
-      beim Verbinden übertragen.
+      Mitspieler benÃ¶tigen kein eigenes Savegame, dieses wird automatisch
+      beim Verbinden Ã¼bertragen.
 
    5. Optionen
 
-      Die Einstellungen im Optionsmenü sollten so weit selbsterklärend sein.
+      Die Einstellungen im OptionsmenÃ¼ sollten so weit selbsterklÃ¤rend sein.
 
 
 --------------------------------------------------------------------------------
 
-D. Abstürze und Fehler
+D. AbstÃ¼rze und Fehler
 
    Es handelt sich selbst bei dieser Version zwar schon um eine stabilere
-   Variante. Abstürze, Asyncs, Speicherzugriffs- und sonstige Fehler
-   lassen sich aber leider immer noch nicht ausschließen.
+   Variante. AbstÃ¼rze, Asyncs, Speicherzugriffs- und sonstige Fehler
+   lassen sich aber leider immer noch nicht ausschlieÃŸen.
 
-   Durch Replays können Fehler leicht rekonstruiert werden. Ihr könnt uns
+   Durch Replays kÃ¶nnen Fehler leicht rekonstruiert werden. Ihr kÃ¶nnt uns
    mit dem Zusenden euer Replays helfen, weitere zu finden. Bitte stellt
    aber sicher, dass ihr immer die neuste Daily-Version verwendet. Fehler
-   aus möglicherweise veralteten Releaseversionen sind mitunter schon lange
+   aus mÃ¶glicherweise veralteten Releaseversionen sind mitunter schon lange
    behoben.
 
    Falls ein Async aufgetreten ist, findet ihr im RTTR/LOGS/-Verzeichnis
-   Log-Dateien. Schickt uns diese bitte von JEDEM(!) Spieler einschließlich
+   Log-Dateien. Schickt uns diese bitte von JEDEM(!) Spieler einschlieÃŸlich
    eines Replays (Verzeichnis RTTR/REPLAYS).
    Bitte stellt sicher, dass ihr den Async nicht absichtlich durch Spielen mit
-   verschiedenen Versionen oder Cheaten herbeigeführt habt!
+   verschiedenen Versionen oder Cheaten herbeigefÃ¼hrt habt!
 
    Wenn ihr Fehler findet, bitte diese im Launchpad posten:
 
                http://bugs.siedler25.org/
 
-   Das Launchpad erhöht die Übersichtlichkeit für Bugs und ermöglicht euch
-   zudem selber einsehen zu können, wann der Bug gefixt wurde.
+   Das Launchpad erhÃ¶ht die Ãœbersichtlichkeit fÃ¼r Bugs und ermÃ¶glicht euch
+   zudem selber einsehen zu kÃ¶nnen, wann der Bug gefixt wurde.
 
    Bei weiteren Fragen bitte an
         
@@ -224,8 +224,8 @@ D. Abstürze und Fehler
 
    wenden.
 
-   Alternativ könnt ihr euch auch im Forum oder im IRC-Channel unter
-   irc.freenode.net:6667/#siedler2.5 melden. Ihr könnt dem Chat auch über
+   Alternativ kÃ¶nnt ihr euch auch im Forum oder im IRC-Channel unter
+   irc.freenode.net:6667/#siedler2.5 melden. Ihr kÃ¶nnt dem Chat auch Ã¼ber
    unsere Seite beitreten.
 
    Vielen Dank!
@@ -235,7 +235,7 @@ D. Abstürze und Fehler
 
 --------------------------------------------------------------------------------
 
-E. Übersicht: Updates und Änderungen
+E. Ãœbersicht: Updates und Ã„nderungen
 
  * 0.7.2 - 17.01.2011 *
    --------------------------------------------------------------------------
@@ -244,57 +244,57 @@ E. Übersicht: Updates und Änderungen
  * 0.7 - Seventh version - 24.12.2010 *
    --------------------------------------------------------------------------
    - OpenSource!
-   - Übersetzung: Niederländisch
-   - Übersetzung: Russisch (Zeichensatz fehlt)
-   - Übersetzung: Czech
-   - Übersetzung: Estonian
-   - Übersetzung: Italian
-   - Übersetzung: Norwegian
-   - Übersetzung: Polish
-   - Übersetzung: Slovenian
-   - Übersetzung: Slovak
+   - Ãœbersetzung: NiederlÃ¤ndisch
+   - Ãœbersetzung: Russisch (Zeichensatz fehlt)
+   - Ãœbersetzung: Czech
+   - Ãœbersetzung: Estonian
+   - Ãœbersetzung: Italian
+   - Ãœbersetzung: Norwegian
+   - Ãœbersetzung: Polish
+   - Ãœbersetzung: Slovenian
+   - Ãœbersetzung: Slovak
    - Statistik
    - Post
    - Diplomatie - noch nicht fertig
    - Erste KI von jh
    - Seefahrt (noch nicht fertig)
-   - Addon Menü
+   - Addon MenÃ¼
 
  * 0.6 - Sechste Version - 25.01.2009 *
    -------------------------------------------------------------------------
    - viele Bugs behoben
    - Fog of War (mit Teamview-Option)
-   - Spähturm
+   - SpÃ¤hturm
    - Minimap
-   - Mapvorschau im Hostmenü
+   - Mapvorschau im HostmenÃ¼
    - Planierer
    - Balancing
-   - Trägeranimationen hinzugefügt
-   - Mehrsprachenunterstützung
-   - Übersetzung: Spanisch
-   - Übersetzung: Ungarisch
-   - Übersetzung: Schwedisch
-   - Übersetzung: Französisch (nicht abgeschlossen)
-   - Übersetzung: Finnisch (nicht abgeschlossen)
+   - TrÃ¤geranimationen hinzugefÃ¼gt
+   - MehrsprachenunterstÃ¼tzung
+   - Ãœbersetzung: Spanisch
+   - Ãœbersetzung: Ungarisch
+   - Ãœbersetzung: Schwedisch
+   - Ãœbersetzung: FranzÃ¶sisch (nicht abgeschlossen)
+   - Ãœbersetzung: Finnisch (nicht abgeschlossen)
    - Siegesmeldungen
    - Tastaturbefehle + Readme
-   - Option im Hostmenü: Abriss-Verbot
-   - Gebäude Info
-   - Einige Hausanimationen hinzugefügt
+   - Option im HostmenÃ¼: Abriss-Verbot
+   - GebÃ¤ude Info
+   - Einige Hausanimationen hinzugefÃ¼gt
    
-  * 0.5 - Fünfte Version - 27.01.2008 *
+  * 0.5 - FÃ¼nfte Version - 27.01.2008 *
    -------------------------------------------------------------------------
    - sehr viele Bugs behoben
-   - Eselstraßen, Eselzüchter
-   - Bootsstraßen mit Booten und Werft (baut nur Boote)
-   - Bergstraßen
+   - EselstraÃŸen, EselzÃ¼chter
+   - BootsstraÃŸen mit Booten und Werft (baut nur Boote)
+   - BergstraÃŸen
    - Katapulte
-   - Soldatenverhalten verändert, rücken nicht mehr so schnell nach
-   - beim Abbrennen von Lagerhäusern und dem Hauptquartier flüchten
-     nun alle Leute nach draußen wie im Original
+   - Soldatenverhalten verÃ¤ndert, rÃ¼cken nicht mehr so schnell nach
+   - beim Abbrennen von LagerhÃ¤usern und dem Hauptquartier flÃ¼chten
+     nun alle Leute nach drauÃŸen wie im Original
    - Async-Logdatei
    - diverse Kleinigkeiten wie ein das Original-Abfragefenster vor dem
-     Abbrennen von Gebäuden oder fehlende/falsche Tooltips
+     Abbrennen von GebÃ¤uden oder fehlende/falsche Tooltips
    - Sound an/aus Buttons im Spiel
 
    * 0.4 - Vierte Version - 09.10.2007 *
@@ -310,30 +310,30 @@ E. Übersicht: Updates und Änderungen
    -------------------------------------------------------------------------
    - diverse Absturzbugs behoben
    - Siedler warten nun, falls der Platz vor ihnen besetzt ist
-     (durch Kämpfe z.B.)
+     (durch KÃ¤mpfe z.B.)
    - Settings unter Linux im Home-Verzeichnis untergebracht
    - Settings in lesbares Format gebracht (GER-File)
    - Build-System unter Linux von autotools auf CMake umgestellt
-   - CIA-Bot für den IRC aktiviert
+   - CIA-Bot fÃ¼r den IRC aktiviert
    - Lobbygrundfunktionen fertiggestellt
-   - Vorbereitungen für Speichern und Laden getroffen
+   - Vorbereitungen fÃ¼r Speichern und Laden getroffen
 
    * 0.2 - Zweite Version - 15.07.2007 *
    -------------------------------------------------------------------------
-   - diverse Bugs behoben und diverse Verzögerungsbugs unterdrückt
-   - Menüs in variabler Auflösung
-   - Prüfen der Synchronität und Rausschmiss asynchroner Spieler
+   - diverse Bugs behoben und diverse VerzÃ¶gerungsbugs unterdrÃ¼ckt
+   - MenÃ¼s in variabler AuflÃ¶sung
+   - PrÃ¼fen der SynchronitÃ¤t und Rausschmiss asynchroner Spieler
    - Inventurfenster eingebaut
-   - "Nicht Einlagern"/"Auslagern" möglich
-   - Bereit-Button im Host-Menü
+   - "Nicht Einlagern"/"Auslagern" mÃ¶glich
+   - Bereit-Button im Host-MenÃ¼
    - Verteilung korrigiert
    - diverse fehlende Zierobjekte (z.B Stalagmiten, Ruinen) eingebaut
-   - zu allen GebÃ¤uden kann nun gesprungen werden
+   - zu allen GebÃƒÂ¤uden kann nun gesprungen werden
    - einige Zierobjekte werden beim Wegbau nun abgerissen
-   - Produktivitätsanzeige und Namenanzeige (C, S) teilweise schon korrekt
+   - ProduktivitÃ¤tsanzeige und Namenanzeige (C, S) teilweise schon korrekt
      implementiert
-   - Abrissbestätigung eingebaut
-   - RoadWindow schließt sich nun, wenn man woanders hinklickt
+   - AbrissbestÃ¤tigung eingebaut
+   - RoadWindow schlieÃŸt sich nun, wenn man woanders hinklickt
 
    * 0.1 - Erster Release - 01.07.2007 *
    -------------------------------------------------------------------------

--- a/src/GameClient.cpp
+++ b/src/GameClient.cpp
@@ -1766,7 +1766,7 @@ void GameClient::SkipGF(unsigned int gf)
             road.start = MapPoint(0, 0);
 
             // spiel aktualisieren
-            gw->Draw(GetPlayerID(), &water_percent, false, MapPoint(0, 0), road);
+            gw->Draw(&water_percent, false, MapPoint(0, 0), road);
 
             // text oben noch hinschreiben
             snprintf(nwf_string, 255, _("current GF: %u - still fast forwarding: %d GFs left (%d %%)"), GetGFNumber(), gf - i, (i * 100 / gf) );            

--- a/src/TerrainRenderer.cpp
+++ b/src/TerrainRenderer.cpp
@@ -25,7 +25,6 @@
 #include "Settings.h"
 #include "GameClient.h"
 #include "world/MapGeometry.h"
-#include "world/GameWorldView.h"
 #include "world/GameWorldViewer.h"
 #include "gameData/TerrainData.h"
 #include "ExtensionList.h"

--- a/src/TerrainRenderer.cpp
+++ b/src/TerrainRenderer.cpp
@@ -676,12 +676,12 @@ void TerrainRenderer::Draw(const GameWorldView& gwv, unsigned int* water)
     Point<int> lastOffset(0, 0);
  
     // Beim zeichnen immer nur beginnen, wo man auch was sieht
-    for(int y = gwv.GetFirstPt().y; y < gwv.GetLastPt().y; ++y)
+    for(int y = gwv.GetFirstPt().y; y <= gwv.GetLastPt().y; ++y)
     {
         unsigned char lastTerrain = 255;
         unsigned char lastBorder  = 255;
 
-        for(int x = gwv.GetFirstPt().x; x < gwv.GetLastPt().x; ++x)
+        for(int x = gwv.GetFirstPt().x; x <= gwv.GetLastPt().x; ++x)
         {
             Point<int> posOffset;
             MapPoint tP = ConvertCoords(Point<int>(x, y), &posOffset);

--- a/src/TerrainRenderer.cpp
+++ b/src/TerrainRenderer.cpp
@@ -807,12 +807,10 @@ void TerrainRenderer::Draw(const GameWorldView& gwv, unsigned int* water)
     glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE_EXT);
     glTexEnvf(GL_TEXTURE_ENV, GL_RGB_SCALE_EXT, 2.0f);
 
-    // Verschieben gem#ß x und y offset
-    glTranslatef( float(-gwv.GetXOffset()), float(-gwv.GetYOffset()), 0.0f);
-
     // Alphablending aus
     glDisable(GL_BLEND);
 
+    glPushMatrix();
     for(unsigned char t = 0; t < TT_COUNT; ++t)
     {
         if(sorted_textures[t].empty())
@@ -841,13 +839,12 @@ void TerrainRenderer::Draw(const GameWorldView& gwv, unsigned int* water)
             glDrawArrays(GL_TRIANGLES, it->tileOffset * 3, it->count * 3); // Arguments are in Elements. 1 triangle has 3 values
         }
     }
+    glPopMatrix();
 
     glEnable(GL_BLEND);
 
-    glLoadIdentity();
-    glTranslatef( float(-gwv.GetXOffset()), float(-gwv.GetYOffset()), 0.0f);
-
     lastOffset = PointI(0, 0);
+    glPushMatrix();
     for(unsigned short i = 0; i < 5; ++i)
     {
         if(sorted_borders[i].empty())
@@ -866,7 +863,7 @@ void TerrainRenderer::Draw(const GameWorldView& gwv, unsigned int* water)
             glDrawArrays(GL_TRIANGLES, it->tileOffset * 3, it->count * 3); // Arguments are in Elements. 1 triangle has 3 values
         }
     }
-    glLoadIdentity();
+    glPopMatrix();
 
     DrawWays(sorted_roads);
 
@@ -925,7 +922,7 @@ struct GL_T2F_C3F_V3F_Struct
 
 void TerrainRenderer::PrepareWaysPoint(PreparedRoads& sorted_roads, const GameWorldView& gwv, MapPoint t, const PointI& offset)
 {
-    PointI startPos = PointI(GetNodePos(t)) - gwv.GetOffset() + offset;
+    PointI startPos = PointI(GetNodePos(t)) + offset;
 
     GameWorldViewer& gwViewer = gwv.GetGameWorldViewer();
     Visibility visibility = gwViewer.GetVisibility(t);
@@ -941,7 +938,7 @@ void TerrainRenderer::PrepareWaysPoint(PreparedRoads& sorted_roads, const GameWo
             continue;
         MapPoint ta = gwViewer.GetNeighbour(t, 3 + dir);
 
-        PointI endPos = PointI(GetNodePos(ta)) - gwv.GetOffset() + offset;
+        PointI endPos = PointI(GetNodePos(ta)) + offset;
         PointI diff = startPos - endPos;
 
         // Gehen wir über einen Kartenrand (horizontale Richung?)

--- a/src/buildings/nobUsual.h
+++ b/src/buildings/nobUsual.h
@@ -127,9 +127,9 @@ protected:
         /// Stoppt/Erlaubt Produktion (real)
         void SetProductionEnabled(const bool enabled);
         /// Fragt ab, ob Produktion ausgeschaltet ist (visuell)
-        bool IsProductionDisabledVirtual() { return disable_production_virtual; }
+        bool IsProductionDisabledVirtual() const { return disable_production_virtual; }
         /// Fragt ab, ob Produktion ausgeschaltet ist (real)
-        bool IsProductionDisabled() { return disable_production; }
+        bool IsProductionDisabled() const { return disable_production; }
         /// Setzt Produktivität instant auf 0 (Keine Ressourcen mehr)
         void SetProductivityToZero();
 

--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -309,7 +309,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
     if(road.mode)
     {
         // in "richtige" Map-Koordinaten Konvertieren, den aktuellen selektierten Punkt
-        MapPoint cSel = gwv->GetSel();
+        MapPoint cSel = gwv->GetSelectedPt();
         // Um auf Wasserweglängenbegrenzun reagieren zu können:
         MapPoint cSel2(cSel);
 
@@ -377,7 +377,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
 
         iwAction::Tabs action_tabs;
 
-        const MapPoint cSel = gwv->GetSel();
+        const MapPoint cSel = gwv->GetSelectedPt();
 
         // Vielleicht steht hier auch ein Schiff?
         if(noShip* ship = gwv->GetShip(cSel, GAMECLIENT.GetPlayerID()))

--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -54,6 +54,7 @@
 #include "ingameWindows/iwTrade.h"
 #include "ingameWindows/iwMapDebug.h"
 #include "nodeObjs/noFlag.h"
+#include "nodeObjs/noTree.h"
 #include "buildings/nobHQ.h"
 #include "buildings/nobHarborBuilding.h"
 #include "buildings/noBuildingSite.h"
@@ -753,11 +754,15 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
  */
 void dskGameInterface::Run()
 {
+    // Reset draw counter of the trees before drawing
+    noTree::ResetDrawCounter();
+
     unsigned water_percent;
-    gwv->Draw(GAMECLIENT.GetPlayerID(), &water_percent, actionwindow != NULL, selected, road);
+    gwv->Draw(&water_percent, actionwindow != NULL, selected, road);
 
     // Evtl Meeresrauschen-Sounds abspieln
     SOUNDMANAGER.PlayOceanBrawling(water_percent);
+    SOUNDMANAGER.PlayBirdSounds(noTree::QueryDrawCounter());
 
     messenger.Draw();
 }

--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -84,7 +84,7 @@ dskGameInterface::dskGameInterface()
     : Desktop(NULL),
       gwv(GAMECLIENT.QueryGameWorldViewer()), cbb(LOADER.GetPaletteN("pal5")),
       actionwindow(NULL), roadwindow(NULL),
-      selected(0, 0), minimap(*gwv)
+      selected(0, 0), minimap(*gwv), zoomLvl(0)
 {
     road.mode = RM_DISABLED;
     road.point = MapPoint(0, 0);
@@ -741,6 +741,24 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
         {
             gwv->ShowProductivity();
         } return true;
+        case 'z': // zoom
+            if(++zoomLvl > 5)
+                zoomLvl = 0;
+            float zoomFactor;
+            if(zoomLvl == 0)
+                zoomFactor = 1.f;
+            else if(zoomLvl == 1)
+                zoomFactor = 1.1f;
+            else if(zoomLvl == 2)
+                zoomFactor = 1.2f;
+            else if(zoomLvl == 3)
+                zoomFactor = 1.3f;
+            else if(zoomLvl == 4)
+                zoomFactor = 1.5f;
+            else
+                zoomFactor = 1.9f;
+            gwv->GetView()->SetZoomFactor(zoomFactor);
+            return true;
     }
 
     return false;

--- a/src/desktops/dskGameInterface.h
+++ b/src/desktops/dskGameInterface.h
@@ -82,6 +82,7 @@ class dskGameInterface :
         /// Minimap-Instanz
         IngameMinimap minimap;
 
+        unsigned zoomLvl;
     public:
         /// Konstruktor von @p dskGameInterface.
         dskGameInterface();
@@ -95,11 +96,6 @@ class dskGameInterface :
 
         /// Lässt das Spiel laufen (zeichnen)
         void Run();
-
-        /// Wird aufgerufen, wenn eine Taste gedrückt wurde
-        void KeyPressed(KeyEvent ke);
-        /// Wird bei Linksmausklicks aufgerufen
-        void MouseClicked(MouseCoords* mc);
 
         /// Aktiviert Straßenbaumodus bzw gibt zurück, ob er aktiviert ist
         void ActivateRoadMode(const RoadMode rm);

--- a/src/ingameWindows/iwObservate.cpp
+++ b/src/ingameWindows/iwObservate.cpp
@@ -34,10 +34,9 @@
 
 // 260x190, 300x250, 340x310
 
-//IngameWindow::IngameWindow(unsigned int id, const MapPoint pt, unsigned short width, unsigned short height, const std::string& title, glArchivItem_Bitmap *background, bool modal)
 iwObservate::iwObservate(GameWorldViewer* const gwv, const MapPoint selectedPt)
     : IngameWindow(gwv->CreateGUIID(selectedPt), 0xFFFE, 0xFFFE, 300, 250, _("Observation window"), NULL),
-      view(new GameWorldView(MapPoint(GetX() + 10, GetY() + 15), 300 - 20, 250 - 20)), selectedPt(selectedPt), last_x(-1), last_y(-1), scroll(false)
+      view(new GameWorldView(MapPoint(GetX() + 10, GetY() + 15), 300 - 20, 250 - 20)), selectedPt(selectedPt), last_x(-1), last_y(-1), scroll(false), zoomLvl(0)
 {
     view->SetGameWorldViewer(gwv);
     view->MoveToMapObject(selectedPt);
@@ -59,6 +58,18 @@ void iwObservate::Msg_ButtonClick(const unsigned int ctrl_id)
     switch (ctrl_id)
     {
         case 1:
+            if(++zoomLvl > 4)
+                zoomLvl = 0;
+            if(zoomLvl == 0)
+                view->zoomFactor = 1.f;
+            else if(zoomLvl == 1)
+                view->zoomFactor = 1.3f;
+            else if(zoomLvl == 2)
+                view->zoomFactor = 1.6f;
+            else if(zoomLvl == 3)
+                view->zoomFactor = 1.9f;
+            else
+                view->zoomFactor = 2.3f;
             break;
         case 2:
             break;

--- a/src/ingameWindows/iwObservate.cpp
+++ b/src/ingameWindows/iwObservate.cpp
@@ -36,10 +36,10 @@
 
 iwObservate::iwObservate(GameWorldViewer* const gwv, const MapPoint selectedPt)
     : IngameWindow(gwv->CreateGUIID(selectedPt), 0xFFFE, 0xFFFE, 300, 250, _("Observation window"), NULL),
-      view(new GameWorldView(MapPoint(GetX() + 10, GetY() + 15), 300 - 20, 250 - 20)), selectedPt(selectedPt), last_x(-1), last_y(-1), scroll(false), zoomLvl(0)
+      view(new GameWorldView(Point<int>(GetX() + 10, GetY() + 15), 300 - 20, 250 - 20)), selectedPt(selectedPt), last_x(-1), last_y(-1), scroll(false), zoomLvl(0)
 {
     view->SetGameWorldViewer(gwv);
-    view->MoveToMapObject(selectedPt);
+    view->MoveToMapPt(selectedPt);
     SetCloseOnRightClick(false);
 
     // Lupe: 36
@@ -61,15 +61,15 @@ void iwObservate::Msg_ButtonClick(const unsigned int ctrl_id)
             if(++zoomLvl > 4)
                 zoomLvl = 0;
             if(zoomLvl == 0)
-                view->zoomFactor = 1.f;
+                view->SetZoomFactor(1.f);
             else if(zoomLvl == 1)
-                view->zoomFactor = 1.3f;
+                view->SetZoomFactor(1.3f);
             else if(zoomLvl == 2)
-                view->zoomFactor = 1.6f;
+                view->SetZoomFactor(1.6f);
             else if(zoomLvl == 3)
-                view->zoomFactor = 1.9f;
+                view->SetZoomFactor(1.9f);
             else
-                view->zoomFactor = 2.3f;
+                view->SetZoomFactor(2.3f);
             break;
         case 2:
             break;
@@ -123,7 +123,7 @@ bool iwObservate::Draw_()
 {
     if ((x_ != last_x) || (y_ != last_y))
     {
-        view->SetPos(MapPoint(GetX() + 10, GetY() + 15));
+        view->SetPos(Point<int>(GetX() + 10, GetY() + 15));
         last_x = x_;
         last_y = y_;
     }
@@ -136,7 +136,7 @@ bool iwObservate::Draw_()
         road.point = MapPoint(0, 0);
         road.start = MapPoint(0, 0);
 
-        view->Draw(NULL, true, view->GetGameWorldViewer().GetSel(), road);
+        view->Draw(NULL, true, view->GetGameWorldViewer().GetSelectedPt(), road);
     }
 
     return(IngameWindow::Draw_());

--- a/src/ingameWindows/iwObservate.cpp
+++ b/src/ingameWindows/iwObservate.cpp
@@ -125,7 +125,7 @@ bool iwObservate::Draw_()
         road.point = MapPoint(0, 0);
         road.start = MapPoint(0, 0);
 
-        view->Draw(GAMECLIENT.GetPlayerID(), NULL, true, view->GetGameWorldViewer().GetSel(), road);
+        view->Draw(NULL, true, view->GetGameWorldViewer().GetSel(), road);
     }
 
     return(IngameWindow::Draw_());

--- a/src/ingameWindows/iwObservate.h
+++ b/src/ingameWindows/iwObservate.h
@@ -38,6 +38,8 @@ class iwObservate : public IngameWindow
         bool scroll;
         int sx, sy;
 
+        unsigned zoomLvl;
+
     public:
         iwObservate(GameWorldViewer* const gwv, const MapPoint selectedPt);
 

--- a/src/ingameWindows/iwSave.cpp
+++ b/src/ingameWindows/iwSave.cpp
@@ -61,10 +61,6 @@ iwSaveLoad::iwSaveLoad(const unsigned short add_height, const std::string& windo
     : IngameWindow(CGI_SAVE, 0xFFFF, 0xFFFF, 600, 400 + add_height, window_title, LOADER.GetImageN("resource", 41))
 {
     AddTable(0, 20, 30, 560, 300, TC_GREEN2, NormalFont, 5, _("Filename"), 270, ctrlTable::SRT_STRING, _("Map"), 250, ctrlTable::SRT_STRING, _("Time"), 250, ctrlTable::SRT_DATE, _("Start GF"), 320, ctrlTable::SRT_NUMBER,  "", 0, ctrlTable::SRT_STRING);
-
-
-    // Tabelle ausfüllen beim Start
-    RefreshTable();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -98,8 +94,7 @@ void iwSaveLoad::Msg_ButtonClick(const unsigned int  /*ctrl_id*/)
 void iwSaveLoad::Msg_TableSelectItem(const unsigned int  /*ctrl_id*/, const int selection)
 {
     // Dateiname ins Edit schreiben, wenn wir entsprechende Einträge auswählen
-    GetCtrl<ctrlEdit>(1)->SetText
-    (GetCtrl<ctrlTable>(0)->GetItemText(selection, 0));
+    GetCtrl<ctrlEdit>(1)->SetText(GetCtrl<ctrlTable>(0)->GetItemText(selection, 0));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -223,6 +218,9 @@ iwSave::iwSave() : iwSaveLoad(40, _("Save game!"))
     // Ungültig oder 0 --> Deaktiviert auswählen
     if(!found)
         combo->SetSelection(0);
+
+    // Tabelle ausfüllen beim Start
+    RefreshTable();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -252,6 +250,8 @@ iwLoad::iwLoad(const CreateServerInfo& csi) : iwSaveLoad(0, _("Load game!")),  c
 {
     AddEdit(1, 20, 350, 510, 22, TC_GREEN2, NormalFont);
     AddImageButton(2, 540, 346, 40, 40, TC_GREEN2, LOADER.GetImageN("io", 48));
+    // Tabelle ausfüllen beim Start
+    RefreshTable();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -98,6 +98,12 @@ void GameWorldView::Draw(unsigned* water, const bool draw_selected, const MapPoi
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glScalef(zoomFactor, zoomFactor, 1);
+        // Offset to center view
+        Point<float> diff(width - width / zoomFactor, height - height / zoomFactor);
+        diff = diff / 2.f;
+        glTranslatef(-diff.x, -diff.y, 0.f);
+        // Also adjust mouse
+        mousePos = Point<int>(Point<float>(mousePos) / zoomFactor + diff);
         glMatrixMode(GL_MODELVIEW);
     }
 
@@ -573,10 +579,11 @@ void GameWorldView::CalcFxLx()
         // Greater zoom reduces visible area
         Point<float> reducedSize = size / zoomFactor;
         // Difference we need to remove
-        Point<float> diff = size - reducedSize;
+        Point<float> diff = (size - reducedSize) / 2.f;
         // Don't remove to much
         diff.x = std::floor(diff.x);
         diff.y = std::floor(diff.y);
+        firstPt = Point<int>(Point<float>(firstPt) + diff);
         lastPt = Point<int>(Point<float>(lastPt) - diff);
     }
 }

--- a/src/world/GameWorldView.h
+++ b/src/world/GameWorldView.h
@@ -39,94 +39,89 @@ struct ObjectBetweenLines;
 
 class GameWorldView
 {
-    /// Selektierter Punkt
+    /// Currently selected point (where the mouse points to)
     MapPoint selPt;
-    Point<int> selO;
+    /// Offset to selected point
+    Point<int> selPtOffset;
 
-    /// Koordinaten auf der Map anzeigen (zum Debuggen)?
+    /// Class for printing debug map data
     IDebugNodePrinter* debugNodePrinter;
 
-    bool show_bq;    ///< Bauqualitäten-Anzeigen ein oder aus
-    bool show_names; ///< Gebäudenamen-Anzeigen ein oder aus
-    bool show_productivity; ///< Produktivität-Anzeigen ein oder aus
+    /// Show building quality icons
+    bool show_bq;
+    /// Show building names
+    bool show_names;
+    /// Show productivities
+    bool show_productivity;
 
-    /// Scrolling-Zeug
+    /// Offset from world origin in screen units (not map units): "scroll position"
     Point<int> offset;
-    /// Letzte Scrollposition, an der man war, bevor man weggesprungen ist
+    /// Last scroll position (before jump)
     Point<int> lastOffset;
-    /// Erster gezeichneter Map-Punkt
+    /// First drawn map point (might be slightly outside map -> Wrapping)
     Point<int> firstPt;
-    /// Letzter gezeichneter Map-Punkt
+    /// Last drawn map point
     Point<int> lastPt;
 
     GameWorldViewer* gwv;
 
-protected:
     unsigned d_what;
     unsigned d_player;
     bool d_active;
 
-    MapPoint pos;
-    unsigned short width, height;
+    /// Top-Left position of the view (window)
+    Point<int> pos;
+    /// Size of the view
+    unsigned width, height;
 
-public:
-    unsigned int terrain_list;
-    Point<int> terrainLastOffset;
-    unsigned int terrain_last_global_animation;
-    unsigned int terrain_last_water;
+    /// How much the view is scaled (1=normal, >1=bigger, >0 && <1=smaller)
     float zoomFactor;
 
-    GameWorldView(const MapPoint pt, unsigned short width, unsigned short height);
+public:
+    GameWorldView(const Point<int>& pos, unsigned width, unsigned height);
     ~GameWorldView();
 
     GameWorldViewer& GetGameWorldViewer() const {return *gwv;}
     void SetGameWorldViewer(GameWorldViewer* viewer);
 
+    void SetPos(const Point<int>& newPos) { pos = newPos; }
+    Point<int> GetPos() const { return pos; }
 
-    inline void SetPos(MapPoint newPos) { pos = newPos; }
-    inline MapPoint GetPos() const {return pos;}
+    void SetZoomFactor(float zoomFactor);
 
     /// Bauqualitäten anzeigen oder nicht
-    inline void ShowBQ() { show_bq = !show_bq; }
+    void ToggleShowBQ() { show_bq = !show_bq; }
     /// Gebäudenamen zeigen oder nicht
-    inline void ShowNames() { show_names = !show_names; }
+    void ToggleShowNames() { show_names = !show_names; }
     /// Produktivität zeigen oder nicht
-    inline void ShowProductivity() { show_productivity = !show_productivity; };
+    void ToggleShowProductivity() { show_productivity = !show_productivity; };
     /// Schaltet Produktivitäten/Namen komplett aus oder an
-    void ShowNamesAndProductivity();
+    void ToggleShowNamesAndProductivity();
 
     void Draw(unsigned* water, const bool draw_selected, const MapPoint selected, const RoadsBuilding& rb);
 
     /// Bewegt sich zu einer bestimmten Position in Pixeln auf der Karte
     void MoveTo(int x, int y, bool absolute = false);
     /// Zentriert den Bildschirm auf ein bestimmtes Map-Object
-    void MoveToMapObject(const MapPoint pt);
+    void MoveToMapPt(const MapPoint pt);
     /// Springt zur letzten Position, bevor man "weggesprungen" ist
     void MoveToLastPosition();
 
-    inline void MoveToX(int x, bool absolute = false) { MoveTo( (absolute ? 0 : offset.x) + x, offset.y, true); }
-    inline void MoveToY(int y, bool absolute = false) { MoveTo( offset.x, (absolute ? 0 : offset.y) + y, true); }
+    void MoveToX(int x, bool absolute = false) { MoveTo( (absolute ? 0 : offset.x) + x, offset.y, true); }
+    void MoveToY(int y, bool absolute = false) { MoveTo( offset.x, (absolute ? 0 : offset.y) + y, true); }
 
-    /// Koordinatenanzeige ein/aus
+    /// Set the debug node printer used. Max. 1 at a time. NULL for disabling
     void SetDebugNodePrinter(IDebugNodePrinter* newPrinter) { debugNodePrinter = newPrinter; }
 
     /// Gibt selektierten Punkt zurück
-    inline MapCoord GetSelX() const { return selPt.x; }
-    inline MapCoord GetSelY() const { return selPt.y; }
-    inline MapPoint GetSel() const { return selPt; }
+    MapPoint GetSelectedPt() const { return selPt; }
 
-    inline Point<int> GetSelo() const { return selO; }
-
-    /// Gibt Scrolling-Offset zurück
-    inline int GetXOffset() const { return offset.x - pos.x; }
-    inline int GetYOffset() const { return offset.y - pos.y; }
-    inline Point<int> GetOffset() const { return offset - Point<int>(pos); }
     /// Gibt ersten Punkt an, der beim Zeichnen angezeigt wird
-    inline Point<int> GetFirstPt() const { return firstPt; }
+    Point<int> GetFirstPt() const { return firstPt; }
     /// Gibt letzten Punkt an, der beim Zeichnen angezeigt wird
-    inline Point<int> GetLastPt() const { return lastPt; }
+    Point<int> GetLastPt() const { return lastPt; }
 
-    void Resize(unsigned short width, unsigned short height);
+    void Resize(unsigned width, unsigned height);
 
     void SetAIDebug(unsigned what, unsigned player, bool active)
     {

--- a/src/world/GameWorldView.h
+++ b/src/world/GameWorldView.h
@@ -20,9 +20,12 @@
 
 #include "gameTypes/MapTypes.h"
 #include "Point.h"
+#include <vector>
 
 class GameWorldViewer;
 struct RoadsBuilding;
+class TerrainRenderer;
+class noBaseBuilding;
 
 class IDebugNodePrinter{
 public:
@@ -31,6 +34,8 @@ public:
     /// Can e.g. print coordinates
     virtual void print(const MapPoint& pt, const Point<int>& displayPt) = 0;
 };
+
+struct ObjectBetweenLines;
 
 class GameWorldView
 {
@@ -89,7 +94,7 @@ public:
     /// Schaltet Produktivitäten/Namen komplett aus oder an
     void ShowNamesAndProductivity();
 
-    void Draw(const unsigned char player, unsigned* water, const bool draw_selected, const MapPoint selected, const RoadsBuilding& rb);
+    void Draw(unsigned* water, const bool draw_selected, const MapPoint selected, const RoadsBuilding& rb);
 
     /// Bewegt sich zu einer bestimmten Position in Pixeln auf der Karte
     void MoveTo(int x, int y, bool absolute = false);
@@ -100,8 +105,6 @@ public:
 
     inline void MoveToX(int x, bool absolute = false) { MoveTo( (absolute ? 0 : offset.x) + x, offset.y, true); }
     inline void MoveToY(int y, bool absolute = false) { MoveTo( offset.x, (absolute ? 0 : offset.y) + y, true); }
-
-    void CalcFxLx();
 
     /// Koordinatenanzeige ein/aus
     void SetDebugNodePrinter(IDebugNodePrinter* newPrinter) { debugNodePrinter = newPrinter; }
@@ -122,14 +125,24 @@ public:
     /// Gibt letzten Punkt an, der beim Zeichnen angezeigt wird
     inline Point<int> GetLastPt() const { return lastPt; }
 
-    void DrawBoundaryStone(const int x, const int y, const MapPoint t, const Point<int> pos, Visibility vis);
-
     void Resize(unsigned short width, unsigned short height);
 
     void SetAIDebug(unsigned what, unsigned player, bool active)
     {
         d_what = what; d_player = player; d_active = active;
     }
+
+private:
+    void CalcFxLx();
+    void DrawAIDebug(const MapPoint& pt, const Point<int>& curPos);
+    void DrawBoundaryStone(const MapPoint& pt, const Point<int> pos, Visibility vis);
+    void DrawObject(const MapPoint& pt, const Point<int>& curPos);
+    void DrawConstructionAid(const MapPoint& pt, const Point<int>& curPos);
+    void DrawFigures(const MapPoint& pt, const Point<int>&curPos, std::vector<ObjectBetweenLines>& between_lines);
+    void DrawNameProductivityOverlay(const TerrainRenderer& terrainRenderer);
+    void DrawProductivity(const noBaseBuilding& no, const Point<int>& curPos);
+    void DrawGUI(const RoadsBuilding& rb, const TerrainRenderer& terrainRenderer, const bool draw_selected, const MapPoint& selectedPt);
+
 };
 
 #endif // GameWorldView_h__

--- a/src/world/GameWorldView.h
+++ b/src/world/GameWorldView.h
@@ -74,6 +74,7 @@ public:
     Point<int> terrainLastOffset;
     unsigned int terrain_last_global_animation;
     unsigned int terrain_last_water;
+    float zoomFactor;
 
     GameWorldView(const MapPoint pt, unsigned short width, unsigned short height);
     ~GameWorldView();

--- a/src/world/GameWorldViewer.cpp
+++ b/src/world/GameWorldViewer.cpp
@@ -33,7 +33,7 @@
 #include "DebugNew.h" // IWYU pragma: keep
 class FOWObject;
 
-GameWorldViewer::GameWorldViewer() : scroll(false), sx(0), sy(0), view(GameWorldView(MapPoint(0, 0), VIDEODRIVER.GetScreenWidth(), VIDEODRIVER.GetScreenHeight()))
+GameWorldViewer::GameWorldViewer() : scroll(false), sx(0), sy(0), view(GameWorldView(Point<int>(0, 0), VIDEODRIVER.GetScreenWidth(), VIDEODRIVER.GetScreenHeight()))
 {
     view.SetGameWorldViewer(this);
     MoveTo(0, 0);

--- a/src/world/GameWorldViewer.h
+++ b/src/world/GameWorldViewer.h
@@ -40,9 +40,9 @@ public:
 
     GameWorldViewer();
 
-    void Draw(const unsigned char player, unsigned* water, const bool draw_selected, const MapPoint selected, const RoadsBuilding& rb)
+    void Draw(unsigned* water, const bool draw_selected, const MapPoint selected, const RoadsBuilding& rb)
     {
-        view.Draw(player, water, draw_selected, selected, rb);
+        view.Draw(water, draw_selected, selected, rb);
     }
 
     inline GameWorldView* GetView() {return(&view);}

--- a/src/world/GameWorldViewer.h
+++ b/src/world/GameWorldViewer.h
@@ -29,7 +29,7 @@ class TerrainRenderer;
 struct RoadsBuilding;
 
 /// "Interface-Klasse" für GameWorldBase, die die Daten grafisch anzeigt
-class GameWorldViewer : public virtual GameWorldBase
+class GameWorldViewer: public virtual GameWorldBase
 {
     /// Wird gerade gescrollt?
     bool scroll;
@@ -45,18 +45,18 @@ public:
         view.Draw(water, draw_selected, selected, rb);
     }
 
-    inline GameWorldView* GetView() {return(&view);}
+    GameWorldView* GetView() { return(&view); }
 
-    inline TerrainRenderer* GetTerrainRenderer() {return(&tr);}
+    TerrainRenderer* GetTerrainRenderer() { return(&tr); }
 
     /// Bauqualitäten anzeigen oder nicht
-    inline void ShowBQ() {view.ShowBQ();}
+    void ShowBQ() { view.ToggleShowBQ(); }
     /// Gebäudenamen zeigen oder nicht
-    inline void ShowNames() {view.ShowNames();}
+    void ShowNames() { view.ToggleShowNames(); }
     /// Produktivität zeigen oder nicht
-    inline void ShowProductivity() {view.ShowProductivity();};
+    void ShowProductivity() { view.ToggleShowProductivity(); };
     /// Schaltet Produktivitäten/Namen komplett aus oder an
-    inline void ShowNamesAndProductivity() {view.ShowNamesAndProductivity();}
+    void ShowNamesAndProductivity() { view.ToggleShowNamesAndProductivity(); }
 
     /// Wegfinden ( A* ) --> Wegfindung auf allgemeinen Terrain ( ohne Straäcn ) ( fr Wegebau oder frei herumlaufende )
     bool FindRoadPath(const MapPoint start, const MapPoint dest, std::vector<unsigned char>& route, const bool boat_road);
@@ -67,27 +67,25 @@ public:
     void MouseMove(const MouseCoords& mc);
     void MouseDown(const MouseCoords& mc);
     void MouseUp();
-    inline void DontScroll() { scroll = false; }
+    void DontScroll() { scroll = false; }
 
     /// Bewegt sich zu einer bestimmten Position in Pixeln auf der Karte
-    inline void MoveTo(int x, int y, bool absolute = false) {view.MoveTo(x, y, absolute);};
+    void MoveTo(int x, int y, bool absolute = false) { view.MoveTo(x, y, absolute); };
     /// Zentriert den Bildschirm auf ein bestimmtes Map-Object
-    inline void MoveToMapObject(const MapPoint pt) {view.MoveToMapObject(pt);};
+    void MoveToMapObject(const MapPoint pt) { view.MoveToMapPt(pt); };
     /// Springt zur letzten Position, bevor man "weggesprungen" ist
-    inline void MoveToLastPosition() {view.MoveToLastPosition();};
+    void MoveToLastPosition() { view.MoveToLastPosition(); };
 
-    void MoveToX(int x, bool absolute = false) {view.MoveToX(x, absolute);}
-    void MoveToY(int y, bool absolute = false) {view.MoveToY(y, absolute);}
+    void MoveToX(int x, bool absolute = false) { view.MoveToX(x, absolute); }
+    void MoveToY(int y, bool absolute = false) { view.MoveToY(y, absolute); }
 
     /// Gibt selektierten Punkt zurück
-    inline MapCoord GetSelX() const { return(view.GetSelX()); }
-    inline MapCoord GetSelY() const { return(view.GetSelY()); }
-    MapPoint GetSel() const { return view.GetSel(); }
+    MapPoint GetSelectedPt() const { return view.GetSelectedPt(); }
 
     /// Gibt ersten Punkt an, der beim Zeichnen angezeigt wird
-    inline Point<int> GetFirstPt() const { return(view.GetFirstPt()); }
+    Point<int> GetFirstPt() const { return(view.GetFirstPt()); }
     /// Gibt letzten Punkt an, der beim Zeichnen angezeigt wird
-    inline Point<int> GetLastPt() const { return(view.GetLastPt()); }
+    Point<int> GetLastPt() const { return(view.GetLastPt()); }
 
     /// Ermittelt Sichtbarkeit eines Punktes für den lokalen Spieler, berücksichtigt ggf. Teamkameraden
     Visibility GetVisibility(const MapPoint pt) const;
@@ -110,16 +108,15 @@ public:
     /// Schattierungen (vor allem FoW) neu berechnen
     void RecalcAllColors();
 
-    /// Gibt das erste Schiff, was gefunden wird von diesem Spieler, zurück, ansonsten NULL, falls es nicht
-    /// existiert
+    /// Gibt das erste Schiff, was gefunden wird von diesem Spieler, zurück, ansonsten NULL, falls es nicht existiert
     noShip* GetShip(const MapPoint pt, const unsigned char player) const;
 
     /// Gibt die verfügbar Anzahl der Angreifer für einen Seeangriff zurück
     unsigned GetAvailableSoldiersForSeaAttackCount(const unsigned char player_attacker, const MapPoint pt) const;
 
-    inline void Resize(unsigned short width, unsigned short height) {view.Resize(width, height);}
+    void Resize(unsigned short width, unsigned short height) { view.Resize(width, height); }
 
-    inline void SetAIDebug(unsigned what, unsigned player, bool active) {view.SetAIDebug(what, player, active);}
+    void SetAIDebug(unsigned what, unsigned player, bool active) { view.SetAIDebug(what, player, active); }
 };
 
 #endif // GameWorldViewer_h__


### PR DESCRIPTION
As request here #425 this implements zooming for observation windows.

- [x] Needs rebase onto #437

Zooming is implemented via an option in `GameWorldViewer` which will call `glScale`.
This also fixes a minor bug, where the cursor in observation windows was not correctly displayed (wrong position)
Zooming the whole game is also possible, although not yet implemented