### PR TITLE
Save BQ for all players, not for the current one

### DIFF
--- a/src/GameSavegame.cpp
+++ b/src/GameSavegame.cpp
@@ -29,7 +29,7 @@
 /// Kleine Signatur am Anfang "RTTRSAVE", die ein gültiges S25 RTTR Savegame kennzeichnet
 const char Savegame::SAVE_SIGNATURE[8] = {'R', 'T', 'T', 'R', 'S', 'A', 'V', 'E'};
 /// Version des Savegame-Formates
-const unsigned short Savegame::SAVE_VERSION = 33;
+const unsigned short Savegame::SAVE_VERSION = 34;
 
 Savegame::Savegame() : SavedFile(), start_gf(0)
 {

--- a/src/Pathfinding.cpp
+++ b/src/Pathfinding.cpp
@@ -65,8 +65,8 @@ bool IsPointOK_RoadPathEvenStep(const GameWorldBase& gwb, const MapPoint pt, con
     // Feld bebaubar?
     if(!gwb.RoadAvailable(prp->boat_road, pt))
         return false;
-	if(!prp->boat_road && (gwb.CalcBQ(pt, gwb.GetNode(pt).owner-1, true, false) != BQ_FLAG))
-		return false;	
+    if(!prp->boat_road && gwb.GetBQ(pt, gwb.GetNode(pt).owner - 1, false) == BQ_NOTHING)
+        return false;
 
     return true;
 }

--- a/src/ai/AIInterface.cpp
+++ b/src/ai/AIInterface.cpp
@@ -190,15 +190,9 @@ bool AIInterface::FindFreePathForNewRoad(MapPoint start, MapPoint target, std::v
     return gwb.GetFreePathFinder().FindPathAlternatingConditions(start, target, false, 100, route, length, NULL, IsPointOK_RoadPath,IsPointOK_RoadPathEvenStep, NULL, (void*) &boat, false);
 }
 
-bool AIInterface::CalcBQSumDifference(const MapPoint pt, const MapPoint t)
+bool AIInterface::CalcBQSumDifference(const MapPoint pt1, const MapPoint pt2)
 {
-    unsigned s1 = 0, s2 = 0;
-    if(gwb.CalcBQ(pt, playerID_) != BQ_DANGER)
-        s1 += gwb.CalcBQ(pt, playerID_);
-    if(gwb.CalcBQ(t, playerID_) != BQ_DANGER)
-        s2 += gwb.CalcBQ(t, playerID_);
-    //LOG.lprintf("AIInterface::bqdiff - s1 %i,%i,%i s2 %i,%i,%i\n", pt,s1,tx,ty,s2);
-    return s2 < s1;
+    return gwb.GetBQ(pt2, playerID_) < gwb.GetBQ(pt1, playerID_);
 }
 
 bool AIInterface::FindPathOnRoads(const noRoadNode& start, const noRoadNode& target, unsigned* length) const

--- a/src/ai/AIInterface.h
+++ b/src/ai/AIInterface.h
@@ -175,8 +175,8 @@ class AIInterface: public GameCommandFactory<AIInterface>
         bool CalcBQSumDifference(const MapPoint pt, const MapPoint t);
 
         /// Returns building quality on a given spot
-        BuildingQuality GetBuildingQuality(const MapPoint pt) const { return gwb.CalcBQ(pt, playerID_); }
-		BuildingQuality GetBuildingQualityAnyOwner(const MapPoint pt) const { return gwb.CalcBQ(pt, playerID_,false,true,true); }
+        BuildingQuality GetBuildingQuality(const MapPoint pt) const { return gwb.GetBQ(pt, playerID_); }
+		BuildingQuality GetBuildingQualityAnyOwner(const MapPoint pt) const { return gwb.GetNode(pt).bqVisual; }
 
         // Tries to find a free path for a road and return length and the route
         bool FindFreePathForNewRoad(MapPoint start, MapPoint target, std::vector<unsigned char> *route = NULL,

--- a/src/ai/AIJHHelper.cpp
+++ b/src/ai/AIJHHelper.cpp
@@ -284,8 +284,7 @@ void AIJH::BuildJob::BuildMainRoad()
     {
         // Prüfen ob sich vielleicht die BQ geändert hat und damit Bau unmöglich ist
         BuildingQuality bq = aiInterface.GetBuildingQuality(target);
-        if (!(bq >= BUILDING_SIZE[type] && bq < BQ_MINE) // normales Gebäude
-                && !(bq == BUILDING_SIZE[type]))    // auch Bergwerke
+        if((BUILDING_SIZE[type] == BQ_MINE && bq != BQ_MINE) || (bq < BUILDING_SIZE[type]))
         {
             status = AIJH::JOB_FAILED;
 #ifdef DEBUG_AI

--- a/src/gameData/TerrainData.cpp
+++ b/src/gameData/TerrainData.cpp
@@ -583,7 +583,7 @@ bool TerrainData::IsMineable(TerrainType t)
     }
 }
 
-BuildingQuality TerrainData::GetBuildingQuality(TerrainType t)
+TerrainBQ TerrainData::GetBuildingQuality(TerrainType t)
 {
     switch(t)
     {
@@ -592,18 +592,18 @@ BuildingQuality TerrainData::GetBuildingQuality(TerrainType t)
     case TT_LAVA2:
     case TT_LAVA3:
     case TT_LAVA4:
-        return BQ_DANGER;
+        return TerrainBQ::DANGER;
     case TT_DESERT:
-        return BQ_FLAG;
+        return TerrainBQ::FLAG;
     case TT_SWAMPLAND:
     case TT_WATER:
     case TT_WATER_NOSHIP:
-        return BQ_NOTHING;
+        return TerrainBQ::NOTHING;
     case TT_MOUNTAIN1:
     case TT_MOUNTAIN2:
     case TT_MOUNTAIN3:
     case TT_MOUNTAIN4:
-        return BQ_MINE;
+        return TerrainBQ::MINE;
     case TT_MEADOW_FLOWERS:
     case TT_SAVANNAH:
     case TT_MEADOW1:
@@ -613,7 +613,7 @@ BuildingQuality TerrainData::GetBuildingQuality(TerrainType t)
     case TT_MOUNTAINMEADOW:
     case TT_BUILDABLE_WATER:
     case TT_BUILDABLE_MOUNTAIN:
-        return BQ_CASTLE;
+        return TerrainBQ::CASTLE;
     }
     throw std::logic_error("Invalid terrain type");
 }

--- a/src/gameData/TerrainData.h
+++ b/src/gameData/TerrainData.h
@@ -22,6 +22,17 @@
 #include "gameTypes/LandscapeType.h"
 #include "gameTypes/BuildingQuality.h"
 #include "Rect.h"
+#include <boost/detail/scoped_enum_emulation.hpp>
+
+BOOST_SCOPED_ENUM_DECLARE_BEGIN(TerrainBQ)
+{
+    NOTHING,
+    DANGER,
+    FLAG,
+    CASTLE,
+    MINE
+}
+BOOST_SCOPED_ENUM_DECLARE_END(TerrainBQ)
 
 class TerrainData
 {
@@ -68,7 +79,7 @@ public:
     /// Returns whether the given terrain is a mineable mountain
     static bool IsMineable(TerrainType t);
     /// Returns what kind of buildings can be build on that terrain
-    static BuildingQuality GetBuildingQuality(TerrainType t);
+    static TerrainBQ GetBuildingQuality(TerrainType t);
 };
 
 #endif // TerrainData_h__

--- a/src/gameTypes/BuildingQuality.h
+++ b/src/gameTypes/BuildingQuality.h
@@ -25,8 +25,7 @@ enum BuildingQuality
     BQ_HOUSE,
     BQ_CASTLE,
     BQ_MINE,
-    BQ_HARBOR,
-    BQ_DANGER = 255
+    BQ_HARBOR
 };
 
 #endif // BuildingQuality_h__

--- a/src/gameTypes/MapNode.cpp
+++ b/src/gameTypes/MapNode.cpp
@@ -43,6 +43,7 @@ void MapNode::Serialize(SerializedGameData& sgd) const
     for(unsigned b = 0; b < boundary_stones.size(); ++b)
         sgd.PushUnsignedChar(boundary_stones[b]);
     sgd.PushUnsignedChar(static_cast<unsigned char>(bq));
+    sgd.PushUnsignedChar(static_cast<unsigned char>(bqVisual));
     for(unsigned z = 0; z < GAMECLIENT.GetPlayerCount(); ++z)
     {
         const MapNode::FoWData& curFoW = fow[z];
@@ -86,6 +87,7 @@ void MapNode::Deserialize(SerializedGameData& sgd)
     for(unsigned b = 0; b < boundary_stones.size(); ++b)
         boundary_stones[b] = sgd.PopUnsignedChar();
     bq = BuildingQuality(sgd.PopUnsignedChar());
+    bqVisual = BuildingQuality(sgd.PopUnsignedChar());
     for(unsigned z = 0; z < GAMECLIENT.GetPlayerCount(); ++z)
     {
         MapNode::FoWData& curFoW = fow[z];

--- a/src/gameTypes/MapNode.h
+++ b/src/gameTypes/MapNode.h
@@ -50,7 +50,7 @@ struct MapNode
     typedef boost::array<unsigned char, 4> BoundaryStones;
     BoundaryStones boundary_stones;
     /// Bauqualität
-    BuildingQuality bq;
+    BuildingQuality bq, bqVisual;
     /// Visuelle Sachen für alle Spieler, die in Zusammenhang mit dem FoW stehen
     struct FoWData
     {

--- a/src/world/GameWorld.cpp
+++ b/src/world/GameWorld.cpp
@@ -137,7 +137,7 @@ void GameWorld::Deserialize(SerializedGameData& sgd)
     {
         for(unsigned x = 0; x < GetWidth(); ++x)
         {
-            CalcAndSetBQ(MapPoint(x, y), GAMECLIENT.GetPlayerID());
+            RecalcBQ(MapPoint(x, y));
         }
     }
 

--- a/src/world/GameWorldBase.h
+++ b/src/world/GameWorldBase.h
@@ -114,6 +114,11 @@ public:
     /// Ver�ndert die H�he eines Punktes und die damit verbundenen Schatten
     void AltitudeChanged(const MapPoint pt) override;
 
+    /// Berechnet Bauqualitäten an Punkt x;y und den ersten Kreis darum neu
+    void RecalcBQAroundPoint(const MapPoint pt);
+    /// Berechnet Bauqualitäten wie bei letzterer Funktion, bloß noch den 2. Kreis um x;y herum
+    void RecalcBQAroundPointBig(const MapPoint pt);
+
     /// Ermittelt Sichtbarkeit eines Punktes auch unter Einbeziehung der Verb�ndeten des jeweiligen Spielers
     Visibility CalcWithAllyVisiblity(const MapPoint pt, const unsigned char player) const;
 

--- a/src/world/GameWorldGame.h
+++ b/src/world/GameWorldGame.h
@@ -72,11 +72,6 @@ public:
     /// Stellt anderen Spielern/Spielobjekten das Game-GUI-Interface zur Verfüung
     inline GameInterface* GetGameInterface() const { return gi; }
 
-    /// Berechnet Bauqualitäten an Punkt x;y und den ersten Kreis darum neu
-    void RecalcBQAroundPoint(const MapPoint pt);
-    /// Berechnet Bauqualitäten wie bei letzterer Funktion, bloß noch den 2. Kreis um x;y herum
-    void RecalcBQAroundPointBig(const MapPoint pt);
-
     /// Prüft, ob dieser Punkt von Menschen betreten werden kann
     bool IsNodeForFigures(const MapPoint pt) const;
     /// Kann dieser Punkt von auf Straßen laufenden Menschen betreten werden? (Kämpfe!)

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -211,7 +211,7 @@ void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& ter
                 // Mauszeiger am boten
                 unsigned mid = 22;
                 if(rb.mode == RM_DISABLED){
-                    switch(gwv.GetNode(curPt).bq)
+                    switch(gwv.GetBQ(curPt, GAMECLIENT.GetPlayerID()))
                     {
                     case BQ_FLAG: mid = 40; break;
                     case BQ_MINE: mid = 41; break;
@@ -248,10 +248,8 @@ void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& ter
                 if(rb.mode == RM_BOAT && maxWaterWayLen != 0 && rb.route.size() >= maxWaterWayLen)
                     continue;
 
-                if(((gwv.RoadAvailable(rb.mode == RM_BOAT, curPt)
-                    && gwv.GetNode(curPt).owner - 1 == (signed)GAMECLIENT.GetPlayerID())
-                    || (gwv.GetNode(curPt).bq == BQ_FLAG))
-                    && gwv.IsPlayerTerritory(curPt))
+                if((gwv.RoadAvailable(rb.mode == RM_BOAT, curPt) && gwv.GetNode(curPt).owner == GAMECLIENT.GetPlayerID() + 1 && gwv.IsPlayerTerritory(curPt))
+                    || (gwv.GetBQ(curPt, GAMECLIENT.GetPlayerID()) == BQ_FLAG))
                 {
                     unsigned id;
                     switch(int(gwv.GetNode(curPt).altitude) - altitude)
@@ -387,8 +385,8 @@ void GameWorldView::DrawFigures(const MapPoint& pt, const Point<int>&curPos, std
 
 void GameWorldView::DrawConstructionAid(const MapPoint& pt, const Point<int>& curPos)
 {
-    BuildingQuality bq = gwv.GetNode(pt).bq;
-    if(bq != BQ_NOTHING && bq != BQ_DANGER) //-V807
+    BuildingQuality bq = gwv.GetBQ(pt, GAMECLIENT.GetPlayerID());
+    if(bq != BQ_NOTHING) //-V807
     {
         glArchivItem_Bitmap* bm = LOADER.GetMapImageN(49 + bq);
         //Draw building quality icon

--- a/src/world/MapLoader.cpp
+++ b/src/world/MapLoader.cpp
@@ -55,7 +55,7 @@ void MapLoader::Load(const glArchivItem_Map& map)
         for(pt.x = 0; pt.x < world.GetWidth(); ++pt.x)
         {
             world.RecalcShadow(pt);
-            world.CalcAndSetBQ(pt, GAMECLIENT.GetPlayerID());
+            world.RecalcBQ(pt);
         }
     }
 
@@ -125,6 +125,7 @@ void MapLoader::InitNodes(const glArchivItem_Map& map)
             node.owner = 0;
             std::fill(node.boundary_stones.begin(), node.boundary_stones.end(), 0);
             node.bq = BQ_NOTHING;
+            node.bqVisual = BQ_NOTHING;
             node.sea_id = 0;
 
             Visibility fowVisibility;

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -170,13 +170,12 @@ public:
     bool IsPlayerTerritory(const MapPoint pt) const;
     /// Ist eine Flagge irgendwo um x,y ?
     bool FlagNear(const MapPoint pt) const;
-    /// Bauqualitäten berechnen, bei flagonly gibt er nur 1 zurück, wenn eine Flagge möglich ist
-    BuildingQuality CalcBQ(const MapPoint pt, const unsigned char player, const bool flagonly = false, const bool visual = true, const bool ignore_player = false) const;
-    /// Setzt die errechnete BQ gleich mit
-    void CalcAndSetBQ(const MapPoint pt, const unsigned char player, const bool flagonly = false, const bool visual = true);
+    /// Recalculates the BQ for the given point
+    void RecalcBQ(const MapPoint pt);
+    /// Returns the BQ for the given player
+    BuildingQuality GetBQ(const MapPoint pt, const unsigned char player, const bool visual = true) const;
 
     /// Gibt Figuren, die sich auf einem bestimmten Punkt befinden, zurück
-    /// nicht bei laufenden Figuren oder
     const std::list<noBase*>& GetFigures(const MapPoint pt) const { return GetNode(pt).figures; }
 
     // Gibt ein spezifisches Objekt zurück
@@ -235,6 +234,11 @@ protected:
 
     /// Berechnet die Schattierung eines Punktes neu
     void RecalcShadow(const MapPoint pt);
+
+private:
+    /// Calculates BQ for a point. Visual affects used road state, flagOnly checks only if flag is possible
+    BuildingQuality CalcBQ(const MapPoint pt, const bool visual, const bool flagOnly = false) const;
+
 };
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This stores the BQ as a per-field value independent of the current owner. This allows e.g. multiple players on one world, and especially avoids costly recalculation of the BQ by the AI.

Bumps savegame version
Adresses #82 (Prepares #451 which will work upon this)