### PR TITLE
Don't instantiate new BQCalculator classes in tests

### DIFF
--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -64,6 +64,7 @@
 #include "world/GameWorldViewer.h"
 #include "pathfinding/FreePathFinderImpl.h"
 #include "pathfinding/PathConditions.h"
+#include "postSystem/PostMsg.h"
 #include "notifications/BuildingNote.h"
 #include "notifications/NotificationManager.h"
 #include "gameData/TerrainData.h"
@@ -81,7 +82,6 @@
 #include <boost/lambda/bind.hpp>
 #include <sstream>
 #include <algorithm>
-#include "postSystem/PostMsg.h"
 
 dskGameInterface::dskGameInterface(GameWorldBase& world) : Desktop(NULL),
     gameClient(GAMECLIENT),

--- a/src/test/CreateSeaWorld.cpp
+++ b/src/test/CreateSeaWorld.cpp
@@ -19,7 +19,6 @@
 #include "CreateSeaWorld.h"
 #include "world/GameWorldGame.h"
 #include "world/MapLoader.h"
-#include "world/BQCalculator.h"
 #include <boost/foreach.hpp>
 
 CreateSeaWorld::CreateSeaWorld(unsigned width, unsigned height, unsigned numPlayers):
@@ -27,16 +26,15 @@ CreateSeaWorld::CreateSeaWorld(unsigned width, unsigned height, unsigned numPlay
 {}
 
 namespace{
-    bool PlaceHarbor(MapPoint pt, const World& world, std::vector<MapPoint>& harbors)
+    bool PlaceHarbor(MapPoint pt, GameWorldBase& world, std::vector<MapPoint>& harbors)
     {
         // Get all points within a radius of 3 and place the harbor on the first possible place
         std::vector<MapPoint> pts = world.GetPointsInRadius(pt, 3);
-        BQCalculator calcBQ(world);
-        ReturnConst<bool, false> retFalse;
         BOOST_FOREACH(MapPoint curPt, pts)
         {
             // Harbor only at castles
-            if(calcBQ(curPt, retFalse) != BQ_CASTLE)
+            world.RecalcBQ(curPt);
+            if(world.GetNode(curPt).bq != BQ_CASTLE)
                 continue;
             // We must have a coast around
             for(unsigned i = 0; i < 6; i++)


### PR DESCRIPTION
This should increase test coverage as the actual BQCalculator functions are tested and not separate instances.