### PR TITLE
fix for scoped enum emulation

### DIFF
--- a/contrib/backport/boost_1.55-1.56/boost/core/scoped_enum.hpp
+++ b/contrib/backport/boost_1.55-1.56/boost/core/scoped_enum.hpp
@@ -1,1 +1,17 @@
+#ifndef BOOST_CORE_SCOPED_ENUM_HPP
+#define BOOST_CORE_SCOPED_ENUM_HPP
+
 #include <boost/detail/scoped_enum_emulation.hpp>
+
+#ifdef BOOST_NO_CXX11_SCOPED_ENUMS
+    // Bugfix: Boost 1.55 expects native_value_ member
+#   undef BOOST_SCOPED_ENUM_DECLARE_END
+#   define BOOST_SCOPED_ENUM_DECLARE_END(EnumType)                                     \
+        ;                                                                              \
+        EnumType(enum_type v) BOOST_NOEXCEPT : v_(v) {}                                \
+	    enum_type native_value_() const BOOST_NOEXCEPT { return get_native_value_(); } \
+	    BOOST_SCOPED_ENUM_DECLARE_END2()
+#endif
+
+#endif // BOOST_CORE_SCOPED_ENUM_HPP
+

--- a/src/SoundEffect.h
+++ b/src/SoundEffect.h
@@ -18,7 +18,7 @@
 #ifndef SoundEffect_h__
 #define SoundEffect_h__
 
-#include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/core/scoped_enum.hpp>
 
 BOOST_SCOPED_ENUM_DECLARE_BEGIN(SoundEffect)
 {

--- a/src/gameData/TerrainData.h
+++ b/src/gameData/TerrainData.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2016 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -22,7 +22,7 @@
 #include "gameTypes/LandscapeType.h"
 #include "gameTypes/BuildingQuality.h"
 #include "Rect.h"
-#include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/core/scoped_enum.hpp>
 
 BOOST_SCOPED_ENUM_DECLARE_BEGIN(TerrainBQ)
 {

--- a/src/gameTypes/ServerType.h
+++ b/src/gameTypes/ServerType.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2016 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -18,7 +18,7 @@
 #ifndef ServerType_h__
 #define ServerType_h__
 
-#include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/core/scoped_enum.hpp>
 
 // Servertypen
 BOOST_SCOPED_ENUM_DECLARE_BEGIN(ServerType) //-V730

--- a/src/postSystem/PostCategory.h
+++ b/src/postSystem/PostCategory.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2016 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -18,7 +18,7 @@
 #ifndef PostCategory_h__
 #define PostCategory_h__
 
-#include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/core/scoped_enum.hpp>
 
 BOOST_SCOPED_ENUM_DECLARE_BEGIN(PostCategory)
 {


### PR DESCRIPTION
boost 1.55 has a bug in `boost::native_value()` which this fixes