### PR TITLE
Fix mem leak of BurnedWarehouse

### DIFF
--- a/src/buildings/BurnedWarehouse.cpp
+++ b/src/buildings/BurnedWarehouse.cpp
@@ -54,6 +54,8 @@ BurnedWarehouse::~BurnedWarehouse()
 
 void BurnedWarehouse::Destroy()
 {
+    gwg->RemoveFigure(this, pos);
+    noCoordBase::Destroy();
 }
 
 

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -115,7 +115,7 @@ void nobBaseWarehouse::Destroy_nobBaseWarehouse()
         gwg->GetPlayer(player).DecreaseInventoryWare(GoodType(i), inventory[GoodType(i)]);
 
     // Objekt, das die flüchtenden Leute nach und nach ausspuckt, erzeugen
-    new BurnedWarehouse(pos, player, inventory.real.people);
+    gwg->AddFigure(new BurnedWarehouse(pos, player, inventory.real.people), pos);
 
     Destroy_nobBaseMilitary();
 }


### PR DESCRIPTION
This instance is not registred anywhere. If the game is closed when it is active, it will leak. This puts it into figures (like the fighting)