### PR TITLE
Zoom by mouse wheel

### DIFF
--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -70,6 +70,7 @@
 #include "gameData/TerrainData.h"
 #include "gameData/const_gui_ids.h"
 #include "gameData/GameConsts.h"
+#include "gameData/GuiConsts.h"
 #include "ogl/glArchivItem_Font.h"
 #include "ogl/glArchivItem_Bitmap_Player.h"
 #include "ogl/glArchivItem_Sound.h"

--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -340,7 +340,7 @@ void dskGameInterface::Msg_PaintAfter()
     }
 
     // Draw zoom level indicator icon
-    if (zoomLvl > 0)
+    if (gwv.GetCurrentTargetZoomFactor() != 1.f)
     {
         glArchivItem_Bitmap* magnifierImg = LOADER.GetImageN("io", 36);
         const DrawPoint drawPos(iconPos);
@@ -348,8 +348,8 @@ void dskGameInterface::Msg_PaintAfter()
         iconPos -= DrawPoint(magnifierImg->getWidth() + 4, 0);
         magnifierImg->Draw(drawPos, 0, 0, 0, 0);
 
-        std::string multiplier = helpers::toString(zoomLvl);
-        NormalFont->Draw(drawPos - magnifierImg->GetOrigin() + DrawPoint(9, 7), multiplier, glArchivItem_Font::DF_LEFT, COLOR_YELLOW);
+        std::string zoom_percent = helpers::toString((int)(gwv.GetCurrentTargetZoomFactor() * 100)) + "%";
+        NormalFont->Draw(drawPos - magnifierImg->GetOrigin() + DrawPoint(9, 7), zoom_percent, glArchivItem_Font::DF_CENTER, COLOR_YELLOW);
     }
 }
 
@@ -763,15 +763,16 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
         case 's': // Produktivität anzeigen
             gwv.ToggleShowProductivity();
             return true;
+        case 26: // ctrl+z
+            gwv.SetZoomFactor(ZOOM_FACTORS[ZOOM_DEFAULT_INDEX]);
+            return true;
         case 'z': // zoom
-            if (ke.ctrl)
-                zoomLvl = ZOOM_DEFAULT_INDEX;
-            else if (++zoomLvl >= ZOOM_FACTORS.size())
+            if (++zoomLvl >= ZOOM_FACTORS.size())
                 zoomLvl = 0;
 
             gwv.SetZoomFactor(ZOOM_FACTORS[zoomLvl]);
             return true;
-        case 'Z':
+        case 'Z': // shift-z, reverse zoom
             if (zoomLvl == 0)
                 zoomLvl = ZOOM_FACTORS.size() - 1;
             else

--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -91,7 +91,7 @@ dskGameInterface::dskGameInterface(GameWorldBase& world) : Desktop(NULL),
     gwv(worldViewer, Point<int>(0,0), VIDEODRIVER.GetScreenWidth(), VIDEODRIVER.GetScreenHeight()),
     cbb(LOADER.GetPaletteN("pal5")),
     actionwindow(NULL), roadwindow(NULL),
-    selected(0, 0), minimap(worldViewer), isScrolling(false), zoomLvl(0)
+    selected(0, 0), minimap(worldViewer), isScrolling(false), zoomLvl(0), wheelzoomLvl(1.0)
 {
     road.mode = RM_DISABLED;
     road.point = MapPoint(0, 0);
@@ -767,6 +767,7 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
             if(++zoomLvl > 5)
                 zoomLvl = 0;
             gwv.SetZoomFactor(ZOOM_FACTORS[zoomLvl]);
+            wheelzoomLvl = ZOOM_FACTORS[zoomLvl];
             return true;
         case 'Z':
             if (zoomLvl == 0)
@@ -777,10 +778,32 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
                 zoomLvl--;
             }
             gwv.SetZoomFactor(ZOOM_FACTORS[zoomLvl]);
+            wheelzoomLvl = ZOOM_FACTORS[zoomLvl];
             return true;
     }
 
     return false;
+}
+
+bool dskGameInterface::Msg_WheelUp(const MouseCoords& mc) 
+{ 
+    zoomLvl = 5;
+    if (wheelzoomLvl < 5)
+    {
+        wheelzoomLvl *= 1.03;
+        gwv.SetZoomFactor((float)wheelzoomLvl);
+    }
+    return true; 
+}
+bool dskGameInterface::Msg_WheelDown(const MouseCoords& mc) 
+{ 
+    zoomLvl = 5;
+    if (wheelzoomLvl > 0.1)
+    {
+        wheelzoomLvl *= 0.97;
+        gwv.SetZoomFactor((float)wheelzoomLvl);
+    }
+    return true; 
 }
 
 void dskGameInterface::OnBuildingNote(const BuildingNote& note)

--- a/src/desktops/dskGameInterface.h
+++ b/src/desktops/dskGameInterface.h
@@ -79,6 +79,7 @@ class dskGameInterface :
         bool isScrolling;
         Point<int> startScrollPt;
         unsigned zoomLvl;
+        double wheelzoomLvl;
     public:
         dskGameInterface(GameWorldBase& world);
         ~dskGameInterface() override;
@@ -158,6 +159,8 @@ class dskGameInterface :
         bool Msg_RightDown(const MouseCoords& mc) override;
         bool Msg_RightUp(const MouseCoords& mc) override;
         bool Msg_KeyDown(const KeyEvent& ke) override;
+        bool Msg_WheelUp(const MouseCoords& mc) override;
+        bool Msg_WheelDown(const MouseCoords& mc) override;
 
         void OnBuildingNote(const BuildingNote& note);
 

--- a/src/desktops/dskGameInterface.h
+++ b/src/desktops/dskGameInterface.h
@@ -45,8 +45,6 @@ class PostMsg;
 struct BuildingNote;
 struct KeyEvent;
 
-const float ZOOM_FACTORS[6] = {1.f, 1.1f, 1.2f, 1.3f, 1.5f, 1.9f};
-
 class dskGameInterface :
     public Desktop,
     public ClientInterface,
@@ -78,8 +76,7 @@ class dskGameInterface :
 
         bool isScrolling;
         Point<int> startScrollPt;
-        unsigned zoomLvl;
-        double wheelzoomLvl;
+        size_t zoomLvl;
     public:
         dskGameInterface(GameWorldBase& world);
         ~dskGameInterface() override;
@@ -159,8 +156,11 @@ class dskGameInterface :
         bool Msg_RightDown(const MouseCoords& mc) override;
         bool Msg_RightUp(const MouseCoords& mc) override;
         bool Msg_KeyDown(const KeyEvent& ke) override;
+        
         bool Msg_WheelUp(const MouseCoords& mc) override;
         bool Msg_WheelDown(const MouseCoords& mc) override;
+        void WheelZoom(float step);
+
 
         void OnBuildingNote(const BuildingNote& note);
 

--- a/src/gameData/GameConsts.h
+++ b/src/gameData/GameConsts.h
@@ -24,6 +24,13 @@
 /// Geschwindigkeitsabstufungen - Längen der GFs in ms
 const boost::array<unsigned, 6> SUPPRESS_UNUSED SPEED_GF_LENGTHS = {{80, 60, 50, 40, 30, 1}};
 
+const boost::array<float, 5> ZOOM_FACTORS = { 0.5f, 0.75f, 1.f, 1.25f, 1.5f};
+const size_t ZOOM_DEFAULT_INDEX = 2;
+const float ZOOM_ACCELERATION = 0.001f;
+const float ZOOM_WHEEL_INCREMENT = 0.03f;
+const float ZOOM_MIN = 0.1f;
+const float ZOOM_MAX = 3.f;
+
 /// Konvertierungstabelle von Rohstoff-Indizes von den Bergwerken --> Map
 const boost::array<unsigned char, 5> SUPPRESS_UNUSED RESOURCES_MINE_TO_MAP = {{3, 0, 1, 2, 4}};
 

--- a/src/gameData/GameConsts.h
+++ b/src/gameData/GameConsts.h
@@ -24,13 +24,6 @@
 /// Geschwindigkeitsabstufungen - Längen der GFs in ms
 const boost::array<unsigned, 6> SUPPRESS_UNUSED SPEED_GF_LENGTHS = {{80, 60, 50, 40, 30, 1}};
 
-const boost::array<float, 5> ZOOM_FACTORS = { 0.5f, 0.75f, 1.f, 1.25f, 1.5f};
-const size_t ZOOM_DEFAULT_INDEX = 2;
-const float ZOOM_ACCELERATION = 0.001f;
-const float ZOOM_WHEEL_INCREMENT = 0.03f;
-const float ZOOM_MIN = 0.1f;
-const float ZOOM_MAX = 3.f;
-
 /// Konvertierungstabelle von Rohstoff-Indizes von den Bergwerken --> Map
 const boost::array<unsigned char, 5> SUPPRESS_UNUSED RESOURCES_MINE_TO_MAP = {{3, 0, 1, 2, 4}};
 

--- a/src/gameData/GuiConsts.h
+++ b/src/gameData/GuiConsts.h
@@ -20,7 +20,7 @@
 
 #include <boost/array.hpp>
 
-const boost::array<float, 5> ZOOM_FACTORS = { 0.5f, 0.75f, 1.f, 1.25f, 1.5f};
+const boost::array<float, 5> SUPPRESS_UNUSED ZOOM_FACTORS = {{ 0.5f, 0.75f, 1.f, 1.25f, 1.5f}};
 const size_t ZOOM_DEFAULT_INDEX = 2;
 const float ZOOM_ACCELERATION = 0.001f;
 const float ZOOM_WHEEL_INCREMENT = 0.03f;

--- a/src/gameData/GuiConsts.h
+++ b/src/gameData/GuiConsts.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GUICONSTS_H_
+#define GUICONSTS_H_
+
+#include <boost/array.hpp>
+
+const boost::array<float, 5> ZOOM_FACTORS = { 0.5f, 0.75f, 1.f, 1.25f, 1.5f};
+const size_t ZOOM_DEFAULT_INDEX = 2;
+const float ZOOM_ACCELERATION = 0.001f;
+const float ZOOM_WHEEL_INCREMENT = 0.03f;
+const float ZOOM_MIN = 0.1f;
+const float ZOOM_MAX = 3.f;
+
+
+#endif // GUICONSTS_H_

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -35,7 +35,7 @@
 #include "addons/AddonMaxWaterwayLength.h"
 #include "gameTypes/RoadBuildState.h"
 #include "helpers/converters.h"
-#include "gameData/GameConsts.h"
+#include "gameData/GuiConsts.h"
 #include <boost/format.hpp>
 #include <stdexcept>
 
@@ -71,47 +71,47 @@ const GameWorldBase& GameWorldView::GetWorld() const
 
 void GameWorldView::SetNextZoomFactor()
 {
-    if (zoomFactor == targetZoomFactor)
+    if (zoomFactor == targetZoomFactor) // == with float is ok here, is explicitly set in last step
         return;
 
-    float zoomDirection = targetZoomFactor - zoomFactor;
+    float remainingZoomDiff = targetZoomFactor - zoomFactor;
 
-    // last step
-    if (abs(zoomDirection) < abs(zoomSpeed))
+    if (abs(remainingZoomDiff) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
     {
-        zoomFactor = targetZoomFactor;
-        zoomSpeed = 0;
-    }
-    // deceleration towards zero zoom speed
-    else if (abs(zoomDirection) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
-    {
+        // deceleration towards zero zoom speed
         if (zoomSpeed > 0)
             zoomSpeed -= ZOOM_ACCELERATION;
         else
             zoomSpeed += ZOOM_ACCELERATION;
     }
-    // acceleration to unlimited speed
     else
     {
-        if (zoomDirection > 0)
+        // acceleration to unlimited speed
+        if (remainingZoomDiff > 0)
             zoomSpeed += ZOOM_ACCELERATION;
         else
             zoomSpeed -= ZOOM_ACCELERATION;
     }
 
+    if (abs(remainingZoomDiff) < abs(zoomSpeed))
+    {
+        // last step
+        zoomFactor = targetZoomFactor;
+        zoomSpeed = 0;
+    }
+
     zoomFactor = zoomFactor + zoomSpeed;
     CalcFxLx();
-
-    // allow overshoot, but swing back
-    if (zoomFactor < ZOOM_MIN)
-        targetZoomFactor = ZOOM_MIN;
-    else if (zoomFactor > ZOOM_MAX)
-        targetZoomFactor = ZOOM_MAX;
 }
 
 void GameWorldView::SetZoomFactor(float zoomFactor)
 {
-    targetZoomFactor = zoomFactor;
+    if (zoomFactor < ZOOM_MIN)
+        targetZoomFactor = ZOOM_MIN;
+    else if (zoomFactor > ZOOM_MAX)
+        targetZoomFactor = ZOOM_MAX;
+    else
+        targetZoomFactor = zoomFactor;
 }
 
 float GameWorldView::GetCurrentTargetZoomFactor() const

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -76,29 +76,32 @@ void GameWorldView::SetNextZoomFactor()
 
     float remainingZoomDiff = targetZoomFactor - zoomFactor;
 
-    if (abs(remainingZoomDiff) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
-    {
-        // deceleration towards zero zoom speed
-        if (zoomSpeed > 0)
-            zoomSpeed -= ZOOM_ACCELERATION;
-        else
-            zoomSpeed += ZOOM_ACCELERATION;
-    }
-    else
-    {
-        // acceleration to unlimited speed
-        if (remainingZoomDiff > 0)
-            zoomSpeed += ZOOM_ACCELERATION;
-        else
-            zoomSpeed -= ZOOM_ACCELERATION;
-    }
-
-    if (abs(remainingZoomDiff) < abs(zoomSpeed))
+    if (std::abs(remainingZoomDiff) < std::abs(zoomSpeed))
     {
         // last step
         zoomFactor = targetZoomFactor;
         zoomSpeed = 0;
     }
+    else
+    {
+        if (std::abs(remainingZoomDiff) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
+        {
+            // deceleration towards zero zoom speed
+            if (zoomSpeed > 0)
+                zoomSpeed -= ZOOM_ACCELERATION;
+            else
+                zoomSpeed += ZOOM_ACCELERATION;
+        }
+        else
+        {
+            // acceleration to unlimited speed
+            if (remainingZoomDiff > 0)
+                zoomSpeed += ZOOM_ACCELERATION;
+            else
+                zoomSpeed -= ZOOM_ACCELERATION;
+        }
+    }
+
 
     zoomFactor = zoomFactor + zoomSpeed;
     CalcFxLx();

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -76,7 +76,7 @@ void GameWorldView::SetNextZoomFactor()
 
     float remainingZoomDiff = targetZoomFactor - zoomFactor;
 
-    if (abs(remainingZoomDiff) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
+    if (std::abs(remainingZoomDiff) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
     {
         // deceleration towards zero zoom speed
         if (zoomSpeed > 0)
@@ -93,7 +93,7 @@ void GameWorldView::SetNextZoomFactor()
             zoomSpeed -= ZOOM_ACCELERATION;
     }
 
-    if (abs(remainingZoomDiff) < abs(zoomSpeed))
+    if (std::abs(remainingZoomDiff) < std::abs(zoomSpeed))
     {
         // last step
         zoomFactor = targetZoomFactor;

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -76,32 +76,29 @@ void GameWorldView::SetNextZoomFactor()
 
     float remainingZoomDiff = targetZoomFactor - zoomFactor;
 
-    if (std::abs(remainingZoomDiff) < std::abs(zoomSpeed))
+    if (abs(remainingZoomDiff) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
+    {
+        // deceleration towards zero zoom speed
+        if (zoomSpeed > 0)
+            zoomSpeed -= ZOOM_ACCELERATION;
+        else
+            zoomSpeed += ZOOM_ACCELERATION;
+    }
+    else
+    {
+        // acceleration to unlimited speed
+        if (remainingZoomDiff > 0)
+            zoomSpeed += ZOOM_ACCELERATION;
+        else
+            zoomSpeed -= ZOOM_ACCELERATION;
+    }
+
+    if (abs(remainingZoomDiff) < abs(zoomSpeed))
     {
         // last step
         zoomFactor = targetZoomFactor;
         zoomSpeed = 0;
     }
-    else
-    {
-        if (std::abs(remainingZoomDiff) <= 0.5 * zoomSpeed * zoomSpeed / ZOOM_ACCELERATION)
-        {
-            // deceleration towards zero zoom speed
-            if (zoomSpeed > 0)
-                zoomSpeed -= ZOOM_ACCELERATION;
-            else
-                zoomSpeed += ZOOM_ACCELERATION;
-        }
-        else
-        {
-            // acceleration to unlimited speed
-            if (remainingZoomDiff > 0)
-                zoomSpeed += ZOOM_ACCELERATION;
-            else
-                zoomSpeed -= ZOOM_ACCELERATION;
-        }
-    }
-
 
     zoomFactor = zoomFactor + zoomSpeed;
     CalcFxLx();

--- a/src/world/GameWorldView.h
+++ b/src/world/GameWorldView.h
@@ -78,6 +78,9 @@ class GameWorldView
 
     /// How much the view is scaled (1=normal, >1=bigger, >0 && <1=smaller)
     float zoomFactor;
+    float targetZoomFactor;
+    float zoomSpeed;
+    //float zoomAcceleration;
 
 public:
     GameWorldView(const GameWorldViewer& gwv, const Point<int>& pos, unsigned width, unsigned height);
@@ -90,6 +93,7 @@ public:
     Point<int> GetPos() const { return pos; }
 
     void SetZoomFactor(float zoomFactor);
+    void SetNextZoomFactor();
 
     /// Bauqualitäten anzeigen oder nicht
     void ToggleShowBQ() { show_bq = !show_bq; }

--- a/src/world/GameWorldView.h
+++ b/src/world/GameWorldView.h
@@ -80,7 +80,6 @@ class GameWorldView
     float zoomFactor;
     float targetZoomFactor;
     float zoomSpeed;
-    //float zoomAcceleration;
 
 public:
     GameWorldView(const GameWorldViewer& gwv, const Point<int>& pos, unsigned width, unsigned height);
@@ -93,6 +92,7 @@ public:
     Point<int> GetPos() const { return pos; }
 
     void SetZoomFactor(float zoomFactor);
+    float GetCurrentTargetZoomFactor() const;
     void SetNextZoomFactor();
 
     /// Bauqualitäten anzeigen oder nicht


### PR DESCRIPTION
This adds zooming by mouse wheel.

Existing fix states for zoom changed into 50%, 75%, 100%(default), 125% and 150%
These can switched by pressing Z (or Shift-Z in reverse order).
Ctrl+Z resets to default
Magnifying glass in top right now shows zoom percentage (except 100%).