### PR TITLE
Don't increment object counter on assignment

### DIFF
--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -52,15 +52,6 @@ GameObject::GameObject(const GameObject& go) : objId(go.objId)
     ++objCounter_;
 }
 
-GameObject& GameObject::operator=(const GameObject& obj)
-{
-    if(this == &obj)
-        return *this;
-    objId = obj.objId;
-    ++objCounter_;
-    return *this;
-}
-
 void GameObject::Destroy()
 {
 }

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -40,8 +40,6 @@ class GameObject
         GameObject(const GameObject& go);
         virtual ~GameObject();
 
-        GameObject& operator=(const GameObject& obj);
-
         /// zerstört das Objekt.
         virtual void Destroy() = 0;
 


### PR DESCRIPTION
As we don't get a new object, we should not count it. Hence the default assignment operator is ok.