### PR TITLE
Seafaring fixes

### DIFF
--- a/src/ai/AIInterface.h
+++ b/src/ai/AIInterface.h
@@ -160,7 +160,7 @@ class AIInterface: public GameCommandFactory
         }
 
         /// Tests whether the ai player can see a point
-        bool IsVisible(const MapPoint pt) const { return gwb.CalcWithAllyVisiblity(pt, playerID_) == VIS_VISIBLE; }
+        bool IsVisible(const MapPoint pt) const { return gwb.CalcVisiblityWithAllies(pt, playerID_) == VIS_VISIBLE; }
 
         bool IsMilitaryBuildingNearNode(const MapPoint pt, const unsigned char player) const { return gwb.IsMilitaryBuildingNearNode(pt, player); }
 

--- a/src/ai/AIPlayerJH.cpp
+++ b/src/ai/AIPlayerJH.cpp
@@ -1498,7 +1498,7 @@ void AIPlayerJH::HandleExpedition(const MapPoint pt)
     {
         if((*it)->GetGOT() == GOT_SHIP)
         {
-            if(static_cast<noShip*>(*it)->GetPlayer() == playerId)
+            if(static_cast<noShip*>(*it)->GetPlayerId() == playerId)
             {
                 if (static_cast<noShip*>(*it)->IsWaitingForExpeditionInstructions())
                 {

--- a/src/buildings/nobBaseWarehouse.h
+++ b/src/buildings/nobBaseWarehouse.h
@@ -266,6 +266,7 @@ class nobBaseWarehouse : public nobBaseMilitary, public DataChangedObservable
         /// Gibt Zeiger auf dir Reserve zurück für das GUI
         const unsigned* GetReservePointerAvailable(unsigned rank) const { return &reserve_soldiers_available[rank]; }
         const unsigned* GetReservePointerClaimed(unsigned rank) const { return &reserve_soldiers_claimed_visual[rank]; }
+        unsigned GetReserveClaimed(unsigned rank) const { return reserve_soldiers_claimed_real[rank]; }
 
         /// Available goods of a specific type that can be used for trading
         unsigned GetAvailableWaresForTrading(const GoodType gt) const;

--- a/src/figures/nofScout_Free.cpp
+++ b/src/figures/nofScout_Free.cpp
@@ -148,7 +148,7 @@ namespace{
         bool operator()(const MapPoint& pt) const
         {
             // Liegt Punkt im Nebel und für Figuren begehbar?
-            return gwg.CalcWithAllyVisiblity(pt, player) != VIS_VISIBLE && gwg.IsNodeForFigures(pt);
+            return gwg.CalcVisiblityWithAllies(pt, player) != VIS_VISIBLE && gwg.IsNodeForFigures(pt);
         }
     };
 }

--- a/src/ingameWindows/iwShip.cpp
+++ b/src/ingameWindows/iwShip.cpp
@@ -38,7 +38,7 @@
 iwShip::iwShip(GameWorldView& gwv, GameCommandFactory& gcFactory, noShip* const ship):
     IngameWindow(CGI_SHIP, IngameWindow::posAtMouse,  252, 238, _("Ship register"), LOADER.GetImageN("resource", 41)),
     gwv(gwv), gcFactory(gcFactory),
-    player(ship ? ship->GetPlayer() : gwv.GetViewer().GetPlayerId()),
+    player(ship ? ship->GetPlayerId() : gwv.GetViewer().GetPlayerId()),
     ship_id(ship ? gwv.GetWorld().GetPlayer(player).GetShipID(ship) : 0)
 {
     AddImage(  0, 126, 101, LOADER.GetImageN("io", 228));
@@ -110,7 +110,7 @@ void iwShip::Msg_PaintAfter()
         GetCtrl<Window>(11)->SetVisible(true);
 
         for(unsigned char i = 0; i < 6; ++i)
-            GetCtrl<Window>(12 + i)->SetVisible(gwv.GetWorld().GetNextFreeHarborPoint(ship->GetPos(), ship->GetCurrentHarbor(), ShipDirection::fromInt(i), ship->GetPlayer()) > 0);
+            GetCtrl<Window>(12 + i)->SetVisible(gwv.GetWorld().GetNextFreeHarborPoint(ship->GetPos(), ship->GetCurrentHarbor(), ShipDirection::fromInt(i), ship->GetPlayerId()) > 0);
     }
     else
     {
@@ -163,7 +163,7 @@ void iwShip::Msg_ButtonClick(const unsigned int ctrl_id)
         case 4:
         {
             if(ship_id == 0)
-                ship_id = gwv.GetWorld().GetPlayer(ship->GetPlayer()).GetShipCount() - 1;
+                ship_id = gwv.GetWorld().GetPlayer(ship->GetPlayerId()).GetShipCount() - 1;
             else
                 --ship_id;
         } break;
@@ -171,14 +171,14 @@ void iwShip::Msg_ButtonClick(const unsigned int ctrl_id)
         case 5:
         {
             ++ship_id;
-            if(ship_id == gwv.GetWorld().GetPlayer(ship->GetPlayer()).GetShipCount())
+            if(ship_id == gwv.GetWorld().GetPlayer(ship->GetPlayerId()).GetShipCount())
                 ship_id = 0;
 
         } break;
         // Letztes Schiff
         case 6:
         {
-            ship_id = gwv.GetWorld().GetPlayer(ship->GetPlayer()).GetShipCount() - 1;
+            ship_id = gwv.GetWorld().GetPlayer(ship->GetPlayerId()).GetShipCount() - 1;
         } break;
         case 7: // "Gehe Zu Ort"
         {

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -1202,18 +1202,28 @@ void noShip::ContinueExplorationExpedition()
     }
     else
     {
-        // Nächsten Zielpunkt bestimmen
+        // Find the next harbor spot to explore
         std::vector<unsigned> hps;
         if(goal_harborId)
             hps = gwg->GetUnexploredHarborPoints(goal_harborId, seaId_, GetPlayerId());
 
-        // Keine möglichen Häfen gefunden?
+        // No possible spots?
         if(hps.empty())
-            // Dann wieder Heimathafen ansteuern
-            goal_harborId = home_harbor;
-        else
-            // Zufällig den nächsten Hafen auswählen
+        {
+            if(goal_harborId != home_harbor)
+                goal_harborId = home_harbor;
+            else
+            {
+                // We are already at home -> End
+                state = STATE_EXPLORATIONEXPEDITION_UNLOADING;
+                current_ev = GetEvMgr().AddEvent(this, UNLOADING_TIME, 1);
+                return;
+            }
+        } else
+        {
+            // Choose one randomly
             goal_harborId = hps[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), hps.size())];
+        }
     }
 
     StartDrivingToHarborPlace();

--- a/src/nodeObjs/noShip.cpp
+++ b/src/nodeObjs/noShip.cpp
@@ -72,7 +72,7 @@ const DrawPointInit SHIPS_FLAG_POS[2][6] =
 
 noShip::noShip(const MapPoint pos, const unsigned char player)
     : noMovable(NOP_SHIP, pos),
-      player(player), state(STATE_IDLE), seaId_(0), goal_harborId(0), goal_dir(0),
+      ownerId_(player), state(STATE_IDLE), seaId_(0), goal_harborId(0), goal_dir(0),
       name(ship_names[gwg->GetPlayer(player).nation][RANDOM.Rand(__FILE__, __LINE__, GetObjId(), ship_count)]),
       curRouteIdx(0), lost(false), remaining_sea_attackers(0), home_harbor(0), covered_distance(0)
 {
@@ -92,7 +92,7 @@ void noShip::Serialize(SerializedGameData& sgd) const
 {
     Serialize_noMovable(sgd);
 
-    sgd.PushUnsignedChar(player);
+    sgd.PushUnsignedChar(ownerId_);
     sgd.PushUnsignedChar(static_cast<unsigned char>(state));
     sgd.PushUnsignedShort(seaId_);
     sgd.PushUnsignedInt(goal_harborId);
@@ -112,7 +112,7 @@ void noShip::Serialize(SerializedGameData& sgd) const
 
 noShip::noShip(SerializedGameData& sgd, const unsigned obj_id) :
     noMovable(sgd, obj_id),
-    player(sgd.PopUnsignedChar()),
+    ownerId_(sgd.PopUnsignedChar()),
     state(State(sgd.PopUnsignedChar())),
     seaId_(sgd.PopUnsignedShort()),
     goal_harborId(sgd.PopUnsignedInt()),
@@ -137,9 +137,9 @@ void noShip::Destroy()
         RTTR_Assert(!*it);
     for(std::list<Ware*>::iterator it = wares.begin(); it != wares.end(); ++it)
         RTTR_Assert(!*it);
-    gwg->GetNotifications().publish(ShipNote(ShipNote::Destroyed, player, pos));
+    gwg->GetNotifications().publish(ShipNote(ShipNote::Destroyed, ownerId_, pos));
     // Schiff wieder abmelden
-    gwg->GetPlayer(player).RemoveShip(this);
+    gwg->GetPlayer(ownerId_).RemoveShip(this);
 }
 
 void noShip::Draw(DrawPoint drawPt)
@@ -203,7 +203,7 @@ void noShip::Draw(DrawPoint drawPt)
     }
 
     LOADER.GetPlayerImage("boot_z", 40 + GAMECLIENT.GetGlobalAnimation(6, 1, 1, GetObjId()))->
-    Draw(drawPt + SHIPS_FLAG_POS[flag_drawing_type][GetCurMoveDir()], 0, 0, 0, 0, 0, 0, COLOR_WHITE, gwg->GetPlayer(player).color);
+    Draw(drawPt + SHIPS_FLAG_POS[flag_drawing_type][GetCurMoveDir()], 0, 0, 0, 0, 0, 0, COLOR_WHITE, gwg->GetPlayer(ownerId_).color);
     // Second, white flag, only when on expedition, always swinging in the opposite direction
     if(state >= STATE_EXPEDITION_LOADING && state <= STATE_EXPEDITION_DRIVING)
         LOADER.GetPlayerImage("boot_z", 40 + GAMECLIENT.GetGlobalAnimation(6, 1, 1, GetObjId() + 4))->
@@ -266,8 +266,8 @@ void noShip::HandleEvent(const unsigned int id)
             state = STATE_EXPEDITION_WAITING;
 
             // Spieler benachrichtigen
-            SendPostMessage(player, new ShipPostMsg(GetEvMgr().GetCurrentGF(), _("A ship is ready for an expedition."), PostCategory::Economy, *this));
-            gwg->GetNotifications().publish(ExpeditionNote(ExpeditionNote::Waiting, player, pos));
+            SendPostMessage(ownerId_, new ShipPostMsg(GetEvMgr().GetCurrentGF(), _("A ship is ready for an expedition."), PostCategory::Economy, *this));
+            gwg->GetNotifications().publish(ExpeditionNote(ExpeditionNote::Waiting, ownerId_, pos));
             break;
         case STATE_EXPLORATIONEXPEDITION_LOADING:
         case STATE_EXPLORATIONEXPEDITION_WAITING:
@@ -282,14 +282,14 @@ void noShip::HandleEvent(const unsigned int id)
             if(hb && hb->GetGOT() == GOT_NOB_HARBORBUILDING)
             {
                 Inventory goods;
-                unsigned char nation = gwg->GetPlayer(player).nation;
+                unsigned char nation = gwg->GetPlayer(ownerId_).nation;
                 goods.goods[GD_BOARDS] = BUILDING_COSTS[nation][BLD_HARBORBUILDING].boards;
                 goods.goods[GD_STONES] = BUILDING_COSTS[nation][BLD_HARBORBUILDING].stones;
                 goods.people[JOB_BUILDER] = 1;
                 static_cast<nobBaseWarehouse*>(hb)->AddGoods(goods, false);
                 // Wieder idlen und ggf. neuen Job suchen
                 StartIdling();
-                gwg->GetPlayer(player).GetJobForShip(this);
+                gwg->GetPlayer(ownerId_).GetJobForShip(this);
             }
             else
             {
@@ -314,7 +314,7 @@ void noShip::HandleEvent(const unsigned int id)
                 static_cast<nobBaseWarehouse*>(hb)->AddGoods(goods, false);
                 // Wieder idlen und ggf. neuen Job suchen
                 StartIdling();
-                gwg->GetPlayer(player).GetJobForShip(this);
+                gwg->GetPlayer(ownerId_).GetJobForShip(this);
             }
             else
             {
@@ -324,7 +324,7 @@ void noShip::HandleEvent(const unsigned int id)
             }
 
             // Sichtbarkeiten neu berechnen
-            gwg->RecalcVisibilitiesAroundPoint(pos, old_visual_range, player, NULL);
+            gwg->RecalcVisibilitiesAroundPoint(pos, old_visual_range, ownerId_, NULL);
 
             break;
         }
@@ -352,7 +352,7 @@ void noShip::HandleEvent(const unsigned int id)
                 {
                     // Wieder idlen und ggf. neuen Job suchen
                     StartIdling();
-                    gwg->GetPlayer(player).GetJobForShip(this);
+                    gwg->GetPlayer(ownerId_).GetJobForShip(this);
                 }
             }
             else
@@ -402,14 +402,14 @@ void noShip::StartDriving(const unsigned char dir)
 void noShip::Driven()
 {
     MapPoint enemy_territory_discovered(MapPoint::Invalid());
-    gwg->RecalcMovingVisibilities(pos, player, GetVisualRange(), GetCurMoveDir(), &enemy_territory_discovered);
+    gwg->RecalcMovingVisibilities(pos, ownerId_, GetVisualRange(), GetCurMoveDir(), &enemy_territory_discovered);
 
     // Feindliches Territorium entdeckt?
     if(enemy_territory_discovered.isValid())
     {
         // Send message if necessary
-        if(gwg->GetPlayer(player).ShipDiscoveredHostileTerritory(enemy_territory_discovered))
-            SendPostMessage(player, new PostMsg(GetEvMgr().GetCurrentGF(), _("A ship disovered an enemy territory"), PostCategory::Military, enemy_territory_discovered));
+        if(gwg->GetPlayer(ownerId_).ShipDiscoveredHostileTerritory(enemy_territory_discovered))
+            SendPostMessage(ownerId_, new PostMsg(GetEvMgr().GetCurrentGF(), _("A ship disovered an enemy territory"), PostCategory::Military, enemy_territory_discovered));
     }
 
     switch(state)
@@ -481,7 +481,7 @@ void noShip::StartExplorationExpedition(unsigned homeHarborId)
     home_harbor = homeHarborId;
     goal_harborId = homeHarborId; // This is current goal (commands are relative to current goal)
     // Sichtbarkeiten neu berechnen
-    gwg->SetVisibilitiesAroundPoint(pos, GetVisualRange(), player);
+    gwg->SetVisibilitiesAroundPoint(pos, GetVisualRange(), ownerId_);
 }
 
 /// Fährt weiter zu einem Hafen
@@ -548,13 +548,21 @@ noShip::Result noShip::DriveToHarbourPlace()
     return DRIVING;
 }
 
-
 unsigned noShip::GetCurrentHarbor() const
 {
     RTTR_Assert(state == STATE_EXPEDITION_WAITING);
     return goal_harborId;
 }
 
+unsigned noShip::GetTargetHarbor() const
+{
+    return goal_harborId;
+}
+
+unsigned noShip::GetHomeHarbor() const
+{
+    return home_harbor;
+}
 
 /// Weist das Schiff an, in einer bestimmten Richtung die Expedition fortzusetzen
 void noShip::ContinueExpedition(const ShipDirection dir)
@@ -563,7 +571,7 @@ void noShip::ContinueExpedition(const ShipDirection dir)
         return;
 
     // Nächsten Hafenpunkt in dieser Richtung suchen
-    unsigned new_goal = gwg->GetNextFreeHarborPoint(pos, goal_harborId, dir, player);
+    unsigned new_goal = gwg->GetNextFreeHarborPoint(pos, goal_harborId, dir, ownerId_);
 
     // Auch ein Ziel gefunden?
     if(!new_goal)
@@ -619,15 +627,15 @@ void noShip::FoundColony()
         return;
 
     // Kolonie gründen
-    if(gwg->FoundColony(goal_harborId, player, seaId_))
+    if(gwg->FoundColony(goal_harborId, ownerId_, seaId_))
     {
         // Dann idlen wir wieder
         StartIdling();
         // Neue Arbeit suchen
-        gwg->GetPlayer(player).GetJobForShip(this);
+        gwg->GetPlayer(ownerId_).GetJobForShip(this);
     }
     else //colony founding FAILED
-        gwg->GetNotifications().publish(ExpeditionNote(ExpeditionNote::Waiting, player, pos));
+        gwg->GetNotifications().publish(ExpeditionNote(ExpeditionNote::Waiting, ownerId_, pos));
 }
 
 void noShip::HandleState_GoToHarbor()
@@ -696,8 +704,8 @@ void noShip::HandleState_ExpeditionDriving()
                 state = STATE_EXPEDITION_WAITING;
 
                 // Spieler benachrichtigen
-                SendPostMessage(player, new ShipPostMsg(GetEvMgr().GetCurrentGF(), _("A ship has reached the destination of its expedition."), PostCategory::Economy, *this));
-                gwg->GetNotifications().publish(ExpeditionNote(ExpeditionNote::Waiting, player, pos));
+                SendPostMessage(ownerId_, new ShipPostMsg(GetEvMgr().GetCurrentGF(), _("A ship has reached the destination of its expedition."), PostCategory::Economy, *this));
+                gwg->GetNotifications().publish(ExpeditionNote(ExpeditionNote::Waiting, ownerId_, pos));
             }
         } break;
         case NO_ROUTE_FOUND:
@@ -748,7 +756,7 @@ void noShip::HandleState_ExplorationExpeditionDriving()
         } break;
         case NO_ROUTE_FOUND:
         case HARBOR_DOESNT_EXIST:
-            gwg->RecalcVisibilitiesAroundPoint(pos, GetVisualRange(), player, NULL);
+            gwg->RecalcVisibilitiesAroundPoint(pos, GetVisualRange(), ownerId_, NULL);
             StartIdling();
             break;
     }
@@ -839,7 +847,7 @@ bool noShip::IsAbleToFoundColony() const
         // We must always have a goal harbor
         RTTR_Assert(goal_harborId);
         // Ist der Punkt, an dem wir gerade ankern, noch frei?
-        if(gwg->IsHarborPointFree(goal_harborId, player))
+        if(gwg->IsHarborPointFree(goal_harborId, ownerId_))
             return true;
     }
 
@@ -992,7 +1000,7 @@ void noShip::StartDrivingToHarborPlace()
         // todo
         RTTR_Assert(false);
         LOG.write("WARNING: Bug detected (GF: %u). Please report this with the savegame and replay. noShip::StartDrivingToHarborPlace: Schiff hat keinen Weg gefunden! player %i state %i pos %u,%u goal coastal %u,%u goal-id %i goalpos %u,%u \n")
-            % GetEvMgr().GetCurrentGF() % player % state % pos.x % pos.y % coastalPos.x % coastalPos.y % goal_harborId % gwg->GetHarborPoint(goal_harborId).x % gwg->GetHarborPoint(goal_harborId).y;
+            % GetEvMgr().GetCurrentGF() % ownerId_ % state % pos.x % pos.y % coastalPos.x % coastalPos.y % goal_harborId % gwg->GetHarborPoint(goal_harborId).x % gwg->GetHarborPoint(goal_harborId).y;
         goal_harborId = 0;
         return;
     }
@@ -1014,7 +1022,7 @@ void noShip::FindUnloadGoal(State newState)
     state = newState;
     // Das Schiff muss einen Notlandeplatz ansteuern
     // Neuen Hafen suchen
-    if(gwg->GetPlayer(player).FindHarborForUnloading(this, pos, &goal_harborId, &route_, NULL))
+    if(gwg->GetPlayer(ownerId_).FindHarborForUnloading(this, pos, &goal_harborId, &route_, NULL))
     {
         curRouteIdx = 0;
         home_harbor = goal_harborId; // To allow unloading here
@@ -1158,7 +1166,7 @@ void noShip::SeaAttackerWishesNoReturn()
         {
             // Wenn keine Soldaten mehr da sind können wir auch erstmal idlen
             StartIdling();
-            gwg->GetPlayer(player).GetJobForShip(this);
+            gwg->GetPlayer(ownerId_).GetJobForShip(this);
         }
     }
 
@@ -1197,7 +1205,7 @@ void noShip::ContinueExplorationExpedition()
         // Nächsten Zielpunkt bestimmen
         std::vector<unsigned> hps;
         if(goal_harborId)
-            hps = gwg->GetHarborPointsWithinReach(goal_harborId, seaId_);
+            hps = gwg->GetUnexploredHarborPoints(goal_harborId, seaId_, GetPlayerId());
 
         // Keine möglichen Häfen gefunden?
         if(hps.empty())

--- a/src/nodeObjs/noShip.h
+++ b/src/nodeObjs/noShip.h
@@ -36,7 +36,7 @@ class SerializedGameData;
 class noShip : public noMovable
 {
         /// Spieler des Schiffes
-        unsigned char player;
+        unsigned char ownerId_;
 
         /// Was macht das Schiff gerade?
         enum State
@@ -157,7 +157,7 @@ class noShip : public noMovable
         void HandleEvent(const unsigned int id) override;
 
         /// Gibt den Besitzer zurück
-        unsigned char GetPlayer() const { return player; }
+        unsigned char GetPlayerId() const { return ownerId_; }
         /// Gibt die ID des Meeres zurück, auf dem es sich befindet
         unsigned short GetSeaID() const { return seaId_; }
         /// Gibt den Schiffsnamen zurück
@@ -189,8 +189,12 @@ class noShip : public noMovable
         /// Gibt Sichtradius dieses Schiffes zurück
         unsigned GetVisualRange() const;
 
-        /// Beim Warten bei der Expedition: Gibt die Hafenpunkt-ID zurück, wo es sich gerade befindet
+        /// Return the harbor ID where the ship currently is. Only valid when waiting for expedition instructions
         unsigned GetCurrentHarbor() const;
+        /// Return the harbor the ship is currently targetting (0 if ship is idling)
+        unsigned GetTargetHarbor() const;
+        /// Return the source harbor from where the ship left the current mission (0 if ship is idling)
+        unsigned GetHomeHarbor() const;
 
         /// Fährt zum Hafen, um dort eine Mission (Expedition) zu erledigen
         void GoToHarbor(const nobHarborBuilding& hb, const std::vector<unsigned char>& route);

--- a/src/test/CreateSeaWorld.cpp
+++ b/src/test/CreateSeaWorld.cpp
@@ -140,3 +140,40 @@ bool CreateSeaWorld::operator()(GameWorldGame& world) const
     world.InitAfterLoad();
     return true;
 }
+
+
+CreateWaterWorld::CreateWaterWorld(unsigned width, unsigned height, unsigned numPlayers): width_(width), height_(height), playerNations_(numPlayers, NAT_ROMANS)
+{
+    // Only 2 players supported
+    RTTR_Assert(numPlayers == 2u);
+}
+
+bool CreateWaterWorld::operator()(GameWorldGame& world) const
+{
+    world.Init(width_, height_, LT_GREENLAND);
+    // Set everything to water
+    RTTR_FOREACH_PT(MapPoint, width_, height_)
+    {
+        MapNode& node = world.GetNodeWriteable(pt);
+        node.t1 = node.t2 = TT_WATER;
+    }
+    // Create some land
+    for(MapPoint pt(0, 0); pt.y < 10; ++pt.y)
+    {
+        for(pt.x = 0; pt.x < 10; ++pt.x)
+        {
+            MapNode& node = world.GetNodeWriteable(pt);
+            node.t1 = node.t2 = TT_MEADOW1;
+        }
+    }
+    std::vector<MapPoint> hqPositions;
+    hqPositions.push_back(MapPoint(5, 9));
+    hqPositions.push_back(MapPoint(9, 9));
+    MapLoader::PlaceHQs(world, hqPositions, playerNations_, false);
+
+    std::vector<MapPoint> harbors;
+    PlaceHarbor(MapPoint(5, 0), world, harbors);
+    RTTR_Assert(harbors.size() == 1u);
+    MapLoader::InitSeasAndHarbors(world, harbors);
+    return true;
+}

--- a/src/test/CreateSeaWorld.h
+++ b/src/test/CreateSeaWorld.h
@@ -34,5 +34,14 @@ private:
     std::vector<Nation> playerNations_;
 };
 
+/// World for 2 players with all water except a small patch of land with player 0 HQ in the middle and player 1 HQ in the bottom left
+struct CreateWaterWorld
+{
+    CreateWaterWorld(unsigned width, unsigned height, unsigned numPlayers);
+    bool operator()(GameWorldGame& world) const;
+private:
+    unsigned width_, height_;
+    std::vector<Nation> playerNations_;
+};
 
 #endif // CreateSeaWorld_h__

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -85,3 +85,25 @@ BOOST_AUTO_TEST_CASE(Basic)
     // Check if tests work
     BOOST_CHECK(true);
 }
+
+BOOST_AUTO_TEST_CASE(RandomTest)
+{
+    initGameRNG();
+    std::vector<unsigned> resultCt6(6);
+    std::vector<unsigned> resultCt13(13);
+    std::vector<unsigned> resultCt28(28);
+    const unsigned numSamples = 3000;
+    for(unsigned i = 0; i < numSamples; i++)
+    {
+        ++resultCt6.at(RANDOM.Rand(__FILE__, __LINE__, 0, resultCt6.size()));
+        ++resultCt13.at(RANDOM.Rand(__FILE__, __LINE__, 0, resultCt13.size()));
+        ++resultCt28.at(RANDOM.Rand(__FILE__, __LINE__, 0, resultCt28.size()));
+    }
+    // Result must be at least 70% of the average
+    for(unsigned i = 0; i < resultCt6.size(); i++)
+        BOOST_REQUIRE_GT(resultCt6[i], numSamples / resultCt6.size() * 70u / 100u);
+    for(unsigned i = 0; i < resultCt13.size(); i++)
+        BOOST_REQUIRE_GT(resultCt13[i], numSamples / resultCt13.size() * 70u / 100u);
+    for(unsigned i = 0; i < resultCt28.size(); i++)
+        BOOST_REQUIRE_GT(resultCt28[i], numSamples / resultCt28.size() * 70u / 100u);
+}

--- a/src/test/testAttacking.cpp
+++ b/src/test/testAttacking.cpp
@@ -232,7 +232,7 @@ BOOST_FIXTURE_TEST_CASE(StartAttack, AttackFixture)
     TestFailingAttack(hqPos[0], attackSrc);
 
     // Try to attack newly build bld -> Fail
-    BOOST_REQUIRE_EQUAL(world.CalcWithAllyVisiblity(milBld1NearPos, curPlayer), VIS_VISIBLE);
+    BOOST_REQUIRE_EQUAL(world.CalcVisiblityWithAllies(milBld1NearPos, curPlayer), VIS_VISIBLE);
     BOOST_REQUIRE(milBld1Near->IsNewBuilt());
     TestFailingAttack(milBld1NearPos, attackSrc);
 
@@ -243,7 +243,7 @@ BOOST_FIXTURE_TEST_CASE(StartAttack, AttackFixture)
     MapNode& node = world.GetNodeWriteable(milBld1NearPos);
     node.fow[0].visibility = VIS_FOW;
     node.fow[2].visibility = VIS_FOW;
-    BOOST_REQUIRE_EQUAL(world.CalcWithAllyVisiblity(milBld1NearPos, curPlayer), VIS_FOW);
+    BOOST_REQUIRE_EQUAL(world.CalcVisiblityWithAllies(milBld1NearPos, curPlayer), VIS_FOW);
     BOOST_REQUIRE_EQUAL(gwv.GetNumSoldiersForAttack(milBld1NearPos), 5u);
     this->Attack(milBld1NearPos, 1, true);
     BOOST_REQUIRE_EQUAL(attackSrc.GetTroopsCount(), 6u);

--- a/src/test/testGameCommands.cpp
+++ b/src/test/testGameCommands.cpp
@@ -806,7 +806,7 @@ BOOST_FIXTURE_TEST_CASE(ChangeReserveTest, WorldWithGCExecution2P)
     for(unsigned i = 0; i < SOLDIER_JOBS.size(); i++)
     {
         // We already have soldier per rank as reserve
-        BOOST_REQUIRE_EQUAL(*wh->GetReservePointerClaimed(i), 1u);
+        BOOST_REQUIRE_EQUAL(wh->GetReserveClaimed(i), 1u);
         BOOST_REQUIRE_EQUAL(*wh->GetReservePointerAvailable(i), 1u);
 
         unsigned newVal = i * 5 + 2;
@@ -814,7 +814,7 @@ BOOST_FIXTURE_TEST_CASE(ChangeReserveTest, WorldWithGCExecution2P)
         BOOST_REQUIRE_EQUAL(wh->GetRealFiguresCount(SOLDIER_JOBS[i]), numSoldiersAv);
         // Update reserve -> Removed from inventory
         this->ChangeReserve(hqPos, i, newVal);
-        BOOST_REQUIRE_EQUAL(*wh->GetReservePointerClaimed(i), newVal);
+        BOOST_REQUIRE_EQUAL(wh->GetReserveClaimed(i), newVal);
         BOOST_REQUIRE_EQUAL(*wh->GetReservePointerAvailable(i), newVal);
         // Current figure ct should be old figure count minus the new reserve soldiers (currentVal - 1 for old reserve val)
         BOOST_REQUIRE_EQUAL(wh->GetVisualFiguresCount(SOLDIER_JOBS[i]), numSoldiersAv - (newVal - 1));
@@ -828,7 +828,7 @@ BOOST_FIXTURE_TEST_CASE(ChangeReserveTest, WorldWithGCExecution2P)
         unsigned numSoldiersReleased = *wh->GetReservePointerAvailable(i) - newVal;
         // Release some soldiers from reserve -> Added to inventory
         this->ChangeReserve(hqPos, i, newVal);
-        BOOST_REQUIRE_EQUAL(*wh->GetReservePointerClaimed(i), newVal);
+        BOOST_REQUIRE_EQUAL(wh->GetReserveClaimed(i), newVal);
         BOOST_REQUIRE_EQUAL(*wh->GetReservePointerAvailable(i), newVal);
         BOOST_REQUIRE_EQUAL(wh->GetVisualFiguresCount(SOLDIER_JOBS[i]), numSoldiersAv + numSoldiersReleased);
         BOOST_REQUIRE_EQUAL(wh->GetRealFiguresCount(SOLDIER_JOBS[i]), numSoldiersAv + numSoldiersReleased);

--- a/src/world/GameWorldBase.cpp
+++ b/src/world/GameWorldBase.cpp
@@ -299,7 +299,7 @@ void GameWorldBase::RecalcBQAroundPointBig(const MapPoint pt)
         RecalcBQ(GetNeighbour2(pt, i));
 }
 
-Visibility GameWorldBase::CalcWithAllyVisiblity(const MapPoint pt, const unsigned char player) const
+Visibility GameWorldBase::CalcVisiblityWithAllies(const MapPoint pt, const unsigned char player) const
 {
     Visibility best_visibility = GetNode(pt).fow[player].visibility;
 
@@ -312,7 +312,7 @@ Visibility GameWorldBase::CalcWithAllyVisiblity(const MapPoint pt, const unsigne
         // Dann prüfen, ob Teammitglieder evtl. eine bessere Sicht auf diesen Punkt haben
         for(unsigned i = 0; i < GetPlayerCount(); ++i)
         {
-            if(GetPlayer(i).IsAlly(player))
+            if(i != player && GetPlayer(i).IsAlly(player))
             {
                 if(GetNode(pt).fow[i].visibility > best_visibility)
                     best_visibility = GetNode(pt).fow[i].visibility;
@@ -705,7 +705,7 @@ std::vector<GameWorldBase::PotentialSeaAttacker> GameWorldBase::GetSoldiersForSe
     if(!milBld || !milBld->IsAttackable(player_attacker))
         return attackers;
     // Prüfen, ob der angreifende Spieler das Gebäude überhaupt sieht (Cheatvorsorge)
-    if(CalcWithAllyVisiblity(pt, player_attacker) != VIS_VISIBLE)
+    if(CalcVisiblityWithAllies(pt, player_attacker) != VIS_VISIBLE)
         return attackers;
     std::vector<bool> use_seas(GetNumSeas());
 

--- a/src/world/GameWorldBase.h
+++ b/src/world/GameWorldBase.h
@@ -120,7 +120,7 @@ public:
     void RecalcBQAroundPointBig(const MapPoint pt);
 
     /// Ermittelt Sichtbarkeit eines Punktes auch unter Einbeziehung der Verbündeten des jeweiligen Spielers
-    Visibility CalcWithAllyVisiblity(const MapPoint pt, const unsigned char player) const;
+    Visibility CalcVisiblityWithAllies(const MapPoint pt, const unsigned char player) const;
 
     /// Ist es an dieser Stelle für einen Spieler möglich einen Hafen zu bauen
     bool IsHarborPointFree(const unsigned harborId, const unsigned char player) const;

--- a/src/world/GameWorldGame.h
+++ b/src/world/GameWorldGame.h
@@ -157,7 +157,7 @@ public:
     /// Gibt zurück, ob eine bestimmte Baustellen eine Baustelle ist, die vom Schiff aus errichtet wurde
     bool IsHarborBuildingSiteFromSea(const noBuildingSite* building_site) const;
     /// Liefert eine Liste der Hafenpunkte, die von einem bestimmten Hafenpunkt erreichbar sind
-    std::vector<unsigned> GetHarborPointsWithinReach(const unsigned hbId, const unsigned seaId) const;
+    std::vector<unsigned> GetUnexploredHarborPoints(const unsigned hbIdToSkip, const unsigned seaId, unsigned playerId) const;
 
     /// Returns true, if the given (map)-resource is available at that node
     bool IsResourcesOnNode(const MapPoint pt, const unsigned char type) const;

--- a/src/world/GameWorldViewer.cpp
+++ b/src/world/GameWorldViewer.cpp
@@ -125,7 +125,7 @@ Visibility GameWorldViewer::GetVisibility(const MapPoint pt) const
     if(GetPlayer().IsDefeated())
         return VIS_VISIBLE;
 
-    return GetWorld().CalcWithAllyVisiblity(pt, playerId_);
+    return GetWorld().CalcVisiblityWithAllies(pt, playerId_);
 }
 
 bool GameWorldViewer::IsOwner(const MapPoint& pt) const
@@ -220,7 +220,7 @@ noShip* GameWorldViewer::GetShip(const MapPoint pt) const
                 continue;
             noShip* curShip = static_cast<noShip*>(*it);
 
-            if (curShip->GetPlayer() == playerId_ && (curShip->GetPos() == pt || curShip->GetDestinationForCurrentMove() == pt))
+            if (curShip->GetPlayerId() == playerId_ && (curShip->GetPos() == pt || curShip->GetDestinationForCurrentMove() == pt))
             {
                 if(curShip->IsWaitingForExpeditionInstructions())
                     return curShip;

--- a/src/world/MapLoader.cpp
+++ b/src/world/MapLoader.cpp
@@ -395,8 +395,16 @@ bool MapLoader::PlaceHQs(World& world, std::vector<MapPoint> hqPositions, const 
 void MapLoader::InitSeasAndHarbors(World& world, const std::vector<MapPoint>& additionalHarbors)
 {
     world.harbor_pos.insert(world.harbor_pos.end(), additionalHarbors.begin(), additionalHarbors.end());
+    // Clear current harbors and seas
+    RTTR_FOREACH_PT(MapPoint, world.GetWidth(), world.GetHeight())
+    {
+        MapNode& node = world.GetNodeInt(pt);
+        node.seaId = 0u;
+        node.harborId = 0;
+    }
 
     /// Weltmeere vermessen
+    world.seas.clear();
     RTTR_FOREACH_PT(MapPoint, world.GetWidth(), world.GetHeight())
     {
         // Noch kein Meer an diesem Punkt  Aber trotzdem Teil eines noch nicht vermessenen Meeres?

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -487,12 +487,11 @@ MapPoint World::GetCoastalPoint(const unsigned harborId, const unsigned short se
     RTTR_Assert(harborId);
     RTTR_Assert(seaId);
 
-    for(unsigned i = 0; i < 6; ++i)
+    // Take point at NW last as often there is no path from it if the harbor is north of an island
+    for(unsigned i = 2; i < 6 + 2; ++i)
     {
-        if(harbor_pos[harborId].cps[i].seaId == seaId)
-        {
-            return GetNeighbour(harbor_pos[harborId].pos, i);
-        }
+        if(harbor_pos[harborId].cps[i % 6].seaId == seaId)
+            return GetNeighbour(harbor_pos[harborId].pos, Direction(i));
     }
 
     // Keinen Punkt gefunden


### PR DESCRIPTION
This fixes the non-attackable harbor issue in #550 by starting the coast-search after the critical NW point, which should be ok for almost all maps (except one really tries to cause this bug)

It also makes explorations (ship and scout) correctly honor visible points so they are not explored again.