### PR TITLE
More UTF8 filesystem checks

### DIFF
--- a/src/ogl/glArchivItem_Font.cpp
+++ b/src/ogl/glArchivItem_Font.cpp
@@ -217,7 +217,7 @@ void glArchivItem_Font::Draw(DrawPoint pos,
         initFont();
 
     std::string text;
-    if(!utf8::is_valid(textIn.begin(), textIn.end()))
+    if(!isValidUTF8(textIn))
     {
         RTTR_Assert(false); // Can only handle UTF-8 strings!
         // However old savegames/replays might contain invalid chars -> Replace
@@ -227,7 +227,7 @@ void glArchivItem_Font::Draw(DrawPoint pos,
     } else
         text = textIn;
 
-    RTTR_Assert(utf8::is_valid(end.begin(), end.end()));
+    RTTR_Assert(isValidUTF8(end));
 
     // Breite bestimmen
     if(length == 0)
@@ -391,7 +391,7 @@ unsigned short glArchivItem_Font::getWidth(const std::string& text, unsigned len
  */
 std::vector<std::string> glArchivItem_Font::WrapInfo::CreateSingleStrings(const std::string& text)
 {
-    RTTR_Assert(utf8::is_valid(text.begin(), text.end())); // Can only handle UTF-8 strings!
+    RTTR_Assert(isValidUTF8(text)); // Can only handle UTF-8 strings!
 
     std::vector<std::string> destStrings;
     if(positions.empty())
@@ -424,7 +424,7 @@ glArchivItem_Font::WrapInfo glArchivItem_Font::GetWrapInfo(const std::string& te
     if(!fontNoOutline)
         initFont();
 
-    RTTR_Assert(utf8::is_valid(text.begin(), text.end())); // Can only handle UTF-8 strings!
+    RTTR_Assert(isValidUTF8(text)); // Can only handle UTF-8 strings!
     
     // Current line width
     unsigned line_width = 0;

--- a/src/test/testFileIO.cpp
+++ b/src/test/testFileIO.cpp
@@ -17,6 +17,7 @@
 
 #include "defines.h" // IWYU pragma: keep
 #include "ListDir.h"
+#include "libutil/src/ucString.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/test/unit_test.hpp>
@@ -70,6 +71,9 @@ BOOST_FIXTURE_TEST_CASE(TestListDir, FileOpenFixture)
     {
         BOOST_REQUIRE(bfs::exists(file));
         BOOST_REQUIRE(bfs::path(file).is_absolute());
+        // Filepath must be utf8 encoded
+        BOOST_REQUIRE(isValidUTF8(file));
+
 
         // Scopes for auto-close
         {

--- a/src/test/testFileIO.cpp
+++ b/src/test/testFileIO.cpp
@@ -74,11 +74,13 @@ BOOST_FIXTURE_TEST_CASE(TestListDir, FileOpenFixture)
         // Filepath must be utf8 encoded
         BOOST_REQUIRE(isValidUTF8(file));
 
+        bfs::path filePath(file);
+        // String result must still be utf8
+        BOOST_REQUIRE(isValidUTF8(filePath.string()));
 
         // Scopes for auto-close
         {
             // path input
-            bfs::path filePath(file);
             bfs::ifstream sFile(filePath);
             BOOST_REQUIRE(sFile);
             std::string content;


### PR DESCRIPTION
In preparation for fixing #618 this checks that everything is UTF8