### PR TITLE
Fix NULL in getEnvVar

### DIFF
--- a/src/test/testSystem.cpp
+++ b/src/test/testSystem.cpp
@@ -23,26 +23,68 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem/operations.hpp>
 
+namespace std{
+    std::ostream& operator<<(std::ostream& out, const std::wstring& value)
+    {
+        return out << cvWideStringToUTF8(value);
+    }
+}
+
+
 BOOST_AUTO_TEST_SUITE(SystemTestSuite)
 
-std::string nonExistingVarName = "NonExistantVar";
-#ifdef _WIN32
-std::string existingVarName = "WINDIR";
-#else
-std::string existingVarName = "HOME";
-#endif // _WIN32
-
-BOOST_AUTO_TEST_CASE(GetEnvVar)
+BOOST_AUTO_TEST_CASE(GetSetRemoveEnvVar)
 {
-    BOOST_REQUIRE(!System::envVarExists(nonExistingVarName));
-    BOOST_REQUIRE_EQUAL(System::getEnvVar(nonExistingVarName), std::string());
-    BOOST_REQUIRE(System::envVarExists(existingVarName));
-    BOOST_REQUIRE_NE(System::getEnvVar(existingVarName), std::string());
-    BOOST_REQUIRE(isValidUTF8(System::getEnvVar(existingVarName)));
+#ifdef _WIN32
+    std::string varName  = cvWideStringToUTF8(L"_RTTR_TEST_VAR_WITH_UMLAUTS_\u00E4\u00F6\u00FC_END_");
+    std::string varValue = cvWideStringToUTF8(L"ValueWithSpecialChars_\u0139\u00D4_END");
+#else
+    // Use UTF8 (wide string not portable, either 16 or 32 bit)
+    std::string varName = "_RTTR_TEST_VAR_WITH_UMLAUTS_\xC3\xA4\xC3\xB6\xC3\xBC""_END_";
+    std::string varValue = "ValueWithSpecialChars_\xC4\xB9\xC3\x94""_END";
+#endif // _WIN32
+    // Create wide string versions
+    std::wstring varNameW = cvUTF8ToWideString(varName);
+    std::wstring varValueW = cvUTF8ToWideString(varValue);
+
+    // Var should not exist
+    BOOST_REQUIRE(!System::envVarExists(varName));
+    BOOST_REQUIRE_EQUAL(System::getEnvVar(varName), "");
+    BOOST_REQUIRE(!System::envVarExists(varNameW));
+    BOOST_REQUIRE_EQUAL(System::getEnvVar(varNameW), L"");
+
+    // Set variable
+    BOOST_REQUIRE(System::setEnvVar(varName, varValue));
+    for(int i = 0; i < 2; i++)
+    {
+        // Now it should exist
+        BOOST_REQUIRE(System::envVarExists(varName));
+        std::string value = System::getEnvVar(varName);
+        BOOST_REQUIRE(isValidUTF8(value));
+        BOOST_REQUIRE_EQUAL(value, varValue);
+        // Same with wide string
+        BOOST_REQUIRE(System::envVarExists(varNameW));
+        std::wstring valueW = System::getEnvVar(varNameW);
+        BOOST_REQUIRE_EQUAL(valueW, varValueW);
+
+        // Remove and set wide string version
+        BOOST_REQUIRE(System::removeEnvVar(varName));
+        BOOST_REQUIRE(!System::envVarExists(varName));
+        BOOST_REQUIRE(System::setEnvVar(varNameW, varValueW));
+    }
+    // Remove also wide string version
+    BOOST_REQUIRE(System::removeEnvVar(varNameW));
+    BOOST_REQUIRE(!System::envVarExists(varNameW));
 }
 
 BOOST_AUTO_TEST_CASE(GetPathFromEnv)
 {
+    std::string nonExistingVarName = "NonExistantVar";
+#ifdef _WIN32
+    std::string existingVarName = "WINDIR";
+#else
+    std::string existingVarName = "HOME";
+#endif // _WIN32
     BOOST_REQUIRE(!System::envVarExists(nonExistingVarName));
     BOOST_REQUIRE(System::getPathFromEnvVar(nonExistingVarName).empty());
     BOOST_REQUIRE(System::envVarExists(existingVarName));
@@ -93,6 +135,20 @@ BOOST_AUTO_TEST_CASE(PrefixPath)
     BOOST_REQUIRE(!prefixPath.empty());
     BOOST_REQUIRE(bfs::exists(prefixPath));
     BOOST_REQUIRE(bfs::is_directory(prefixPath));
+    std::string strPrefixPath = prefixPath.string();
+    // No entry of the path should be the NULL terminator
+    for(unsigned i = 0; i < strPrefixPath.size(); i++)
+    {
+        BOOST_REQUIRE_NE(strPrefixPath[i], 0);
+    }
+    // If the env var is not set (usually should not be) then set it to check if that is used as the prefix path
+    if(!System::envVarExists("RTTR_PREFIX_DIR"))
+    {
+        bfs::path fakePrefixPath = bfs::current_path() / "testPrefixPath";
+        BOOST_REQUIRE(System::setEnvVar("RTTR_PREFIX_DIR", fakePrefixPath.string()));
+        BOOST_REQUIRE_EQUAL(GetPrefixPath(argv[0]), fakePrefixPath);
+        BOOST_REQUIRE(System::removeEnvVar("RTTR_PREFIX_DIR"));
+    }
     {
         ResetWorkDir resetWorkDir;
         BOOST_REQUIRE(InitWorkingDirectory(argv[0]));


### PR DESCRIPTION
Windows only: getEnvVar returns the terminating NULL as part of the string which is wrong