### PR TITLE
Avoid unnecessary libminiupnp remove

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -80,9 +80,6 @@ install: build
 	# remove updater
 	rm -vf $(CURDIR)/debian/s25rttr/usr/share/s25rttr/RTTR/s25update
 	
-	# remove miniupnp
-	rm -vf $(CURDIR)/debian/s25rttr/usr/lib/libminiupnpc*
-	
 	# move maps to maps-package
 	mkdir -vp $(CURDIR)/debian/s25rttr-maps/usr/share/s25rttr/RTTR
 	mv -v $(CURDIR)/debian/s25rttr/usr/share/s25rttr/RTTR/MAPS $(CURDIR)/debian/s25rttr-maps/usr/share/s25rttr/RTTR


### PR DESCRIPTION
Looks like it is no longer necessary as it isn't bundled and installed anymore.