### PR TITLE
Fix for AI issue #674

### DIFF
--- a/src/ai/AIConstruction.cpp
+++ b/src/ai/AIConstruction.cpp
@@ -66,7 +66,7 @@ void AIConstruction::AddBuildJob(AIJH::BuildJob* job, bool front)
         delete job;
         return;
     }
-    if(job->GetType() < BLD_FORTRESS) // non military buildings can only be added once to the contruction que for every location
+    if(job->GetType() <= BLD_FORTRESS) // non military buildings can only be added once to the contruction que for every location
     {
         if(front)
             buildJobs.push_front(job);
@@ -591,6 +591,16 @@ bool AIConstruction::MilitaryBuildingSitesLimit()
     unsigned inconstruction = buildingCounts.buildingSites[BLD_WATCHTOWER] + buildingCounts.buildingSites[BLD_FORTRESS]
                               + buildingCounts.buildingSites[BLD_GUARDHOUSE] + buildingCounts.buildingSites[BLD_BARRACKS];
     return complete + 3 > inconstruction;
+}
+
+bool AIConstruction::IncrementWanted(BuildingType type)
+{
+    if (GetBuildingCount(type) <= buildingsWanted[type])
+    {
+        buildingsWanted[type]++;
+        return true;
+    }
+    return false;
 }
 
 void AIConstruction::RefreshBuildingCount()

--- a/src/ai/AIConstruction.h
+++ b/src/ai/AIConstruction.h
@@ -109,6 +109,10 @@ public:
     /// Initializes the wanted-buildings-vector
     void InitBuildingsWanted();
 
+    /// Increments a wanted count of a building type, used in case AI gets stuck, e.g. allow border expansion
+    /// where map gen was extremely unlucky and no BQ_HOUSE available for sawmill, return true if incremented
+    bool IncrementWanted(BuildingType type);
+
     /// Update BQ and farming ground around new building site + road
     /// HIer oder in AIPlayerJH?
     // void RecalcGround(const MapPoint buildingPos, std::vector<unsigned char> &route_road);

--- a/src/ai/AIJHHelper.cpp
+++ b/src/ai/AIJHHelper.cpp
@@ -101,7 +101,23 @@ void AIJH::BuildJob::TryToBuild()
         return;
     }
 
-    if(!aiConstruction.Wanted(type))
+    // In case the map terrain is very unlucky (no BQ_HOUSE), try to build unwanted types (e.g. military building)
+    bool forceBuild = false;
+    if (!aijh.SimpleFindPosition(bPos, BUILDING_SIZE[type], 11) && aiConstruction.GetBuildingCount(BLD_SAWMILL) == 0)
+    {
+        if (!aiConstruction.Wanted(type))
+        {
+            if (type > BLD_GUARDHOUSE && type <= BLD_FORTRESS)
+            {
+                // We can't build watchtower or fortress because no BQ_HOUSE or higher is available, build a
+                // guardhouse instead
+                type = BLD_GUARDHOUSE;
+            }
+            forceBuild = aiConstruction.IncrementWanted(type);
+        }
+    }
+
+    if(!aiConstruction.Wanted(type) && !forceBuild)
     {
         status = AIJH::JOB_FINISHED;
         return;

--- a/src/ai/AIJHHelper.cpp
+++ b/src/ai/AIJHHelper.cpp
@@ -117,7 +117,7 @@ void AIJH::BuildJob::TryToBuild()
         }
     }
 
-    if(!aiConstruction.Wanted(type) && !forceBuild)
+    if(!forceBuild && !aiConstruction.Wanted(type))
     {
         status = AIJH::JOB_FINISHED;
         return;


### PR DESCRIPTION
Changes made: if AI generates a build job with a military building and sawmill but can't build a sawmill (cause no middle build quality tile is available), it will build a military building instead (in this specific case a military building was not wanted, so build is forced when there is no sawmill built yet). It also downgrades fortress/watchtower to guardhouse in this case. Only applies if no sawmill is built yet.

Also fixes a minor build job sorting bug/already built check, where fortress wasn't included with other military buildings.