### PR TITLE
Geologist puts a coal sign instead of gold

### DIFF
--- a/src/nodeObjs/noSign.cpp
+++ b/src/nodeObjs/noSign.cpp
@@ -51,7 +51,7 @@ void noSign::Draw(DrawPoint drawPt)
     switch(resource.getType())
     {
         case Resource::Iron: imgId = 680; break;
-        case Resource::Gold: imgId = 684; break;
+        case Resource::Gold: imgId = 683; break;
         case Resource::Coal: imgId = 686; break;
         case Resource::Granite: imgId = 689; break;
         case Resource::Water: imgId = 692; break;


### PR DESCRIPTION
Since the refactoring of noSign.cpp from 02.11. by Flamefire, the geologist places a coal sign instead of a gold sign, if he founds gold.

![2017-11-18 16_00_51-return to the roots - v20171118 - 2f17d6c](https://user-images.githubusercontent.com/12239057/32981724-b31d7300-cc79-11e7-8cab-4854e3d481f5.png)

i assume a misstyping here for the imageId.