### PR TITLE
AI will accept pact cancel & basic lua interface

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -21,6 +21,7 @@
 #include "GamePlayer.h"
 #include "ai/AIPlayer.h"
 #include "lua/LuaInterfaceGame.h"
+#include <boost/foreach.hpp>
 
 Game::Game(const GlobalGameSettings& settings, unsigned startGF, const std::vector<PlayerInfo>& players)
     : ggs(settings), em(new EventManager(startGF)), world(players, ggs, *em), started(false), finished(false)
@@ -150,4 +151,14 @@ void Game::CheckObjective()
         else
             world.GetGameInterface()->GI_TeamWinner(bestteam);
     }
+}
+
+AIPlayer* Game::GetAIPlayer(unsigned id)
+{
+    BOOST_FOREACH(AIPlayer& ai, aiPlayers)
+    {
+        if (ai.GetPlayerId() == id)
+            return &ai;
+    }
+    return NULL;
 }

--- a/src/Game.h
+++ b/src/Game.h
@@ -45,6 +45,7 @@ public:
     void RunGF();
     bool IsStarted() const { return started; }
     bool IsGameFinished() const { return finished; }
+    AIPlayer* GetAIPlayer(unsigned id);
 
 private:
     /// Updates the statistics

--- a/src/GamePlayer.h
+++ b/src/GamePlayer.h
@@ -263,7 +263,7 @@ public:
     void NotifyAlliesOfLocation(const MapPoint pt);
 
     /// This player suggests a pact to target player
-    void SuggestPact(const unsigned char targetPlayer, const PactType pt, const unsigned duration);
+    void SuggestPact(const unsigned char targetPlayerId, const PactType pt, const unsigned duration);
     /// Accepts a pact, that this player suggested target player
     void AcceptPact(const unsigned id, const PactType pt, const unsigned char targetPlayer);
     /// Gibt Einverständnis, dass dieser Spieler den Pakt auflösen will

--- a/src/SerializedGameData.cpp
+++ b/src/SerializedGameData.cpp
@@ -247,7 +247,7 @@ void SerializedGameData::MakeSnapshot(const GameWorld& gw)
     writtenEventIds.clear();
 }
 
-void SerializedGameData::ReadSnapshot(GameWorld& gw)
+void SerializedGameData::ReadSnapshot(boost::weak_ptr<Game> game, GameWorld& gw)
 {
     Prepare(true);
 
@@ -255,7 +255,7 @@ void SerializedGameData::ReadSnapshot(GameWorld& gw)
 
     expectedNumObjects = PopUnsignedInt();
 
-    gw.Deserialize(*this);
+    gw.Deserialize(game, *this);
     em->Deserialize(*this);
     for(unsigned i = 0; i < gw.GetNumPlayers(); ++i)
         gw.GetPlayer(i).Deserialize(*this);

--- a/src/SerializedGameData.cpp
+++ b/src/SerializedGameData.cpp
@@ -20,6 +20,7 @@
 #include "CatapultStone.h"
 #include "EventManager.h"
 #include "FOWObjects.h"
+#include "Game.h"
 #include "GameEvent.h"
 #include "GameObject.h"
 #include "GamePlayer.h"
@@ -209,10 +210,11 @@ void SerializedGameData::Prepare(bool reading)
     isReading = reading;
 }
 
-void SerializedGameData::MakeSnapshot(const GameWorld& gw)
+void SerializedGameData::MakeSnapshot(boost::shared_ptr<Game> game)
 {
     Prepare(false);
-
+    
+    GameWorld& gw = game->world;
     writeEm = &gw.GetEvMgr();
 
     // Anzahl Objekte reinschreiben (used for safety checks only)
@@ -247,10 +249,11 @@ void SerializedGameData::MakeSnapshot(const GameWorld& gw)
     writtenEventIds.clear();
 }
 
-void SerializedGameData::ReadSnapshot(boost::weak_ptr<Game> game, GameWorld& gw)
+void SerializedGameData::ReadSnapshot(boost::shared_ptr<Game> game)
 {
     Prepare(true);
 
+    GameWorld& gw = game->world;
     em = &gw.GetEvMgr();
 
     expectedNumObjects = PopUnsignedInt();

--- a/src/SerializedGameData.h
+++ b/src/SerializedGameData.h
@@ -29,7 +29,7 @@
 #include <map>
 #include <set>
 #include <stdexcept>
-#include <boost/weak_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 
 class GameObject;
 class GameWorld;
@@ -52,10 +52,10 @@ public:
     SerializedGameData();
 
     /// Nimmt das gesamte Spiel auf und speichert es im Buffer
-    void MakeSnapshot(const GameWorld& gw);
+    void MakeSnapshot(boost::shared_ptr<Game> game);
 
     /// Reads the snapshot from the internal buffer
-    void ReadSnapshot(boost::weak_ptr<Game> game, GameWorld& gw);
+    void ReadSnapshot(boost::shared_ptr<Game> game);
 
     unsigned GetGameDataVersion() const { return gameDataVersion; }
 

--- a/src/SerializedGameData.h
+++ b/src/SerializedGameData.h
@@ -29,12 +29,14 @@
 #include <map>
 #include <set>
 #include <stdexcept>
+#include <boost/weak_ptr.hpp>
 
 class GameObject;
 class GameWorld;
 class EventManager;
 class BinaryFile;
 class GameEvent;
+class Game;
 
 /// Kümmert sich um das Serialisieren der GameDaten fürs Speichern und Resynchronisieren
 class SerializedGameData : public Serializer
@@ -53,7 +55,7 @@ public:
     void MakeSnapshot(const GameWorld& gw);
 
     /// Reads the snapshot from the internal buffer
-    void ReadSnapshot(GameWorld& gw);
+    void ReadSnapshot(boost::weak_ptr<Game> game, GameWorld& gw);
 
     unsigned GetGameDataVersion() const { return gameDataVersion; }
 

--- a/src/ai/AIPlayer.h
+++ b/src/ai/AIPlayer.h
@@ -50,6 +50,9 @@ public:
         return tmp;
     }
 
+    // access to ais CommandFactory
+    const AIInterface& getAIInterface() const { return aii; }
+
     /// Eigene PlayerId, die der KI-Spieler wissen sollte, z.B. wenn er die Karte untersucht
     const unsigned char playerId;
     /// Verweis auf den eigenen GameClientPlayer, d.h. die Wirtschaft, um daraus entsprechend Informationen zu gewinnen

--- a/src/lua/LuaInterfaceGame.cpp
+++ b/src/lua/LuaInterfaceGame.cpp
@@ -34,7 +34,7 @@
 #include "libutil/Serializer.h"
 #include <boost/nowide/fstream.hpp>
 
-LuaInterfaceGame::LuaInterfaceGame(boost::weak_ptr<Game> game) : game(game), gw(game.lock()->world)
+LuaInterfaceGame::LuaInterfaceGame(boost::weak_ptr<Game> gameInstance) : gw(gameInstance.lock()->world), game(gameInstance)
 {
 #pragma region ConstDefs
 #define ADD_LUA_CONST(name) lua[#name] = name

--- a/src/lua/LuaInterfaceGame.cpp
+++ b/src/lua/LuaInterfaceGame.cpp
@@ -327,7 +327,7 @@ LuaPlayer LuaInterfaceGame::GetPlayer(unsigned playerIdx)
 {
     if(playerIdx >= gw.GetNumPlayers())
         throw std::runtime_error("Invalid player idx");
-    return LuaPlayer(gw.GetPlayer(playerIdx));
+    return LuaPlayer(game, gw.GetPlayer(playerIdx));
 }
 
 LuaWorld LuaInterfaceGame::GetWorld()
@@ -390,7 +390,8 @@ bool LuaInterfaceGame::EventCancelPactRequest(PactType pt, unsigned char cancele
 
 void LuaInterfaceGame::EventSuggestPact(const PactType pt, unsigned char suggestedByPlayerId, unsigned char targetPlayerId, const unsigned duration)
 {
-    const AIPlayer* ai = GAMECLIENT.GetAIPlayer(targetPlayerId);
+    Game& gameInst = *game.lock();
+    AIPlayer* ai =  gameInst.GetAIPlayer(targetPlayerId);
     if (ai != NULL)
     {
         kaguya::LuaRef onPactCancel = lua["onSuggestPact"];

--- a/src/lua/LuaInterfaceGame.cpp
+++ b/src/lua/LuaInterfaceGame.cpp
@@ -23,7 +23,10 @@
 #include "ingameWindows/iwMissionStatement.h"
 #include "lua/LuaPlayer.h"
 #include "lua/LuaWorld.h"
+#include "gameTypes/PactTypes.h"
 #include "network/GameClient.h"
+#include "ai/AIPlayer.h"
+#include "ai/AIInterface.h"
 #include "postSystem/PostMsg.h"
 #include "world/GameWorldGame.h"
 #include "gameTypes/Resource.h"
@@ -139,6 +142,11 @@ LuaInterfaceGame::LuaInterfaceGame(GameWorldGame& gw) : gw(gw)
     lua["RES_COAL"] = Resource::Coal;
     lua["RES_GRANITE"] = Resource::Granite;
     lua["RES_WATER"] = Resource::Water;
+
+    lua["NON_AGGRESSION_PACT"] = PactType::NON_AGGRESSION_PACT;
+    lua["TREATY_OF_ALLIANCE"] = PactType::TREATY_OF_ALLIANCE;
+    // infinite pact duration, see GamePlayer::GetRemainingPactTime
+    lua["DURATION_INFINITE"] = 0xFFFFFFFF;
 
 #undef ADD_LUA_CONST
 #define ADD_LUA_CONST(name) lua[#name] = iwMissionStatement::name
@@ -370,4 +378,48 @@ void LuaInterfaceGame::EventResourceFound(unsigned char player, const MapPoint p
     kaguya::LuaRef onResourceFound = lua["onResourceFound"];
     if(onResourceFound.type() == LUA_TFUNCTION)
         onResourceFound.call<void>(player, pt.x, pt.y, type, quantity);
+}
+
+bool LuaInterfaceGame::EventCancelPactRequest(PactType pt, unsigned char canceledByPlayerId, unsigned char targetPlayerId)
+{
+    kaguya::LuaRef onPactCancel = lua["onCancelPactRequest"];
+    if (onPactCancel.type() == LUA_TFUNCTION)
+        return onPactCancel.call<bool>(pt, canceledByPlayerId, targetPlayerId);
+    return true; // always accept pact cancel if there is no handler
+}
+
+void LuaInterfaceGame::EventSuggestPact(const PactType pt, unsigned char suggestedByPlayerId, unsigned char targetPlayerId, const unsigned duration)
+{
+    const AIPlayer* ai = GAMECLIENT.GetAIPlayer(targetPlayerId);
+    if (ai != NULL)
+    {
+        kaguya::LuaRef onPactCancel = lua["onSuggestPact"];
+        if (onPactCancel.type() == LUA_TFUNCTION)
+        {
+            AIInterface aii = ai->getAIInterface();
+            bool luaResult = onPactCancel.call<bool>(pt, suggestedByPlayerId, targetPlayerId, duration);
+            if (luaResult)
+                aii.AcceptPact(gw.GetEvMgr().GetCurrentGF(), pt, suggestedByPlayerId);
+            else
+                aii.CancelPact(pt, suggestedByPlayerId);
+        }
+    }
+}
+
+void LuaInterfaceGame::EventPactCanceled(const PactType pt, unsigned char canceledByPlayerId, unsigned char targetPlayerId)
+{
+    kaguya::LuaRef onPactCanceled = lua["onPactCanceled"];
+    if (onPactCanceled.type() == LUA_TFUNCTION)
+    {
+        onPactCanceled.call<void>(pt, canceledByPlayerId, targetPlayerId);
+    }
+}
+
+void LuaInterfaceGame::EventPactCreated(const PactType pt, unsigned char suggestedByPlayerId, unsigned char targetPlayerId, const unsigned duration)
+{
+    kaguya::LuaRef onPactCreated = lua["onPactCreated"];
+    if (onPactCreated.type() == LUA_TFUNCTION)
+    {
+        onPactCreated.call<void>(pt, suggestedByPlayerId, targetPlayerId, duration);
+    }
 }

--- a/src/lua/LuaInterfaceGame.cpp
+++ b/src/lua/LuaInterfaceGame.cpp
@@ -23,7 +23,6 @@
 #include "ingameWindows/iwMissionStatement.h"
 #include "lua/LuaPlayer.h"
 #include "lua/LuaWorld.h"
-#include "gameTypes/PactTypes.h"
 #include "network/GameClient.h"
 #include "ai/AIPlayer.h"
 #include "ai/AIInterface.h"
@@ -143,8 +142,8 @@ LuaInterfaceGame::LuaInterfaceGame(GameWorldGame& gw) : gw(gw)
     lua["RES_GRANITE"] = Resource::Granite;
     lua["RES_WATER"] = Resource::Water;
 
-    lua["NON_AGGRESSION_PACT"] = PactType::NON_AGGRESSION_PACT;
-    lua["TREATY_OF_ALLIANCE"] = PactType::TREATY_OF_ALLIANCE;
+    lua["NON_AGGRESSION_PACT"] = NON_AGGRESSION_PACT;
+    lua["TREATY_OF_ALLIANCE"] = TREATY_OF_ALLIANCE;
     // infinite pact duration, see GamePlayer::GetRemainingPactTime
     lua["DURATION_INFINITE"] = 0xFFFFFFFF;
 

--- a/src/lua/LuaInterfaceGame.cpp
+++ b/src/lua/LuaInterfaceGame.cpp
@@ -29,11 +29,12 @@
 #include "postSystem/PostMsg.h"
 #include "world/GameWorldGame.h"
 #include "gameTypes/Resource.h"
+#include "Game.h"
 #include "libutil/Log.h"
 #include "libutil/Serializer.h"
 #include <boost/nowide/fstream.hpp>
 
-LuaInterfaceGame::LuaInterfaceGame(GameWorldGame& gw) : gw(gw)
+LuaInterfaceGame::LuaInterfaceGame(boost::weak_ptr<Game> game) : game(game), gw(game.lock()->world)
 {
 #pragma region ConstDefs
 #define ADD_LUA_CONST(name) lua[#name] = name

--- a/src/lua/LuaInterfaceGame.h
+++ b/src/lua/LuaInterfaceGame.h
@@ -21,17 +21,19 @@
 #include "LuaInterfaceBase.h"
 #include "gameTypes/MapCoordinates.h"
 #include "gameTypes/PactTypes.h"
+#include <boost/weak_ptr.hpp>
 #include <string>
 
 class GameWorldGame;
 class LuaPlayer;
 class LuaWorld;
 class Serializer;
+class Game;
 
 class LuaInterfaceGame : public LuaInterfaceBase
 {
 public:
-    LuaInterfaceGame(GameWorldGame& gw);
+    LuaInterfaceGame(boost::weak_ptr<Game> game);
     virtual ~LuaInterfaceGame();
 
     static void Register(kaguya::State& state);
@@ -66,7 +68,7 @@ public:
 
 private:
     GameWorldGame& gw;
-
+    boost::weak_ptr<Game> game;
     LuaPlayer GetPlayer(unsigned playerIdx);
     LuaWorld GetWorld();
 };

--- a/src/lua/LuaInterfaceGame.h
+++ b/src/lua/LuaInterfaceGame.h
@@ -20,6 +20,7 @@
 
 #include "LuaInterfaceBase.h"
 #include "gameTypes/MapCoordinates.h"
+#include "gameTypes/PactTypes.h"
 #include <string>
 
 class GameWorldGame;
@@ -43,7 +44,14 @@ public:
     void EventStart(bool isFirstStart);
     void EventGameFrame(unsigned number);
     void EventResourceFound(unsigned char player, const MapPoint pt, unsigned char type, unsigned char quantity);
-
+    // Called if player wants to cancel a pact
+    bool EventCancelPactRequest(PactType pt, unsigned char canceledByPlayerId, unsigned char targetPlayerId);
+    // Called if player suggests a pact
+    void EventSuggestPact(const PactType pt, unsigned char suggestedByPlayerId, unsigned char targetPlayerId, const unsigned duration);
+    // called if pact was canceled
+    void EventPactCanceled(const PactType pt, unsigned char canceledByPlayerId, unsigned char targetPlayerId);
+    // called if pact was created
+    void EventPactCreated(const PactType pt, unsigned char suggestedByPlayerId, unsigned char targetPlayerId, const unsigned duration);
     // Callable from Lua
     void ClearResources();
     unsigned GetGF() const;

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -315,7 +315,7 @@ bool LuaPlayer::IsAttackable(unsigned char otherPlayerId)
 void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const PactType pt, const unsigned duration)
 {
     Game& gameInst = *game.lock();
-    AIPlayer* ai = gameInst.GetAIPlayer(otherPlayerId);
+    AIPlayer* ai = gameInst.GetAIPlayer(player.GetPlayerId());
     if (ai != NULL)
     {
         AIInterface aii = ai->getAIInterface();
@@ -326,7 +326,7 @@ void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const PactType pt, cons
 void LuaPlayer::CancelPact(const PactType pt, unsigned char otherPlayerId) 
 {
     Game& gameInst = *game.lock();
-    AIPlayer* ai = gameInst.GetAIPlayer(otherPlayerId);
+    AIPlayer* ai = gameInst.GetAIPlayer(player.GetPlayerId());
     if (ai != NULL)
     {
         AIInterface aii = ai->getAIInterface();

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -23,6 +23,8 @@
 #include "buildings/nobHQ.h"
 #include "helpers/converters.h"
 #include "lua/LuaHelpers.h"
+#include "ai/AIPlayer.h"
+#include "network/GameClient.h"
 #include "notifications/BuildingNote.h"
 #include "postSystem/PostMsgWithBuilding.h"
 #include "world/GameWorldGame.h"
@@ -59,6 +61,10 @@ void LuaPlayer::Register(kaguya::State& state)
                                .addFunction("GetHQPos", &LuaPlayer::GetHQPos)
                                .addFunction("IsDefeated", &LuaPlayer::IsDefeated)
                                .addFunction("Surrender", &LuaPlayer::Surrender)
+                               .addFunction("IsAlly", &LuaPlayer::IsAlly)
+                               .addFunction("IsAttackable", &LuaPlayer::IsAttackable)
+                               .addFunction("SuggestPact", &LuaPlayer::SuggestPact)
+                               .addFunction("CancelPact", &LuaPlayer::CancelPact)
                                // Old names
                                .addFunction("GetBuildingCount", &LuaPlayer::GetNumBuildings)
                                .addFunction("GetBuildingSitesCount", &LuaPlayer::GetNumBuildingSites)
@@ -293,4 +299,35 @@ void LuaPlayer::Surrender(bool destroyBlds)
 kaguya::standard::tuple<unsigned, unsigned> LuaPlayer::GetHQPos() const
 {
     return kaguya::standard::tuple<unsigned, unsigned>(player.GetHQPos().x, player.GetHQPos().y);
+}
+
+bool LuaPlayer::IsAlly(unsigned char otherPlayerId)
+{
+    return player.IsAlly(otherPlayerId);
+}
+
+bool LuaPlayer::IsAttackable(unsigned char otherPlayerId) 
+{
+    return player.IsAttackable(otherPlayerId);
+}
+
+void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const PactType pt, const unsigned duration)
+{
+    const AIPlayer* ai = GAMECLIENT.GetAIPlayer(player.GetPlayerId());
+    if (ai != NULL)
+    {
+        AIInterface aii = ai->getAIInterface();
+        aii.SuggestPact(otherPlayerId, pt, duration);
+    }
+}
+
+void LuaPlayer::CancelPact(const PactType pt, unsigned char otherPlayerId) 
+{
+    const AIPlayer* ai = GAMECLIENT.GetAIPlayer(player.GetPlayerId());
+    if (ai != NULL)
+    {
+        AIInterface aii = ai->getAIInterface();
+        GameWorldGame& world = player.GetGameWorld();
+        aii.CancelPact(pt, otherPlayerId);
+    }
 }

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -327,7 +327,6 @@ void LuaPlayer::CancelPact(const PactType pt, unsigned char otherPlayerId)
     if (ai != NULL)
     {
         AIInterface aii = ai->getAIInterface();
-        GameWorldGame& world = player.GetGameWorld();
         aii.CancelPact(pt, otherPlayerId);
     }
 }

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -19,6 +19,7 @@
 #include "LuaPlayer.h"
 #include "EventManager.h"
 #include "GamePlayer.h"
+#include "Game.h"
 #include "buildings/nobBaseWarehouse.h"
 #include "buildings/nobHQ.h"
 #include "helpers/converters.h"
@@ -313,7 +314,8 @@ bool LuaPlayer::IsAttackable(unsigned char otherPlayerId)
 
 void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const PactType pt, const unsigned duration)
 {
-    const AIPlayer* ai = GAMECLIENT.GetAIPlayer(player.GetPlayerId());
+    Game& gameInst = *game.lock();
+    AIPlayer* ai = gameInst.GetAIPlayer(otherPlayerId);
     if (ai != NULL)
     {
         AIInterface aii = ai->getAIInterface();
@@ -323,7 +325,8 @@ void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const PactType pt, cons
 
 void LuaPlayer::CancelPact(const PactType pt, unsigned char otherPlayerId) 
 {
-    const AIPlayer* ai = GAMECLIENT.GetAIPlayer(player.GetPlayerId());
+    Game& gameInst = *game.lock();
+    AIPlayer* ai = gameInst.GetAIPlayer(otherPlayerId);
     if (ai != NULL)
     {
         AIInterface aii = ai->getAIInterface();

--- a/src/lua/LuaPlayer.h
+++ b/src/lua/LuaPlayer.h
@@ -22,6 +22,7 @@
 #include "gameTypes/BuildingType.h"
 #include "gameTypes/GoodTypes.h"
 #include "gameTypes/JobTypes.h"
+#include "gameTypes/PactTypes.h"
 #include <kaguya/kaguya.hpp>
 #include <map>
 
@@ -56,6 +57,10 @@ public:
     bool IsDefeated() const;
     void Surrender(bool destroyBlds);
     kaguya::standard::tuple<unsigned, unsigned> GetHQPos() const;
+    bool IsAlly(unsigned char otherPlayerId);
+    bool IsAttackable(unsigned char otherPlayerId);
+    void SuggestPact(unsigned char otherPlayerId, PactType pt, const unsigned duration);
+    void CancelPact(const PactType pt, unsigned char otherPlayerId);
 };
 
 #endif // LuaPlayer_h__

--- a/src/lua/LuaPlayer.h
+++ b/src/lua/LuaPlayer.h
@@ -23,20 +23,23 @@
 #include "gameTypes/GoodTypes.h"
 #include "gameTypes/JobTypes.h"
 #include "gameTypes/PactTypes.h"
+#include <boost/weak_ptr.hpp>
 #include <kaguya/kaguya.hpp>
 #include <map>
 
 class GamePlayer;
+class Game;
 
 class LuaPlayer : public LuaPlayerBase
 {
+    boost::weak_ptr<Game> game;
     GamePlayer& player;
 
 protected:
     const BasePlayerInfo& GetPlayer() const override;
 
 public:
-    LuaPlayer(GamePlayer& player) : player(player) {}
+    LuaPlayer(boost::weak_ptr<Game> game, GamePlayer& player) : game(game), player(player) {}
     static void Register(kaguya::State& state);
 
     void EnableBuilding(BuildingType bld, bool notify);

--- a/src/network/CreateServerInfo.h
+++ b/src/network/CreateServerInfo.h
@@ -21,7 +21,7 @@
 #include "gameTypes/ServerType.h"
 #include <string>
 
-/// Struktur zur Weitergabe der Spiel-Eröffnungsdaten
+/// Struktur zur Weitergabe der Spiel-ErÃ¶ffnungsdaten
 struct CreateServerInfo
 {
     ServerType type;      /// Typ des Servers.

--- a/src/network/GameClient.cpp
+++ b/src/network/GameClient.cpp
@@ -309,7 +309,7 @@ void GameClient::StartGame(const unsigned random_init)
 
     GameWorld& gameWorld = game->world;
     if(mapinfo.savegame)
-        mapinfo.savegame->sgd.ReadSnapshot(gameWorld);
+        mapinfo.savegame->sgd.ReadSnapshot(game, gameWorld);
     else
     {
         RTTR_Assert(mapinfo.type != MAPTYPE_SAVEGAME);
@@ -317,7 +317,7 @@ void GameClient::StartGame(const unsigned random_init)
         for(unsigned i = 0; i < gameWorld.GetNumPlayers(); ++i)
             gameWorld.GetPlayer(i).MakeStartPacts();
 
-        gameWorld.LoadMap(mapinfo.filepath, mapinfo.luaFilepath);
+        gameWorld.LoadMap(game, mapinfo.filepath, mapinfo.luaFilepath);
 
         /// Evtl. Goldvorkommen ändern
         Resource::Type target; // löschen

--- a/src/network/GameClient.cpp
+++ b/src/network/GameClient.cpp
@@ -309,7 +309,7 @@ void GameClient::StartGame(const unsigned random_init)
 
     GameWorld& gameWorld = game->world;
     if(mapinfo.savegame)
-        mapinfo.savegame->sgd.ReadSnapshot(game, gameWorld);
+        mapinfo.savegame->sgd.ReadSnapshot(game);
     else
     {
         RTTR_Assert(mapinfo.type != MAPTYPE_SAVEGAME);
@@ -1599,7 +1599,7 @@ bool GameClient::SaveToFile(const std::string& filename)
     save.sgd.debugMode = SETTINGS.global.debugMode;
 
     // Spiel serialisieren
-    save.sgd.MakeSnapshot(game->world);
+    save.sgd.MakeSnapshot(game);
 
     // Und alles speichern
     return save.Save(filename, mapinfo.title);

--- a/src/network/GameClient.cpp
+++ b/src/network/GameClient.cpp
@@ -244,12 +244,7 @@ const AIPlayer* GameClient::GetAIPlayer(unsigned id) const
 {
     if(!game)
         return NULL;
-    BOOST_FOREACH(const AIPlayer& ai, game->aiPlayers)
-    {
-        if(ai.GetPlayerId() == id)
-            return &ai;
-    }
-    return NULL;
+    return game->GetAIPlayer(id);
 }
 
 /**

--- a/src/test/GameWithLuaAccess.h
+++ b/src/test/GameWithLuaAccess.h
@@ -34,16 +34,40 @@
 #include "libutil/StringStreamWriter.h"
 #include "libutil/colors.h"
 #include "Game.h"
+#include "factories/AIFactory.h"
+#include "ai/AIPlayer.h"
 #include <boost/test/unit_test.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
 #include <vector>
 
 class GameWithLuaAccess : public Game
 {
 public:
-    GameWithLuaAccess() : Game(GlobalGameSettings(), (unsigned int)0, CreatePlayers()) { }
+    GameWithLuaAccess() : Game(GlobalGameSettings(), (unsigned int)0, CreatePlayers())
+    {
+        for (unsigned id = 0; id < world.GetNumPlayers(); id++)
+        {
+            aiPlayers.push_back(AIFactory::Create(world.GetPlayer(id).aiInfo, id, world));
+        }
+    }
+
+    void executeAICommands() {
+        AIPlayer* ai = GetAIPlayer(1);
+        std::vector<gc::GameCommandPtr> aiGcs = ai->FetchGameCommands();
+        for (unsigned i = 0; i < 5; i++)
+        {
+            world.GetEvMgr().ExecuteNextGF();
+            ai->RunGF(world.GetEvMgr().GetCurrentGF(), i == 0);
+        }
+        BOOST_FOREACH(gc::GameCommandPtr& gc, aiGcs)
+        {
+            gc->Execute(world, 1);
+        }
+
+    }
 
     static std::vector<PlayerInfo> CreatePlayers()
     {

--- a/src/test/GameWithLuaAccess.h
+++ b/src/test/GameWithLuaAccess.h
@@ -34,6 +34,7 @@
 #include "libutil/StringStreamWriter.h"
 #include "libutil/colors.h"
 #include "Game.h"
+#include "test/GCExecutor.h"
 #include "factories/AIFactory.h"
 #include "ai/AIPlayer.h"
 #include <boost/test/unit_test.hpp>
@@ -50,7 +51,9 @@ public:
     {
         for (unsigned id = 0; id < world.GetNumPlayers(); id++)
         {
-            aiPlayers.push_back(AIFactory::Create(world.GetPlayer(id).aiInfo, id, world));
+            GamePlayer& player = world.GetPlayer(id);
+            if (!player.isHuman() && player.isUsed())
+                aiPlayers.push_back(AIFactory::Create(world.GetPlayer(id).aiInfo, id, world));
         }
     }
 
@@ -66,7 +69,6 @@ public:
         {
             gc->Execute(world, 1);
         }
-
     }
 
     static std::vector<PlayerInfo> CreatePlayers()
@@ -91,7 +93,7 @@ public:
     }
 };
 
-struct LuaTestsFixture : public LogAccessor, public LuaBaseFixture
+struct LuaTestsFixture : public LogAccessor, public LuaBaseFixture, GCExecutor
 {
 public:
     boost::shared_ptr<GameWithLuaAccess> game;
@@ -116,6 +118,8 @@ public:
         playerNations.push_back(world.GetPlayer(1).nation);
         BOOST_REQUIRE(MapLoader::PlaceHQs(world, hqPositions, playerNations, false));
     }
+
+    virtual GameWorldGame& GetWorld() { return world; }
 };
 
 #endif // GameWithLuaAccess_h__

--- a/src/test/GameWithLuaAccess.h
+++ b/src/test/GameWithLuaAccess.h
@@ -43,8 +43,7 @@
 class GameWithLuaAccess : public Game
 {
 public:
-    GlobalGameSettings ggs;
-    GameWithLuaAccess() : Game(ggs, (unsigned int)0, CreatePlayers()) { }
+    GameWithLuaAccess() : Game(GlobalGameSettings(), (unsigned int)0, CreatePlayers()) { }
 
     static std::vector<PlayerInfo> CreatePlayers()
     {

--- a/src/test/GameWithLuaAccess.h
+++ b/src/test/GameWithLuaAccess.h
@@ -15,8 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef GameWorldWithLuaAccess_h__
-#define GameWorldWithLuaAccess_h__
+#ifndef GameWithLuaAccess_h__
+#define GameWithLuaAccess_h__
 
 #include "BufferedWriter.h"
 #include "EventManager.h"
@@ -44,12 +44,7 @@ class GameWithLuaAccess : public Game
 {
 public:
     GlobalGameSettings ggs;
-    GameWithLuaAccess() : Game(ggs, (unsigned int)0, CreatePlayers()) { createLua(); }
-
-    void createLua() { 
-        //boost::shared_ptr<Game> game = boost::make_shared<Game>(*this);
-        //world.lua.reset(new LuaInterfaceGame(game));
-    }
+    GameWithLuaAccess() : Game(ggs, (unsigned int)0, CreatePlayers()) { }
 
     static std::vector<PlayerInfo> CreatePlayers()
     {
@@ -76,12 +71,13 @@ public:
 struct LuaTestsFixture : public LogAccessor, public LuaBaseFixture
 {
 public:
-    GameWithLuaAccess game;
+    boost::shared_ptr<GameWithLuaAccess> game;
     GameWorld& world;
     std::vector<MapPoint> hqPositions;
 
-    LuaTestsFixture() : world(game.world) { 
-        luaBase = &game.world.GetLua(); 
+    LuaTestsFixture() : game(new GameWithLuaAccess), world(game->world) { 
+        game->world.SetLua(new LuaInterfaceGame(game));
+        luaBase = &game->world.GetLua(); 
     }
 
     void initWorld()
@@ -99,4 +95,4 @@ public:
     }
 };
 
-#endif // GameWorldWithLuaAccess_h__
+#endif // GameWithLuaAccess_h__

--- a/src/test/GameWorldWithLuaAccess.h
+++ b/src/test/GameWorldWithLuaAccess.h
@@ -33,18 +33,23 @@
 #include "libutil/Log.h"
 #include "libutil/StringStreamWriter.h"
 #include "libutil/colors.h"
+#include "Game.h"
 #include <boost/test/unit_test.hpp>
+#include <boost/weak_ptr.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 #include <vector>
 
-class GameWorldWithLuaAccess : public GameWorldGame
+class GameWithLuaAccess : public Game
 {
 public:
     GlobalGameSettings ggs;
-    EventManager em;
+    GameWithLuaAccess() : Game(ggs, (unsigned int)0, CreatePlayers()) { createLua(); }
 
-    GameWorldWithLuaAccess() : GameWorldGame(CreatePlayers(), ggs, em), em(0) { createLua(); }
-
-    void createLua() { lua.reset(new LuaInterfaceGame(*this)); }
+    void createLua() { 
+        //boost::shared_ptr<Game> game = boost::make_shared<Game>(*this);
+        //world.lua.reset(new LuaInterfaceGame(game));
+    }
 
     static std::vector<PlayerInfo> CreatePlayers()
     {
@@ -70,10 +75,14 @@ public:
 
 struct LuaTestsFixture : public LogAccessor, public LuaBaseFixture
 {
-    GameWorldWithLuaAccess world;
+public:
+    GameWithLuaAccess game;
+    GameWorld& world;
     std::vector<MapPoint> hqPositions;
 
-    LuaTestsFixture() { luaBase = &world.GetLua(); }
+    LuaTestsFixture() : world(game.world) { 
+        luaBase = &game.world.GetLua(); 
+    }
 
     void initWorld()
     {

--- a/src/test/WorldFixture.h
+++ b/src/test/WorldFixture.h
@@ -106,7 +106,7 @@ struct WorldFixture
     GameWorld& world;
     T_WorldCreator worldCreator;
     WorldFixture()
-        : game(boost::shared_ptr<Game>(new Game(GlobalGameSettings(), new TestEventManager, std::vector<PlayerInfo>(T_numPlayers, GetPlayer())))),
+        : game(new Game(GlobalGameSettings(), new TestEventManager, std::vector<PlayerInfo>(T_numPlayers, GetPlayer()))),
           em(static_cast<TestEventManager&>(*game->em)), ggs(const_cast<GlobalGameSettings&>(game->ggs)), world(game->world),
           worldCreator(MapExtent(T_width, T_height), T_numPlayers)
     {

--- a/src/test/WorldFixture.h
+++ b/src/test/WorldFixture.h
@@ -27,6 +27,8 @@
 #include "gameTypes/MapCoordinates.h"
 #include "gameTypes/Nation.h"
 #include <boost/test/unit_test.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 #include <vector>
 
 //////////////////////////////////////////////////////////////////////////
@@ -98,14 +100,14 @@ template<class T_WorldCreator, unsigned T_numPlayers = 0, unsigned T_width = Wor
          unsigned T_height = WorldDefault<T_numPlayers>::height>
 struct WorldFixture
 {
-    Game game;
+    boost::shared_ptr<Game> game;
     TestEventManager& em;
     GlobalGameSettings& ggs;
     GameWorld& world;
     T_WorldCreator worldCreator;
     WorldFixture()
-        : game(GlobalGameSettings(), new TestEventManager, std::vector<PlayerInfo>(T_numPlayers, GetPlayer())),
-          em(static_cast<TestEventManager&>(*game.em)), ggs(const_cast<GlobalGameSettings&>(game.ggs)), world(game.world),
+        : game(boost::shared_ptr<Game>(new Game(GlobalGameSettings(), new TestEventManager, std::vector<PlayerInfo>(T_numPlayers, GetPlayer())))),
+          em(static_cast<TestEventManager&>(*game->em)), ggs(const_cast<GlobalGameSettings&>(game->ggs)), world(game->world),
           worldCreator(MapExtent(T_width, T_height), T_numPlayers)
     {
         // Fast moving ships

--- a/src/test/testBuilding.cpp
+++ b/src/test/testBuilding.cpp
@@ -213,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE(BQWithVisualRoad, EmptyWorldFixture1PBigger)
     GAMECLIENT.SetTestPlayerId(0);
 
     GLOBALVARS.isTest = true;
-    dskGameInterface gameDesktop(boost::shared_ptr<Game>(&this->game, &deleteNoting));
+    dskGameInterface gameDesktop(this->game);
     const GameWorldViewer& gwv = gameDesktop.GetViewer();
     // Start at a position a bit away from the HQ so all points are castles
     const MapPoint roadPt = world.MakeMapPoint(world.GetPlayer(0).GetHQPos() - Position(6, 6));

--- a/src/test/testLua.cpp
+++ b/src/test/testLua.cpp
@@ -29,7 +29,7 @@
 #include "nodeObjs/noEnvObject.h"
 #include "nodeObjs/noStaticObject.h"
 #include "gameTypes/Resource.h"
-#include "test/GameWorldWithLuaAccess.h"
+#include "test/GameWithLuaAccess.h"
 #include "test/helperFuncs.h"
 #include "test/initTestHelpers.h"
 #include "libutil/Serializer.h"
@@ -199,7 +199,9 @@ BOOST_AUTO_TEST_CASE(GameFunctions)
     hqs[0] = world.GetSpecObj<nobHQ>(world.GetPlayer(0).GetHQPos());
     hqs[1] = world.GetSpecObj<nobHQ>(world.GetPlayer(1).GetHQPos());
 
-    BOOST_REQUIRE_GT(hqs[0]->GetNumRealWares(GD_BOARDS), 0u);
+    unsigned numBoards = hqs[0]->GetNumRealWares(GD_BOARDS);
+
+    BOOST_REQUIRE_GT(numBoards, 0u);
 
     executeLua("rttr:ClearResources()");
     for(unsigned i = 0; i < hqs.size(); i++)

--- a/src/test/testLua.cpp
+++ b/src/test/testLua.cpp
@@ -29,6 +29,7 @@
 #include "nodeObjs/noEnvObject.h"
 #include "nodeObjs/noStaticObject.h"
 #include "gameTypes/Resource.h"
+#include "postSystem/DiplomacyPostQuestion.h"
 #include "test/GameWithLuaAccess.h"
 #include "test/helperFuncs.h"
 #include "test/initTestHelpers.h"
@@ -798,6 +799,17 @@ BOOST_AUTO_TEST_CASE(LuaPacts)
     player.CancelPact(NON_AGGRESSION_PACT, 1);
     BOOST_REQUIRE(player.IsAttackable(1));  
     BOOST_REQUIRE_EQUAL(getLog(), "Pact canceled\n");
+
+    PostBox* postbox = world.GetPostMgr().AddPostBox(0);
+    // Suggest Pact from Lua
+    executeLua("player:SuggestPact(0, TREATY_OF_ALLIANCE, DURATION_INFINITE)");
+    game->executeAICommands();
+    const DiplomacyPostQuestion* msg = dynamic_cast<const DiplomacyPostQuestion*>(postbox->GetMsg(0));
+    this->AcceptPact(msg->GetPactId(), TREATY_OF_ALLIANCE, 1);
+    BOOST_REQUIRE(!player.IsAttackable(1));
+    executeLua("assert(not player:IsAttackable(0))");
+
+    BOOST_REQUIRE_EQUAL(getLog(), "Pact created\n");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/testLua.cpp
+++ b/src/test/testLua.cpp
@@ -199,9 +199,7 @@ BOOST_AUTO_TEST_CASE(GameFunctions)
     hqs[0] = world.GetSpecObj<nobHQ>(world.GetPlayer(0).GetHQPos());
     hqs[1] = world.GetSpecObj<nobHQ>(world.GetPlayer(1).GetHQPos());
 
-    unsigned numBoards = hqs[0]->GetNumRealWares(GD_BOARDS);
-
-    BOOST_REQUIRE_GT(numBoards, 0u);
+    BOOST_REQUIRE_GT(hqs[0]->GetNumRealWares(GD_BOARDS), 0u);
 
     executeLua("rttr:ClearResources()");
     for(unsigned i = 0; i < hqs.size(); i++)

--- a/src/test/testLua.cpp
+++ b/src/test/testLua.cpp
@@ -218,8 +218,8 @@ BOOST_AUTO_TEST_CASE(GameFunctions)
 
     for(unsigned i = 0; i < 2; i++)
     {
-        BOOST_CHECK(isLuaEqual("rttr:GetGF()", s25util::toStringClassic(world.em.GetCurrentGF())));
-        world.em.ExecuteNextGF();
+        BOOST_CHECK(isLuaEqual("rttr:GetGF()", s25util::toStringClassic(world.GetEvMgr().GetCurrentGF())));
+        world.GetEvMgr().ExecuteNextGF();
     }
 
     StoreChat storeChat;

--- a/src/test/testLuaGUI.cpp
+++ b/src/test/testLuaGUI.cpp
@@ -26,7 +26,7 @@
 #include "ingameWindows/iwMsgbox.h"
 #include "network/GameClient.h"
 #include "ogl/glArchivItem_Font.h"
-#include "test/GameWorldWithLuaAccess.h"
+#include "test/GameWithLuaAccess.h"
 #include <boost/assign/std/vector.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(LuaGUITestSuite, LuaTestsFixture)

--- a/src/test/testSerialization.cpp
+++ b/src/test/testSerialization.cpp
@@ -266,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
             boost::shared_ptr<Game> sharedGame(new Game(save.ggs, loadSave.start_gf, players));
             GameWorld& newWorld = sharedGame->world;
             save.sgd.ReadSnapshot(sharedGame);
-            TestEventManager newEm = static_cast<TestEventManager&>(sharedGame->world.GetEvMgr());
+            TestEventManager& newEm = static_cast<TestEventManager&>(sharedGame->world.GetEvMgr());
 
             BOOST_REQUIRE_EQUAL(newWorld.GetSize(), world.GetSize());
             BOOST_REQUIRE_EQUAL(newEm.GetCurrentGF(), em.GetCurrentGF());

--- a/src/test/testSerialization.cpp
+++ b/src/test/testSerialization.cpp
@@ -36,6 +36,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace {
 struct RandWorldFixture : public WorldFixture<CreateEmptyWorld, 4>
@@ -262,10 +263,13 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
             std::vector<PlayerInfo> players;
             for(unsigned j = 0; j < 4; j++)
                 players.push_back(PlayerInfo(loadSave.GetPlayer(j)));
-            GlobalGameSettings newGGS = save.ggs;
+            GlobalGameSettings& newGGS = save.ggs;
             TestEventManager newEm(loadSave.start_gf);
             GameWorld newWorld(players, newGGS, newEm);
-            save.sgd.ReadSnapshot(newWorld);
+            Game newGame(newGGS, loadSave.start_gf, players);
+            boost::shared_ptr<Game> sharedGame;
+            sharedGame.reset(&newGame);
+            save.sgd.ReadSnapshot(sharedGame, newWorld);
 
             BOOST_REQUIRE_EQUAL(newWorld.GetSize(), world.GetSize());
             BOOST_REQUIRE_EQUAL(newEm.GetCurrentGF(), em.GetCurrentGF());

--- a/src/test/testSerialization.cpp
+++ b/src/test/testSerialization.cpp
@@ -210,7 +210,7 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
 
     save.ggs = ggs;
     save.start_gf = em.GetCurrentGF();
-    save.sgd.MakeSnapshot(world);
+    save.sgd.MakeSnapshot(game);
 
     TmpFile tmpFile;
     BOOST_REQUIRE(tmpFile.isValid());
@@ -263,13 +263,10 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
             std::vector<PlayerInfo> players;
             for(unsigned j = 0; j < 4; j++)
                 players.push_back(PlayerInfo(loadSave.GetPlayer(j)));
-            GlobalGameSettings& newGGS = save.ggs;
-            TestEventManager newEm(loadSave.start_gf);
-            GameWorld newWorld(players, newGGS, newEm);
-            Game newGame(newGGS, loadSave.start_gf, players);
-            boost::shared_ptr<Game> sharedGame;
-            sharedGame.reset(&newGame);
-            save.sgd.ReadSnapshot(sharedGame, newWorld);
+            boost::shared_ptr<Game> sharedGame(new Game(save.ggs, loadSave.start_gf, players));
+            GameWorld& newWorld = sharedGame->world;
+            save.sgd.ReadSnapshot(sharedGame);
+            TestEventManager newEm = static_cast<TestEventManager&>(sharedGame->world.GetEvMgr());
 
             BOOST_REQUIRE_EQUAL(newWorld.GetSize(), world.GetSize());
             BOOST_REQUIRE_EQUAL(newEm.GetCurrentGF(), em.GetCurrentGF());
@@ -309,7 +306,7 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
             BOOST_REQUIRE_EQUAL(newUsual->GetProductivity(), usualBld->GetProductivity());
 
             SerializedGameData loadedSgd;
-            loadedSgd.MakeSnapshot(newWorld);
+            loadedSgd.MakeSnapshot(sharedGame);
             BOOST_REQUIRE_EQUAL_COLLECTIONS(loadedSgd.GetData(), loadedSgd.GetData() + loadedSgd.GetLength(), save.sgd.GetData(),
                                             save.sgd.GetData() + save.sgd.GetLength());
         }
@@ -443,7 +440,7 @@ BOOST_FIXTURE_TEST_CASE(ReplayWithSavegame, RandWorldFixture)
 
     map.savegame->ggs = ggs;
     map.savegame->start_gf = em.GetCurrentGF();
-    map.savegame->sgd.MakeSnapshot(world);
+    map.savegame->sgd.MakeSnapshot(game);
 
     Replay replay;
     BOOST_REQUIRE(!replay.IsValid());
@@ -465,7 +462,7 @@ BOOST_FIXTURE_TEST_CASE(ReplayWithSavegame, RandWorldFixture)
     BOOST_REQUIRE(replay.IsRecording());
     BOOST_REQUIRE(!replay.IsReplaying());
 
-    PlayerGameCommands cmds = GetTestCommands().create(game).result;
+    PlayerGameCommands cmds = GetTestCommands().create(*game).result;
     AddReplayCmds(replay, cmds);
     replay.StopRecording();
     BOOST_REQUIRE(!replay.IsValid());

--- a/src/world/GameWorld.cpp
+++ b/src/world/GameWorld.cpp
@@ -37,7 +37,7 @@ GameWorld::GameWorld(const std::vector<PlayerInfo>& playerInfos, const GlobalGam
 {}
 
 /// Lädt eine Karte
-bool GameWorld::LoadMap(const std::string& mapFilePath, const std::string& luaFilePath)
+bool GameWorld::LoadMap(boost::weak_ptr<Game> game, const std::string& mapFilePath, const std::string& luaFilePath)
 {
     // Map laden
     libsiedler2::Archiv mapArchiv;
@@ -52,7 +52,7 @@ bool GameWorld::LoadMap(const std::string& mapFilePath, const std::string& luaFi
 
     if(bfs::exists(luaFilePath))
     {
-        lua.reset(new LuaInterfaceGame(*this));
+        lua.reset(new LuaInterfaceGame(game));
         if(!lua->LoadScript(luaFilePath) || !lua->CheckScriptVersion())
         {
             lua.reset();
@@ -105,7 +105,7 @@ void GameWorld::Serialize(SerializedGameData& sgd) const
     }
 }
 
-void GameWorld::Deserialize(SerializedGameData& sgd)
+void GameWorld::Deserialize(boost::weak_ptr<Game> game, SerializedGameData& sgd)
 {
     // Headinformationen
     const MapExtent size = sgd.PopPoint<MapExtent::ElementType>();
@@ -135,7 +135,7 @@ void GameWorld::Deserialize(SerializedGameData& sgd)
             throw SerializedGameData::Error(_("Invalid end-id for lua data"));
 
         // Now init and load lua
-        lua.reset(new LuaInterfaceGame(*this));
+        lua.reset(new LuaInterfaceGame(game));
         if(!lua->LoadScriptString(luaScript))
         {
             lua.reset();

--- a/src/world/GameWorld.h
+++ b/src/world/GameWorld.h
@@ -22,8 +22,10 @@
 #include "world/GameWorldViewer.h"
 #include "gameTypes/MapCoordinates.h"
 #include <string>
+#include <boost/weak_ptr.hpp>
 
 class SerializedGameData;
+class Game;
 
 class GameWorld : public GameWorldGame
 {
@@ -31,11 +33,11 @@ public:
     GameWorld(const std::vector<PlayerInfo>& playerInfos, const GlobalGameSettings& gameSettings, EventManager& em);
 
     /// Lädt eine Karte
-    bool LoadMap(const std::string& mapFilePath, const std::string& luaFilePath);
+    bool LoadMap(boost::weak_ptr<Game> game, const std::string& mapFilePath, const std::string& luaFilePath);
 
     /// Serialisiert den gesamten GameWorld
     void Serialize(SerializedGameData& sgd) const;
-    void Deserialize(SerializedGameData& sgd);
+    void Deserialize(boost::weak_ptr<Game> game, SerializedGameData& sgd);
 };
 
 #endif // GameWorld_h__

--- a/src/world/GameWorld.h
+++ b/src/world/GameWorld.h
@@ -22,7 +22,7 @@
 #include "world/GameWorldViewer.h"
 #include "gameTypes/MapCoordinates.h"
 #include <string>
-#include <boost/weak_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 
 class SerializedGameData;
 class Game;
@@ -33,11 +33,11 @@ public:
     GameWorld(const std::vector<PlayerInfo>& playerInfos, const GlobalGameSettings& gameSettings, EventManager& em);
 
     /// Lädt eine Karte
-    bool LoadMap(boost::weak_ptr<Game> game, const std::string& mapFilePath, const std::string& luaFilePath);
+    bool LoadMap(boost::shared_ptr<Game> game, const std::string& mapFilePath, const std::string& luaFilePath);
 
     /// Serialisiert den gesamten GameWorld
     void Serialize(SerializedGameData& sgd) const;
-    void Deserialize(boost::weak_ptr<Game> game, SerializedGameData& sgd);
+    void Deserialize(boost::shared_ptr<Game> game, SerializedGameData& sgd);
 };
 
 #endif // GameWorld_h__

--- a/src/world/GameWorldBase.cpp
+++ b/src/world/GameWorldBase.cpp
@@ -697,3 +697,11 @@ void GameWorldBase::RecalcBQ(const MapPoint pt)
     if(SetBQ(pt, calcBQ(pt, boost::bind(&GameWorldBase::IsOnRoad, this, _1))))
         GetNotifications().publish(NodeNote(NodeNote::BQ, pt));
 }
+
+void GameWorldBase::SetLua(LuaInterfaceGame* newLua)
+{
+    if (newLua != NULL)
+        lua.reset(newLua);
+    else
+        lua.reset();
+}

--- a/src/world/GameWorldBase.cpp
+++ b/src/world/GameWorldBase.cpp
@@ -697,11 +697,3 @@ void GameWorldBase::RecalcBQ(const MapPoint pt)
     if(SetBQ(pt, calcBQ(pt, boost::bind(&GameWorldBase::IsOnRoad, this, _1))))
         GetNotifications().publish(NodeNote(NodeNote::BQ, pt));
 }
-
-void GameWorldBase::SetLua(LuaInterfaceGame* newLua)
-{
-    if (newLua != NULL)
-        lua.reset(newLua);
-    else
-        lua.reset();
-}

--- a/src/world/GameWorldBase.h
+++ b/src/world/GameWorldBase.h
@@ -23,6 +23,7 @@
 #include "notifications/NotificationManager.h"
 #include "postSystem/PostManager.h"
 #include "world/World.h"
+#include "lua/LuaInterfaceGame.h"
 #include <boost/interprocess/smart_ptr/unique_ptr.hpp>
 #include <vector>
 
@@ -50,6 +51,7 @@ class GameWorldBase : public World
     std::vector<GamePlayer> players;
     const GlobalGameSettings& gameSettings;
     EventManager& em;
+    boost::interprocess::unique_ptr<LuaInterfaceGame, Deleter<LuaInterfaceGame> > lua;
 
 protected:
     /// Interface zum GUI
@@ -62,7 +64,6 @@ public:
     ~GameWorldBase() override;
 
 
-    boost::interprocess::unique_ptr<LuaInterfaceGame, Deleter<LuaInterfaceGame> > lua;
     // Grundlegende Initialisierungen
     void Init(const MapExtent& mapSize, LandscapeType lt) override;
     // Remaining initialization after loading (BQ...)
@@ -191,6 +192,7 @@ public:
 
     bool HasLua() const { return lua.get() != NULL; }
     LuaInterfaceGame& GetLua() const { return *lua.get(); }
+    void SetLua(LuaInterfaceGame* newLua);
 
 protected:
     /// Called when the visibility of point changed for a player

--- a/src/world/GameWorldBase.h
+++ b/src/world/GameWorldBase.h
@@ -192,7 +192,7 @@ public:
 
     bool HasLua() const { return lua.get() != NULL; }
     LuaInterfaceGame& GetLua() const { return *lua.get(); }
-    void SetLua(LuaInterfaceGame* newLua);
+    void SetLua(LuaInterfaceGame* newLua) { lua.reset(newLua); }
 
 protected:
     /// Called when the visibility of point changed for a player

--- a/src/world/GameWorldBase.h
+++ b/src/world/GameWorldBase.h
@@ -52,7 +52,6 @@ class GameWorldBase : public World
     EventManager& em;
 
 protected:
-    boost::interprocess::unique_ptr<LuaInterfaceGame, Deleter<LuaInterfaceGame> > lua;
     /// Interface zum GUI
     GameInterface* gi;
     /// harbor building sites created by ships
@@ -62,6 +61,8 @@ public:
     GameWorldBase(const std::vector<GamePlayer>& players, const GlobalGameSettings& gameSettings, EventManager& em);
     ~GameWorldBase() override;
 
+
+    boost::interprocess::unique_ptr<LuaInterfaceGame, Deleter<LuaInterfaceGame> > lua;
     // Grundlegende Initialisierungen
     void Init(const MapExtent& mapSize, LandscapeType lt) override;
     // Remaining initialization after loading (BQ...)


### PR DESCRIPTION
This commit adds the logic discussed in issue #517, that the ai will accept cancel requests.
In addition i have added basic checks for the pact state and the possibility to suggest a pact to the player.

I skipped the implementation for accepting or starting a cancel request by AI, because i had some problems with finding a GameCommandFactory (i guess im missing this), which is usable for this intent.

But despite that, i am creating this pull request, cause it resolves the discussed logic from issue #517.