### PR TITLE
Fix localization if system has multiple configurations

### DIFF
--- a/src/lua/LuaInterfaceBase.cpp
+++ b/src/lua/LuaInterfaceBase.cpp
@@ -20,11 +20,12 @@
 #include "GlobalVars.h"
 #include "WindowManager.h"
 #include "ingameWindows/iwMsgbox.h"
-#include "mygettext/mygettext.h"
+#include "mygettext/utils.h"
 #include "network/GameClient.h"
 #include "libutf8/utf8.h"
 #include "libutil/Log.h"
 #include <boost/bind.hpp>
+#include <boost/foreach.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <algorithm>
 #include <utility>
@@ -170,21 +171,13 @@ void LuaInterfaceBase::MsgBoxEx2(const std::string& title, const std::string& ms
 
 std::map<std::string, std::string> LuaInterfaceBase::GetTranslation(const kaguya::LuaRef& luaTranslations, const std::string& code)
 {
-    kaguya::LuaRef entry = luaTranslations[code];
-    if(entry.type() == LUA_TTABLE)
-        return entry;
-    std::string lang, region, encoding;
-    splitLanguageCode(code, lang, region, encoding);
-
-    if(!region.empty())
+    std::vector<std::string> folders = getPossibleFoldersForLangCode(code);
+    BOOST_FOREACH(const std::string& folder, folders)
     {
-        entry = luaTranslations[lang + "_" + region];
+        kaguya::LuaRef entry = luaTranslations[folder];
         if(entry.type() == LUA_TTABLE)
             return entry;
     }
-    entry = luaTranslations[lang];
-    if(entry.type() == LUA_TTABLE)
-        return entry;
     return std::map<std::string, std::string>();
 }
 


### PR DESCRIPTION
Fixes #777 

@Flow86 Could you check the mygettext implementation changes?
Basically the problem was: We set LC_ALL to the locale and use the result of `setLocale` to select a catalogue. If the system configuration is not unique (e.g. `LC_CTYPE=en_US.UTF-8;LC_NUMERIC=de_DE.UTF-8;LC_TIME=de_DE.UTF-8;LC_COLLATE=en_US.UTF-8;LC_MONETARY=de_DE.UTF-8;LC_MESSAGES=en_US.UTF-8;LC_PAPER=de_DE.UTF-8;LC_NAME=de_DE.UTF-8;LC_ADDRESS=de_DE.UTF-8;LC_TELEPHONE=de_DE.UTF-8;LC_MEASUREMENT=de_DE.UTF-8;LC_IDENTIFICATION=de_DE.UTF-8`) then we don't get a single language back.

This uses Boost.Locale to parse and pick the language configuration which is much more robust.

Besides that: We should use standard locations for language files (`de_DE/LC_MESSAGES/rttr.mo`) and probably simply use gettext or Boost.Locale (wrapper around gettext) and get rid of mygettext or simplify mygettext in a way that it simply has a `setLanguage` and a `translate` function. Do we really need all those (incomplete!) wrappers around gettext?