### PR TITLE
 Fix invalid savegame after second load-save-cycle 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
             - libboost-iostreams1.55-dev
             - libboost-program-options1.55-dev
             - libboost-system1.55-dev
+            - libboost-random1.55-dev
             - libboost-test1.55-dev
             - libboost-locale1.55-dev
             - g++-4.8

--- a/src/Savegame.cpp
+++ b/src/Savegame.cpp
@@ -64,19 +64,26 @@ bool Savegame::Load(const std::string& filePath, bool loadSettings, bool loadGam
 
 bool Savegame::Load(BinaryFile& file, bool loadSettings, bool loadGameData)
 {
-    ClearPlayers();
-    sgd.Clear();
-    if(!ReadAllHeaderData(file))
+    try
+    {
+        ClearPlayers();
+        sgd.Clear();
+        if(!ReadAllHeaderData(file))
+            return false;
+
+        if(!loadSettings)
+            return true;
+
+        ReadPlayerData(file);
+        ReadGGS(file);
+
+        if(loadGameData)
+            ReadGameData(file);
+    } catch(std::runtime_error& e)
+    {
+        lastErrorMsg = e.what();
         return false;
-
-    if(!loadSettings)
-        return true;
-
-    ReadPlayerData(file);
-    ReadGGS(file);
-
-    if(loadGameData)
-        ReadGameData(file);
+    }
 
     return true;
 }

--- a/src/network/GameServer.cpp
+++ b/src/network/GameServer.cpp
@@ -207,12 +207,12 @@ bool GameServer::Start()
     if(!mapinfo.mapData.CompressFromFile(mapinfo.filepath, &mapinfo.mapChecksum))
         return false;
 
-    std::string luaFilePath = mapinfo.filepath.substr(0, mapinfo.filepath.length() - 3) + "lua";
-    if(bfs::exists(luaFilePath))
+    bfs::path luaFilePath = bfs::path(mapinfo.filepath).replace_extension("lua");
+    if(bfs::is_regular_file(luaFilePath))
     {
-        if(!mapinfo.luaData.CompressFromFile(luaFilePath, &mapinfo.luaChecksum))
+        if(!mapinfo.luaData.CompressFromFile(luaFilePath.string(), &mapinfo.luaChecksum))
             return false;
-        mapinfo.luaFilepath = luaFilePath;
+        mapinfo.luaFilepath = luaFilePath.string();
     } else
         RTTR_Assert(mapinfo.luaFilepath.empty() && mapinfo.luaChecksum == 0);
 


### PR DESCRIPTION
Background: When you connect, the server sends you map-meta-data (name, size). The client checks if it is already in <cfgDir aka .s25rttr>/MAPS  (played maps folder) and if yes, send the checksum of to the server. If  no or the checksum mismatches the server sends the map compressed with  bz2. Once received it is uncompressed which seems to fail with '-8'  which means 'output buffer to small'. This does not make sense, because  that map was just compressed by the server and the size send to the  client. 

This happens when saving a  game, loading that, saving to the same name and trying to load that  again. This shows a bug in the above algorithm. A file with the same name exists but is smaller then the wanted one. Bug 1 overwrites the size sent by the server and Bug 2 does not handle errors during reading of invalid savegames (and replays)