### PR TITLE
Added Trade-Message if caravan leader arrives.

### DIFF
--- a/src/figures/nofTradeDonkey.h
+++ b/src/figures/nofTradeDonkey.h
@@ -72,8 +72,11 @@ public:
     /// Gets the type of ware this donkey is carrying
     GoodType GetCarriedWare() const { return gt; }
 
-    /// Sets the sucessor in the caravane
+    /// Sets the successor in the caravane
     void SetSuccessor(nofTradeDonkey* const successor) { this->successor = successor; }
+
+    // get the successor in the caravane
+    nofTradeDonkey* GetSuccessor() { return successor; }
 
     /// Inform successor that the caravane is canceled
     void CancelTradeCaravane();

--- a/src/figures/nofTradeLeader.cpp
+++ b/src/figures/nofTradeLeader.cpp
@@ -54,8 +54,7 @@ void nofTradeLeader::Serialize(SerializedGameData& sgd) const
 void nofTradeLeader::GoalReached()
 {
     noBase* nob = gwg->GetNO(goalPos);
-    RTTR_Assert(dynamic_cast<nobBaseWarehouse*>(nob));
-    nobBaseWarehouse* targetWarehouse = static_cast<nobBaseWarehouse*>(nob);
+    nobBaseWarehouse* targetWarehouse = checkedCast<nobBaseWarehouse*>(nob);
     if(successor)
     {
         unsigned amountWares = 0;

--- a/src/figures/nofTradeLeader.cpp
+++ b/src/figures/nofTradeLeader.cpp
@@ -66,7 +66,7 @@ void nofTradeLeader::GoalReached()
             successorDonkey = successorDonkey->GetSuccessor();
         }
         GamePlayer& owner = gwg->GetPlayer(player);
-        std::string waresName = goodType == GD_NOTHING ? JOB_NAMES[jobType] : WARE_NAMES[goodType];
+        std::string waresName = _(goodType == GD_NOTHING ? JOB_NAMES[jobType] : WARE_NAMES[goodType]);
         std::string text = boost::str(boost::format(_("Trade caravan with %s %s arrives from player '%s'.")) % amountWares % waresName % owner.name);
         SendPostMessage(targetWarehouse->GetPlayer(), new PostMsgWithBuilding(GetEvMgr().GetCurrentGF(), text,PostCategory::Economy, *targetWarehouse));
         successor->AddNextDir(REACHED_GOAL);

--- a/src/figures/nofTradeLeader.cpp
+++ b/src/figures/nofTradeLeader.cpp
@@ -18,12 +18,17 @@
 #include "rttrDefines.h" // IWYU pragma: keep
 #include "nofTradeLeader.h"
 #include "GamePlayer.h"
+#include "GameObject.h"
+#include "gameData/JobConsts.h"
+#include "EventManager.h"
 #include "SerializedGameData.h"
 #include "buildings/nobBaseWarehouse.h"
 #include "nofTradeDonkey.h"
+#include "postSystem/PostMsgWithBuilding.h"
 #include "world/GameWorldGame.h"
 #include "gameData/BuildingProperties.h"
 #include "gameData/GameConsts.h"
+#include <boost/format.hpp>
 
 nofTradeLeader::nofTradeLeader(const MapPoint pos, const unsigned char player, const TradeRoute& tr, const MapPoint homePos,
                                const MapPoint goalPos)
@@ -48,17 +53,30 @@ void nofTradeLeader::Serialize(SerializedGameData& sgd) const
 
 void nofTradeLeader::GoalReached()
 {
+    noBase* nob = gwg->GetNO(goalPos);
+    RTTR_Assert(dynamic_cast<nobBaseWarehouse*>(nob));
+    nobBaseWarehouse* targetWarehouse = static_cast<nobBaseWarehouse*>(nob);
     if(successor)
     {
+        unsigned amountWares = 0;
+        Job jobType = successor->GetJobType();
+        GoodType goodType = successor->GetCarriedWare();
+        nofTradeDonkey* successorDonkey = successor;
+        while (successorDonkey != NULL) {
+            amountWares++;
+            successorDonkey = successorDonkey->GetSuccessor();
+        }
+        GamePlayer& owner = gwg->GetPlayer(player);
+        std::string waresName = goodType == GD_NOTHING ? JOB_NAMES[jobType] : WARE_NAMES[goodType];
+        std::string text = boost::str(boost::format(_("Trade caravan with %s %s arrives from player '%s'.")) % amountWares % waresName % owner.name);
+        SendPostMessage(targetWarehouse->GetPlayer(), new PostMsgWithBuilding(GetEvMgr().GetCurrentGF(), text,PostCategory::Economy, *targetWarehouse));
         successor->AddNextDir(REACHED_GOAL);
         successor = NULL;
     }
 
-    noBase* nob = gwg->GetNO(goalPos);
-    RTTR_Assert(dynamic_cast<nobBaseWarehouse*>(nob));
-    gwg->GetPlayer(static_cast<nobBaseWarehouse*>(nob)->GetPlayer()).IncreaseInventoryJob(this->GetJobType(), 1);
+    gwg->GetPlayer(targetWarehouse->GetPlayer()).IncreaseInventoryJob(this->GetJobType(), 1);
     gwg->RemoveFigure(pos, this);
-    static_cast<nobBaseWarehouse*>(nob)->AddFigure(this);
+    targetWarehouse->AddFigure(this);
 }
 
 void nofTradeLeader::Walked()

--- a/src/test/testTrading.cpp
+++ b/src/test/testTrading.cpp
@@ -291,7 +291,7 @@ BOOST_FIXTURE_TEST_CASE(TradeMessages, TradeFixture)
     BOOST_REQUIRE(post);
     const PostMsgWithBuilding* msg = dynamic_cast<const PostMsgWithBuilding*>(post);
     BOOST_REQUIRE(msg->GetText().find('2') != std::string::npos);
-    BOOST_REQUIRE(msg->GetText().find(JOB_NAMES[JOB_WOODCUTTER]) != std::string::npos);
+    BOOST_REQUIRE(msg->GetText().find(_(JOB_NAMES[JOB_WOODCUTTER])) != std::string::npos);
     BOOST_REQUIRE(msg->GetText().find(players[1]->name) != std::string::npos);
 
     this->TradeOverLand(players[0]->GetHQPos(), GD_BOARDS, JOB_NOTHING, 2);
@@ -307,7 +307,7 @@ BOOST_FIXTURE_TEST_CASE(TradeMessages, TradeFixture)
     BOOST_REQUIRE(post2);
     const PostMsgWithBuilding* msg2 = dynamic_cast<const PostMsgWithBuilding*>(post2);
     BOOST_REQUIRE(msg2->GetText().find('2') != std::string::npos);
-    BOOST_REQUIRE(msg2->GetText().find(WARE_NAMES[GD_BOARDS]) != std::string::npos);
+    BOOST_REQUIRE(msg2->GetText().find(_(WARE_NAMES[GD_BOARDS])) != std::string::npos);
     BOOST_REQUIRE(msg2->GetText().find(players[1]->name) != std::string::npos);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/testTrading.cpp
+++ b/src/test/testTrading.cpp
@@ -290,8 +290,9 @@ BOOST_FIXTURE_TEST_CASE(TradeMessages, TradeFixture)
     const PostMsg* post = postbox->GetMsg(0);
     BOOST_REQUIRE(post);
     const PostMsgWithBuilding* msg = dynamic_cast<const PostMsgWithBuilding*>(post);
-    std::string text = boost::str(boost::format(_("Trade caravan with %s %s arrives from player '%s'.")) % 2 % JOB_NAMES[JOB_WOODCUTTER] % players[1]->name);
-    BOOST_REQUIRE_EQUAL(msg->GetText(), text);
+    BOOST_REQUIRE(msg->GetText().find('2') != std::string::npos);
+    BOOST_REQUIRE(msg->GetText().find(JOB_NAMES[JOB_WOODCUTTER]) != std::string::npos);
+    BOOST_REQUIRE(msg->GetText().find(players[1]->name) != std::string::npos);
 
     this->TradeOverLand(players[0]->GetHQPos(), GD_BOARDS, JOB_NOTHING, 2);
     numHelpers -= 1;
@@ -305,7 +306,8 @@ BOOST_FIXTURE_TEST_CASE(TradeMessages, TradeFixture)
     const PostMsg* post2 = postbox->GetMsg(1);
     BOOST_REQUIRE(post2);
     const PostMsgWithBuilding* msg2 = dynamic_cast<const PostMsgWithBuilding*>(post2);
-    std::string text2 = boost::str(boost::format(_("Trade caravan with %s %s arrives from player '%s'.")) % 2 % WARE_NAMES[GD_BOARDS] % players[1]->name);
-    BOOST_REQUIRE_EQUAL(msg2->GetText(), text2);
+    BOOST_REQUIRE(msg2->GetText().find('2') != std::string::npos);
+    BOOST_REQUIRE(msg2->GetText().find(WARE_NAMES[GD_BOARDS]) != std::string::npos);
+    BOOST_REQUIRE(msg2->GetText().find(players[1]->name) != std::string::npos);
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I have added a simple PostMsg when a trade leader arrives in a ware house.

If this PR will be merged before #792, named PR has to add a patch to change the figure calculation for the trade leader (helpers -> scout).
If it will be merged after named PR, this test case has to be adjusted.