### PR TITLE
Added Addon FrontierDistanceReachable

### DIFF
--- a/src/GlobalGameSettings.cpp
+++ b/src/GlobalGameSettings.cpp
@@ -124,6 +124,8 @@ void GlobalGameSettings::registerAllAddons()
     registerAddon(new AddonMilitaryHitpoints);
 
     registerAddon(new AddonNumScoutsExploration);
+
+    registerAddon(new AddonFrontierDistanceReachable);
 }
 
 void GlobalGameSettings::resetAddons()

--- a/src/addons/AddonFrontierDistanceReachable.h
+++ b/src/addons/AddonFrontierDistanceReachable.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2005 - 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef ADDONFRONTIERDISTANCEREACHABLE_H_INCLUDED
+#define ADDONFRONTIERDISTANCEREACHABLE_H_INCLUDED
+
+#pragma once
+
+#include "AddonBool.h"
+
+class AddonFrontierDistanceReachable : public AddonBool
+{
+public:
+    AddonFrontierDistanceReachable()
+        : AddonBool(AddonId::FRONTIER_DISTANCE_REACHABLE, ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY,
+                    _("Frontier Distance checks Reachability"),
+                    _("Checks if the military building is reachable by triple distance of both military buildings (minimum distance is "
+                      "10). If its not reachable within this distance a military building counts as far away."),
+                    0)
+    {}
+};
+
+#endif

--- a/src/addons/Addons.h
+++ b/src/addons/Addons.h
@@ -67,4 +67,6 @@
 
 #include "addons/AddonNumScoutsExploration.h"
 
+#include "addons/AddonFrontierDistanceReachable.h"
+
 #endif // !ADDONS_H_INCLUDED

--- a/src/addons/const_addons.h
+++ b/src/addons/const_addons.h
@@ -36,8 +36,9 @@
 // 00A Marcus
 // 00B Ribosom
 // 00C Flamefire
+// 00D Shawn8901
 
-// Do not forget to add your Addon to GlobalGameSettings::reset @ GlobalGameSettings.cpp!
+// Do not forget to add your Addon to GlobalGameSettings::clearAddons @ GlobalGameSettings.cpp!
 // Never use a number twice!
 
 // AAA = Author
@@ -72,7 +73,9 @@ ENUM_WITH_STRING(AddonId, LIMIT_CATAPULTS = 0x00000000, INEXHAUSTIBLE_MINES = 0x
 
                  MILITARY_HITPOINTS = 0x00B00000,
 
-                 NUM_SCOUTS_EXPLORATION = 0x00C00000)
+                 NUM_SCOUTS_EXPLORATION = 0x00C00000,
+
+                 FRONTIER_DISTANCE_REACHABLE = 0x00D0000)
 //-V:AddonId:801
 
 enum AddonGroup

--- a/src/buildings/nobBaseMilitary.cpp
+++ b/src/buildings/nobBaseMilitary.cpp
@@ -165,7 +165,7 @@ nofAttacker* nobBaseMilitary::FindAggressor(nofAggressiveDefender* defender)
         if(gwg->CalcDistance(attackerPos, defenderPos) <= 5)
         {
             // Check it further (e.g. if they have to walk around a river...)
-            if(gwg->FindHumanPath(attackerPos, defenderPos, 5) != 0xFF)
+            if(gwg->FindHumanPath(attackerPos, defenderPos, 5) != INVALID_DIR)
             {
                 (*it)->LetsFight(defender);
                 return (*it);

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -321,7 +321,7 @@ void nobMilitary::LookForEnemyBuildings(const nobBaseMilitary* const exception)
 {
     // Umgebung nach Militärgebäuden absuchen
     sortedMilitaryBlds buildings = gwg->LookForMilitaryBuildings(pos, 3);
-    frontier_distance = FAR_BORDER;
+    frontier_distance = DIST_FAR;
 
     for(sortedMilitaryBlds::iterator it = buildings.begin(); it != buildings.end(); ++it)
     {
@@ -334,13 +334,13 @@ void nobMilitary::LookForEnemyBuildings(const nobBaseMilitary* const exception)
             if(gwg->GetGGS().isEnabled(AddonId::FRONTIER_DISTANCE_REACHABLE)
                && !DoesReachablePathExist(*gwg, (*it)->GetPos(), pos, MAX_ATTACKING_RUN_DISTANCE))
             {
-                frontier_distance = FAR_BORDER;
+                frontier_distance = DIST_FAR;
             }
             // in nahem Umkreis, also Grenzen berühren sich
             else if(distance <= MILITARY_RADIUS[size] + (*it)->GetMilitaryRadius()) // warum erzeugtn das ne warning in vs2008?
             {
                 // Grenznähe entsprechend setzen
-                frontier_distance = NEAR_BORDER;
+                frontier_distance = DIST_NEAR;
 
                 // Wenns ein richtiges Militärgebäude ist, dann dort auch entsprechend setzen
                 if(BuildingProperties::IsMilitary((*it)->GetBuildingType()))
@@ -351,7 +351,7 @@ void nobMilitary::LookForEnemyBuildings(const nobBaseMilitary* const exception)
             {
                 // Grenznähe entsprechend setzen
                 if(!frontier_distance)
-                    frontier_distance = MID_BORDER;
+                    frontier_distance = DIST_MID;
 
                 // Wenns ein richtiges Militärgebäude ist, dann dort auch entsprechend setzen
                 if(BuildingProperties::IsMilitary((*it)->GetBuildingType()))
@@ -365,7 +365,7 @@ void nobMilitary::LookForEnemyBuildings(const nobBaseMilitary* const exception)
                 {
                     // Grenznähe entsprechend setzen
                     if(!frontier_distance)
-                        frontier_distance = MID_BORDER;
+                        frontier_distance = DIST_MID;
 
                     // dort auch entsprechend setzen
                     mil->NewEnemyMilitaryBuilding(1);
@@ -375,11 +375,11 @@ void nobMilitary::LookForEnemyBuildings(const nobBaseMilitary* const exception)
     }
 
     // Evtl. Hafenpunkte in der N? mit ber?htigen
-    if(frontier_distance <= MID_BORDER)
+    if(frontier_distance <= DIST_MID)
         if(gwg->CalcDistanceToNearestHarbor(pos) < SEAATTACK_DISTANCE + 2)
         {
             // if(gwg->IsAHarborInSeaAttackDistance(MapPoint(x,y)))
-            frontier_distance = HARBOR;
+            frontier_distance = DIST_HARBOR;
         }
 
     // Truppen schicken
@@ -389,19 +389,18 @@ void nobMilitary::LookForEnemyBuildings(const nobBaseMilitary* const exception)
 void nobMilitary::NewEnemyMilitaryBuilding(const unsigned short distance)
 {
     // Neues Grenzgebäude in der Nähe --> Distanz entsprechend setzen
-    if(distance == NEAR_BORDER)
+    if(distance == DIST_NEAR)
     {
         // Nah
-        frontier_distance = NEAR_BORDER;
+        frontier_distance = DIST_NEAR;
     }
     // in mittlerem Umkreis?
-    else if(distance == MID_BORDER)
+    else if(distance == DIST_MID)
     {
         // Mittel (nur wenns vorher auf weit weg war)
         if(!frontier_distance)
-            frontier_distance = MID_BORDER;
+            frontier_distance = DIST_MID;
     }
-
     RegulateTroops();
 }
 

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -36,6 +36,7 @@
 #include "notifications/BuildingNote.h"
 #include "ogl/glArchivItem_Bitmap.h"
 #include "ogl/glArchivItem_Bitmap_Player.h"
+#include "pathfinding/FindPathReachable.h"
 #include "postSystem/PostMsgWithBuilding.h"
 #include "random/Random.h"
 #include "world/GameWorldGame.h"
@@ -328,8 +329,14 @@ void nobMilitary::LookForEnemyBuildings(const nobBaseMilitary* const exception)
         {
             unsigned distance = gwg->CalcDistance(pos, (*it)->GetPos());
 
+            // check if military building is reachable
+            if(gwg->GetGGS().isEnabled(AddonId::FRONTIER_DISTANCE_REACHABLE)
+               && !DoesReachablePathExist(*gwg, (*it)->GetPos(), pos, MAX_ATTACKING_RUN_DISTANCE))
+            {
+                frontier_distance = 0;
+            }
             // in nahem Umkreis, also Grenzen berühren sich
-            if(distance <= MILITARY_RADIUS[size] + (*it)->GetMilitaryRadius()) // warum erzeugtn das ne warning in vs2008?
+            else if(distance <= MILITARY_RADIUS[size] + (*it)->GetMilitaryRadius()) // warum erzeugtn das ne warning in vs2008?
             {
                 // Grenznähe entsprechend setzen
                 frontier_distance = 3;

--- a/src/buildings/nobMilitary.h
+++ b/src/buildings/nobMilitary.h
@@ -40,10 +40,10 @@ public:
     /// Distance to the next enemy border
     enum FrontierDistance
     {
-        FAR_BORDER = 0, /// next military building is far away
-        MID_BORDER,     /// Next military building is in reachable range
-        HARBOR,         /// Military building is near a harbor
-        NEAR_BORDER,    /// Military building is next to a border
+        DIST_FAR = 0, /// next military building is far away
+        DIST_MID,     /// Next military building is in reachable range
+        DIST_HARBOR,  /// Military building is near a harbor
+        DIST_NEAR     /// Military building is next to a border
     };
 
 private:

--- a/src/buildings/nobMilitary.h
+++ b/src/buildings/nobMilitary.h
@@ -36,6 +36,17 @@ class GameEvent;
 /// Stellt ein Militärgebäude beliebiger Größe (also von Baracke bis Festung) dar
 class nobMilitary : public nobBaseMilitary
 {
+public:
+    /// Distance to the next enemy border
+    enum FrontierDistance
+    {
+        FAR_BORDER = 0, /// next military building is far away
+        MID_BORDER,     /// Next military building is in reachable range
+        HARBOR,         /// Military building is near a harbor
+        NEAR_BORDER,    /// Military building is next to a border
+    };
+
+private:
     /// wurde das Gebäude gerade neu gebaut (muss also die Landgrenze beim Eintreffen von einem Soldaten neu berechnet werden?)
     bool new_built;
     /// Anzahl der Goldmünzen im Gebäude
@@ -43,7 +54,7 @@ class nobMilitary : public nobBaseMilitary
     /// Gibt an, ob Goldmünzen gesperrt worden (letzteres nur visuell, um Netzwerk-Latenzen zu verstecken)
     bool coinsDisabled, coinsDisabledVirtual;
     /// Entfernung zur freindlichen Grenze (woraus sich dann die Besatzung ergibt) von 0-3, 0 fern, 3 nah, 2 Hafen!
-    unsigned char frontier_distance;
+    FrontierDistance frontier_distance;
     /// Größe bzw Typ des Militärgebäudes (0 = Baracke, 3 = Festung)
     unsigned char size;
     /// Bestellte Soldaten
@@ -121,7 +132,7 @@ public:
     bool IsUseless() const;
     bool IsAttackable(unsigned playerIdx) const override;
     /// Gibt Distanz zurück
-    unsigned char GetFrontierDistance() const { return frontier_distance; }
+    FrontierDistance GetFrontierDistance() const { return frontier_distance; }
 
     /// Berechnet die gewünschte Besatzung je nach Grenznähe
     unsigned CalcRequiredNumTroops() const;

--- a/src/pathfinding/FindPathReachable.cpp
+++ b/src/pathfinding/FindPathReachable.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "rttrDefines.h" // IWYU pragma: keep
+
+#include "pathfinding/FreePathFinderImpl.h"
+#include "pathfinding/PathConditionReachable.h"
+#include "world/GameWorldBase.h"
+
+bool DoesReachablePathExist(const GameWorldBase& world, const MapPoint startPt, const MapPoint endPt, unsigned maxLen)
+{
+    RTTR_Assert(startPt != endPt);
+    return world.GetFreePathFinder().FindPath(startPt, endPt, false, maxLen, NULL, NULL, NULL, PathConditionReachable(world));
+}

--- a/src/pathfinding/FindPathReachable.h
+++ b/src/pathfinding/FindPathReachable.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation,  either version 2 of the License,  or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not,  see <http://www.gnu.org/licenses/>.
+
+#ifndef FindPathReachable_h__
+#define FindPathReachable_h__
+
+#include "gameTypes/MapCoordinates.h"
+
+class GameWorldBase;
+bool DoesReachablePathExist(const GameWorldBase& world, const MapPoint startPt, const MapPoint endPt, unsigned maxLen);
+
+#endif // FindPathReachable_h__

--- a/src/test/testFrontierDistance.cpp
+++ b/src/test/testFrontierDistance.cpp
@@ -42,7 +42,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNear, FrontierWorldSmall)
     for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tWater);
-        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable))
             break;
     }
 
@@ -104,7 +104,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNearOtherFields, FrontierWorldSmall)
         for(; tUnreachable.value < world.GetDescription().terrain.size(); tUnreachable.value++)
         {
             TerrainDesc fieldDesc = world.GetDescription().get(tUnreachable);
-            if(fieldDesc.kind == searchedTerrain && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+            if(fieldDesc.kind == searchedTerrain && fieldDesc.Is(ETerrain::Unreachable))
                 break;
         }
 
@@ -164,7 +164,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceMiddle, FrontierWorldMiddle)
     for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tWater);
-        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable))
             break;
     }
 
@@ -223,7 +223,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceFar, FrontierWorldBig)
     for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tWater);
-        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable))
             break;
     }
 
@@ -282,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
     for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tWater);
-        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable))
             break;
     }
 

--- a/src/test/testFrontierDistance.cpp
+++ b/src/test/testFrontierDistance.cpp
@@ -38,10 +38,10 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNear, FrontierWorldSmall)
     nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
     nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
 
-    DescIdx<TerrainDesc> tUnwalkable(0);
-    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    DescIdx<TerrainDesc> tWater(0);
+    for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
-        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        TerrainDesc fieldDesc = world.GetDescription().get(tWater);
         if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
@@ -69,8 +69,8 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNear, FrontierWorldSmall)
             }
 
             MapNode& mapPoint = world.GetNodeWriteable(curPoint);
-            mapPoint.t1 = tUnwalkable;
-            mapPoint.t2 = tUnwalkable;
+            mapPoint.t1 = tWater;
+            mapPoint.t2 = tWater;
         }
     }
 
@@ -84,7 +84,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNear, FrontierWorldSmall)
         unsigned distance1 = milBld1->GetFrontierDistance();
 
         BOOST_REQUIRE_EQUAL(distance0, distance1);
-        BOOST_REQUIRE_EQUAL(distance0, i == 0 ? 3u : 0u); // near if addon is inactive, otherwise inland
+        BOOST_REQUIRE_EQUAL(distance0 + i * 100, (i == 0 ? 3u : 0u) + i * 100); // near if addon is inactive, otherwise inland
     }
 }
 
@@ -100,10 +100,10 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNearOtherFields, FrontierWorldSmall)
     for(int terrain = 0; terrain < 2; terrain++)
     {
         TerrainKind searchedTerrain = terrain == 1 ? TerrainKind::LAVA : TerrainKind::SNOW;
-        DescIdx<TerrainDesc> tUnwalkable(0);
-        for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+        DescIdx<TerrainDesc> tUnreachable(0);
+        for(; tUnreachable.value < world.GetDescription().terrain.size(); tUnreachable.value++)
         {
-            TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+            TerrainDesc fieldDesc = world.GetDescription().get(tUnreachable);
             if(fieldDesc.kind == searchedTerrain && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
                 break;
         }
@@ -131,8 +131,8 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNearOtherFields, FrontierWorldSmall)
                 }
 
                 MapNode& mapPoint = world.GetNodeWriteable(curPoint);
-                mapPoint.t1 = tUnwalkable;
-                mapPoint.t2 = tUnwalkable;
+                mapPoint.t1 = tUnreachable;
+                mapPoint.t2 = tUnreachable;
             }
         }
 
@@ -146,7 +146,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNearOtherFields, FrontierWorldSmall)
             unsigned distance1 = milBld1->GetFrontierDistance();
 
             BOOST_REQUIRE_EQUAL(distance0, distance1);
-            BOOST_REQUIRE_EQUAL(distance0, i == 0 ? 3u : 0u); // near if addon is inactive, otherwise inland
+            BOOST_REQUIRE_EQUAL(distance0 + i * 100, (i == 0 ? 3u : 0u) + i * 100); // near if addon is inactive, otherwise inland
         }
     }
 }
@@ -160,10 +160,10 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceMiddle, FrontierWorldMiddle)
     nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
     nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
 
-    DescIdx<TerrainDesc> tUnwalkable(0);
-    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    DescIdx<TerrainDesc> tWater(0);
+    for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
-        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        TerrainDesc fieldDesc = world.GetDescription().get(tWater);
         if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
@@ -191,8 +191,8 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceMiddle, FrontierWorldMiddle)
             }
 
             MapNode& mapPoint = world.GetNodeWriteable(curPoint);
-            mapPoint.t1 = tUnwalkable;
-            mapPoint.t2 = tUnwalkable;
+            mapPoint.t1 = tWater;
+            mapPoint.t2 = tWater;
         }
     }
 
@@ -206,7 +206,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceMiddle, FrontierWorldMiddle)
         unsigned distance1 = milBld1->GetFrontierDistance();
 
         BOOST_REQUIRE_EQUAL(distance0, distance1);
-        BOOST_REQUIRE_EQUAL(distance0, i == 0 ? 1u : 0u); // middle if addon is inactive, otherwise inland
+        BOOST_REQUIRE_EQUAL(distance0 + i * 100, (i == 0 ? 1u : 0u) + i * 100); // middle if addon is inactive, otherwise inland
     }
 }
 
@@ -219,10 +219,10 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceFar, FrontierWorldBig)
     nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
     nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
 
-    DescIdx<TerrainDesc> tUnwalkable(0);
-    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    DescIdx<TerrainDesc> tWater(0);
+    for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
-        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        TerrainDesc fieldDesc = world.GetDescription().get(tWater);
         if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
@@ -250,8 +250,8 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceFar, FrontierWorldBig)
             }
 
             MapNode& mapPoint = world.GetNodeWriteable(curPoint);
-            mapPoint.t1 = tUnwalkable;
-            mapPoint.t2 = tUnwalkable;
+            mapPoint.t1 = tWater;
+            mapPoint.t2 = tWater;
         }
     }
 
@@ -265,7 +265,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceFar, FrontierWorldBig)
         unsigned distance1 = milBld1->GetFrontierDistance();
 
         BOOST_REQUIRE_EQUAL(distance0, distance1);
-        BOOST_REQUIRE_EQUAL(distance0, 0u); // everytime inland
+        BOOST_REQUIRE_EQUAL(distance0 + i * 100, 0u + i * 100); // everytime inland
     }
 }
 
@@ -278,10 +278,10 @@ BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
     nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
     nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
 
-    DescIdx<TerrainDesc> tUnwalkable(0);
-    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    DescIdx<TerrainDesc> tWater(0);
+    for(; tWater.value < world.GetDescription().terrain.size(); tWater.value++)
     {
-        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        TerrainDesc fieldDesc = world.GetDescription().get(tWater);
         if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
@@ -294,19 +294,13 @@ BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
         {
             MapPoint curPoint(x, y);
 
-            // basic island
-            if(curPoint.x < 5 || curPoint.x > world.GetWidth() - 5)
-                continue;
-            if(curPoint.y < 5 || curPoint.y > world.GetHeight() - 5)
-                continue;
-
-            // river in the middle
-            if(curPoint.x >= middle - 1 && curPoint.x <= middle)
-                continue;
-
-            MapNode& mapPoint = world.GetNodeWriteable(curPoint);
-            mapPoint.t1 = tUnwalkable;
-            mapPoint.t2 = tUnwalkable;
+            if(curPoint.x < 5 || curPoint.x > world.GetWidth() - 5 || curPoint.y < 5 || curPoint.y > world.GetHeight() - 5
+               || (curPoint.x >= middle - 1 && curPoint.x <= middle))
+            {
+                MapNode& mapPoint = world.GetNodeWriteable(curPoint);
+                mapPoint.t1 = tWater;
+                mapPoint.t2 = tWater;
+            }
         }
     }
 
@@ -320,7 +314,7 @@ BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
         unsigned distance1 = milBld1->GetFrontierDistance();
 
         BOOST_REQUIRE_EQUAL(distance0, distance1);
-        BOOST_REQUIRE_EQUAL(distance0, 3u); // far
+        BOOST_REQUIRE_EQUAL(distance0 + i * 100, 3u + i * 100); // near
     }
 }
 

--- a/src/test/testFrontierDistance.cpp
+++ b/src/test/testFrontierDistance.cpp
@@ -1,0 +1,327 @@
+// Copyright (c) 2016 - 2017 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "rttrDefines.h" // IWYU pragma: keep
+
+#include "addons/Addon.h"
+#include "buildings/nobMilitary.h"
+#include "factories/BuildingFactory.h"
+#include "test/WorldWithGCExecution.h"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(FrontierDistance)
+
+typedef WorldWithGCExecution<2, 20u, 20u> FrontierWorldSmall;
+typedef WorldWithGCExecution<2, 38u, 38u> FrontierWorldMiddle;
+typedef WorldWithGCExecution<2, 60u, 60u> FrontierWorldBig;
+
+BOOST_FIXTURE_TEST_CASE(FrontierDistanceNear, FrontierWorldSmall)
+{
+    GamePlayer& p0 = world.GetPlayer(0);
+    MapPoint milBld0Pos = p0.GetHQPos() - MapPoint(0, 2);
+    GamePlayer& p1 = world.GetPlayer(1);
+    MapPoint milBld1Pos = p1.GetHQPos() - MapPoint(0, 2);
+    nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
+    nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
+
+    DescIdx<TerrainDesc> tUnwalkable(0);
+    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    {
+        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+            break;
+    }
+
+    for(int y = 1; y < world.GetHeight(); y++)
+    {
+        for(int x = 1; x < world.GetWidth(); x++)
+        {
+            MapPoint curPoint(x, y);
+            if(curPoint == milBld0Pos)
+            {
+                continue;
+            }
+            if(curPoint == p0.GetHQPos())
+            {
+                continue;
+            }
+            if(curPoint == milBld1Pos)
+            {
+                continue;
+            }
+            if(curPoint == p1.GetHQPos())
+            {
+                continue;
+            }
+
+            MapNode& mapPoint = world.GetNodeWriteable(curPoint);
+            mapPoint.t1 = tUnwalkable;
+            mapPoint.t2 = tUnwalkable;
+        }
+    }
+
+    for(int i = 0; i <= 1; i++)
+    {
+        this->ggs.setSelection(AddonId::FRONTIER_DISTANCE_REACHABLE, i); // addon is active on second run
+        p0.RecalcMilitaryFlags();
+        p1.RecalcMilitaryFlags();
+
+        unsigned distance0 = milBld0->GetFrontierDistance();
+        unsigned distance1 = milBld1->GetFrontierDistance();
+
+        BOOST_REQUIRE_EQUAL(distance0, distance1);
+        BOOST_REQUIRE_EQUAL(distance0, i == 0 ? 3u : 0u); // near if addon is inactive, otherwise inland
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(FrontierDistanceNearOtherFields, FrontierWorldSmall)
+{
+    GamePlayer& p0 = world.GetPlayer(0);
+    MapPoint milBld0Pos = p0.GetHQPos() - MapPoint(0, 2);
+    GamePlayer& p1 = world.GetPlayer(1);
+    MapPoint milBld1Pos = p1.GetHQPos() - MapPoint(0, 2);
+    nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
+    nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
+
+    for(int terrain = 0; terrain < 2; terrain++)
+    {
+        TerrainKind searchedTerrain = terrain == 1 ? TerrainKind::LAVA : TerrainKind::SNOW;
+        DescIdx<TerrainDesc> tUnwalkable(0);
+        for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+        {
+            TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+            if(fieldDesc.kind == searchedTerrain && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+                break;
+        }
+
+        for(int y = 1; y < world.GetHeight(); y++)
+        {
+            for(int x = 1; x < world.GetWidth(); x++)
+            {
+                MapPoint curPoint(x, y);
+                if(curPoint == milBld0Pos)
+                {
+                    continue;
+                }
+                if(curPoint == p0.GetHQPos())
+                {
+                    continue;
+                }
+                if(curPoint == milBld1Pos)
+                {
+                    continue;
+                }
+                if(curPoint == p1.GetHQPos())
+                {
+                    continue;
+                }
+
+                MapNode& mapPoint = world.GetNodeWriteable(curPoint);
+                mapPoint.t1 = tUnwalkable;
+                mapPoint.t2 = tUnwalkable;
+            }
+        }
+
+        for(int i = 0; i <= 1; i++)
+        {
+            this->ggs.setSelection(AddonId::FRONTIER_DISTANCE_REACHABLE, i); // addon is active on second run
+            p0.RecalcMilitaryFlags();
+            p1.RecalcMilitaryFlags();
+
+            unsigned distance0 = milBld0->GetFrontierDistance();
+            unsigned distance1 = milBld1->GetFrontierDistance();
+
+            BOOST_REQUIRE_EQUAL(distance0, distance1);
+            BOOST_REQUIRE_EQUAL(distance0, i == 0 ? 3u : 0u); // near if addon is inactive, otherwise inland
+        }
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(FrontierDistanceMiddle, FrontierWorldMiddle)
+{
+    GamePlayer& p0 = world.GetPlayer(0);
+    MapPoint milBld0Pos = p0.GetHQPos() - MapPoint(0, 2);
+    GamePlayer& p1 = world.GetPlayer(1);
+    MapPoint milBld1Pos = p1.GetHQPos() - MapPoint(0, 2);
+    nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
+    nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
+
+    DescIdx<TerrainDesc> tUnwalkable(0);
+    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    {
+        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+            break;
+    }
+
+    for(int y = 1; y < world.GetHeight(); y++)
+    {
+        for(int x = 1; x < world.GetWidth(); x++)
+        {
+            MapPoint curPoint(x, y);
+            if(curPoint == milBld0Pos)
+            {
+                continue;
+            }
+            if(curPoint == p0.GetHQPos())
+            {
+                continue;
+            }
+            if(curPoint == milBld1Pos)
+            {
+                continue;
+            }
+            if(curPoint == p1.GetHQPos())
+            {
+                continue;
+            }
+
+            MapNode& mapPoint = world.GetNodeWriteable(curPoint);
+            mapPoint.t1 = tUnwalkable;
+            mapPoint.t2 = tUnwalkable;
+        }
+    }
+
+    for(int i = 0; i <= 1; i++)
+    {
+        this->ggs.setSelection(AddonId::FRONTIER_DISTANCE_REACHABLE, i); // addon is active on second run
+        p0.RecalcMilitaryFlags();
+        p1.RecalcMilitaryFlags();
+
+        unsigned distance0 = milBld0->GetFrontierDistance();
+        unsigned distance1 = milBld1->GetFrontierDistance();
+
+        BOOST_REQUIRE_EQUAL(distance0, distance1);
+        BOOST_REQUIRE_EQUAL(distance0, i == 0 ? 1u : 0u); // middle if addon is inactive, otherwise inland
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(FrontierDistanceFar, FrontierWorldBig)
+{
+    GamePlayer& p0 = world.GetPlayer(0);
+    MapPoint milBld0Pos = p0.GetHQPos() - MapPoint(0, 2);
+    GamePlayer& p1 = world.GetPlayer(1);
+    MapPoint milBld1Pos = p1.GetHQPos() - MapPoint(0, 2);
+    nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
+    nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
+
+    DescIdx<TerrainDesc> tUnwalkable(0);
+    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    {
+        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+            break;
+    }
+
+    for(int y = 1; y < world.GetHeight(); y++)
+    {
+        for(int x = 1; x < world.GetWidth(); x++)
+        {
+            MapPoint curPoint(x, y);
+            if(curPoint == milBld0Pos)
+            {
+                continue;
+            }
+            if(curPoint == p0.GetHQPos())
+            {
+                continue;
+            }
+            if(curPoint == milBld1Pos)
+            {
+                continue;
+            }
+            if(curPoint == p1.GetHQPos())
+            {
+                continue;
+            }
+
+            MapNode& mapPoint = world.GetNodeWriteable(curPoint);
+            mapPoint.t1 = tUnwalkable;
+            mapPoint.t2 = tUnwalkable;
+        }
+    }
+
+    for(int i = 0; i <= 1; i++)
+    {
+        this->ggs.setSelection(AddonId::FRONTIER_DISTANCE_REACHABLE, i); // addon is active on second run
+        p0.RecalcMilitaryFlags();
+        p1.RecalcMilitaryFlags();
+
+        unsigned distance0 = milBld0->GetFrontierDistance();
+        unsigned distance1 = milBld1->GetFrontierDistance();
+
+        BOOST_REQUIRE_EQUAL(distance0, distance1);
+        BOOST_REQUIRE_EQUAL(distance0, 0u); // everytime inland
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
+{
+    GamePlayer& p0 = world.GetPlayer(0);
+    MapPoint milBld0Pos = p0.GetHQPos() - MapPoint(0, 2);
+    GamePlayer& p1 = world.GetPlayer(1);
+    MapPoint milBld1Pos = p1.GetHQPos() - MapPoint(0, 2);
+    nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
+    nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
+
+    DescIdx<TerrainDesc> tUnwalkable(0);
+    for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
+    {
+        TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
+        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+            break;
+    }
+
+    unsigned middle = world.GetWidth() / 2;
+
+    for(int y = 1; y < world.GetHeight(); y++)
+    {
+        for(int x = 1; x < world.GetWidth(); x++)
+        {
+            MapPoint curPoint(x, y);
+
+            // basic island
+            if(curPoint.x < 5 || curPoint.x > world.GetWidth() - 5)
+                continue;
+            if(curPoint.y < 5 || curPoint.y > world.GetHeight() - 5)
+                continue;
+
+            // river in the middle
+            if(curPoint.x >= middle - 1 && curPoint.x <= middle)
+                continue;
+
+            MapNode& mapPoint = world.GetNodeWriteable(curPoint);
+            mapPoint.t1 = tUnwalkable;
+            mapPoint.t2 = tUnwalkable;
+        }
+    }
+
+    for(int i = 0; i <= 1; i++)
+    {
+        this->ggs.setSelection(AddonId::FRONTIER_DISTANCE_REACHABLE, i); // addon is active on second run
+        p0.RecalcMilitaryFlags();
+        p1.RecalcMilitaryFlags();
+
+        unsigned distance0 = milBld0->GetFrontierDistance();
+        unsigned distance1 = milBld1->GetFrontierDistance();
+
+        BOOST_REQUIRE_EQUAL(distance0, distance1);
+        BOOST_REQUIRE_EQUAL(distance0, 1u); // far
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/testFrontierDistance.cpp
+++ b/src/test/testFrontierDistance.cpp
@@ -42,7 +42,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceNear, FrontierWorldSmall)
     for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
-        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
 
@@ -164,7 +164,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceMiddle, FrontierWorldMiddle)
     for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
-        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
 
@@ -223,7 +223,7 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceFar, FrontierWorldBig)
     for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
-        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
 
@@ -272,9 +272,9 @@ BOOST_FIXTURE_TEST_CASE(FrontierDistanceFar, FrontierWorldBig)
 BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
 {
     GamePlayer& p0 = world.GetPlayer(0);
-    MapPoint milBld0Pos = p0.GetHQPos() - MapPoint(0, 2);
+    MapPoint milBld0Pos = p0.GetHQPos() + MapPoint(5, 0);
     GamePlayer& p1 = world.GetPlayer(1);
-    MapPoint milBld1Pos = p1.GetHQPos() - MapPoint(0, 2);
+    MapPoint milBld1Pos = p1.GetHQPos() - MapPoint(5, 0);
     nobMilitary* milBld0 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld0Pos, 0, NAT_ROMANS));
     nobMilitary* milBld1 = dynamic_cast<nobMilitary*>(BuildingFactory::CreateBuilding(world, BLD_WATCHTOWER, milBld1Pos, 1, NAT_VIKINGS));
 
@@ -282,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
     for(; tUnwalkable.value < world.GetDescription().terrain.size(); tUnwalkable.value++)
     {
         TerrainDesc fieldDesc = world.GetDescription().get(tUnwalkable);
-        if(fieldDesc.kind == TerrainKind::WATER && (!fieldDesc.Is(ETerrain::Walkable) || fieldDesc.Is(ETerrain::Unreachable)))
+        if(fieldDesc.kind == TerrainKind::WATER && !fieldDesc.Is(ETerrain::Walkable) && !fieldDesc.Is(ETerrain::Unreachable))
             break;
     }
 
@@ -320,7 +320,7 @@ BOOST_FIXTURE_TEST_CASE(IslandTest, FrontierWorldMiddle)
         unsigned distance1 = milBld1->GetFrontierDistance();
 
         BOOST_REQUIRE_EQUAL(distance0, distance1);
-        BOOST_REQUIRE_EQUAL(distance0, 1u); // far
+        BOOST_REQUIRE_EQUAL(distance0, 3u); // far
     }
 }
 


### PR DESCRIPTION
This addon enables a check for frontier distance calculation. If this addon is enabled, a human path as to be within the triple distance length between both military buildings.

If the distance between both buildings is less then 10, the calculation base will a distance of 30 (maybe this value is a bit high?)

I hope that this "calculation" some how fits the request (#206).

@Flamefire: is there any test case for those frontier logic?

  