### PR TITLE
Do not display Snails in Replays 

### DIFF
--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -316,15 +316,17 @@ void dskGameInterface::Msg_PaintAfter()
     // Replaydateianzeige in der linken unteren Ecke
     if(GAMECLIENT.IsReplayModeOn())
         NormalFont->Draw(DrawPoint(0, VIDEODRIVER.GetScreenSize().y), GAMECLIENT.GetReplayFileName(), FontStyle::BOTTOM, 0xFFFFFF00);
-
-    // Laggende Spieler anzeigen in Form von Schnecken
-    DrawPoint snailPos(VIDEODRIVER.GetScreenSize().x - 70, 35);
-    BOOST_FOREACH(const NWFPlayerInfo& player, nwfInfo->getPlayerInfos())
+    else
     {
-        if(player.isLagging)
+        // Laggende Spieler anzeigen in Form von Schnecken
+        DrawPoint snailPos(VIDEODRIVER.GetScreenSize().x - 70, 35);
+        BOOST_FOREACH(const NWFPlayerInfo& player, nwfInfo->getPlayerInfos())
         {
-            LOADER.GetPlayerImage("rttr", 0)->DrawFull(Rect(snailPos, 30, 30), COLOR_WHITE, game_->world.GetPlayer(player.id).color);
-            snailPos.x -= 40;
+            if(player.isLagging)
+            {
+                LOADER.GetPlayerImage("rttr", 0)->DrawFull(Rect(snailPos, 30, 30), COLOR_WHITE, game_->world.GetPlayer(player.id).color);
+                snailPos.x -= 40;
+            }
         }
     }
 


### PR DESCRIPTION
In issue #801 its documented, that replays do not work.
After some debugging i realized that the issue is in dskGameInterface line 323. In this code block the snails for lagging players are drawn. But in a replay the variable nwfInfo is null.
So i added an else clause, to display replay info in replay mode and otherwise the snails may be drawn.