### PR TITLE
Added new addon to control the coin order for captured military buildings

### DIFF
--- a/src/GlobalGameSettings.cpp
+++ b/src/GlobalGameSettings.cpp
@@ -126,6 +126,7 @@ void GlobalGameSettings::registerAllAddons()
     registerAddon(new AddonNumScoutsExploration);
 
     registerAddon(new AddonFrontierDistanceReachable);
+    registerAddon(new AddonCoinsCapturedBld);
 }
 
 void GlobalGameSettings::resetAddons()

--- a/src/addons/AddonCoinsCapturedBld.h
+++ b/src/addons/AddonCoinsCapturedBld.h
@@ -24,14 +24,14 @@
 #include "mygettext/mygettext.h"
 
 /**
-*  Addon which controls the behavior of the coin order after capturing the military building
+*  Addon which controls if coins should be enabled/disabled on capture
 */
 class AddonCoinsCapturedBld: public AddonList
 {
 public:
     AddonCoinsCapturedBld()
-        : AddonList(AddonId::COINS_CAPTURED_BLD, ADDONGROUP_MILITARY, _("Sets the coin order for captured buildings"),
-            _("Sets the coin order captured military buildings."), 0)
+        : AddonList(AddonId::COINS_CAPTURED_BLD, ADDONGROUP_MILITARY, _("Coins on captured buildings"),
+            _("Change the coin setting for captured military buildings."), 0)
     {
         this->addOption(_("Keep setting"));
         this->addOption(_("Enable"));

--- a/src/addons/AddonCoinsCapturedBld.h
+++ b/src/addons/AddonCoinsCapturedBld.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2005 - 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef COINSCAPTUREDBLD_H_INCLUDED
+#define COINSCAPTUREDBLD_H_INCLUDED
+
+#pragma once
+
+#include "AddonList.h"
+#include "mygettext/mygettext.h"
+
+/**
+*  Addon which controls the behavior of the coin order after capturing the military building
+*/
+class AddonCoinsCapturedBld: public AddonList
+{
+public:
+    AddonCoinsCapturedBld()
+        : AddonList(AddonId::COINS_CAPTURED_BLD, ADDONGROUP_MILITARY, _("Sets the coin order for captured buildings"),
+            _("Sets the coin order captured military buildings."), 0)
+    {
+        this->addOption(_("Keep setting"));
+        this->addOption(_("Enable"));
+        this->addOption(_("Disable"));
+    }
+};
+
+#endif // !COINSCAPTUREDBLD_H_INCLUDED

--- a/src/addons/Addons.h
+++ b/src/addons/Addons.h
@@ -67,7 +67,7 @@
 
 #include "addons/AddonNumScoutsExploration.h"
 
-#include "addons/AddonCoinsCapturedBld.h"
 #include "addons/AddonFrontierDistanceReachable.h"
+#include "addons/AddonCoinsCapturedBld.h"
 
 #endif // !ADDONS_H_INCLUDED

--- a/src/addons/Addons.h
+++ b/src/addons/Addons.h
@@ -67,6 +67,7 @@
 
 #include "addons/AddonNumScoutsExploration.h"
 
+#include "addons/AddonCoinsCapturedBld.h"
 #include "addons/AddonFrontierDistanceReachable.h"
 
 #endif // !ADDONS_H_INCLUDED

--- a/src/addons/const_addons.h
+++ b/src/addons/const_addons.h
@@ -38,12 +38,15 @@
 // 00C Flamefire
 // 00D Shawn8901
 
-// Do not forget to add your Addon to GlobalGameSettings::clearAddons @ GlobalGameSettings.cpp!
+// Do not forget to add your Addon to GlobalGameSettings::registerAllAddons @ GlobalGameSettings.cpp!
 // Never use a number twice!
 
 // AAA = Author
 // NNNNN = Number
 //                                   AAANNNNN
+//
+// Add the #include for your AddonXXX.h in Addons.h!
+//
 ENUM_WITH_STRING(AddonId, LIMIT_CATAPULTS = 0x00000000, INEXHAUSTIBLE_MINES = 0x00000001, REFUND_MATERIALS = 0x00000002,
                  EXHAUSTIBLE_WATER = 0x00000003, REFUND_ON_EMERGENCY = 0x00000004, MANUAL_ROAD_ENLARGEMENT = 0x00000005,
                  CATAPULT_GRAPHICS = 0x00000006, METALWORKSBEHAVIORONZERO = 0x00000007,
@@ -75,7 +78,7 @@ ENUM_WITH_STRING(AddonId, LIMIT_CATAPULTS = 0x00000000, INEXHAUSTIBLE_MINES = 0x
 
                  NUM_SCOUTS_EXPLORATION = 0x00C00000,
 
-                 FRONTIER_DISTANCE_REACHABLE = 0x00D0000)
+                 FRONTIER_DISTANCE_REACHABLE = 0x00D0000, COINS_CAPTURED_BLD = 0x00D0001)
 //-V:AddonId:801
 
 enum AddonGroup

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -860,9 +860,10 @@ unsigned nobMilitary::GetSoldiersStrength() const
 /// is there a max rank soldier in the building?
 bool nobMilitary::HasMaxRankSoldier() const
 {
+    unsigned maxRank = gwg->GetGGS().GetMaxMilitaryRank();
     for(SortedTroops::const_reverse_iterator it = troops.rbegin(); it != troops.rend(); ++it)
     {
-        if((*it)->GetRank() >= gwg->GetGGS().GetMaxMilitaryRank())
+        if((*it)->GetRank() >= maxRank)
             return true;
     }
     return false;
@@ -986,6 +987,13 @@ void nobMilitary::Capture(const unsigned char new_owner)
 
     gwg->GetNotifications().publish(BuildingNote(BuildingNote::Captured, player, pos, bldType_));
     gwg->GetNotifications().publish(BuildingNote(BuildingNote::Lost, old_player, pos, bldType_));
+
+    // Check if we need to change the coin order
+    unsigned coinOrder = gwg->GetGGS().getSelection(AddonId::COINS_CAPTURED_BLD);
+    if(coinOrder == 1)
+        SetCoinsAllowed(true);
+    else if(coinOrder == 2)
+        SetCoinsAllowed(false);
 }
 
 void nobMilitary::NeedOccupyingTroops()

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -991,9 +991,14 @@ void nobMilitary::Capture(const unsigned char new_owner)
     // Check if we need to change the coin order
     unsigned coinOrder = gwg->GetGGS().getSelection(AddonId::COINS_CAPTURED_BLD);
     if(coinOrder == 1)
-        SetCoinsAllowed(true);
-    else if(coinOrder == 2)
-        SetCoinsAllowed(false);
+    {
+        coinsDisabled = false;
+        coinsDisabledVirtual = false;
+    } else if(coinOrder == 2)
+    {
+        coinsDisabled = true;
+        coinsDisabledVirtual = true;
+    }
 }
 
 void nobMilitary::NeedOccupyingTroops()

--- a/src/buildings/nobMilitary.cpp
+++ b/src/buildings/nobMilitary.cpp
@@ -860,7 +860,7 @@ unsigned nobMilitary::GetSoldiersStrength() const
 /// is there a max rank soldier in the building?
 bool nobMilitary::HasMaxRankSoldier() const
 {
-    unsigned maxRank = gwg->GetGGS().GetMaxMilitaryRank();
+    const unsigned maxRank = gwg->GetGGS().GetMaxMilitaryRank();
     for(SortedTroops::const_reverse_iterator it = troops.rbegin(); it != troops.rend(); ++it)
     {
         if((*it)->GetRank() >= maxRank)
@@ -989,15 +989,17 @@ void nobMilitary::Capture(const unsigned char new_owner)
     gwg->GetNotifications().publish(BuildingNote(BuildingNote::Lost, old_player, pos, bldType_));
 
     // Check if we need to change the coin order
-    unsigned coinOrder = gwg->GetGGS().getSelection(AddonId::COINS_CAPTURED_BLD);
-    if(coinOrder == 1)
+
+    switch(gwg->GetGGS().getSelection(AddonId::COINS_CAPTURED_BLD))
     {
-        coinsDisabled = false;
-        coinsDisabledVirtual = false;
-    } else if(coinOrder == 2)
-    {
-        coinsDisabled = true;
-        coinsDisabledVirtual = true;
+        case 1: // enable coin order
+            coinsDisabled = false;
+            coinsDisabledVirtual = false;
+            break;
+        case 2: // disable coin order
+            coinsDisabled = true;
+            coinsDisabledVirtual = true;
+            break;
     }
 }
 
@@ -1122,11 +1124,12 @@ unsigned nobMilitary::CalcCoinsPoints() const
     // Wenn hier schon Münzen drin sind oder welche bestellt sind, wirkt sich das natürlich negativ auf die "Wichtigkeit" aus
     points -= (numCoins + ordered_coins.size()) * 30;
 
+    const unsigned maxRank = gwg->GetGGS().GetMaxMilitaryRank();
     // Beförderbare Soldaten zählen
     BOOST_FOREACH(const nofPassiveSoldier* soldier, troops)
     {
         // Solange es kein Max Rank ist, kann der Soldat noch befördert werden
-        if(soldier->GetRank() < gwg->GetGGS().GetMaxMilitaryRank())
+        if(soldier->GetRank() < maxRank)
             points += 20;
     }
 
@@ -1183,9 +1186,10 @@ void nobMilitary::PrepareUpgrading()
     // Noch Soldaten, die befördert werden können?
     bool soldiers_available = false;
 
+    const unsigned maxRank = gwg->GetGGS().GetMaxMilitaryRank();
     for(SortedTroops::iterator it = troops.begin(); it != troops.end(); ++it)
     {
-        if((*it)->GetRank() < gwg->GetGGS().GetMaxMilitaryRank())
+        if((*it)->GetRank() < maxRank)
         {
             // es wurde ein Soldat gefunden, der befördert werden kann
             soldiers_available = true;


### PR DESCRIPTION
I have added a new addon to the game which takes over the control of coin order for captured buildings. This feature was requested by #388.

For unit testing i have added 2 new test cases to testAttacking, because it somehow plays into that.
i have copied the ConquerBld - test case and removed everything not related / unneeded for my test case. i hope that you are okay with that.

if you have any improvements, i will try to include them.

