### PR TITLE
Continue for #681 (Show direction glyph toward flag halfway out)

### DIFF
--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -408,8 +408,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
             WINDOWMANAGER.Close((unsigned)CGI_ROADWINDOW);
 
             // Ist das ein gültiger neuer Wegpunkt?
-            if(worldViewer.IsRoadAvailable(road.mode == RM_BOAT, selPt) && worldViewer.IsOwner(selPt)
-               && worldViewer.GetWorld().IsPlayerTerritory(selPt))
+            if(worldViewer.IsRoadAvailable(road.mode == RM_BOAT, selPt) && worldViewer.IsPlayerTerritory(selPt))
             {
                 MapPoint targetPt = selPt;
                 if(!BuildRoadPart(targetPt))

--- a/src/ingameWindows/iwPostWindow.cpp
+++ b/src/ingameWindows/iwPostWindow.cpp
@@ -218,6 +218,9 @@ bool iwPostWindow::Msg_KeyDown(const KeyEvent& ke)
     {
         default: break;
         case KT_DELETE: // Delete current message
+#ifdef __APPLE__
+        case KT_BACKSPACE: // Macs usually have no delete key on small keyboards, so backspace is more convenient
+#endif
             Msg_ButtonClick(ID_DELETE);
             return true;
     }

--- a/src/world/GameWorldGame.cpp
+++ b/src/world/GameWorldGame.cpp
@@ -1302,9 +1302,9 @@ void GameWorldGame::RecalcMovingVisibilities(const MapPoint pt, const unsigned c
     }
 }
 
-bool GameWorldGame::IsBorderNode(const MapPoint pt, const unsigned char player) const
+bool GameWorldGame::IsBorderNode(const MapPoint pt, const unsigned char owner) const
 {
-    return (GetNode(pt).owner == player && !IsPlayerTerritory(pt, player));
+    return (GetNode(pt).owner == owner && !IsPlayerTerritory(pt, owner));
 }
 
 /**

--- a/src/world/GameWorldGame.cpp
+++ b/src/world/GameWorldGame.cpp
@@ -1304,7 +1304,7 @@ void GameWorldGame::RecalcMovingVisibilities(const MapPoint pt, const unsigned c
 
 bool GameWorldGame::IsBorderNode(const MapPoint pt, const unsigned char player) const
 {
-    return (GetNode(pt).owner == player && !IsPlayerTerritory(pt));
+    return (GetNode(pt).owner == player && !IsPlayerTerritory(pt, player));
 }
 
 /**

--- a/src/world/GameWorldGame.h
+++ b/src/world/GameWorldGame.h
@@ -156,7 +156,7 @@ public:
                                   MapPoint* enemy_territory);
 
     /// Return whether this is a border node (node belongs to player, but not all others around)
-    bool IsBorderNode(const MapPoint pt, const unsigned char player) const;
+    bool IsBorderNode(const MapPoint pt, const unsigned char owner) const;
 
     // Konvertiert Ressourcen zwischen Typen hin und her oder löscht sie.
     // Für Spiele ohne Gold.

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -291,8 +291,7 @@ void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& ter
             }
 
             // ensure that curPt is a neighbour of rb.point
-            unsigned int roadIdx = helpers::indexOf(road_points, curPt);
-            if(roadIdx == -1)
+            if(helpers::contains(road_points, curPt))
             {
                 continue;
             }

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -293,8 +293,9 @@ void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& ter
                 if(rb.mode == RM_BOAT && maxWaterWayLen != 0 && rb.route.size() >= maxWaterWayLen)
                     continue;
 
+                const bool targetsFlag = GetWorld().GetNO(curPt)->GetType() == NOP_FLAG && curPt != rb.start;
                 if((gwv.IsRoadAvailable(rb.mode == RM_BOAT, curPt) && gwv.IsOwner(curPt) && GetWorld().IsPlayerTerritory(curPt))
-                   || (gwv.GetBQ(curPt) == BQ_FLAG))
+                   || (gwv.GetBQ(curPt) == BQ_FLAG) || targetsFlag)
                 {
                     unsigned id;
                     switch(int(GetWorld().GetNode(curPt).altitude) - altitude)
@@ -311,12 +312,18 @@ void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& ter
                         case -5: id = 66; break;
                         default: id = 60; break;
                     }
-
-                    LOADER.GetMapImageN(id)->DrawFull(curPos);
+                    if(!targetsFlag)
+                        LOADER.GetMapImageN(id)->DrawFull(curPos);
+                    else
+                    {
+                        DrawPoint lastPos = GetWorld().GetNodePos(rb.point) - offset + curOffset;
+                        DrawPoint halfWayPos = (curPos + lastPos) / 2;
+                        LOADER.GetMapImageN(id)->DrawFull(halfWayPos);
+                    }
                 }
 
                 // Flaggenanschluss? --> extra zeichnen
-                if(GetWorld().GetNO(curPt)->GetType() == NOP_FLAG && curPt != rb.start)
+                if(targetsFlag)
                     LOADER.GetMapImageN(20)->DrawFull(curPos);
 
                 if(!rb.route.empty() && rb.route.back() + 3u == Direction::fromInt(dir))

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -291,7 +291,7 @@ void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& ter
             }
 
             // ensure that curPt is a neighbour of rb.point
-            if(helpers::contains(road_points, curPt))
+            if(!helpers::contains(road_points, curPt))
             {
                 continue;
             }

--- a/src/world/GameWorldView.cpp
+++ b/src/world/GameWorldView.cpp
@@ -227,7 +227,7 @@ void GameWorldView::Draw(const RoadBuildState& rb, const MapPoint selected, bool
 void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& terrainRenderer, const MapPoint& selectedPt, bool drawMouse)
 {
     // Falls im Straßenbaumodus: Punkte um den aktuellen Straßenbaupunkt herum ermitteln
-    std::array<MapPoint, 6> road_points;
+    boost::array<MapPoint, 6> road_points;
 
     unsigned maxWaterWayLen = 0;
     if(rb.mode != RM_DISABLED)
@@ -302,7 +302,7 @@ void GameWorldView::DrawGUI(const RoadBuildState& rb, const TerrainRenderer& ter
                 continue;
 
             // render special icon for route revert
-            if(!rb.route.empty() && road_points[(rb.route.back().toUInt() + 3u) % Direction::COUNT] == curPt)
+            if(!rb.route.empty() && road_points[(rb.route.back() + 3u).toUInt()] == curPt)
             {
                 LOADER.GetMapImageN(67)->DrawFull(curPos);
                 continue;

--- a/src/world/GameWorldViewer.cpp
+++ b/src/world/GameWorldViewer.cpp
@@ -128,7 +128,7 @@ bool GameWorldViewer::IsOwner(const MapPoint& pt) const
 
 bool GameWorldViewer::IsPlayerTerritory(const MapPoint& pt) const
 {
-    return GetWorld().IsPlayerTerritory(pt);
+    return GetWorld().IsPlayerTerritory(pt, playerId_ + 1);
 }
 
 const MapNode& GameWorldViewer::GetNode(const MapPoint& pt) const

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -243,6 +243,23 @@ bool World::IsPlayerTerritory(const MapPoint pt) const
     return true;
 }
 
+bool World::IsPlayerTerritory(const MapPoint pt, const unsigned char owner) const
+{
+    const unsigned char ptOwner = GetNode(pt).owner;
+
+    if(ptOwner != owner)
+        return false;
+
+    // Neighbour nodes must belong to this player
+    for(unsigned i = 0; i < Direction::COUNT; ++i)
+    {
+        if(GetNeighbourNode(pt, Direction::fromInt(i)).owner != owner)
+            return false;
+    }
+
+    return true;
+}
+
 BuildingQuality World::GetBQ(const MapPoint pt, const unsigned char player) const
 {
     return AdjustBQ(pt, player, GetNode(pt).bq);

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -233,7 +233,7 @@ bool World::IsPlayerTerritory(const MapPoint pt, const unsigned char owner) cons
 {
     const unsigned char ptOwner = GetNode(pt).owner;
 
-    if(owner != '0' && ptOwner != owner)
+    if(owner != 0 && ptOwner != owner)
         return false;
 
     // Neighbour nodes must belong to this player

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -229,31 +229,17 @@ void World::ChangeAltitude(const MapPoint pt, const unsigned char altitude)
     AltitudeChanged(pt);
 }
 
-bool World::IsPlayerTerritory(const MapPoint pt) const
-{
-    const unsigned char owner = GetNode(pt).owner;
-
-    // Neighbour nodes must belong to this player
-    for(unsigned i = 0; i < Direction::COUNT; ++i)
-    {
-        if(GetNeighbourNode(pt, Direction::fromInt(i)).owner != owner)
-            return false;
-    }
-
-    return true;
-}
-
 bool World::IsPlayerTerritory(const MapPoint pt, const unsigned char owner) const
 {
     const unsigned char ptOwner = GetNode(pt).owner;
 
-    if(ptOwner != owner)
+    if(owner != '0' && ptOwner != owner)
         return false;
 
     // Neighbour nodes must belong to this player
     for(unsigned i = 0; i < Direction::COUNT; ++i)
     {
-        if(GetNeighbourNode(pt, Direction::fromInt(i)).owner != owner)
+        if(GetNeighbourNode(pt, Direction::fromInt(i)).owner != ptOwner)
             return false;
     }
 
@@ -267,7 +253,7 @@ BuildingQuality World::GetBQ(const MapPoint pt, const unsigned char player) cons
 
 BuildingQuality World::AdjustBQ(const MapPoint pt, unsigned char player, BuildingQuality nodeBQ) const
 {
-    if(nodeBQ == BQ_NOTHING || GetNode(pt).owner != player + 1 || !IsPlayerTerritory(pt))
+    if(nodeBQ == BQ_NOTHING || !IsPlayerTerritory(pt, player + 1))
         return BQ_NOTHING;
     // If we could build a building, but the buildings flag point is at the border, we can only build a flag
     if(nodeBQ != BQ_FLAG && !IsPlayerTerritory(GetNeighbour(pt, Direction::SOUTHEAST)))

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -121,6 +121,9 @@ public:
 
     /// Check if the point completely belongs to a player (if false but point itself belongs to player then it is a border)
     bool IsPlayerTerritory(const MapPoint pt) const;
+    /// Checks if the point complyetly belongs to a given player (if false but point itself belongs to player then it is a border)
+    bool IsPlayerTerritory(const MapPoint pt, const unsigned char owner) const;
+
     /// Return the BQ for the given player at the point (including ownership constraints)
     BuildingQuality GetBQ(const MapPoint pt, const unsigned char player) const;
     /// Incorporates node ownership into the given BQ

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -119,10 +119,9 @@ public:
 
     void ChangeAltitude(const MapPoint pt, const unsigned char altitude);
 
-    /// Check if the point completely belongs to a player (if false but point itself belongs to player then it is a border)
-    bool IsPlayerTerritory(const MapPoint pt) const;
-    /// Checks if the point complyetly belongs to a given player (if false but point itself belongs to player then it is a border)
-    bool IsPlayerTerritory(const MapPoint pt, const unsigned char owner) const;
+    /// Checks if the point completely belongs to a player (if false but point itself belongs to player then it is a border)
+    /// if owner is != '0' it checks if the points specific ownership
+    bool IsPlayerTerritory(const MapPoint pt, const unsigned char owner = '0') const;
 
     /// Return the BQ for the given player at the point (including ownership constraints)
     BuildingQuality GetBQ(const MapPoint pt, const unsigned char player) const;

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -120,7 +120,7 @@ public:
     void ChangeAltitude(const MapPoint pt, const unsigned char altitude);
 
     /// Checks if the point completely belongs to a player (if false but point itself belongs to player then it is a border)
-    /// if owner is != '0' it checks if the points specific ownership
+    /// if owner is != 0 it checks if the points specific ownership
     bool IsPlayerTerritory(const MapPoint pt, const unsigned char owner = 0) const;
 
     /// Return the BQ for the given player at the point (including ownership constraints)

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -121,7 +121,7 @@ public:
 
     /// Checks if the point completely belongs to a player (if false but point itself belongs to player then it is a border)
     /// if owner is != '0' it checks if the points specific ownership
-    bool IsPlayerTerritory(const MapPoint pt, const unsigned char owner = '0') const;
+    bool IsPlayerTerritory(const MapPoint pt, const unsigned char owner = 0) const;
 
     /// Return the BQ for the given player at the point (including ownership constraints)
     BuildingQuality GetBQ(const MapPoint pt, const unsigned char player) const;


### PR DESCRIPTION
Since there seems no work on #681 i have picked up the changes on the glyph rendering and applied the requested changes.
Also i have combined the evaluation if a direction targets a flag (which was used 3 times in the code block).

The changes related to saving i have skipped, because someone else already added a similar logic.

As i found it is a good idea: i also included the change to enable backspace for post message deletion for macs.
@Flamefire  if you have any improvements left, i would be willing to apply them.

