### PR TITLE
Prevent Crash on fast click startup if sounds not loaded

### DIFF
--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -297,8 +297,11 @@ void WindowManager::Msg_LeftDown(MouseCoords mc)
     if(!curDesktop)
         return;
 
-    // Sound abspielen
-    LOADER.GetSoundN("sound", 112)->Play(255, false);
+    if (!disable_mouse)
+    {
+        // Sound abspielen
+        SoundEffectItem* sound = LOADER.GetSoundN("sound", 112)->Play(255, false);
+    }
 
     // haben wir überhaupt fenster?
     if(windows.empty())


### PR DESCRIPTION
If a user is very fast and raises a mouse click event on the black screen (before the splash screen is shown), the loader is not initialized.
Due its state as a singleton its created, but is empty. GetSoundN will not find the sound to play and will cause an application crash (nullpointer).
As the disable_mouse flag is true in that state i have added a check for that before playing the sound.
This should prevent the crash.
I hope this attempt is okay, otherwise i could check if there was a sound found (null check), but this looked somehow strange for me.