### PR TITLE
Fix unused variable errors

### DIFF
--- a/src/ingameWindows/iwObservate.cpp
+++ b/src/ingameWindows/iwObservate.cpp
@@ -39,7 +39,7 @@ const Extent MediumWndSize(300, 250);
 const Extent BigWndSize(340, 310);
 
 iwObservate::iwObservate(GameWorldView& gwv, const MapPoint selectedPt)
-    : IngameWindow(gwv.GetWorld().CreateGUIID(selectedPt), IngameWindow::posAtMouse, Extent(260, 190), _("Observation window"), NULL),
+    : IngameWindow(gwv.GetWorld().CreateGUIID(selectedPt), IngameWindow::posAtMouse, SmallWndSize, _("Observation window"), NULL),
       parentView(gwv), view(new GameWorldView(gwv.GetViewer(), Position(GetDrawPos() * DrawPoint(10, 15)), GetSize() - Extent::all(20))),
       selectedPt(selectedPt), lastWindowPos(Point<unsigned short>::Invalid()), isScrolling(false), zoomLvl(0), followMovableId(0)
 {
@@ -134,19 +134,16 @@ void iwObservate::Msg_ButtonClick(const unsigned ctrl_id)
         case 4:
             int diff = GetSize().x;
 
-            if(GetSize().x == 260)
+            if(GetSize() == SmallWndSize)
             {
-                SetWidth(300);
-                SetHeight(250);
-            } else if(GetSize().x == 300)
+                Resize(MediumWndSize);
+            } else if(GetSize() == MediumWndSize)
             {
-                SetWidth(340);
-                SetHeight(310);
+                Resize(BigWndSize);
                 GetCtrl<ctrlImageButton>(4)->SetImage(LOADER.GetImageN("io", 108));
             } else
             {
-                SetWidth(260);
-                SetHeight(190);
+                Resize(SmallWndSize);
                 GetCtrl<ctrlImageButton>(4)->SetImage(LOADER.GetImageN("io", 109));
             }
 


### PR DESCRIPTION
I tried to compile it with **clang** compiler and had this error:

...
[ 62%] Building CXX object src/CMakeFiles/s25Main.dir/ingameWindows/iwMsgbox.cpp.o
[ 62%] Building CXX object src/CMakeFiles/s25Main.dir/ingameWindows/iwMusicPlayer.cpp.o
[ 62%] Building CXX object src/CMakeFiles/s25Main.dir/ingameWindows/iwObservate.cpp.o
/home/goiko/s25client/src/ingameWindows/iwObservate.cpp:37:14: error: unused
      variable 'SmallWndSize' [-Werror,-Wunused-const-variable]
const Extent SmallWndSize(260, 190);
             ^
/home/goiko/s25client/src/ingameWindows/iwObservate.cpp:38:14: error: unused
      variable 'MediumWndSize' [-Werror,-Wunused-const-variable]
const Extent MediumWndSize(300, 250);
             ^
/home/goiko/s25client/src/ingameWindows/iwObservate.cpp:39:14: error: unused
      variable 'BigWndSize' [-Werror,-Wunused-const-variable]
const Extent BigWndSize(340, 310);
             ^
3 errors generated.
src/CMakeFiles/s25Main.dir/build.make:5583: recipe for target 'src/CMakeFiles/s25Main.dir/ingameWindows/iwObservate.cpp.o' failed
make[2]: *** [src/CMakeFiles/s25Main.dir/ingameWindows/iwObservate.cpp.o] Error 1
CMakeFiles/Makefile2:1480: recipe for target 'src/CMakeFiles/s25Main.dir/all' failed
make[1]: *** [src/CMakeFiles/s25Main.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2

----
Found a solution to use the three variables in the code. 

Compiled with:
```
$ ./cmake.sh --prefix=. -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0
$ make
```
- Used IDE to debug and test changes: **Visual Studio Code**
- Used configuration for VSC: https://gist.github.com/goikoo/303924ceeaff3f98e518bd8b445733d8