### PR TITLE
Re-Add Reserve soldiers to inventory if Warehouse gets destroyed

### DIFF
--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -21,6 +21,7 @@
 #include "EventManager.h"
 #include "FindWhConditions.h"
 #include "GamePlayer.h"
+#include "GlobalGameSettings.h"
 #include "SerializedGameData.h"
 #include "Ware.h"
 #include "factories/JobFactory.h"
@@ -101,6 +102,16 @@ void nobBaseWarehouse::DestroyBuilding()
     // restliche Warenbestände von der Inventur wieder abziehen
     for(unsigned i = 0; i < NUM_WARE_TYPES; ++i)
         gwg->GetPlayer(player).DecreaseInventoryWare(GoodType(i), inventory[GoodType(i)]);
+
+    // move soldiers from reserve to inventory.
+    if(!GAMECLIENT.IsReplayModeOn() && GAMECLIENT.GetPlayerId() == player)
+    {
+        for(unsigned rank = 0; rank < gwg->GetGGS().GetMaxMilitaryRank(); ++rank)
+        {
+            if(reserve_soldiers_available[rank] > 0)
+                inventory.real.Add(SOLDIER_JOBS[rank], reserve_soldiers_available[rank]);
+        }
+    }
 
     // Objekt, das die flüchtenden Leute nach und nach ausspuckt, erzeugen
     gwg->AddFigure(pos, new BurnedWarehouse(pos, player, inventory.real.people));

--- a/src/buildings/nobBaseWarehouse.cpp
+++ b/src/buildings/nobBaseWarehouse.cpp
@@ -104,14 +104,12 @@ void nobBaseWarehouse::DestroyBuilding()
         gwg->GetPlayer(player).DecreaseInventoryWare(GoodType(i), inventory[GoodType(i)]);
 
     // move soldiers from reserve to inventory.
-    if(!GAMECLIENT.IsReplayModeOn() && GAMECLIENT.GetPlayerId() == player)
+    for (unsigned rank = 0; rank < gwg->GetGGS().GetMaxMilitaryRank(); ++rank)
     {
-        for(unsigned rank = 0; rank < gwg->GetGGS().GetMaxMilitaryRank(); ++rank)
-        {
-            if(reserve_soldiers_available[rank] > 0)
-                inventory.real.Add(SOLDIER_JOBS[rank], reserve_soldiers_available[rank]);
-        }
+        if (reserve_soldiers_available[rank] > 0)
+            inventory.real.Add(SOLDIER_JOBS[rank], reserve_soldiers_available[rank]);
     }
+    
 
     // Objekt, das die flüchtenden Leute nach und nach ausspuckt, erzeugen
     gwg->AddFigure(pos, new BurnedWarehouse(pos, player, inventory.real.people));


### PR DESCRIPTION
Move soldiers from reserve back to inventory, if the warehouse is getting destroyed.

fixes #839