### PR TITLE
Remove Humidity Check from placing resources on mineable terrain.

### DIFF
--- a/src/mapGenerator/RandomMapGenerator.cpp
+++ b/src/mapGenerator/RandomMapGenerator.cpp
@@ -243,9 +243,7 @@ void RandomMapGenerator::SetResources(const MapSettings& settings, Map& map)
 
         uint8_t res = libsiedler2::R_None;
 
-        if(tRsu.kind == TerrainKind::WATER || tLsd.kind == TerrainKind::WATER)
-        {
-            if(tRsu.kind == TerrainKind::WATER && tLsd.kind == TerrainKind::WATER)
+        if(tRsu.kind == TerrainKind::WATER && tLsd.kind == TerrainKind::WATER) {
                 res = libsiedler2::R_Fish;
         } else if(tRsu.IsVital() && tLsd.IsVital())
         {
@@ -269,7 +267,7 @@ void RandomMapGenerator::SetResources(const MapSettings& settings, Map& map)
             const TerrainDesc& t3 = config.GetTerrainByS2Id(map.textureLsd[nb]);
             nb = VertexUtility::GetIndexOf(GetNeighbour(pt, Direction::EAST), map.size);
             const TerrainDesc& t4 = config.GetTerrainByS2Id(map.textureRsu[nb]);
-            if(tRsu.humidity > 0 && tLsd.humidity > 0 && t1.Is(ETerrain::Mineable) && t2.Is(ETerrain::Mineable) && t3.Is(ETerrain::Mineable)
+            if(t1.Is(ETerrain::Mineable) && t2.Is(ETerrain::Mineable) && t3.Is(ETerrain::Mineable)
                && t4.Is(ETerrain::Mineable))
                 res = helper.objGen.CreateRandomResource(settings.ratioGold, settings.ratioIron, settings.ratioCoal, settings.ratioGranite);
         }


### PR DESCRIPTION
As the humidity check and mountains exclude each other, it has to be a mistake to check it here.
See my comment in #842  as reference. 
I also removed the first if check for placing fish, as it is useless from logical perspective, as it will always return true, if the the second is true, also its excluding the later else-clauses (as water is not vital or mineable).