### PR TITLE
Improve colors for disabled buttons

### DIFF
--- a/src/controls/ctrlButton.cpp
+++ b/src/controls/ctrlButton.cpp
@@ -104,7 +104,7 @@ void ctrlButton::Draw_()
 
     if(tc != TC_INVISIBLE)
     {
-        unsigned color = isEnabled ? COLOR_WHITE : 0xFF666666;
+        unsigned color = isEnabled ? COLOR_WHITE : 0xFFBBBBBB;
         bool isCurIlluminated = isIlluminated || (!isEnabled && isChecked);
         bool isElevated = !isChecked && state != BUTTON_PRESSED;
         bool isHighlighted = isEnabled && !isChecked && state == BUTTON_HOVER;

--- a/src/controls/ctrlTextButton.cpp
+++ b/src/controls/ctrlTextButton.cpp
@@ -33,7 +33,7 @@ void ctrlTextButton::DrawContent() const
     if(this->color_ == COLOR_YELLOW && isPressed)
         color = 0xFFFFAA00;
     else if(!isEnabled)
-        color = COLOR_GREY;
+        color = 0xFF818993;
     else
         color = this->color_;
 


### PR DESCRIPTION
Closes #888 

It uses the font color as suggested and brings the texture color closer to the suggestion: 
![2018-11-05_18-58-26](https://user-images.githubusercontent.com/309017/48017722-558fcc80-e12f-11e8-8dc4-ed757a01072b.png)


The complete match is not possible as we colorize a colored texture where the original uses completely other colors (grey in this case) So we can basically just make it slightly darker or lighter