### PR TITLE
Test also for defeat when a military building was destroyed

### DIFF
--- a/src/GamePlayer.cpp
+++ b/src/GamePlayer.cpp
@@ -473,7 +473,7 @@ void GamePlayer::RemoveBuilding(noBuilding* bld, BuildingType bldType)
             }
         }
     }
-    if(BuildingProperties::IsWareHouse(bldType))
+    if(BuildingProperties::IsWareHouse(bldType) || BuildingProperties::IsMilitary(bldType))
         TestDefeat();
 }
 


### PR DESCRIPTION
The bug in #913 was caused by destroying the HQ first (which triggers a defeat check) and then the military building (semi-random: depends on positions on the map). The latter did not trigger a defeat check and hence the map was not made visible as the game did not know that the player was defeated