### PR TITLE
Fix minimize minimap enlarging window

### DIFF
--- a/src/ingameWindows/iwMinimap.cpp
+++ b/src/ingameWindows/iwMinimap.cpp
@@ -63,7 +63,7 @@ void iwMinimap::Resize(const Extent& newSize)
     IngameWindow::Resize(newSize);
     ctrlIngameMinimap* im = GetCtrl<ctrlIngameMinimap>(0);
 
-    im->Resize(newSize);
+    im->Resize(newSize - contentOffset - contentOffsetEnd);
 
     // Control kürzen in der Höhe
     im->RemoveBoundingBox(Extent(BUTTON_SIZE.x * 4 + WINDOW_MAP_SPACE * 2, 0));


### PR DESCRIPTION
Fixes bug appearing when minimizing or maximizing minimap (title bar enlarges every time window is minimized). I am unsure if it's the best way to do so.