### PR TITLE
Fix cursor image while scrolling

### DIFF
--- a/driver/include/driver/MouseCoords.h
+++ b/driver/include/driver/MouseCoords.h
@@ -28,17 +28,20 @@
 class MouseCoords
 {
 public:
-    MouseCoords() : x(0), y(0), ldown(false), rdown(false), dbl_click(false) {}
-    MouseCoords(int x, int y, bool ldown, bool rdown, const bool dbl_click) : x(x), y(y), ldown(ldown), rdown(rdown), dbl_click(dbl_click)
+    MouseCoords() : pos(0, 0), ldown(false), rdown(false), dbl_click(false) {}
+    MouseCoords(int x, int y, bool ldown = false, bool rdown = false, bool dbl_click = false)
+        : pos(x, y), ldown(ldown), rdown(rdown), dbl_click(dbl_click)
+    {}
+    MouseCoords(Position pos, bool ldown = false, bool rdown = false, bool dbl_click = false)
+        : pos(pos), ldown(ldown), rdown(rdown), dbl_click(dbl_click)
     {}
 
-    int x;          /// xKoordinate
-    int y;          /// yKoordinate
+    Position pos;
     bool ldown;     /// Linke Maustaste gedrückt
     bool rdown;     /// Rechte Maustaste gedrückt
     bool dbl_click; /// Linke Maustaste - Doppelklick
 
-    Point<int> GetPos() const { return Point<int>(x, y); }
+    Position GetPos() const { return pos; }
 };
 
 /// Maximale Zeitdifferenz in ms für einen Doppeklick

--- a/driver/src/VideoDriver.cpp
+++ b/driver/src/VideoDriver.cpp
@@ -43,8 +43,8 @@ VideoDriver::VideoDriver(VideoDriverLoaderInterface* CallBack) : CallBack(CallBa
  */
 void VideoDriver::GetMousePos(int& x, int& y) const
 {
-    x = mouse_xy.x;
-    y = mouse_xy.y;
+    x = mouse_xy.pos.x;
+    y = mouse_xy.pos.y;
 }
 
 /**

--- a/driver/video/SDL/src/VideoSDL.cpp
+++ b/driver/video/SDL/src/VideoSDL.cpp
@@ -470,8 +470,8 @@ bool VideoSDL::MessageLoop()
             break;
             case SDL_MOUSEBUTTONDOWN:
             {
-                mouse_xy.x = ev.button.x;
-                mouse_xy.y = ev.button.y;
+                mouse_xy.pos.x = ev.button.x;
+                mouse_xy.pos.y = ev.button.y;
 
                 if(/*!mouse_xy.ldown && */ ev.button.button == SDL_BUTTON_LEFT)
                 {
@@ -487,8 +487,8 @@ bool VideoSDL::MessageLoop()
             break;
             case SDL_MOUSEBUTTONUP:
             {
-                mouse_xy.x = ev.button.x;
-                mouse_xy.y = ev.button.y;
+                mouse_xy.pos.x = ev.button.x;
+                mouse_xy.pos.y = ev.button.y;
 
                 if(/*mouse_xy.ldown &&*/ ev.button.button == SDL_BUTTON_LEFT)
                 {
@@ -515,8 +515,8 @@ bool VideoSDL::MessageLoop()
                 // Handle only 1st mouse move
                 if(!mouseMoved)
                 {
-                    mouse_xy.x = ev.motion.x;
-                    mouse_xy.y = ev.motion.y;
+                    mouse_xy.pos.x = ev.motion.x;
+                    mouse_xy.pos.y = ev.motion.y;
 
                     CallBack->Msg_MouseMove(mouse_xy);
                     mouseMoved = true;
@@ -572,8 +572,8 @@ void VideoSDL::SetMousePos(int x, int y)
 {
     if(SDL_GetAppState() & SDL_APPMOUSEFOCUS)
     {
-        mouse_xy.x = x;
-        mouse_xy.y = y;
+        mouse_xy.pos.x = x;
+        mouse_xy.pos.y = y;
         SDL_WarpMouse(x, y);
     }
 }

--- a/driver/video/SDL2/VideoSDL2.cpp
+++ b/driver/video/SDL2/VideoSDL2.cpp
@@ -340,8 +340,7 @@ bool VideoSDL2::MessageLoop()
                 break;
             }
             case SDL_MOUSEBUTTONDOWN:
-                mouse_xy.x = ev.button.x;
-                mouse_xy.y = ev.button.y;
+                mouse_xy.pos = Position(ev.button.x, ev.button.y);
 
                 if(/*!mouse_xy.ldown && */ ev.button.button == SDL_BUTTON_LEFT)
                 {
@@ -355,8 +354,7 @@ bool VideoSDL2::MessageLoop()
                 }
                 break;
             case SDL_MOUSEBUTTONUP:
-                mouse_xy.x = ev.button.x;
-                mouse_xy.y = ev.button.y;
+                mouse_xy.pos = Position(ev.button.x, ev.button.y);
 
                 if(/*mouse_xy.ldown &&*/ ev.button.button == SDL_BUTTON_LEFT)
                 {
@@ -384,8 +382,7 @@ bool VideoSDL2::MessageLoop()
                 // Handle only 1st mouse move
                 if(!mouseMoved)
                 {
-                    mouse_xy.x = ev.motion.x;
-                    mouse_xy.y = ev.motion.y;
+                    mouse_xy.pos = Position(ev.button.x, ev.button.y);
 
                     CallBack->Msg_MouseMove(mouse_xy);
                     mouseMoved = true;
@@ -427,8 +424,7 @@ OpenGL_Loader_Proc VideoSDL2::GetLoaderFunction() const
 
 void VideoSDL2::SetMousePos(int x, int y)
 {
-    mouse_xy.x = x;
-    mouse_xy.y = y;
+    mouse_xy.pos = Position(x, y);
     SDL_WarpMouseInWindow(window, x, y);
 }
 

--- a/driver/video/WinAPI/src/WinAPI.cpp
+++ b/driver/video/WinAPI/src/WinAPI.cpp
@@ -501,8 +501,8 @@ void VideoWinAPI::SetMousePos(int x, int y)
 {
     if(GetActiveWindow())
     {
-        mouse_xy.x = x;
-        mouse_xy.y = y;
+        mouse_xy.pos.x = x;
+        mouse_xy.pos.y = y;
 
         POINT p = {x, y};
         ClientToScreen(screen, &p);
@@ -650,8 +650,8 @@ LRESULT CALLBACK VideoWinAPI::WindowProc(HWND window, UINT msg, WPARAM wParam, L
             SetCursor(NULL);
             break;
         case WM_MOUSEMOVE:
-            pVideoWinAPI->mouse_xy.x = LOWORD(lParam);
-            pVideoWinAPI->mouse_xy.y = HIWORD(lParam);
+            pVideoWinAPI->mouse_xy.pos.x = LOWORD(lParam);
+            pVideoWinAPI->mouse_xy.pos.y = HIWORD(lParam);
             pVideoWinAPI->CallBack->Msg_MouseMove(pVideoWinAPI->mouse_xy);
             break;
         case WM_LBUTTONDOWN:

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -39,7 +39,7 @@
 #include "libutil/error.h"
 #include <cstdio>
 
-GameManager::GameManager() : skipgf_last_time(0), skipgf_last_report_gf(0), cursor_(CURSOR_HAND), cursor_next(CURSOR_HAND)
+GameManager::GameManager() : skipgf_last_time(0), skipgf_last_report_gf(0), cursor_(CURSOR_HAND)
 {
     ResetAverageGFPS();
 }
@@ -204,11 +204,9 @@ void GameManager::ResetAverageGFPS()
 /**
  *  Set the cursor type
  */
-void GameManager::SetCursor(CursorType cursor, bool once)
+void GameManager::SetCursor(CursorType cursor)
 {
-    cursor_next = cursor;
-    if(!once)
-        this->cursor_ = cursor;
+    cursor_ = cursor;
 }
 
 /**
@@ -217,14 +215,12 @@ void GameManager::SetCursor(CursorType cursor, bool once)
 void GameManager::DrawCursor()
 {
     unsigned resId;
-    switch(cursor_next)
+    switch(cursor_)
     {
         case CURSOR_HAND: resId = VIDEODRIVER.IsLeftDown() ? 31 : 30; break;
         case CURSOR_RM: resId = VIDEODRIVER.IsLeftDown() ? 35 : 34; break;
-        default: resId = cursor_next;
+        default: resId = cursor_;
     }
     if(resId)
         LOADER.GetImageN("resource", resId)->DrawFull(VIDEODRIVER.GetMousePos());
-
-    cursor_next = cursor_;
 }

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -50,8 +50,7 @@ GameManager::GameManager() : skipgf_last_time(0), skipgf_last_report_gf(0), curs
 bool GameManager::Start()
 {
     // Einstellungen laden
-    if(!SETTINGS.Load())
-        return false;
+    SETTINGS.Load();
 
     /// Videotreiber laden
     if(!VIDEODRIVER.LoadDriver())

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -52,7 +52,8 @@ public:
     unsigned GetNumFrames() { return gfCounter_.getCurNumFrames(); }
     unsigned GetAverageGFPS() { return gfCounter_.getCurFrameRate(); }
 
-    void SetCursor(CursorType cursor = CURSOR_HAND, bool once = false);
+    void SetCursor(CursorType cursor = CURSOR_HAND);
+    CursorType GetCursor() const { return cursor_; }
 
 private:
     bool ShowSplashscreen();
@@ -63,7 +64,6 @@ private:
     unsigned skipgf_last_time;
     unsigned skipgf_last_report_gf;
     CursorType cursor_;
-    CursorType cursor_next;
 };
 
 #define GAMEMANAGER GameManager::inst()

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -42,11 +42,11 @@ public:
 
     Settings();
 
-    bool Load();
+    void Load();
     void Save();
 
 protected:
-    bool LoadDefaults();
+    void LoadDefaults();
 
 public:
     struct

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -737,7 +737,7 @@ void WindowManager::Msg_ScreenResize(const Extent& newSize)
     }
 }
 
-const Window* WindowManager::GetTopMostWindow() const
+const IngameWindow* WindowManager::GetTopMostWindow() const
 {
     if(windows.empty())
         return NULL;

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -645,7 +645,7 @@ void WindowManager::Msg_WheelDown(const MouseCoords& mc)
  */
 void WindowManager::Msg_MouseMove(const MouseCoords& mc)
 {
-    lastMousePos = Position(mc.x, mc.y);
+    lastMousePos = mc.pos;
 
     // ist unser Desktop gültig?
     if(!curDesktop)

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -92,7 +92,7 @@ public:
     void Msg_ScreenResize(const Extent& newSize);
 
     /// Return the window currently on the top (probably active)
-    const Window* GetTopMostWindow() const;
+    const IngameWindow* GetTopMostWindow() const;
     IngameWindow* FindWindowAtPos(const Position& pos) const;
 
 protected:

--- a/src/controls/ctrlList.cpp
+++ b/src/controls/ctrlList.cpp
@@ -53,7 +53,7 @@ bool ctrlList::Msg_MouseMove(const MouseCoords& mc)
     if(IsPointInRect(mc.GetPos(), GetListDrawArea()))
     {
         // Neue Selektierung
-        mouseover = (mc.y - (GetDrawPos().y + 2)) / font->getHeight();
+        mouseover = (mc.pos.y - (GetDrawPos().y + 2)) / font->getHeight();
         const std::string itemTxt = GetItemText(mouseover);
         tooltip_.ShowTooltip((font->getWidth(itemTxt) > GetListDrawArea().getSize().x) ? itemTxt : "");
         return true;

--- a/src/controls/ctrlProgress.cpp
+++ b/src/controls/ctrlProgress.cpp
@@ -155,7 +155,7 @@ bool ctrlProgress::Msg_LeftDown(const MouseCoords& mc)
     Extent progressSize = GetSize() - Extent((GetSize().y + 1) * 2, 8) - padding_ * 2u;
     if(IsPointInRect(mc.GetPos(), Rect(progressOrigin, progressSize)))
     {
-        position = boost::math::iround(static_cast<double>((mc.x - progressOrigin.x) * maximum) / progressSize.x);
+        position = boost::math::iround(static_cast<double>((mc.pos.x - progressOrigin.x) * maximum) / progressSize.x);
 
         if(GetParent())
             GetParent()->Msg_ProgressChange(GetID(), position);

--- a/src/controls/ctrlScrollBar.cpp
+++ b/src/controls/ctrlScrollBar.cpp
@@ -108,14 +108,14 @@ bool ctrlScrollBar::Msg_MouseMove(const MouseCoords& mc)
 {
     if(isMouseScrolling)
     {
-        const int moveDist = mc.y - last_y;
+        const int moveDist = mc.pos.y - last_y;
         sliderPos += moveDist;
         if(sliderPos + sliderHeight > scroll_height)
             sliderPos = moveDist < 0 ? 0 : (scroll_height - sliderHeight);
 
         UpdatePosFromSlider();
     }
-    last_y = mc.y;
+    last_y = mc.pos.y;
 
     // ButtonMessages weiterleiten
     return RelayMouseMessage(&Window::Msg_MouseMove, mc);

--- a/src/controls/ctrlTable.cpp
+++ b/src/controls/ctrlTable.cpp
@@ -333,7 +333,7 @@ bool ctrlTable::Msg_RightDown(const MouseCoords& mc)
 
 int ctrlTable::GetSelectionFromMouse(const MouseCoords& mc)
 {
-    return (mc.y - GetContentDrawArea().top) / font->getHeight() + GetCtrl<ctrlScrollBar>(0)->GetScrollPos();
+    return (mc.pos.y - GetContentDrawArea().top) / font->getHeight() + GetCtrl<ctrlScrollBar>(0)->GetScrollPos();
 }
 
 bool ctrlTable::Msg_WheelUp(const MouseCoords& mc)

--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -106,8 +106,9 @@ enum
 };
 }
 
-dskGameInterface::dskGameInterface(boost::shared_ptr<Game> game, bool initOGL)
-    : Desktop(NULL), game_(game), nwfInfo(GAMECLIENT.GetNWFInfo()), worldViewer(GAMECLIENT.GetPlayerId(), game->world),
+dskGameInterface::dskGameInterface(boost::shared_ptr<Game> game, const boost::shared_ptr<const NWFInfo>& newInfo, unsigned playerIdx,
+                                   bool initOGL)
+    : Desktop(NULL), game_(game), nwfInfo(nwfInfo), worldViewer(playerIdx, game->world),
       gwv(worldViewer, Position(0, 0), VIDEODRIVER.GetScreenSize()), cbb(*LOADER.GetPaletteN("pal5")), actionwindow(NULL), roadwindow(NULL),
       minimap(worldViewer), isScrolling(false), zoomLvl(ZOOM_DEFAULT_INDEX), isCheatModeOn(false)
 {
@@ -611,7 +612,7 @@ bool dskGameInterface::Msg_MouseMove(const MouseCoords& mc)
 
 bool dskGameInterface::Msg_RightDown(const MouseCoords& mc)
 {
-    startScrollPt = Position(mc.x, mc.y);
+    startScrollPt = mc.pos;
     isScrolling = true;
     GAMEMANAGER.SetCursor(CURSOR_SCROLL);
     return false;

--- a/src/desktops/dskGameInterface.cpp
+++ b/src/desktops/dskGameInterface.cpp
@@ -106,9 +106,9 @@ enum
 };
 }
 
-dskGameInterface::dskGameInterface(boost::shared_ptr<Game> game, const boost::shared_ptr<const NWFInfo>& newInfo, unsigned playerIdx,
+dskGameInterface::dskGameInterface(boost::shared_ptr<Game> game, const boost::shared_ptr<const NWFInfo>& nwfInfo, unsigned playerIdx,
                                    bool initOGL)
-    : Desktop(NULL), game_(game), nwfInfo(nwfInfo), worldViewer(playerIdx, game->world),
+    : Desktop(NULL), game_(game), nwfInfo_(nwfInfo), worldViewer(playerIdx, game->world),
       gwv(worldViewer, Position(0, 0), VIDEODRIVER.GetScreenSize()), cbb(*LOADER.GetPaletteN("pal5")), actionwindow(NULL), roadwindow(NULL),
       minimap(worldViewer), isScrolling(false), zoomLvl(ZOOM_DEFAULT_INDEX), isCheatModeOn(false)
 {
@@ -324,7 +324,7 @@ void dskGameInterface::Msg_PaintAfter()
     {
         // Laggende Spieler anzeigen in Form von Schnecken
         DrawPoint snailPos(VIDEODRIVER.GetScreenSize().x - 70, 35);
-        BOOST_FOREACH(const NWFPlayerInfo& player, nwfInfo->getPlayerInfos())
+        BOOST_FOREACH(const NWFPlayerInfo& player, nwfInfo_->getPlayerInfos())
         {
             if(player.isLagging)
             {

--- a/src/desktops/dskGameInterface.h
+++ b/src/desktops/dskGameInterface.h
@@ -49,7 +49,8 @@ class NWFInfo;
 class dskGameInterface : public Desktop, public ClientInterface, public GameInterface, public LobbyInterface, public IChatCmdListener
 {
 public:
-    dskGameInterface(boost::shared_ptr<Game> game, bool initOGL = true);
+    dskGameInterface(boost::shared_ptr<Game> game, const boost::shared_ptr<const NWFInfo>& nwfInfo, unsigned playerIdx,
+                     bool initOGL = true);
     ~dskGameInterface() override;
 
     void Resize(const Extent& newSize) override;
@@ -109,7 +110,7 @@ public:
     void ShowActionWindow(const iwAction::Tabs& action_tabs, MapPoint cSel, const DrawPoint& mousePos,
                           const bool enable_military_buildings);
 
-    const GameWorldViewer& GetViewer() const { return worldViewer; }
+    const GameWorldView& GetView() const { return gwv; }
 
     void OnChatCommand(const std::string& cmd) override;
 
@@ -141,7 +142,7 @@ private:
 
     PostBox& GetPostBox();
     boost::shared_ptr<const Game> game_;
-    boost::shared_ptr<const NWFInfo> nwfInfo;
+    boost::shared_ptr<const NWFInfo> nwfInfo_;
     GameWorldViewer worldViewer;
     GameWorldView gwv;
 

--- a/src/desktops/dskGameInterface.h
+++ b/src/desktops/dskGameInterface.h
@@ -140,6 +140,9 @@ private:
 
     void OnBuildingNote(const BuildingNote& note);
 
+    void StopScrolling();
+    void StartScrolling(const Position& mousePos);
+
     PostBox& GetPostBox();
     boost::shared_ptr<const Game> game_;
     boost::shared_ptr<const NWFInfo> nwfInfo_;

--- a/src/desktops/dskGameLoader.cpp
+++ b/src/desktops/dskGameLoader.cpp
@@ -111,7 +111,7 @@ void dskGameLoader::Msg_Timer(const unsigned /*ctrl_id*/)
             try
             {
                 // Do this here as it will init OGL
-                gameInterface.reset(new dskGameInterface(loader_.getGame()));
+                gameInterface.reset(new dskGameInterface(loader_.getGame(), GAMECLIENT.GetNWFInfo(), GAMECLIENT.GetPlayerId()));
             } catch(std::runtime_error& e)
             {
                 LC_Status_Error(std::string(_("Failed to init GUI: ")) + e.what());

--- a/src/test/mockupDrivers/MockupVideoDriver.cpp
+++ b/src/test/mockupDrivers/MockupVideoDriver.cpp
@@ -91,6 +91,11 @@ unsigned long MockupVideoDriver::GetTickCount() const
     return tickCount_;
 }
 
+OpenGL_Loader_Proc MockupVideoDriver::GetLoaderFunction() const
+{
+    return SDL_GL_GetProcAddress;
+}
+
 void MockupVideoDriver::ListVideoModes(std::vector<VideoMode>& video_modes) const {}
 
 void MockupVideoDriver::SetMousePos(int x, int y)

--- a/src/test/mockupDrivers/MockupVideoDriver.cpp
+++ b/src/test/mockupDrivers/MockupVideoDriver.cpp
@@ -95,8 +95,7 @@ void MockupVideoDriver::ListVideoModes(std::vector<VideoMode>& video_modes) cons
 
 void MockupVideoDriver::SetMousePos(int x, int y)
 {
-    mouse_xy.x = x;
-    mouse_xy.y = y;
+    mouse_xy.pos = Position(x, y);
 }
 
 KeyEvent MockupVideoDriver::GetModKeyState() const

--- a/src/test/mockupDrivers/MockupVideoDriver.h
+++ b/src/test/mockupDrivers/MockupVideoDriver.h
@@ -35,7 +35,7 @@ public:
     bool SwapBuffers() override { return true; }
     bool MessageLoop() override;
     unsigned long GetTickCount() const override;
-    OpenGL_Loader_Proc GetLoaderFunction() const override { return NULL; }
+    OpenGL_Loader_Proc GetLoaderFunction() const override;
     void ListVideoModes(std::vector<VideoMode>& video_modes) const override;
     void SetMousePos(int x, int y) override;
     KeyEvent GetModKeyState() const override;

--- a/src/test/testBuilding.cpp
+++ b/src/test/testBuilding.cpp
@@ -51,10 +51,12 @@ struct MapPointLess
     }
 };
 
+namespace {
 typedef WorldFixture<CreateEmptyWorld, 0> EmptyWorldFixture0P;
 typedef WorldFixture<CreateEmptyWorld, 1> EmptyWorldFixture1P;
 typedef WorldFixture<CreateEmptyWorld, 1, 18, 16> EmptyWorldFixture1PBigger;
 typedef std::map<MapPoint, BuildingQuality, MapPointLess> ReducedBQMap;
+} // namespace
 
 /// Check that the BQ at all points is BQ_CASTLE except the points in the reducedBQs map which have given BQs
 boost::test_tools::predicate_result checkBQs(const GameWorldBase& world, const std::vector<MapPoint>& pts, const ReducedBQMap& reducedBQs)
@@ -209,11 +211,8 @@ BOOST_FIXTURE_TEST_CASE(BQWithVisualRoad, EmptyWorldFixture1PBigger)
     RTTR_FOREACH_PT(MapPoint, world.GetSize())
         world.SetOwner(pt, 1);
 
-    // Set player
-    GAMECLIENT.SetTestPlayerId(0);
-
-    dskGameInterface gameDesktop(this->game, false);
-    const GameWorldViewer& gwv = gameDesktop.GetViewer();
+    dskGameInterface gameDesktop(this->game, NULL, 0, false);
+    const GameWorldViewer& gwv = gameDesktop.GetView().GetViewer();
     // Start at a position a bit away from the HQ so all points are castles
     const MapPoint roadPt = world.MakeMapPoint(world.GetPlayer(0).GetHQPos() - Position(6, 6));
     const std::vector<MapPoint> roadRadiusPts = world.GetPointsInRadiusWithCenter(roadPt, 6);

--- a/src/test/testBuilding.cpp
+++ b/src/test/testBuilding.cpp
@@ -211,7 +211,7 @@ BOOST_FIXTURE_TEST_CASE(BQWithVisualRoad, EmptyWorldFixture1PBigger)
     RTTR_FOREACH_PT(MapPoint, world.GetSize())
         world.SetOwner(pt, 1);
 
-    dskGameInterface gameDesktop(this->game, NULL, 0, false);
+    dskGameInterface gameDesktop(this->game, boost::shared_ptr<NWFInfo>(), 0, false);
     const GameWorldViewer& gwv = gameDesktop.GetView().GetViewer();
     // Start at a position a bit away from the HQ so all points are castles
     const MapPoint roadPt = world.MakeMapPoint(world.GetPlayer(0).GetHQPos() - Position(6, 6));

--- a/src/test/testBuildingProps.cpp
+++ b/src/test/testBuildingProps.cpp
@@ -25,7 +25,9 @@
 #include "test/WorldFixture.h"
 #include <boost/test/unit_test.hpp>
 
+namespace {
 typedef WorldFixture<CreateEmptyWorld, 1> EmptyWorldFixture1P;
+}
 
 BOOST_FIXTURE_TEST_CASE(IsType, EmptyWorldFixture1P)
 {

--- a/src/test/testDskGameInterface.cpp
+++ b/src/test/testDskGameInterface.cpp
@@ -1,0 +1,196 @@
+// Copyright (c) 2016 -2017 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "rttrDefines.h" // IWYU pragma: keep
+#include "GameManager.h"
+#include "GamePlayer.h"
+#include "PointOutput.h"
+#include "WindowManager.h"
+#include "buildings/nobBaseWarehouse.h"
+#include "desktops/dskGameInterface.h"
+#include "driver/KeyEvent.h"
+#include "driver/MouseCoords.h"
+#include "initTestHelpers.h"
+#include "mockupDrivers/MockupVideoDriver.h"
+#include "test/CreateEmptyWorld.h"
+#include "test/WorldFixture.h"
+#include <boost/test/unit_test.hpp>
+
+// Test stuff related to building/building quality
+BOOST_AUTO_TEST_SUITE(GameInterfaceDesktop)
+
+namespace {
+struct dskGameInterfaceMock : public dskGameInterface
+{
+    dskGameInterfaceMock(boost::shared_ptr<Game> game) : dskGameInterface(game, boost::shared_ptr<NWFInfo>(), 0, false) {}
+    void Msg_PaintBefore() override {}
+    void Msg_PaintAfter() override {}
+};
+struct GameInterfaceFixture
+{
+    WorldFixture<CreateEmptyWorld, 1> worldFixture;
+    dskGameInterface* gameDesktop;
+    const GameWorldView* view;
+    GameInterfaceFixture()
+    {
+        initGUITests();
+        gameDesktop = new dskGameInterfaceMock(worldFixture.game);
+        WINDOWMANAGER.Switch(gameDesktop);
+        WINDOWMANAGER.Draw();
+        view = &gameDesktop->GetView();
+    }
+};
+void checkNotScrolling(const GameWorldView& view, CursorType cursor = CURSOR_HAND)
+{
+    const DrawPoint pos = view.GetOffset();
+    MouseCoords mouse(Position(40, 11));
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), cursor);
+    BOOST_REQUIRE_EQUAL(view.GetOffset(), pos);
+    mouse.pos += Position(-20, 30);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), cursor);
+    BOOST_REQUIRE_EQUAL(view.GetOffset(), pos);
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(Scrolling, GameInterfaceFixture)
+{
+    const int acceleration = 2;
+    Position startPos(10, 15);
+    MouseCoords mouse(startPos, false, true);
+    // Regular scrolling: Right down, 2 moves, right up
+    WINDOWMANAGER.Msg_RightDown(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    DrawPoint pos = view->GetOffset();
+    mouse.pos = startPos + Position(4, 3);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    pos += acceleration * Position(4, 3);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    mouse.pos = startPos + Position(-6, 7);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    pos += acceleration * Position(-6, 7);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    mouse.rdown = false;
+    WINDOWMANAGER.Msg_RightUp(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_HAND);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    checkNotScrolling(*view);
+
+    // Opening a window does not cancel scrolling
+    mouse.rdown = true;
+    WINDOWMANAGER.Msg_RightDown(mouse);
+    startPos = mouse.pos;
+    KeyEvent key;
+    key.kt = KT_CHAR;
+    key.c = 'm';
+    key.ctrl = key.alt = key.shift = false;
+    WINDOWMANAGER.Msg_KeyDown(key);
+    BOOST_REQUIRE(WINDOWMANAGER.GetTopMostWindow());
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    mouse.pos = startPos + Position(-6, 7);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    pos += acceleration * Position(-6, 7);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    // Closing it doesn't either
+    WINDOWMANAGER.Msg_KeyDown(key);
+    WINDOWMANAGER.Draw();
+    BOOST_REQUIRE(gameDesktop->IsActive());
+    BOOST_REQUIRE(!WINDOWMANAGER.GetTopMostWindow());
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    mouse.pos = startPos + Position(-6, 7);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    pos += acceleration * Position(-6, 7);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    // Left click does cancel it
+    mouse.ldown = true;
+    WINDOWMANAGER.Msg_LeftDown(mouse);
+    mouse.ldown = false;
+    WINDOWMANAGER.Msg_LeftUp(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_HAND);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    checkNotScrolling(*view);
+}
+
+BOOST_FIXTURE_TEST_CASE(ScrollingWhileRoadBuilding, GameInterfaceFixture)
+{
+    const int acceleration = 2;
+    MapPoint hqPos = worldFixture.world.GetPlayer(0).GetFirstWH()->GetFlagPos();
+    gameDesktop->GI_StartRoadBuilding(hqPos, false);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_RM);
+    Position startPos(10, 15);
+    MouseCoords mouse(startPos, false, true);
+    // Regular scrolling
+    WINDOWMANAGER.Msg_RightDown(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    DrawPoint pos = view->GetOffset();
+    mouse.pos = startPos + Position(4, 3);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    pos += acceleration * Position(4, 3);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    mouse.rdown = false;
+    WINDOWMANAGER.Msg_RightUp(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_RM);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    checkNotScrolling(*view, CURSOR_RM);
+
+    // left click also stops scrolling
+    mouse.rdown = true;
+    WINDOWMANAGER.Msg_RightDown(mouse);
+    startPos = mouse.pos;
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    mouse.pos = startPos + Position(-6, 7);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    pos += acceleration * Position(-6, 7);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    mouse.ldown = true;
+    WINDOWMANAGER.Msg_LeftDown(mouse);
+    mouse.ldown = false;
+    WINDOWMANAGER.Msg_LeftUp(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_RM);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    checkNotScrolling(*view, CURSOR_RM);
+}
+
+BOOST_FIXTURE_TEST_CASE(ScrollingWithCtrl, GameInterfaceFixture)
+{
+    const int acceleration = 2;
+    Position startPos(10, 15);
+    MouseCoords mouse(startPos, true);
+    GetVideoDriver()->modKeyState_.ctrl = true;
+    WINDOWMANAGER.Msg_LeftDown(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    DrawPoint pos = view->GetOffset();
+    mouse.pos = startPos + Position(4, 3);
+    WINDOWMANAGER.Msg_MouseMove(mouse);
+    pos += acceleration * Position(4, 3);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_SCROLL);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    mouse.ldown = false;
+    WINDOWMANAGER.Msg_LeftUp(mouse);
+    BOOST_REQUIRE_EQUAL(GAMEMANAGER.GetCursor(), CURSOR_HAND);
+    BOOST_REQUIRE_EQUAL(view->GetOffset(), pos);
+    checkNotScrolling(*view);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Minor refactoring to make Code more testable.
Keep cursor scoll image while scrolling
Test those for all cases:
- Regular
- Left click cancels it
- Opening/closing window does not cancel scrolling unless it is modal
- Scolling in road mode, at end of scroll you are still in road mode
- Ctrl+leftclick scrolls, left-up cancels

@Spikeone To keep scrolling when opening a window I wanted to stay true to the S2 behaviour but that is inconsistent:
- Opening a (ingame) window makes it "active" (visible on title bar)
- But you keep scrolling -> Background is actually active
- For this I don't make the background(desktop) inactive while scrolling, so desktop AND window is active
- This way input (key,mouse) goes to the desktop not the window and this works

But now we have 2 active "windows" which I don't like out of consistency and the ingame window does not get any key events until it is clicked again which may be surprising. I don't know if this is used anywhere but to avoid issues I'd deactivate the new window while scrolling. The only change to how it is currently implemented (with this PR) is that the new window title bar does not get the active mark until you stop scrolling and click into it.