### PR TITLE
Add shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,14 @@ Most of them can be installed with the package manager.
 - miniupnpc
 All of them can be installed via homebrew
 
+### Prerequesites with Nix
+Nix users can open a nix-shell to get a development environment with all packages ready.
+
 ### Steps:
 ```
 git clone --recursive https://github.com/Return-To-The-Roots/s25client s25client
 cd s25client
+nix-shell # Optional, for Nix users only
 mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+stdenv.mkDerivation {
+  name = "s25client";
+  buildInputs = [
+    boost
+    bzip2
+    cmake
+    curl
+    gettext
+    libiconv
+    miniupnpc
+    SDL
+    SDL_mixer
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -13,5 +13,7 @@ stdenv.mkDerivation {
     miniupnpc
     SDL
     SDL_mixer
+    SDL2
+    SDL2_mixer
   ];
 }


### PR DESCRIPTION
This PR give an easy way to get a working environnement on this project without polluting his system-side installation with uneeded packages (sdl, miniupnpc, ...).
Insteed of installing all the prerequesites, the only requirement is having `nix` installed. Then, in s25client, just open `nix-shell`. This works on both Linux and Darwin/MacOSX.