### PR TITLE
Fix Undefined Behaviour / RTTR_Assert triggering in nofShipWright

### DIFF
--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -49,6 +49,7 @@
 #include "gameTypes/JobTypes.h"
 #include "gameTypes/PactTypes.h"
 #include "gameTypes/VisualSettings.h"
+#include "gameData/BuildingConsts.h"
 #include "gameData/BuildingProperties.h"
 #include "gameData/MilitaryConsts.h"
 #include "gameData/SettingTypeConv.h"
@@ -435,6 +436,14 @@ void GamePlayer::AddBuilding(noBuilding* bld, BuildingType bldType)
     RTTR_Assert(bld->GetPlayer() == GetPlayerId());
     buildings.Add(bld, bldType);
     ChangeStatisticValue(STAT_BUILDINGS, 1);
+
+    // Order a worker if needed
+    const auto& description = BLD_WORK_DESC[bldType];
+    if(description.job != JOB_NOTHING && description.job != JOB_PRIVATE)
+    {
+        AddJobWanted(description.job, bld);
+    }
+
     if(bldType == BLD_HARBORBUILDING)
     {
         // Schiff durchgehen und denen Bescheid sagen

--- a/libs/s25main/buildings/nobUsual.cpp
+++ b/libs/s25main/buildings/nobUsual.cpp
@@ -47,13 +47,10 @@ nobUsual::nobUsual(BuildingType type, MapPoint pos, unsigned char player, Nation
 
     ordered_wares.resize(BLD_WORK_DESC[bldType_].waresNeeded.getNum());
 
-    // Arbeiter bestellen
-    GamePlayer& owner = gwg->GetPlayer(player);
-    owner.AddJobWanted(BLD_WORK_DESC[bldType_].job, this);
-
     // Tür aufmachen,bis Gebäude besetzt ist
     OpenDoor();
 
+    GamePlayer& owner = gwg->GetPlayer(player);
     // New building gets half the average productivity from all buildings of the same type
     productivity = owner.GetBuildingRegister().CalcAverageProductivity(type) / 2u;
     // Set last productivities to current to avoid resetting it on first recalculation event


### PR DESCRIPTION
The assertion is unsafe at this point, even though it might
appear logical. The reason it is unsafe is that it is called from
nobShipYard::nobShipYard (the consturctor) indirectly through the
constructor nobUsual::nobUsual (constructor of the base class).

The dynamic_cast<nobShipYard*> then becomes undefined behaviour,
because the constructor of nobShipYard has not started to run on
the workplace object; it is still running the nobUsual
constructor.

See also https://stackoverflow.com/a/6299463/1248008

Fixes #1048.