### PR TITLE
Update Homebrew on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
       - sdl_mixer
       - gettext
       - miniupnpc
+    update: true
 
 cache:
   - ccache


### PR DESCRIPTION
Build may otherwise fail with "Your Homebrew is outdated. Please run brew update"

Fixes failure of #1067