### PR TITLE
Fix harbor crash

### DIFF
--- a/libs/common/include/helpers/MultiArray.h
+++ b/libs/common/include/helpers/MultiArray.h
@@ -18,6 +18,7 @@
 #ifndef SimpleMultiArray_h__
 #define SimpleMultiArray_h__
 
+#include "RTTR_Assert.h"
 #include <boost/config.hpp>
 #include <array>
 #include <cstddef>

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -756,7 +756,8 @@ void GamePlayer::JobNotWanted(noRoadNode* workplace, bool all)
 void GamePlayer::OneJobNotWanted(const Job job, noRoadNode* workplace)
 {
     const auto it = helpers::findPred(jobs_wanted, [workplace, job](const auto& it) { return it.workplace == workplace && it.job == job; });
-    jobs_wanted.erase(it);
+    if(it != jobs_wanted.end())
+        jobs_wanted.erase(it);
 }
 
 void GamePlayer::SendPostMessage(PostMsg* msg)

--- a/libs/s25main/buildings/nobBaseWarehouse.cpp
+++ b/libs/s25main/buildings/nobBaseWarehouse.cpp
@@ -241,9 +241,8 @@ bool nobBaseWarehouse::OrderJob(const Job job, noRoadNode* const goal, const boo
     // Maybe we have to recruit one
     if(!inventory[job])
     {
-        if(!allow_recruiting)
+        if(!allow_recruiting || !TryRecruitJob(job))
             return false;
-        TryRecruitJob(job);
     }
 
     noFigure* fig = JobFactory::CreateJob(job, pos, player, goal);

--- a/tests/s25Main/integration/testHarbor.cpp
+++ b/tests/s25Main/integration/testHarbor.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2016 - 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "GamePlayer.h"
+#include "buildings/nobHarborBuilding.h"
+#include "factories/BuildingFactory.h"
+#include "worldFixtures/CreateEmptyWorld.h"
+#include "worldFixtures/WorldFixture.h"
+#include <boost/test/unit_test.hpp>
+
+namespace {
+struct HarborFixture : WorldFixture<CreateEmptyWorld, 1>
+{
+    HarborFixture()
+    {
+        GamePlayer& player = world.GetPlayer(0);
+        hq = world.GetSpecObj<nobBaseWarehouse>(player.GetHQPos());
+        hb = static_cast<nobHarborBuilding*>(
+          BuildingFactory::CreateBuilding(world, BLD_HARBORBUILDING, player.GetHQPos() + MapPoint(4, 0), 0, NAT_ROMANS));
+        world.BuildRoad(0, false, hq->GetFlagPos(), {4, Direction::EAST});
+    }
+
+    nobBaseWarehouse* hq;
+    nobHarborBuilding* hb;
+};
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(StartExpeditionThenCancel, HarborFixture)
+{
+    BOOST_TEST_REQUIRE(hq->GetNumRealFigures(JOB_BUILDER) >= 1u); // Must have a builder
+    const auto numLeavingFigs = hq->GetLeavingFigures().size();
+    hb->StartExpedition();
+    // Builder should be ordered
+    BOOST_TEST_REQUIRE(hq->GetLeavingFigures().size() == numLeavingFigs + 1u);
+    hb->StopExpedition();
+    // Builder should still come
+    BOOST_TEST_REQUIRE(hq->GetLeavingFigures().size() == numLeavingFigs + 1u);
+}
+
+BOOST_FIXTURE_TEST_CASE(StartExpeditionThenDestroy, HarborFixture)
+{
+    BOOST_TEST_REQUIRE(hq->GetNumRealFigures(JOB_BUILDER) >= 1u); // Must have a builder
+    const auto numLeavingFigs = hq->GetLeavingFigures().size();
+    hb->StartExpedition();
+    // Builder should be ordered
+    BOOST_TEST_REQUIRE(hq->GetLeavingFigures().size() == numLeavingFigs + 1u);
+    world.DestroyBuilding(hb->GetPos(), 0);
+    // Builder should be canceled
+    BOOST_TEST_REQUIRE(hq->GetLeavingFigures().size() == numLeavingFigs);
+}


### PR DESCRIPTION

Fix crash when destroying harbor with an ordered builder for an expedition

When ordering a builder it is assumed that it is put into the jobsWanted
list which does not happen if the builder can be sent right away. On
destruction the jobWanted is not found and the end-iterator is passed to
list::erase which leads to corruption of the list.