### PR TITLE
Fix crash on close

### DIFF
--- a/libs/common/include/helpers/containerUtils.h
+++ b/libs/common/include/helpers/containerUtils.h
@@ -66,6 +66,12 @@ inline auto erase(T& container, typename T::reverse_iterator it)
     return typename T::reverse_iterator(erase(container, (++it).base()));
 }
 
+template<typename T, typename T_Element>
+void remove(T& container, T_Element&& element)
+{
+    container.erase(std::remove(container.begin(), container.end(), std::forward<T_Element>(element)), container.end());
+}
+
 template<typename T, typename T_Predicate>
 void remove_if(T& container, T_Predicate&& predicate)
 {

--- a/tests/common/testContainerUtils.cpp
+++ b/tests/common/testContainerUtils.cpp
@@ -101,6 +101,28 @@ BOOST_AUTO_TEST_CASE(Reverse)
     BOOST_TEST(vecIn == vecOut, boost::test_tools::per_element());
 }
 
+BOOST_AUTO_TEST_CASE(Remove)
+{
+    std::vector<int> vecIn = {1, 2, 3, 4, 5}, vecExp;
+    helpers::remove(vecIn, 42);
+    BOOST_TEST(vecIn == vecIn, boost::test_tools::per_element());
+    helpers::remove(vecIn, 2);
+    vecExp = {1, 3, 4, 5};
+    BOOST_TEST(vecIn == vecExp, boost::test_tools::per_element());
+    helpers::remove(vecIn, 1);
+    vecExp = {3, 4, 5};
+    BOOST_TEST(vecIn == vecExp, boost::test_tools::per_element());
+    helpers::remove(vecIn, 5);
+    vecExp = {3, 4};
+    BOOST_TEST(vecIn == vecExp, boost::test_tools::per_element());
+    helpers::remove(vecIn, 4);
+    vecExp = {3};
+    BOOST_TEST(vecIn == vecExp, boost::test_tools::per_element());
+    helpers::remove(vecIn, 3);
+    vecExp = {};
+    BOOST_TEST(vecIn == vecExp, boost::test_tools::per_element());
+}
+
 BOOST_AUTO_TEST_CASE(RemoveIf)
 {
     std::vector<int> vecIn = {1, 2, 3, 4, 5, 6}, vecExp = {1, 3, 5};


### PR DESCRIPTION
When the textures stored in LOADER are destroyed the videodriver was
already shut down so the OGL library might already be unloaded. An
access to glDeleteTextures will then result in an AV.
Fix: Check if textures are already freed and don't free again.