### PR TITLE
Add Sanitizers (UBSAN/ASAN)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,6 @@ jobs:
       env:
         - MATRIX_EVAL="CXX=g++-8 && CC=gcc-8"
         - BUILD_TYPE=Debug
-        - BOOST_VERSION=1.67.0
       addons:
         apt:
           <<: *defApt
@@ -119,7 +118,6 @@ jobs:
         - MATRIX_EVAL="CXX=clang++-8 && CC=clang-8"
         - BUILD_TYPE=Debug
         - ADDITIONAL_CMAKE_FLAGS="-DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_SANITIZERS=ON"
-        - BOOST_VERSION=1.67.0
     - <<: *latest-clang-externals
       env:
         - MATRIX_EVAL="CXX=clang++-8 && CC=clang-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,12 +95,10 @@ jobs:
       env: BUILD_TYPE=Debug
     # Latest version GCC with static analysis
     - os: linux
-      dist: bionic # GCC on <18 is broken with -fsanitize: https://stackoverflow.com/q/50024731/1930508
       compiler: gcc
       env:
         - MATRIX_EVAL="CXX=g++-8 && CC=gcc-8"
         - BUILD_TYPE=Debug
-        - ADDITIONAL_CMAKE_FLAGS="-DRTTR_ENABLE_SANITIZERS=ON"
         - BOOST_VERSION=1.67.0
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ jobs:
       env: BUILD_TYPE=Debug
     # Latest version GCC with static analysis
     - os: linux
+      dist: bionic # GCC on <18 is broken with -fsanitize: https://stackoverflow.com/q/50024731/1930508
       compiler: gcc
       env:
         - MATRIX_EVAL="CXX=g++-8 && CC=gcc-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,11 @@ jobs:
     # Latest version GCC with static analysis
     - os: linux
       compiler: gcc
-      env: MATRIX_EVAL="CXX=g++-8 && CC=gcc-8" BUILD_TYPE=Debug
+      env:
+        - MATRIX_EVAL="CXX=g++-8 && CC=gcc-8"
+        - BUILD_TYPE=Debug
+        - ADDITIONAL_CMAKE_FLAGS="-DRTTR_ENABLE_SANITIZERS=ON"
+        - BOOST_VERSION=1.67.0
       addons:
         apt:
           <<: *defApt
@@ -115,10 +119,11 @@ jobs:
       env:
         - MATRIX_EVAL="CXX=clang++-8 && CC=clang-8"
         - BUILD_TYPE=Debug
-        - ADDITIONAL_CMAKE_FLAGS="-DRTTR_EXTERNAL_BUILD_TESTING=ON"
+        - ADDITIONAL_CMAKE_FLAGS="-DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_SANITIZERS=ON"
+        - BOOST_VERSION=1.67.0
     - <<: *latest-clang-externals
       env:
         - MATRIX_EVAL="CXX=clang++-8 && CC=clang-8"
         - BUILD_TYPE=Debug
-        - ADDITIONAL_CMAKE_FLAGS="-DRTTR_EXTERNAL_BUILD_TESTING=ON"
+        - ADDITIONAL_CMAKE_FLAGS="-DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_SANITIZERS=ON"
         - BOOST_VERSION=1.70.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ if(DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules" "${CMAKE_SOURCE_DIR}/external/libutil/cmake")
+if(CMAKE_VERSION VERSION_LESS 3.11)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/cmake_3.11.0")
+endif()
 
 include(CheckGitSubmodules)
 check_git_submodules()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,14 +210,6 @@ if(HAVE_MEMCHECK_H)
     add_definitions(-DHAVE_MEMCHECK_H)
 endif()
 
-# Clang bug workaround
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    try_compile(CHECK_CLANG_INLINE "${CMAKE_CURRENT_BINARY_DIR}/cxx" "${CMAKE_SOURCE_DIR}/cmake/checkclang.cpp")
-    if(NOT ${CHECK_CLANG_INLINE})
-        add_definitions("-D__extern_always_inline=extern __always_inline __attribute__ ((__gnu_inline__))")
-    endif()
-endif()
-
 # Code coverage
 include(RttrCoverageCfg)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ endif()
 
 # Code coverage
 include(RttrCoverageCfg)
+include(EnableSanitizers)
 
 ################################################################################
 # Configure files

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ See the description in CMake-GUI/ccmake for details.
 Note that due to the use of submodules you always need to `git pull && git submodule update --init --recursive` to get the latest version.
 (The `--init` and `--recursive` arguments are only required should we add *new* submodules to the existing set.)
 
+### Tests
+Especially for developing you should build in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`) and run the tests after executing `make` via `make test` or `ctest --output-on-failure`.
+There is also an option to enable checks for undefined behavior (UBSAN) and memory errors (ASAN) like use-after-free or leaks.
+Just pass `-DRTTR_ENABLE_SANITIZERS=ON` to CMake and use a recent GCC or Clang compiler to build.
+Then just run (tests or application) as usual.
+
+**Note**: Boost.Endian < 1.67 is known to have UB so use at least 1.67 when running the sanitizers.
+
 ## On Windows
 
 ### Prerequisites:

--- a/cmake/Modules/cmake_3.11.0/FindBoost.cmake
+++ b/cmake/Modules/cmake_3.11.0/FindBoost.cmake
@@ -1,0 +1,2098 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindBoost
+# ---------
+#
+# Find Boost include dirs and libraries
+#
+# Use this module by invoking find_package with the form::
+#
+#   find_package(Boost
+#     [version] [EXACT]      # Minimum or EXACT version e.g. 1.67.0
+#     [REQUIRED]             # Fail with error if Boost is not found
+#     [COMPONENTS <libs>...] # Boost libraries by their canonical name
+#                            # e.g. "date_time" for "libboost_date_time"
+#     [OPTIONAL_COMPONENTS <libs>...]
+#                            # Optional Boost libraries by their canonical name)
+#     )                      # e.g. "date_time" for "libboost_date_time"
+#
+# This module finds headers and requested component libraries OR a CMake
+# package configuration file provided by a "Boost CMake" build.  For the
+# latter case skip to the "Boost CMake" section below.  For the former
+# case results are reported in variables::
+#
+#   Boost_FOUND            - True if headers and requested libraries were found
+#   Boost_INCLUDE_DIRS     - Boost include directories
+#   Boost_LIBRARY_DIRS     - Link directories for Boost libraries
+#   Boost_LIBRARIES        - Boost component libraries to be linked
+#   Boost_<C>_FOUND        - True if component <C> was found (<C> is upper-case)
+#   Boost_<C>_LIBRARY      - Libraries to link for component <C> (may include
+#                            target_link_libraries debug/optimized keywords)
+#   Boost_VERSION          - BOOST_VERSION value from boost/version.hpp
+#   Boost_LIB_VERSION      - Version string appended to library filenames
+#   Boost_MAJOR_VERSION    - Boost major version number (X in X.y.z)
+#   Boost_MINOR_VERSION    - Boost minor version number (Y in x.Y.z)
+#   Boost_SUBMINOR_VERSION - Boost subminor version number (Z in x.y.Z)
+#   Boost_LIB_DIAGNOSTIC_DEFINITIONS (Windows)
+#                          - Pass to add_definitions() to have diagnostic
+#                            information about Boost's automatic linking
+#                            displayed during compilation
+#
+# Note that Boost Python components require a Python version suffix
+# (Boost 1.67 and later), e.g. ``python36`` or ``python27`` for the
+# versions built against Python 3.6 and 2.7, respectively.  This also
+# applies to additional components using Python including
+# ``mpi_python`` and ``numpy``.  Earlier Boost releases may use
+# distribution-specific suffixes such as ``2``, ``3`` or ``2.7``.
+# These may also be used as suffixes, but note that they are not
+# portable.
+#
+# This module reads hints about search locations from variables::
+#
+#   BOOST_ROOT             - Preferred installation prefix
+#    (or BOOSTROOT)
+#   BOOST_INCLUDEDIR       - Preferred include directory e.g. <prefix>/include
+#   BOOST_LIBRARYDIR       - Preferred library directory e.g. <prefix>/lib
+#   Boost_NO_SYSTEM_PATHS  - Set to ON to disable searching in locations not
+#                            specified by these hint variables. Default is OFF.
+#   Boost_ADDITIONAL_VERSIONS
+#                          - List of Boost versions not known to this module
+#                            (Boost install locations may contain the version)
+#
+# and saves search results persistently in CMake cache entries::
+#
+#   Boost_INCLUDE_DIR         - Directory containing Boost headers
+#   Boost_LIBRARY_DIR_RELEASE - Directory containing release Boost libraries
+#   Boost_LIBRARY_DIR_DEBUG   - Directory containing debug Boost libraries
+#   Boost_<C>_LIBRARY_DEBUG   - Component <C> library debug variant
+#   Boost_<C>_LIBRARY_RELEASE - Component <C> library release variant
+#
+# The following :prop_tgt:`IMPORTED` targets are also defined::
+#
+#   Boost::boost                  - Target for header-only dependencies
+#                                   (Boost include directory)
+#   Boost::<C>                    - Target for specific component dependency
+#                                   (shared or static library); <C> is lower-
+#                                   case
+#   Boost::diagnostic_definitions - interface target to enable diagnostic
+#                                   information about Boost's automatic linking
+#                                   during compilation (adds BOOST_LIB_DIAGNOSTIC)
+#   Boost::disable_autolinking    - interface target to disable automatic
+#                                   linking with MSVC (adds BOOST_ALL_NO_LIB)
+#   Boost::dynamic_linking        - interface target to enable dynamic linking
+#                                   linking with MSVC (adds BOOST_ALL_DYN_LINK)
+#
+# Implicit dependencies such as Boost::filesystem requiring
+# Boost::system will be automatically detected and satisfied, even
+# if system is not specified when using find_package and if
+# Boost::system is not added to target_link_libraries.  If using
+# Boost::thread, then Threads::Threads will also be added automatically.
+#
+# It is important to note that the imported targets behave differently
+# than variables created by this module: multiple calls to
+# find_package(Boost) in the same directory or sub-directories with
+# different options (e.g. static or shared) will not override the
+# values of the targets created by the first call.
+#
+# Users may set these hints or results as cache entries.  Projects
+# should not read these entries directly but instead use the above
+# result variables.  Note that some hint names start in upper-case
+# "BOOST".  One may specify these as environment variables if they are
+# not specified as CMake variables or cache entries.
+#
+# This module first searches for the Boost header files using the above
+# hint variables (excluding BOOST_LIBRARYDIR) and saves the result in
+# Boost_INCLUDE_DIR.  Then it searches for requested component libraries
+# using the above hints (excluding BOOST_INCLUDEDIR and
+# Boost_ADDITIONAL_VERSIONS), "lib" directories near Boost_INCLUDE_DIR,
+# and the library name configuration settings below.  It saves the
+# library directories in Boost_LIBRARY_DIR_DEBUG and
+# Boost_LIBRARY_DIR_RELEASE and individual library
+# locations in Boost_<C>_LIBRARY_DEBUG and Boost_<C>_LIBRARY_RELEASE.
+# When one changes settings used by previous searches in the same build
+# tree (excluding environment variables) this module discards previous
+# search results affected by the changes and searches again.
+#
+# Boost libraries come in many variants encoded in their file name.
+# Users or projects may tell this module which variant to find by
+# setting variables::
+#
+#   Boost_USE_DEBUG_LIBS     - Set to ON or OFF to specify whether to search
+#                              and use the debug libraries.  Default is ON.
+#   Boost_USE_RELEASE_LIBS   - Set to ON or OFF to specify whether to search
+#                              and use the release libraries.  Default is ON.
+#   Boost_USE_MULTITHREADED  - Set to OFF to use the non-multithreaded
+#                              libraries ('mt' tag).  Default is ON.
+#   Boost_USE_STATIC_LIBS    - Set to ON to force the use of the static
+#                              libraries.  Default is OFF.
+#   Boost_USE_STATIC_RUNTIME - Set to ON or OFF to specify whether to use
+#                              libraries linked statically to the C++ runtime
+#                              ('s' tag).  Default is platform dependent.
+#   Boost_USE_DEBUG_RUNTIME  - Set to ON or OFF to specify whether to use
+#                              libraries linked to the MS debug C++ runtime
+#                              ('g' tag).  Default is ON.
+#   Boost_USE_DEBUG_PYTHON   - Set to ON to use libraries compiled with a
+#                              debug Python build ('y' tag). Default is OFF.
+#   Boost_USE_STLPORT        - Set to ON to use libraries compiled with
+#                              STLPort ('p' tag).  Default is OFF.
+#   Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS
+#                            - Set to ON to use libraries compiled with
+#                              STLPort deprecated "native iostreams"
+#                              ('n' tag).  Default is OFF.
+#   Boost_COMPILER           - Set to the compiler-specific library suffix
+#                              (e.g. "-gcc43").  Default is auto-computed
+#                              for the C++ compiler in use.  A list may be
+#                              used if multiple compatible suffixes should
+#                              be tested for, in decreasing order of
+#                              preference.
+#   Boost_THREADAPI          - Suffix for "thread" component library name,
+#                              such as "pthread" or "win32".  Names with
+#                              and without this suffix will both be tried.
+#   Boost_NAMESPACE          - Alternate namespace used to build boost with
+#                              e.g. if set to "myboost", will search for
+#                              myboost_thread instead of boost_thread.
+#
+# Other variables one may set to control this module are::
+#
+#   Boost_DEBUG              - Set to ON to enable debug output from FindBoost.
+#                              Please enable this before filing any bug report.
+#   Boost_DETAILED_FAILURE_MSG
+#                            - Set to ON to add detailed information to the
+#                              failure message even when the REQUIRED option
+#                              is not given to the find_package call.
+#   Boost_REALPATH           - Set to ON to resolve symlinks for discovered
+#                              libraries to assist with packaging.  For example,
+#                              the "system" component library may be resolved to
+#                              "/usr/lib/libboost_system.so.1.67.0" instead of
+#                              "/usr/lib/libboost_system.so".  This does not
+#                              affect linking and should not be enabled unless
+#                              the user needs this information.
+#   Boost_LIBRARY_DIR        - Default value for Boost_LIBRARY_DIR_RELEASE and
+#                              Boost_LIBRARY_DIR_DEBUG.
+#
+# On Visual Studio and Borland compilers Boost headers request automatic
+# linking to corresponding libraries.  This requires matching libraries
+# to be linked explicitly or available in the link library search path.
+# In this case setting Boost_USE_STATIC_LIBS to OFF may not achieve
+# dynamic linking.  Boost automatic linking typically requests static
+# libraries with a few exceptions (such as Boost.Python).  Use::
+#
+#   add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
+#
+# to ask Boost to report information about automatic linking requests.
+#
+# Example to find Boost headers only::
+#
+#   find_package(Boost 1.36.0)
+#   if(Boost_FOUND)
+#     include_directories(${Boost_INCLUDE_DIRS})
+#     add_executable(foo foo.cc)
+#   endif()
+#
+# Example to find Boost libraries and use imported targets::
+#
+#   find_package(Boost 1.56 REQUIRED COMPONENTS
+#                date_time filesystem iostreams)
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo Boost::date_time Boost::filesystem
+#                             Boost::iostreams)
+#
+# Example to find Boost Python 3.6 libraries and use imported targets::
+#
+#   find_package(Boost 1.67 REQUIRED COMPONENTS
+#                python36 numpy36)
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo Boost::python36 Boost::numpy36)
+#
+# Example to find Boost headers and some *static* (release only) libraries::
+#
+#   set(Boost_USE_STATIC_LIBS        ON)  # only find static libs
+#   set(Boost_USE_DEBUG_LIBS         OFF) # ignore debug libs and
+#   set(Boost_USE_RELEASE_LIBS       ON)  # only find release libs
+#   set(Boost_USE_MULTITHREADED      ON)
+#   set(Boost_USE_STATIC_RUNTIME    OFF)
+#   find_package(Boost 1.66.0 COMPONENTS date_time filesystem system ...)
+#   if(Boost_FOUND)
+#     include_directories(${Boost_INCLUDE_DIRS})
+#     add_executable(foo foo.cc)
+#     target_link_libraries(foo ${Boost_LIBRARIES})
+#   endif()
+#
+# Boost CMake
+# ^^^^^^^^^^^
+#
+# If Boost was built using the boost-cmake project it provides a package
+# configuration file for use with find_package's Config mode.  This
+# module looks for the package configuration file called
+# BoostConfig.cmake or boost-config.cmake and stores the result in cache
+# entry "Boost_DIR".  If found, the package configuration file is loaded
+# and this module returns with no further action.  See documentation of
+# the Boost CMake package configuration for details on what it provides.
+#
+# Set Boost_NO_BOOST_CMAKE to ON to disable the search for boost-cmake.
+
+# Save project's policies
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW) # if IN_LIST
+
+#-------------------------------------------------------------------------------
+# Before we go searching, check whether boost-cmake is available, unless the
+# user specifically asked NOT to search for boost-cmake.
+#
+# If Boost_DIR is set, this behaves as any find_package call would. If not,
+# it looks at BOOST_ROOT and BOOSTROOT to find Boost.
+#
+if (NOT Boost_NO_BOOST_CMAKE)
+  # If Boost_DIR is not set, look for BOOSTROOT and BOOST_ROOT as alternatives,
+  # since these are more conventional for Boost.
+  if ("$ENV{Boost_DIR}" STREQUAL "")
+    if (NOT "$ENV{BOOST_ROOT}" STREQUAL "")
+      set(ENV{Boost_DIR} $ENV{BOOST_ROOT})
+    elseif (NOT "$ENV{BOOSTROOT}" STREQUAL "")
+      set(ENV{Boost_DIR} $ENV{BOOSTROOT})
+    endif()
+  endif()
+
+  # Do the same find_package call but look specifically for the CMake version.
+  # Note that args are passed in the Boost_FIND_xxxxx variables, so there is no
+  # need to delegate them to this find_package call.
+  find_package(Boost QUIET NO_MODULE)
+  mark_as_advanced(Boost_DIR)
+
+  # If we found boost-cmake, then we're done.  Print out what we found.
+  # Otherwise let the rest of the module try to find it.
+  if (Boost_FOUND)
+    message(STATUS "Boost ${Boost_FIND_VERSION} found.")
+    if (Boost_FIND_COMPONENTS)
+      message(STATUS "Found Boost components:\n   ${Boost_FIND_COMPONENTS}")
+    endif()
+    # Restore project's policies
+    cmake_policy(POP)
+    return()
+  endif()
+endif()
+
+
+#-------------------------------------------------------------------------------
+#  FindBoost functions & macros
+#
+
+############################################
+#
+# Check the existence of the libraries.
+#
+############################################
+# This macro was taken directly from the FindQt4.cmake file that is included
+# with the CMake distribution. This is NOT my work. All work was done by the
+# original authors of the FindQt4.cmake file. Only minor modifications were
+# made to remove references to Qt and make this file more generally applicable
+# And ELSE/ENDIF pairs were removed for readability.
+#########################################################################
+
+macro(_Boost_ADJUST_LIB_VARS basename)
+  if(Boost_INCLUDE_DIR )
+    if(Boost_${basename}_LIBRARY_DEBUG AND Boost_${basename}_LIBRARY_RELEASE)
+      # if the generator is multi-config or if CMAKE_BUILD_TYPE is set for
+      # single-config generators, set optimized and debug libraries
+      get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+      if(_isMultiConfig OR CMAKE_BUILD_TYPE)
+        set(Boost_${basename}_LIBRARY optimized ${Boost_${basename}_LIBRARY_RELEASE} debug ${Boost_${basename}_LIBRARY_DEBUG})
+      else()
+        # For single-config generators where CMAKE_BUILD_TYPE has no value,
+        # just use the release libraries
+        set(Boost_${basename}_LIBRARY ${Boost_${basename}_LIBRARY_RELEASE} )
+      endif()
+      # FIXME: This probably should be set for both cases
+      set(Boost_${basename}_LIBRARIES optimized ${Boost_${basename}_LIBRARY_RELEASE} debug ${Boost_${basename}_LIBRARY_DEBUG})
+    endif()
+
+    # if only the release version was found, set the debug variable also to the release version
+    if(Boost_${basename}_LIBRARY_RELEASE AND NOT Boost_${basename}_LIBRARY_DEBUG)
+      set(Boost_${basename}_LIBRARY_DEBUG ${Boost_${basename}_LIBRARY_RELEASE})
+      set(Boost_${basename}_LIBRARY       ${Boost_${basename}_LIBRARY_RELEASE})
+      set(Boost_${basename}_LIBRARIES     ${Boost_${basename}_LIBRARY_RELEASE})
+    endif()
+
+    # if only the debug version was found, set the release variable also to the debug version
+    if(Boost_${basename}_LIBRARY_DEBUG AND NOT Boost_${basename}_LIBRARY_RELEASE)
+      set(Boost_${basename}_LIBRARY_RELEASE ${Boost_${basename}_LIBRARY_DEBUG})
+      set(Boost_${basename}_LIBRARY         ${Boost_${basename}_LIBRARY_DEBUG})
+      set(Boost_${basename}_LIBRARIES       ${Boost_${basename}_LIBRARY_DEBUG})
+    endif()
+
+    # If the debug & release library ends up being the same, omit the keywords
+    if("${Boost_${basename}_LIBRARY_RELEASE}" STREQUAL "${Boost_${basename}_LIBRARY_DEBUG}")
+      set(Boost_${basename}_LIBRARY   ${Boost_${basename}_LIBRARY_RELEASE} )
+      set(Boost_${basename}_LIBRARIES ${Boost_${basename}_LIBRARY_RELEASE} )
+    endif()
+
+    if(Boost_${basename}_LIBRARY AND Boost_${basename}_HEADER)
+      set(Boost_${basename}_FOUND ON)
+      if("x${basename}" STREQUAL "xTHREAD" AND NOT TARGET Threads::Threads)
+        string(APPEND Boost_ERROR_REASON_THREAD " (missing dependency: Threads)")
+        set(Boost_THREAD_FOUND OFF)
+      endif()
+    endif()
+
+  endif()
+  # Make variables changeable to the advanced user
+  mark_as_advanced(
+      Boost_${basename}_LIBRARY_RELEASE
+      Boost_${basename}_LIBRARY_DEBUG
+  )
+endmacro()
+
+# Detect changes in used variables.
+# Compares the current variable value with the last one.
+# In short form:
+# v != v_LAST                      -> CHANGED = 1
+# v is defined, v_LAST not         -> CHANGED = 1
+# v is not defined, but v_LAST is  -> CHANGED = 1
+# otherwise                        -> CHANGED = 0
+# CHANGED is returned in variable named ${changed_var}
+macro(_Boost_CHANGE_DETECT changed_var)
+  set(${changed_var} 0)
+  foreach(v ${ARGN})
+    if(DEFINED _Boost_COMPONENTS_SEARCHED)
+      if(${v})
+        if(_${v}_LAST)
+          string(COMPARE NOTEQUAL "${${v}}" "${_${v}_LAST}" _${v}_CHANGED)
+        else()
+          set(_${v}_CHANGED 1)
+        endif()
+      elseif(_${v}_LAST)
+        set(_${v}_CHANGED 1)
+      endif()
+      if(_${v}_CHANGED)
+        set(${changed_var} 1)
+      endif()
+    else()
+      set(_${v}_CHANGED 0)
+    endif()
+  endforeach()
+endmacro()
+
+#
+# Find the given library (var).
+# Use 'build_type' to support different lib paths for RELEASE or DEBUG builds
+#
+macro(_Boost_FIND_LIBRARY var build_type)
+
+  find_library(${var} ${ARGN})
+
+  if(${var})
+    # If this is the first library found then save Boost_LIBRARY_DIR_[RELEASE,DEBUG].
+    if(NOT Boost_LIBRARY_DIR_${build_type})
+      get_filename_component(_dir "${${var}}" PATH)
+      set(Boost_LIBRARY_DIR_${build_type} "${_dir}" CACHE PATH "Boost library directory ${build_type}" FORCE)
+    endif()
+  elseif(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
+    # Try component-specific hints but do not save Boost_LIBRARY_DIR_[RELEASE,DEBUG].
+    find_library(${var} HINTS ${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT} ${ARGN})
+  endif()
+
+  # If Boost_LIBRARY_DIR_[RELEASE,DEBUG] is known then search only there.
+  if(Boost_LIBRARY_DIR_${build_type})
+    set(_boost_LIBRARY_SEARCH_DIRS_${build_type} ${Boost_LIBRARY_DIR_${build_type}} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+    if(Boost_DEBUG)
+      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+        " Boost_LIBRARY_DIR_${build_type} = ${Boost_LIBRARY_DIR_${build_type}}"
+        " _boost_LIBRARY_SEARCH_DIRS_${build_type} = ${_boost_LIBRARY_SEARCH_DIRS_${build_type}}")
+    endif()
+  endif()
+endmacro()
+
+#-------------------------------------------------------------------------------
+
+#
+# Runs compiler with "-dumpversion" and parses major/minor
+# version with a regex.
+#
+function(_Boost_COMPILER_DUMPVERSION _OUTPUT_VERSION)
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.[0-9]+)?" "\\1\\2"
+    _boost_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+
+  set(${_OUTPUT_VERSION} ${_boost_COMPILER_VERSION} PARENT_SCOPE)
+endfunction()
+
+#
+# Take a list of libraries with "thread" in it
+# and prepend duplicates with "thread_${Boost_THREADAPI}"
+# at the front of the list
+#
+function(_Boost_PREPEND_LIST_WITH_THREADAPI _output)
+  set(_orig_libnames ${ARGN})
+  string(REPLACE "thread" "thread_${Boost_THREADAPI}" _threadapi_libnames "${_orig_libnames}")
+  set(${_output} ${_threadapi_libnames} ${_orig_libnames} PARENT_SCOPE)
+endfunction()
+
+#
+# If a library is found, replace its cache entry with its REALPATH
+#
+function(_Boost_SWAP_WITH_REALPATH _library _docstring)
+  if(${_library})
+    get_filename_component(_boost_filepathreal ${${_library}} REALPATH)
+    unset(${_library} CACHE)
+    set(${_library} ${_boost_filepathreal} CACHE FILEPATH "${_docstring}")
+  endif()
+endfunction()
+
+function(_Boost_CHECK_SPELLING _var)
+  if(${_var})
+    string(TOUPPER ${_var} _var_UC)
+    message(FATAL_ERROR "ERROR: ${_var} is not the correct spelling.  The proper spelling is ${_var_UC}.")
+  endif()
+endfunction()
+
+# Guesses Boost's compiler prefix used in built library names
+# Returns the guess by setting the variable pointed to by _ret
+function(_Boost_GUESS_COMPILER_PREFIX _ret)
+  if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntel")
+    if(WIN32)
+      set (_boost_COMPILER "-iw")
+    else()
+      set (_boost_COMPILER "-il")
+    endif()
+  elseif (GHSMULTI)
+    set(_boost_COMPILER "-ghs")
+  elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+      set(_boost_COMPILER "-vc141;-vc140")
+    elseif (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
+      set(_boost_COMPILER "-vc140")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+      set(_boost_COMPILER "-vc120")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
+      set(_boost_COMPILER "-vc110")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+      set(_boost_COMPILER "-vc100")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
+      set(_boost_COMPILER "-vc90")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+      set(_boost_COMPILER "-vc80")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.10)
+      set(_boost_COMPILER "-vc71")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13) # Good luck!
+      set(_boost_COMPILER "-vc7") # yes, this is correct
+    else() # VS 6.0 Good luck!
+      set(_boost_COMPILER "-vc6") # yes, this is correct
+    endif()
+  elseif (BORLAND)
+    set(_boost_COMPILER "-bcb")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
+    set(_boost_COMPILER "-sw")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "XL")
+    set(_boost_COMPILER "-xlc")
+  elseif (MINGW)
+    if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+        set(_boost_COMPILER "-mgw") # no GCC version encoding prior to 1.34
+    else()
+      _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION)
+      set(_boost_COMPILER "-mgw${_boost_COMPILER_VERSION}")
+    endif()
+  elseif (UNIX)
+    if (CMAKE_COMPILER_IS_GNUCXX)
+      if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+        set(_boost_COMPILER "-gcc") # no GCC version encoding prior to 1.34
+      else()
+        _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION)
+        # Determine which version of GCC we have.
+        if(APPLE)
+          if(Boost_MINOR_VERSION)
+            if(${Boost_MINOR_VERSION} GREATER 35)
+              # In Boost 1.36.0 and newer, the mangled compiler name used
+              # on Mac OS X/Darwin is "xgcc".
+              set(_boost_COMPILER "-xgcc${_boost_COMPILER_VERSION}")
+            else()
+              # In Boost <= 1.35.0, there is no mangled compiler name for
+              # the Mac OS X/Darwin version of GCC.
+              set(_boost_COMPILER "")
+            endif()
+          else()
+            # We don't know the Boost version, so assume it's
+            # pre-1.36.0.
+            set(_boost_COMPILER "")
+          endif()
+        else()
+          set(_boost_COMPILER "-gcc${_boost_COMPILER_VERSION}")
+        endif()
+      endif()
+    endif ()
+  else()
+    # TODO at least Boost_DEBUG here?
+    set(_boost_COMPILER "")
+  endif()
+  set(${_ret} ${_boost_COMPILER} PARENT_SCOPE)
+endfunction()
+
+#
+# Get component dependencies.  Requires the dependencies to have been
+# defined for the Boost release version.
+#
+# component - the component to check
+# _ret - list of library dependencies
+#
+function(_Boost_COMPONENT_DEPENDENCIES component _ret)
+  # Note: to add a new Boost release, run
+  #
+  #   % cmake -DBOOST_DIR=/path/to/boost/source -P Utilities/Scripts/BoostScanDeps.cmake
+  #
+  # The output may be added in a new block below.  If it's the same as
+  # the previous release, simply update the version range of the block
+  # for the previous release.  Also check if any new components have
+  # been added, and add any new components to
+  # _Boost_COMPONENT_HEADERS.
+  #
+  # This information was originally generated by running
+  # BoostScanDeps.cmake against every boost release to date supported
+  # by FindBoost:
+  #
+  #   % for version in /path/to/boost/sources/*
+  #     do
+  #       cmake -DBOOST_DIR=$version -P Utilities/Scripts/BoostScanDeps.cmake
+  #     done
+  #
+  # The output was then updated by search and replace with these regexes:
+  #
+  # - Strip message(STATUS) prefix dashes
+  #   s;^-- ;;
+  # - Indent
+  #   s;^set(;    set(;;
+  # - Add conditionals
+  #   s;Scanning /path/to/boost/sources/boost_\(.*\)_\(.*\)_\(.*);  elseif(NOT Boost_VERSION VERSION_LESS \10\20\3 AND Boost_VERSION VERSION_LESS xxxx);
+  #
+  # This results in the logic seen below, but will require the xxxx
+  # replacing with the following Boost release version (or the next
+  # minor version to be released, e.g. 1.59 was the latest at the time
+  # of writing, making 1.60 the next, so 106000 is the needed version
+  # number).  Identical consecutive releases were then merged together
+  # by updating the end range of the first block and removing the
+  # following redundant blocks.
+  #
+  # Running the script against all historical releases should be
+  # required only if the BoostScanDeps.cmake script logic is changed.
+  # The addition of a new release should only require it to be run
+  # against the new release.
+
+  # Handle Python version suffixes
+  if(component MATCHES "^(python|mpi_python|numpy)([0-9][0-9]?|[0-9]\\.[0-9])\$")
+    set(component "${CMAKE_MATCH_1}")
+    set(component_python_version "${CMAKE_MATCH_2}")
+  endif()
+
+  set(_Boost_IMPORTED_TARGETS TRUE)
+  if(Boost_VERSION VERSION_LESS 103300)
+    message(WARNING "Imported targets and dependency information not available for Boost version ${Boost_VERSION} (all versions older than 1.33)")
+    set(_Boost_IMPORTED_TARGETS FALSE)
+  elseif(NOT Boost_VERSION VERSION_LESS 103300 AND Boost_VERSION VERSION_LESS 103500)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex thread)
+    set(_Boost_REGEX_DEPENDENCIES thread)
+    set(_Boost_WAVE_DEPENDENCIES filesystem thread)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 103500 AND Boost_VERSION VERSION_LESS 103600)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 103600 AND Boost_VERSION VERSION_LESS 103800)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 103800 AND Boost_VERSION VERSION_LESS 104300)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES date_time)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 104300 AND Boost_VERSION VERSION_LESS 104400)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES date_time)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 104400 AND Boost_VERSION VERSION_LESS 104500)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random serialization)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES date_time)
+    set(_Boost_WAVE_DEPENDENCIES serialization filesystem system thread date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 104500 AND Boost_VERSION VERSION_LESS 104700)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES date_time)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 104700 AND Boost_VERSION VERSION_LESS 104800)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES date_time)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 104800 AND Boost_VERSION VERSION_LESS 105000)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES date_time)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 105000 AND Boost_VERSION VERSION_LESS 105300)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 105300 AND Boost_VERSION VERSION_LESS 105400)
+    set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 105400 AND Boost_VERSION VERSION_LESS 105500)
+    set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 105500 AND Boost_VERSION VERSION_LESS 105600)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 105600 AND Boost_VERSION VERSION_LESS 105900)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_RANDOM_DEPENDENCIES system)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 105900 AND Boost_VERSION VERSION_LESS 106000)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_RANDOM_DEPENDENCIES system)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 106000 AND Boost_VERSION VERSION_LESS 106100)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_RANDOM_DEPENDENCIES system)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 106100 AND Boost_VERSION VERSION_LESS 106200)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_RANDOM_DEPENDENCIES system)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 106200 AND Boost_VERSION VERSION_LESS 106300)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_RANDOM_DEPENDENCIES system)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 106300 AND Boost_VERSION VERSION_LESS 106500)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_COROUTINE2_DEPENDENCIES context fiber thread chrono system date_time)
+    set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_RANDOM_DEPENDENCIES system)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 106500 AND Boost_VERSION VERSION_LESS 106700)
+    set(_Boost_CHRONO_DEPENDENCIES system)
+    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+    set(_Boost_COROUTINE_DEPENDENCIES context system)
+    set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+    set(_Boost_FILESYSTEM_DEPENDENCIES system)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+    set(_Boost_RANDOM_DEPENDENCIES system)
+    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  else()
+    if(NOT Boost_VERSION VERSION_LESS 106700)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    endif()
+    if(NOT Boost_VERSION VERSION_LESS 106800)
+      message(WARNING "New Boost version may have incorrect or missing dependencies and imported targets")
+    endif()
+  endif()
+
+  string(TOUPPER ${component} uppercomponent)
+  set(${_ret} ${_Boost_${uppercomponent}_DEPENDENCIES} PARENT_SCOPE)
+  set(_Boost_IMPORTED_TARGETS ${_Boost_IMPORTED_TARGETS} PARENT_SCOPE)
+
+  string(REGEX REPLACE ";" " " _boost_DEPS_STRING "${_Boost_${uppercomponent}_DEPENDENCIES}")
+  if (NOT _boost_DEPS_STRING)
+    set(_boost_DEPS_STRING "(none)")
+  endif()
+  # message(STATUS "Dependencies for Boost::${component}: ${_boost_DEPS_STRING}")
+endfunction()
+
+#
+# Get component headers.  This is the primary header (or headers) for
+# a given component, and is used to check that the headers are present
+# as well as the library itself as an extra sanity check of the build
+# environment.
+#
+# component - the component to check
+# _hdrs
+#
+function(_Boost_COMPONENT_HEADERS component _hdrs)
+  # Handle Python version suffixes
+  if(component MATCHES "^(python|mpi_python|numpy)([0-9][0-9]?|[0-9]\\.[0-9])\$")
+    set(component "${CMAKE_MATCH_1}")
+    set(component_python_version "${CMAKE_MATCH_2}")
+  endif()
+
+  # Note: new boost components will require adding here.  The header
+  # must be present in all versions of Boost providing a library.
+  set(_Boost_ATOMIC_HEADERS              "boost/atomic.hpp")
+  set(_Boost_CHRONO_HEADERS              "boost/chrono.hpp")
+  set(_Boost_CONTAINER_HEADERS           "boost/container/container_fwd.hpp")
+  set(_Boost_CONTEXT_HEADERS             "boost/context/all.hpp")
+  set(_Boost_COROUTINE_HEADERS           "boost/coroutine/all.hpp")
+  set(_Boost_DATE_TIME_HEADERS           "boost/date_time/date.hpp")
+  set(_Boost_EXCEPTION_HEADERS           "boost/exception/exception.hpp")
+  set(_Boost_FIBER_HEADERS               "boost/fiber/all.hpp")
+  set(_Boost_FILESYSTEM_HEADERS          "boost/filesystem/path.hpp")
+  set(_Boost_GRAPH_HEADERS               "boost/graph/adjacency_list.hpp")
+  set(_Boost_GRAPH_PARALLEL_HEADERS      "boost/graph/adjacency_list.hpp")
+  set(_Boost_IOSTREAMS_HEADERS           "boost/iostreams/stream.hpp")
+  set(_Boost_LOCALE_HEADERS              "boost/locale.hpp")
+  set(_Boost_LOG_HEADERS                 "boost/log/core.hpp")
+  set(_Boost_LOG_SETUP_HEADERS           "boost/log/detail/setup_config.hpp")
+  set(_Boost_MATH_HEADERS                "boost/math_fwd.hpp")
+  set(_Boost_MATH_C99_HEADERS            "boost/math/tr1.hpp")
+  set(_Boost_MATH_C99F_HEADERS           "boost/math/tr1.hpp")
+  set(_Boost_MATH_C99L_HEADERS           "boost/math/tr1.hpp")
+  set(_Boost_MATH_TR1_HEADERS            "boost/math/tr1.hpp")
+  set(_Boost_MATH_TR1F_HEADERS           "boost/math/tr1.hpp")
+  set(_Boost_MATH_TR1L_HEADERS           "boost/math/tr1.hpp")
+  set(_Boost_MPI_HEADERS                 "boost/mpi.hpp")
+  set(_Boost_MPI_PYTHON_HEADERS          "boost/mpi/python/config.hpp")
+  set(_Boost_NUMPY_HEADERS               "boost/python/numpy.hpp")
+  set(_Boost_PRG_EXEC_MONITOR_HEADERS    "boost/test/prg_exec_monitor.hpp")
+  set(_Boost_PROGRAM_OPTIONS_HEADERS     "boost/program_options.hpp")
+  set(_Boost_PYTHON_HEADERS              "boost/python.hpp")
+  set(_Boost_RANDOM_HEADERS              "boost/random.hpp")
+  set(_Boost_REGEX_HEADERS               "boost/regex.hpp")
+  set(_Boost_SERIALIZATION_HEADERS       "boost/serialization/serialization.hpp")
+  set(_Boost_SIGNALS_HEADERS             "boost/signals.hpp")
+  set(_Boost_SYSTEM_HEADERS              "boost/system/config.hpp")
+  set(_Boost_TEST_EXEC_MONITOR_HEADERS   "boost/test/test_exec_monitor.hpp")
+  set(_Boost_THREAD_HEADERS              "boost/thread.hpp")
+  set(_Boost_TIMER_HEADERS               "boost/timer.hpp")
+  set(_Boost_TYPE_ERASURE_HEADERS        "boost/type_erasure/config.hpp")
+  set(_Boost_UNIT_TEST_FRAMEWORK_HEADERS "boost/test/framework.hpp")
+  set(_Boost_WAVE_HEADERS                "boost/wave.hpp")
+  set(_Boost_WSERIALIZATION_HEADERS      "boost/archive/text_wiarchive.hpp")
+  if(WIN32)
+    set(_Boost_BZIP2_HEADERS             "boost/iostreams/filter/bzip2.hpp")
+    set(_Boost_ZLIB_HEADERS              "boost/iostreams/filter/zlib.hpp")
+  endif()
+
+  string(TOUPPER ${component} uppercomponent)
+  set(${_hdrs} ${_Boost_${uppercomponent}_HEADERS} PARENT_SCOPE)
+
+  string(REGEX REPLACE ";" " " _boost_HDRS_STRING "${_Boost_${uppercomponent}_HEADERS}")
+  if (NOT _boost_HDRS_STRING)
+    set(_boost_HDRS_STRING "(none)")
+  endif()
+  # message(STATUS "Headers for Boost::${component}: ${_boost_HDRS_STRING}")
+endfunction()
+
+#
+# Determine if any missing dependencies require adding to the component list.
+#
+# Sets _Boost_${COMPONENT}_DEPENDENCIES for each required component,
+# plus _Boost_IMPORTED_TARGETS (TRUE if imported targets should be
+# defined; FALSE if dependency information is unavailable).
+#
+# componentvar - the component list variable name
+# extravar - the indirect dependency list variable name
+#
+#
+function(_Boost_MISSING_DEPENDENCIES componentvar extravar)
+  # _boost_unprocessed_components - list of components requiring processing
+  # _boost_processed_components - components already processed (or currently being processed)
+  # _boost_new_components - new components discovered for future processing
+  #
+  list(APPEND _boost_unprocessed_components ${${componentvar}})
+
+  while(_boost_unprocessed_components)
+    list(APPEND _boost_processed_components ${_boost_unprocessed_components})
+    foreach(component ${_boost_unprocessed_components})
+      string(TOUPPER ${component} uppercomponent)
+      set(${_ret} ${_Boost_${uppercomponent}_DEPENDENCIES} PARENT_SCOPE)
+      _Boost_COMPONENT_DEPENDENCIES("${component}" _Boost_${uppercomponent}_DEPENDENCIES)
+      set(_Boost_${uppercomponent}_DEPENDENCIES ${_Boost_${uppercomponent}_DEPENDENCIES} PARENT_SCOPE)
+      set(_Boost_IMPORTED_TARGETS ${_Boost_IMPORTED_TARGETS} PARENT_SCOPE)
+      foreach(componentdep ${_Boost_${uppercomponent}_DEPENDENCIES})
+        if (NOT ("${componentdep}" IN_LIST _boost_processed_components OR "${componentdep}" IN_LIST _boost_new_components))
+          list(APPEND _boost_new_components ${componentdep})
+        endif()
+      endforeach()
+    endforeach()
+    set(_boost_unprocessed_components ${_boost_new_components})
+    unset(_boost_new_components)
+  endwhile()
+  set(_boost_extra_components ${_boost_processed_components})
+  if(_boost_extra_components AND ${componentvar})
+    list(REMOVE_ITEM _boost_extra_components ${${componentvar}})
+  endif()
+  set(${componentvar} ${_boost_processed_components} PARENT_SCOPE)
+  set(${extravar} ${_boost_extra_components} PARENT_SCOPE)
+endfunction()
+
+#
+# Some boost libraries may require particular set of compler features.
+# The very first one was `boost::fiber` introduced in Boost 1.62.
+# One can check required compiler features of it in
+# `${Boost_ROOT}/libs/fiber/build/Jamfile.v2`.
+#
+function(_Boost_COMPILER_FEATURES component _ret)
+  # Boost >= 1.62 and < 1.67
+  if(NOT Boost_VERSION VERSION_LESS 106200 AND Boost_VERSION VERSION_LESS 106700)
+    set(_Boost_FIBER_COMPILER_FEATURES
+        cxx_alias_templates
+        cxx_auto_type
+        cxx_constexpr
+        cxx_defaulted_functions
+        cxx_final
+        cxx_lambdas
+        cxx_noexcept
+        cxx_nullptr
+        cxx_rvalue_references
+        cxx_thread_local
+        cxx_variadic_templates
+    )
+  endif()
+  string(TOUPPER ${component} uppercomponent)
+  set(${_ret} ${_Boost_${uppercomponent}_COMPILER_FEATURES} PARENT_SCOPE)
+endfunction()
+
+#
+# Update library search directory hint variable with paths used by prebuilt boost binaries.
+#
+# Prebuilt windows binaries (https://sourceforge.net/projects/boost/files/boost-binaries/)
+# have library directories named using MSVC compiler version and architecture.
+# This function would append corresponding directories if MSVC is a current compiler,
+# so having `BOOST_ROOT` would be enough to specify to find everything.
+#
+function(_Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS componentlibvar basedir)
+  if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set(_arch_suffix 64)
+    else()
+      set(_arch_suffix 32)
+    endif()
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.1)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-12.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-11.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-10.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-9.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-8.0)
+    endif()
+    set(${componentlibvar} ${${componentlibvar}} PARENT_SCOPE)
+  endif()
+endfunction()
+
+#
+# End functions/macros
+#
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# main.
+#-------------------------------------------------------------------------------
+
+
+# If the user sets Boost_LIBRARY_DIR, use it as the default for both
+# configurations.
+if(NOT Boost_LIBRARY_DIR_RELEASE AND Boost_LIBRARY_DIR)
+  set(Boost_LIBRARY_DIR_RELEASE "${Boost_LIBRARY_DIR}")
+endif()
+if(NOT Boost_LIBRARY_DIR_DEBUG AND Boost_LIBRARY_DIR)
+  set(Boost_LIBRARY_DIR_DEBUG   "${Boost_LIBRARY_DIR}")
+endif()
+
+if(NOT DEFINED Boost_USE_DEBUG_LIBS)
+  set(Boost_USE_DEBUG_LIBS TRUE)
+endif()
+if(NOT DEFINED Boost_USE_RELEASE_LIBS)
+  set(Boost_USE_RELEASE_LIBS TRUE)
+endif()
+if(NOT DEFINED Boost_USE_MULTITHREADED)
+  set(Boost_USE_MULTITHREADED TRUE)
+endif()
+if(NOT DEFINED Boost_USE_DEBUG_RUNTIME)
+  set(Boost_USE_DEBUG_RUNTIME TRUE)
+endif()
+
+# Check the version of Boost against the requested version.
+if(Boost_FIND_VERSION AND NOT Boost_FIND_VERSION_MINOR)
+  message(SEND_ERROR "When requesting a specific version of Boost, you must provide at least the major and minor version numbers, e.g., 1.34")
+endif()
+
+if(Boost_FIND_VERSION_EXACT)
+  # The version may appear in a directory with or without the patch
+  # level, even when the patch level is non-zero.
+  set(_boost_TEST_VERSIONS
+    "${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}.${Boost_FIND_VERSION_PATCH}"
+    "${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
+else()
+  # The user has not requested an exact version.  Among known
+  # versions, find those that are acceptable to the user request.
+  #
+  # Note: When adding a new Boost release, also update the dependency
+  # information in _Boost_COMPONENT_DEPENDENCIES and
+  # _Boost_COMPONENT_HEADERS.  See the instructions at the top of
+  # _Boost_COMPONENT_DEPENDENCIES.
+  set(_Boost_KNOWN_VERSIONS ${Boost_ADDITIONAL_VERSIONS}
+    "1.67.0" "1.67" "1.66.0" "1.66" "1.65.1" "1.65.0" "1.65"
+    "1.64.0" "1.64" "1.63.0" "1.63" "1.62.0" "1.62" "1.61.0" "1.61" "1.60.0" "1.60"
+    "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"
+    "1.54.0" "1.54" "1.53.0" "1.53" "1.52.0" "1.52" "1.51.0" "1.51"
+    "1.50.0" "1.50" "1.49.0" "1.49" "1.48.0" "1.48" "1.47.0" "1.47" "1.46.1"
+    "1.46.0" "1.46" "1.45.0" "1.45" "1.44.0" "1.44" "1.43.0" "1.43" "1.42.0" "1.42"
+    "1.41.0" "1.41" "1.40.0" "1.40" "1.39.0" "1.39" "1.38.0" "1.38" "1.37.0" "1.37"
+    "1.36.1" "1.36.0" "1.36" "1.35.1" "1.35.0" "1.35" "1.34.1" "1.34.0"
+    "1.34" "1.33.1" "1.33.0" "1.33")
+
+  set(_boost_TEST_VERSIONS)
+  if(Boost_FIND_VERSION)
+    set(_Boost_FIND_VERSION_SHORT "${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
+    # Select acceptable versions.
+    foreach(version ${_Boost_KNOWN_VERSIONS})
+      if(NOT "${version}" VERSION_LESS "${Boost_FIND_VERSION}")
+        # This version is high enough.
+        list(APPEND _boost_TEST_VERSIONS "${version}")
+      elseif("${version}.99" VERSION_EQUAL "${_Boost_FIND_VERSION_SHORT}.99")
+        # This version is a short-form for the requested version with
+        # the patch level dropped.
+        list(APPEND _boost_TEST_VERSIONS "${version}")
+      endif()
+    endforeach()
+  else()
+    # Any version is acceptable.
+    set(_boost_TEST_VERSIONS "${_Boost_KNOWN_VERSIONS}")
+  endif()
+endif()
+
+# The reason that we failed to find Boost. This will be set to a
+# user-friendly message when we fail to find some necessary piece of
+# Boost.
+set(Boost_ERROR_REASON)
+
+if(Boost_DEBUG)
+  # Output some of their choices
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_USE_MULTITHREADED = ${Boost_USE_MULTITHREADED}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_USE_STATIC_LIBS = ${Boost_USE_STATIC_LIBS}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_USE_STATIC_RUNTIME = ${Boost_USE_STATIC_RUNTIME}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_ADDITIONAL_VERSIONS = ${Boost_ADDITIONAL_VERSIONS}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Boost_NO_SYSTEM_PATHS = ${Boost_NO_SYSTEM_PATHS}")
+endif()
+
+# Supply Boost_LIB_DIAGNOSTIC_DEFINITIONS as a convenience target. It
+# will only contain any interface definitions on WIN32, but is created
+# on all platforms to keep end user code free from platform dependent
+# code.  Also provide convenience targets to disable autolinking and
+# enable dynamic linking.
+if(NOT TARGET Boost::diagnostic_definitions)
+  add_library(Boost::diagnostic_definitions INTERFACE IMPORTED)
+  add_library(Boost::disable_autolinking INTERFACE IMPORTED)
+  add_library(Boost::dynamic_linking INTERFACE IMPORTED)
+endif()
+if(WIN32)
+  # In windows, automatic linking is performed, so you do not have
+  # to specify the libraries.  If you are linking to a dynamic
+  # runtime, then you can choose to link to either a static or a
+  # dynamic Boost library, the default is to do a static link.  You
+  # can alter this for a specific library "whatever" by defining
+  # BOOST_WHATEVER_DYN_LINK to force Boost library "whatever" to be
+  # linked dynamically.  Alternatively you can force all Boost
+  # libraries to dynamic link by defining BOOST_ALL_DYN_LINK.
+
+  # This feature can be disabled for Boost library "whatever" by
+  # defining BOOST_WHATEVER_NO_LIB, or for all of Boost by defining
+  # BOOST_ALL_NO_LIB.
+
+  # If you want to observe which libraries are being linked against
+  # then defining BOOST_LIB_DIAGNOSTIC will cause the auto-linking
+  # code to emit a #pragma message each time a library is selected
+  # for linking.
+  set(Boost_LIB_DIAGNOSTIC_DEFINITIONS "-DBOOST_LIB_DIAGNOSTIC")
+  set_target_properties(Boost::diagnostic_definitions PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "BOOST_LIB_DIAGNOSTIC")
+  set_target_properties(Boost::disable_autolinking PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_NO_LIB")
+  set_target_properties(Boost::dynamic_linking PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_DYN_LINK")
+endif()
+
+_Boost_CHECK_SPELLING(Boost_ROOT)
+_Boost_CHECK_SPELLING(Boost_LIBRARYDIR)
+_Boost_CHECK_SPELLING(Boost_INCLUDEDIR)
+
+# Collect environment variable inputs as hints.  Do not consider changes.
+foreach(v BOOSTROOT BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR)
+  set(_env $ENV{${v}})
+  if(_env)
+    file(TO_CMAKE_PATH "${_env}" _ENV_${v})
+  else()
+    set(_ENV_${v} "")
+  endif()
+endforeach()
+if(NOT _ENV_BOOST_ROOT AND _ENV_BOOSTROOT)
+  set(_ENV_BOOST_ROOT "${_ENV_BOOSTROOT}")
+endif()
+
+# Collect inputs and cached results.  Detect changes since the last run.
+if(NOT BOOST_ROOT AND BOOSTROOT)
+  set(BOOST_ROOT "${BOOSTROOT}")
+endif()
+set(_Boost_VARS_DIR
+  BOOST_ROOT
+  Boost_NO_SYSTEM_PATHS
+  )
+
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "Declared as CMake or Environmental Variables:")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "  BOOST_ROOT = ${BOOST_ROOT}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "  BOOST_INCLUDEDIR = ${BOOST_INCLUDEDIR}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "  BOOST_LIBRARYDIR = ${BOOST_LIBRARYDIR}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
+endif()
+
+# ------------------------------------------------------------------------
+#  Search for Boost include DIR
+# ------------------------------------------------------------------------
+
+set(_Boost_VARS_INC BOOST_INCLUDEDIR Boost_INCLUDE_DIR Boost_ADDITIONAL_VERSIONS)
+_Boost_CHANGE_DETECT(_Boost_CHANGE_INCDIR ${_Boost_VARS_DIR} ${_Boost_VARS_INC})
+# Clear Boost_INCLUDE_DIR if it did not change but other input affecting the
+# location did.  We will find a new one based on the new inputs.
+if(_Boost_CHANGE_INCDIR AND NOT _Boost_INCLUDE_DIR_CHANGED)
+  unset(Boost_INCLUDE_DIR CACHE)
+endif()
+
+if(NOT Boost_INCLUDE_DIR)
+  set(_boost_INCLUDE_SEARCH_DIRS "")
+  if(BOOST_INCLUDEDIR)
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${BOOST_INCLUDEDIR})
+  elseif(_ENV_BOOST_INCLUDEDIR)
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${_ENV_BOOST_INCLUDEDIR})
+  endif()
+
+  if( BOOST_ROOT )
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${BOOST_ROOT}/include ${BOOST_ROOT})
+  elseif( _ENV_BOOST_ROOT )
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS ${_ENV_BOOST_ROOT}/include ${_ENV_BOOST_ROOT})
+  endif()
+
+  if( Boost_NO_SYSTEM_PATHS)
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
+  else()
+    if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
+      foreach(ver ${_Boost_KNOWN_VERSIONS})
+        string(REPLACE "." "_" ver "${ver}")
+        list(APPEND _boost_INCLUDE_SEARCH_DIRS PATHS "C:/local/boost_${ver}")
+      endforeach()
+    endif()
+    list(APPEND _boost_INCLUDE_SEARCH_DIRS PATHS
+      C:/boost/include
+      C:/boost
+      /sw/local/include
+      )
+  endif()
+
+  # Try to find Boost by stepping backwards through the Boost versions
+  # we know about.
+  # Build a list of path suffixes for each version.
+  set(_boost_PATH_SUFFIXES)
+  foreach(_boost_VER ${_boost_TEST_VERSIONS})
+    # Add in a path suffix, based on the required version, ideally
+    # we could read this from version.hpp, but for that to work we'd
+    # need to know the include dir already
+    set(_boost_BOOSTIFIED_VERSION)
+
+    # Transform 1.35 => 1_35 and 1.36.0 => 1_36_0
+    if(_boost_VER MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+        set(_boost_BOOSTIFIED_VERSION
+          "${CMAKE_MATCH_1}_${CMAKE_MATCH_2}_${CMAKE_MATCH_3}")
+    elseif(_boost_VER MATCHES "([0-9]+)\\.([0-9]+)")
+        set(_boost_BOOSTIFIED_VERSION
+          "${CMAKE_MATCH_1}_${CMAKE_MATCH_2}")
+    endif()
+
+    list(APPEND _boost_PATH_SUFFIXES
+      "boost-${_boost_BOOSTIFIED_VERSION}"
+      "boost_${_boost_BOOSTIFIED_VERSION}"
+      "boost/boost-${_boost_BOOSTIFIED_VERSION}"
+      "boost/boost_${_boost_BOOSTIFIED_VERSION}"
+      )
+
+  endforeach()
+
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "Include debugging info:")
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "  _boost_INCLUDE_SEARCH_DIRS = ${_boost_INCLUDE_SEARCH_DIRS}")
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "  _boost_PATH_SUFFIXES = ${_boost_PATH_SUFFIXES}")
+  endif()
+
+  # Look for a standard boost header file.
+  find_path(Boost_INCLUDE_DIR
+    NAMES         boost/config.hpp
+    HINTS         ${_boost_INCLUDE_SEARCH_DIRS}
+    PATH_SUFFIXES ${_boost_PATH_SUFFIXES}
+    )
+endif()
+
+# ------------------------------------------------------------------------
+#  Extract version information from version.hpp
+# ------------------------------------------------------------------------
+
+# Set Boost_FOUND based only on header location and version.
+# It will be updated below for component libraries.
+if(Boost_INCLUDE_DIR)
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "location of version.hpp: ${Boost_INCLUDE_DIR}/boost/version.hpp")
+  endif()
+
+  # Extract Boost_VERSION and Boost_LIB_VERSION from version.hpp
+  set(Boost_VERSION 0)
+  set(Boost_LIB_VERSION "")
+  file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_VERSION_HPP_CONTENTS REGEX "#define BOOST_(LIB_)?VERSION ")
+  set(_Boost_VERSION_REGEX "([0-9]+)")
+  set(_Boost_LIB_VERSION_REGEX "\"([0-9_]+)\"")
+  foreach(v VERSION LIB_VERSION)
+    if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_${v} ${_Boost_${v}_REGEX}")
+      set(Boost_${v} "${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+  unset(_boost_VERSION_HPP_CONTENTS)
+
+  math(EXPR Boost_MAJOR_VERSION "${Boost_VERSION} / 100000")
+  math(EXPR Boost_MINOR_VERSION "${Boost_VERSION} / 100 % 1000")
+  math(EXPR Boost_SUBMINOR_VERSION "${Boost_VERSION} % 100")
+
+  string(APPEND Boost_ERROR_REASON
+    "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}\nBoost include path: ${Boost_INCLUDE_DIR}")
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "version.hpp reveals boost "
+                   "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+  endif()
+
+  if(Boost_FIND_VERSION)
+    # Set Boost_FOUND based on requested version.
+    set(_Boost_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+    if("${_Boost_VERSION}" VERSION_LESS "${Boost_FIND_VERSION}")
+      set(Boost_FOUND 0)
+      set(_Boost_VERSION_AGE "old")
+    elseif(Boost_FIND_VERSION_EXACT AND
+        NOT "${_Boost_VERSION}" VERSION_EQUAL "${Boost_FIND_VERSION}")
+      set(Boost_FOUND 0)
+      set(_Boost_VERSION_AGE "new")
+    else()
+      set(Boost_FOUND 1)
+    endif()
+    if(NOT Boost_FOUND)
+      # State that we found a version of Boost that is too new or too old.
+      string(APPEND Boost_ERROR_REASON
+        "\nDetected version of Boost is too ${_Boost_VERSION_AGE}. Requested version was ${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
+      if (Boost_FIND_VERSION_PATCH)
+        string(APPEND Boost_ERROR_REASON
+          ".${Boost_FIND_VERSION_PATCH}")
+      endif ()
+      if (NOT Boost_FIND_VERSION_EXACT)
+        string(APPEND Boost_ERROR_REASON " (or newer)")
+      endif ()
+      string(APPEND Boost_ERROR_REASON ".")
+    endif ()
+  else()
+    # Caller will accept any Boost version.
+    set(Boost_FOUND 1)
+  endif()
+else()
+  set(Boost_FOUND 0)
+  string(APPEND Boost_ERROR_REASON
+    "Unable to find the Boost header files. Please set BOOST_ROOT to the root directory containing Boost or BOOST_INCLUDEDIR to the directory containing Boost's headers.")
+endif()
+
+# ------------------------------------------------------------------------
+#  Prefix initialization
+# ------------------------------------------------------------------------
+
+set(Boost_LIB_PREFIX "")
+if ( (GHSMULTI AND Boost_USE_STATIC_LIBS) OR
+    (WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN) )
+  set(Boost_LIB_PREFIX "lib")
+endif()
+
+if ( NOT Boost_NAMESPACE )
+  set(Boost_NAMESPACE "boost")
+endif()
+
+# ------------------------------------------------------------------------
+#  Suffix initialization and compiler suffix detection.
+# ------------------------------------------------------------------------
+
+set(_Boost_VARS_NAME
+  Boost_NAMESPACE
+  Boost_COMPILER
+  Boost_THREADAPI
+  Boost_USE_DEBUG_PYTHON
+  Boost_USE_MULTITHREADED
+  Boost_USE_STATIC_LIBS
+  Boost_USE_STATIC_RUNTIME
+  Boost_USE_STLPORT
+  Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS
+  )
+_Boost_CHANGE_DETECT(_Boost_CHANGE_LIBNAME ${_Boost_VARS_NAME})
+
+# Setting some more suffixes for the library
+if (Boost_COMPILER)
+  set(_boost_COMPILER ${Boost_COMPILER})
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "using user-specified Boost_COMPILER = ${_boost_COMPILER}")
+  endif()
+else()
+  # Attempt to guess the compiler suffix
+  # NOTE: this is not perfect yet, if you experience any issues
+  # please report them and use the Boost_COMPILER variable
+  # to work around the problems.
+  _Boost_GUESS_COMPILER_PREFIX(_boost_COMPILER)
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+      "guessed _boost_COMPILER = ${_boost_COMPILER}")
+  endif()
+endif()
+
+set (_boost_MULTITHREADED "-mt")
+if( NOT Boost_USE_MULTITHREADED )
+  set (_boost_MULTITHREADED "")
+endif()
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_MULTITHREADED = ${_boost_MULTITHREADED}")
+endif()
+
+#======================
+# Systematically build up the Boost ABI tag for the 'tagged' and 'versioned' layouts
+# http://boost.org/doc/libs/1_66_0/more/getting_started/windows.html#library-naming
+# http://boost.org/doc/libs/1_66_0/boost/config/auto_link.hpp
+# http://boost.org/doc/libs/1_66_0/tools/build/src/tools/common.jam
+# http://boost.org/doc/libs/1_66_0/boostcpp.jam
+set( _boost_RELEASE_ABI_TAG "-")
+set( _boost_DEBUG_ABI_TAG   "-")
+# Key       Use this library when:
+#  s        linking statically to the C++ standard library and
+#           compiler runtime support libraries.
+if(Boost_USE_STATIC_RUNTIME)
+  set( _boost_RELEASE_ABI_TAG "${_boost_RELEASE_ABI_TAG}s")
+  set( _boost_DEBUG_ABI_TAG   "${_boost_DEBUG_ABI_TAG}s")
+endif()
+#  g        using debug versions of the standard and runtime
+#           support libraries
+if(WIN32 AND Boost_USE_DEBUG_RUNTIME)
+  if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC"
+          OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang"
+          OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntel")
+    string(APPEND _boost_DEBUG_ABI_TAG "g")
+  endif()
+endif()
+#  y        using special debug build of python
+if(Boost_USE_DEBUG_PYTHON)
+  string(APPEND _boost_DEBUG_ABI_TAG "y")
+endif()
+#  d        using a debug version of your code
+string(APPEND _boost_DEBUG_ABI_TAG "d")
+#  p        using the STLport standard library rather than the
+#           default one supplied with your compiler
+if(Boost_USE_STLPORT)
+  string(APPEND _boost_RELEASE_ABI_TAG "p")
+  string(APPEND _boost_DEBUG_ABI_TAG "p")
+endif()
+#  n        using the STLport deprecated "native iostreams" feature
+#           removed from the documentation in 1.43.0 but still present in
+#           boost/config/auto_link.hpp
+if(Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS)
+  string(APPEND _boost_RELEASE_ABI_TAG "n")
+  string(APPEND _boost_DEBUG_ABI_TAG "n")
+endif()
+
+#  -x86     Architecture and address model tag
+#           First character is the architecture, then word-size, either 32 or 64
+#           Only used in 'versioned' layout, added in Boost 1.66.0
+set(_boost_ARCHITECTURE_TAG "")
+# {CMAKE_CXX_COMPILER_ARCHITECTURE_ID} is not currently set for all compilers
+if(NOT "x${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "x" AND NOT Boost_VERSION VERSION_LESS 106600)
+  string(APPEND _boost_ARCHITECTURE_TAG "-")
+  # This needs to be kept in-sync with the section of CMakePlatformId.h.in
+  # inside 'defined(_WIN32) && defined(_MSC_VER)'
+  if(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "IA64")
+    string(APPEND _boost_ARCHITECTURE_TAG "i")
+  elseif(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "X86"
+            OR ${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "x64")
+    string(APPEND _boost_ARCHITECTURE_TAG "x")
+  elseif(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} MATCHES "^ARM")
+    string(APPEND _boost_ARCHITECTURE_TAG "a")
+  elseif(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "MIPS")
+    string(APPEND _boost_ARCHITECTURE_TAG "m")
+  endif()
+
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    string(APPEND _boost_ARCHITECTURE_TAG "64")
+  else()
+    string(APPEND _boost_ARCHITECTURE_TAG "32")
+  endif()
+endif()
+
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_RELEASE_ABI_TAG = ${_boost_RELEASE_ABI_TAG}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_DEBUG_ABI_TAG = ${_boost_DEBUG_ABI_TAG}")
+endif()
+
+# ------------------------------------------------------------------------
+#  Begin finding boost libraries
+# ------------------------------------------------------------------------
+
+set(_Boost_VARS_LIB "")
+foreach(c DEBUG RELEASE)
+  set(_Boost_VARS_LIB_${c} BOOST_LIBRARYDIR Boost_LIBRARY_DIR_${c})
+  list(APPEND _Boost_VARS_LIB ${_Boost_VARS_LIB_${c}})
+  _Boost_CHANGE_DETECT(_Boost_CHANGE_LIBDIR_${c} ${_Boost_VARS_DIR} ${_Boost_VARS_LIB_${c}} Boost_INCLUDE_DIR)
+  # Clear Boost_LIBRARY_DIR_${c} if it did not change but other input affecting the
+  # location did.  We will find a new one based on the new inputs.
+  if(_Boost_CHANGE_LIBDIR_${c} AND NOT _Boost_LIBRARY_DIR_${c}_CHANGED)
+    unset(Boost_LIBRARY_DIR_${c} CACHE)
+  endif()
+
+  # If Boost_LIBRARY_DIR_[RELEASE,DEBUG] is set, prefer its value.
+  if(Boost_LIBRARY_DIR_${c})
+    set(_boost_LIBRARY_SEARCH_DIRS_${c} ${Boost_LIBRARY_DIR_${c}} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+  else()
+    set(_boost_LIBRARY_SEARCH_DIRS_${c} "")
+    if(BOOST_LIBRARYDIR)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${BOOST_LIBRARYDIR})
+    elseif(_ENV_BOOST_LIBRARYDIR)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${_ENV_BOOST_LIBRARYDIR})
+    endif()
+
+    if(BOOST_ROOT)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${BOOST_ROOT}/lib ${BOOST_ROOT}/stage/lib)
+      _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "${BOOST_ROOT}")
+    elseif(_ENV_BOOST_ROOT)
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${_ENV_BOOST_ROOT}/lib ${_ENV_BOOST_ROOT}/stage/lib)
+      _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "${_ENV_BOOST_ROOT}")
+    endif()
+
+    list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c}
+      ${Boost_INCLUDE_DIR}/lib
+      ${Boost_INCLUDE_DIR}/../lib
+      ${Boost_INCLUDE_DIR}/stage/lib
+      )
+    _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "${Boost_INCLUDE_DIR}/..")
+    _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "${Boost_INCLUDE_DIR}")
+    if( Boost_NO_SYSTEM_PATHS )
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
+    else()
+      foreach(ver ${_Boost_KNOWN_VERSIONS})
+        string(REPLACE "." "_" ver "${ver}")
+        _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "C:/local/boost_${ver}")
+      endforeach()
+      _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "C:/boost")
+      list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} PATHS
+        C:/boost/lib
+        C:/boost
+        /sw/local/lib
+        )
+    endif()
+  endif()
+endforeach()
+
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "_boost_LIBRARY_SEARCH_DIRS_RELEASE = ${_boost_LIBRARY_SEARCH_DIRS_RELEASE}"
+    "_boost_LIBRARY_SEARCH_DIRS_DEBUG   = ${_boost_LIBRARY_SEARCH_DIRS_DEBUG}")
+endif()
+
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if( Boost_USE_STATIC_LIBS )
+  set( _boost_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    list(INSERT CMAKE_FIND_LIBRARY_SUFFIXES 0 .lib .a)
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+  endif()
+endif()
+
+# We want to use the tag inline below without risking double dashes
+if(_boost_RELEASE_ABI_TAG)
+  if(${_boost_RELEASE_ABI_TAG} STREQUAL "-")
+    set(_boost_RELEASE_ABI_TAG "")
+  endif()
+endif()
+if(_boost_DEBUG_ABI_TAG)
+  if(${_boost_DEBUG_ABI_TAG} STREQUAL "-")
+    set(_boost_DEBUG_ABI_TAG "")
+  endif()
+endif()
+
+# The previous behavior of FindBoost when Boost_USE_STATIC_LIBS was enabled
+# on WIN32 was to:
+#  1. Search for static libs compiled against a SHARED C++ standard runtime library (use if found)
+#  2. Search for static libs compiled against a STATIC C++ standard runtime library (use if found)
+# We maintain this behavior since changing it could break people's builds.
+# To disable the ambiguous behavior, the user need only
+# set Boost_USE_STATIC_RUNTIME either ON or OFF.
+set(_boost_STATIC_RUNTIME_WORKAROUND false)
+if(WIN32 AND Boost_USE_STATIC_LIBS)
+  if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
+    set(_boost_STATIC_RUNTIME_WORKAROUND TRUE)
+  endif()
+endif()
+
+# On versions < 1.35, remove the System library from the considered list
+# since it wasn't added until 1.35.
+if(Boost_VERSION AND Boost_FIND_COMPONENTS)
+   if(Boost_VERSION LESS 103500)
+     list(REMOVE_ITEM Boost_FIND_COMPONENTS system)
+   endif()
+endif()
+
+# Additional components may be required via component dependencies.
+# Add any missing components to the list.
+_Boost_MISSING_DEPENDENCIES(Boost_FIND_COMPONENTS _Boost_EXTRA_FIND_COMPONENTS)
+
+# If thread is required, get the thread libs as a dependency
+if("thread" IN_LIST Boost_FIND_COMPONENTS)
+  if(Boost_FIND_QUIETLY)
+    set(_Boost_find_quiet QUIET)
+  else()
+    set(_Boost_find_quiet "")
+  endif()
+  find_package(Threads ${_Boost_find_quiet})
+  unset(_Boost_find_quiet)
+endif()
+
+# If the user changed any of our control inputs flush previous results.
+if(_Boost_CHANGE_LIBDIR_DEBUG OR _Boost_CHANGE_LIBDIR_RELEASE OR _Boost_CHANGE_LIBNAME)
+  foreach(COMPONENT ${_Boost_COMPONENTS_SEARCHED})
+    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+    foreach(c DEBUG RELEASE)
+      set(_var Boost_${UPPERCOMPONENT}_LIBRARY_${c})
+      unset(${_var} CACHE)
+      set(${_var} "${_var}-NOTFOUND")
+    endforeach()
+  endforeach()
+  set(_Boost_COMPONENTS_SEARCHED "")
+endif()
+
+foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+  string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+
+  set( _boost_docstring_release "Boost ${COMPONENT} library (release)")
+  set( _boost_docstring_debug   "Boost ${COMPONENT} library (debug)")
+
+  # Compute component-specific hints.
+  set(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT "")
+  if(${COMPONENT} STREQUAL "mpi" OR ${COMPONENT} STREQUAL "mpi_python" OR
+     ${COMPONENT} STREQUAL "graph_parallel")
+    foreach(lib ${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES})
+      if(IS_ABSOLUTE "${lib}")
+        get_filename_component(libdir "${lib}" PATH)
+        string(REPLACE "\\" "/" libdir "${libdir}")
+        list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT ${libdir})
+      endif()
+    endforeach()
+  endif()
+
+  # Handle Python version suffixes
+  unset(COMPONENT_PYTHON_VERSION_MAJOR)
+  unset(COMPONENT_PYTHON_VERSION_MINOR)
+  if(${COMPONENT} MATCHES "^(python|mpi_python|numpy)([0-9])\$")
+    set(COMPONENT_UNVERSIONED "${CMAKE_MATCH_1}")
+    set(COMPONENT_PYTHON_VERSION_MAJOR "${CMAKE_MATCH_2}")
+  elseif(${COMPONENT} MATCHES "^(python|mpi_python|numpy)([0-9])\\.?([0-9])\$")
+    set(COMPONENT_UNVERSIONED "${CMAKE_MATCH_1}")
+    set(COMPONENT_PYTHON_VERSION_MAJOR "${CMAKE_MATCH_2}")
+    set(COMPONENT_PYTHON_VERSION_MINOR "${CMAKE_MATCH_3}")
+  endif()
+
+  unset(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME)
+  if (COMPONENT_PYTHON_VERSION_MINOR)
+    # Boost >= 1.67
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
+    # Debian/Ubuntu (Some versions omit the 2 and/or 3 from the suffix)
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}${COMPONENT_PYTHON_VERSION_MAJOR}-py${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-py${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
+    # Gentoo
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
+    # RPMs
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
+  endif()
+  if (COMPONENT_PYTHON_VERSION_MAJOR AND NOT COMPONENT_PYTHON_VERSION_MINOR)
+    # Boost < 1.67
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}${COMPONENT_PYTHON_VERSION_MAJOR}")
+  endif()
+
+  # Consolidate and report component-specific hints.
+  if(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME)
+    list(REMOVE_DUPLICATES _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME)
+    if(Boost_DEBUG)
+      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+        "Component-specific library search names for ${COMPONENT_NAME}: "
+        "${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME}")
+    endif()
+  endif()
+  if(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
+    list(REMOVE_DUPLICATES _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
+    if(Boost_DEBUG)
+      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+        "Component-specific library search paths for ${COMPONENT}: "
+        "${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT}")
+    endif()
+  endif()
+
+  #
+  # Find headers
+  #
+  _Boost_COMPONENT_HEADERS("${COMPONENT}" Boost_${UPPERCOMPONENT}_HEADER_NAME)
+  # Look for a standard boost header file.
+  if(Boost_${UPPERCOMPONENT}_HEADER_NAME)
+    if(EXISTS "${Boost_INCLUDE_DIR}/${Boost_${UPPERCOMPONENT}_HEADER_NAME}")
+      set(Boost_${UPPERCOMPONENT}_HEADER ON)
+    else()
+      set(Boost_${UPPERCOMPONENT}_HEADER OFF)
+    endif()
+  else()
+    set(Boost_${UPPERCOMPONENT}_HEADER ON)
+    message(WARNING "No header defined for ${COMPONENT}; skipping header check")
+  endif()
+
+  #
+  # Find RELEASE libraries
+  #
+  unset(_boost_RELEASE_NAMES)
+  foreach(component IN LISTS _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME COMPONENT)
+    foreach(compiler IN LISTS _boost_COMPILER)
+      list(APPEND _boost_RELEASE_NAMES
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG} )
+    endforeach()
+    list(APPEND _boost_RELEASE_NAMES
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component} )
+    if(_boost_STATIC_RUNTIME_WORKAROUND)
+      set(_boost_RELEASE_STATIC_ABI_TAG "-s${_boost_RELEASE_ABI_TAG}")
+      foreach(compiler IN LISTS _boost_COMPILER)
+        list(APPEND _boost_RELEASE_NAMES
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG} )
+      endforeach()
+      list(APPEND _boost_RELEASE_NAMES
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG} )
+    endif()
+  endforeach()
+  if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
+    _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_RELEASE_NAMES ${_boost_RELEASE_NAMES})
+  endif()
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "Searching for ${UPPERCOMPONENT}_LIBRARY_RELEASE: ${_boost_RELEASE_NAMES}")
+  endif()
+
+  # if Boost_LIBRARY_DIR_RELEASE is not defined,
+  # but Boost_LIBRARY_DIR_DEBUG is, look there first for RELEASE libs
+  if(NOT Boost_LIBRARY_DIR_RELEASE AND Boost_LIBRARY_DIR_DEBUG)
+    list(INSERT _boost_LIBRARY_SEARCH_DIRS_RELEASE 0 ${Boost_LIBRARY_DIR_DEBUG})
+  endif()
+
+  # Avoid passing backslashes to _Boost_FIND_LIBRARY due to macro re-parsing.
+  string(REPLACE "\\" "/" _boost_LIBRARY_SEARCH_DIRS_tmp "${_boost_LIBRARY_SEARCH_DIRS_RELEASE}")
+
+  if(Boost_USE_RELEASE_LIBS)
+    _Boost_FIND_LIBRARY(Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE RELEASE
+      NAMES ${_boost_RELEASE_NAMES}
+      HINTS ${_boost_LIBRARY_SEARCH_DIRS_tmp}
+      NAMES_PER_DIR
+      DOC "${_boost_docstring_release}"
+      )
+  endif()
+
+  #
+  # Find DEBUG libraries
+  #
+  unset(_boost_DEBUG_NAMES)
+  foreach(component IN LISTS _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME COMPONENT)
+    foreach(compiler IN LISTS _boost_COMPILER)
+      list(APPEND _boost_DEBUG_NAMES
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG} )
+    endforeach()
+    list(APPEND _boost_DEBUG_NAMES
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component} )
+    if(_boost_STATIC_RUNTIME_WORKAROUND)
+      set(_boost_DEBUG_STATIC_ABI_TAG "-s${_boost_DEBUG_ABI_TAG}")
+      foreach(compiler IN LISTS _boost_COMPILER)
+        list(APPEND _boost_DEBUG_NAMES
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG} )
+      endforeach()
+      list(APPEND _boost_DEBUG_NAMES
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG} )
+    endif()
+  endforeach()
+  if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
+     _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_DEBUG_NAMES ${_boost_DEBUG_NAMES})
+  endif()
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+                   "Searching for ${UPPERCOMPONENT}_LIBRARY_DEBUG: ${_boost_DEBUG_NAMES}")
+  endif()
+
+  # if Boost_LIBRARY_DIR_DEBUG is not defined,
+  # but Boost_LIBRARY_DIR_RELEASE is, look there first for DEBUG libs
+  if(NOT Boost_LIBRARY_DIR_DEBUG AND Boost_LIBRARY_DIR_RELEASE)
+    list(INSERT _boost_LIBRARY_SEARCH_DIRS_DEBUG 0 ${Boost_LIBRARY_DIR_RELEASE})
+  endif()
+
+  # Avoid passing backslashes to _Boost_FIND_LIBRARY due to macro re-parsing.
+  string(REPLACE "\\" "/" _boost_LIBRARY_SEARCH_DIRS_tmp "${_boost_LIBRARY_SEARCH_DIRS_DEBUG}")
+
+  if(Boost_USE_DEBUG_LIBS)
+    _Boost_FIND_LIBRARY(Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG DEBUG
+      NAMES ${_boost_DEBUG_NAMES}
+      HINTS ${_boost_LIBRARY_SEARCH_DIRS_tmp}
+      NAMES_PER_DIR
+      DOC "${_boost_docstring_debug}"
+      )
+  endif ()
+
+  if(Boost_REALPATH)
+    _Boost_SWAP_WITH_REALPATH(Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE "${_boost_docstring_release}")
+    _Boost_SWAP_WITH_REALPATH(Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG   "${_boost_docstring_debug}"  )
+  endif()
+
+  _Boost_ADJUST_LIB_VARS(${UPPERCOMPONENT})
+
+  # Check if component requires some compiler features
+  _Boost_COMPILER_FEATURES(${COMPONENT} _Boost_${UPPERCOMPONENT}_COMPILER_FEATURES)
+
+endforeach()
+
+# Restore the original find library ordering
+if( Boost_USE_STATIC_LIBS )
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_boost_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
+
+# ------------------------------------------------------------------------
+#  End finding boost libraries
+# ------------------------------------------------------------------------
+
+set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIR})
+set(Boost_LIBRARY_DIRS)
+if(Boost_LIBRARY_DIR_RELEASE)
+  list(APPEND Boost_LIBRARY_DIRS ${Boost_LIBRARY_DIR_RELEASE})
+endif()
+if(Boost_LIBRARY_DIR_DEBUG)
+  list(APPEND Boost_LIBRARY_DIRS ${Boost_LIBRARY_DIR_DEBUG})
+endif()
+if(Boost_LIBRARY_DIRS)
+  list(REMOVE_DUPLICATES Boost_LIBRARY_DIRS)
+endif()
+
+# The above setting of Boost_FOUND was based only on the header files.
+# Update it for the requested component libraries.
+if(Boost_FOUND)
+  # The headers were found.  Check for requested component libs.
+  set(_boost_CHECKED_COMPONENT FALSE)
+  set(_Boost_MISSING_COMPONENTS "")
+  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+    set(_boost_CHECKED_COMPONENT TRUE)
+    if(NOT Boost_${UPPERCOMPONENT}_FOUND AND Boost_FIND_REQUIRED_${COMPONENT})
+      list(APPEND _Boost_MISSING_COMPONENTS ${COMPONENT})
+    endif()
+  endforeach()
+  if(_Boost_MISSING_COMPONENTS AND _Boost_EXTRA_FIND_COMPONENTS)
+    # Optional indirect dependencies are not counted as missing.
+    list(REMOVE_ITEM _Boost_MISSING_COMPONENTS ${_Boost_EXTRA_FIND_COMPONENTS})
+  endif()
+
+  if(Boost_DEBUG)
+    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] Boost_FOUND = ${Boost_FOUND}")
+  endif()
+
+  if (_Boost_MISSING_COMPONENTS)
+    set(Boost_FOUND 0)
+    # We were unable to find some libraries, so generate a sensible
+    # error message that lists the libraries we were unable to find.
+    string(APPEND Boost_ERROR_REASON
+      "\nCould not find the following")
+    if(Boost_USE_STATIC_LIBS)
+      string(APPEND Boost_ERROR_REASON " static")
+    endif()
+    string(APPEND Boost_ERROR_REASON
+      " Boost libraries:\n")
+    foreach(COMPONENT ${_Boost_MISSING_COMPONENTS})
+      string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+      string(APPEND Boost_ERROR_REASON
+        "        ${Boost_NAMESPACE}_${COMPONENT}${Boost_ERROR_REASON_${UPPERCOMPONENT}}\n")
+    endforeach()
+
+    list(LENGTH Boost_FIND_COMPONENTS Boost_NUM_COMPONENTS_WANTED)
+    list(LENGTH _Boost_MISSING_COMPONENTS Boost_NUM_MISSING_COMPONENTS)
+    if (${Boost_NUM_COMPONENTS_WANTED} EQUAL ${Boost_NUM_MISSING_COMPONENTS})
+      string(APPEND Boost_ERROR_REASON
+        "No Boost libraries were found. You may need to set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
+    else ()
+      string(APPEND Boost_ERROR_REASON
+        "Some (but not all) of the required Boost libraries were found. You may need to install these additional Boost libraries. Alternatively, set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
+    endif ()
+  endif ()
+
+  if( NOT Boost_LIBRARY_DIRS AND NOT _boost_CHECKED_COMPONENT )
+    # Compatibility Code for backwards compatibility with CMake
+    # 2.4's FindBoost module.
+
+    # Look for the boost library path.
+    # Note that the user may not have installed any libraries
+    # so it is quite possible the Boost_LIBRARY_DIRS may not exist.
+    set(_boost_LIB_DIR ${Boost_INCLUDE_DIR})
+
+    if("${_boost_LIB_DIR}" MATCHES "boost-[0-9]+")
+      get_filename_component(_boost_LIB_DIR ${_boost_LIB_DIR} PATH)
+    endif()
+
+    if("${_boost_LIB_DIR}" MATCHES "/include$")
+      # Strip off the trailing "/include" in the path.
+      get_filename_component(_boost_LIB_DIR ${_boost_LIB_DIR} PATH)
+    endif()
+
+    if(EXISTS "${_boost_LIB_DIR}/lib")
+      string(APPEND _boost_LIB_DIR /lib)
+    elseif(EXISTS "${_boost_LIB_DIR}/stage/lib")
+      string(APPEND _boost_LIB_DIR "/stage/lib")
+    else()
+      set(_boost_LIB_DIR "")
+    endif()
+
+    if(_boost_LIB_DIR AND EXISTS "${_boost_LIB_DIR}")
+      set(Boost_LIBRARY_DIRS ${_boost_LIB_DIR})
+    endif()
+
+  endif()
+else()
+  # Boost headers were not found so no components were found.
+  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+    set(Boost_${UPPERCOMPONENT}_FOUND 0)
+  endforeach()
+endif()
+
+# ------------------------------------------------------------------------
+#  Add imported targets
+# ------------------------------------------------------------------------
+
+if(Boost_FOUND)
+  # For header-only libraries
+  if(NOT TARGET Boost::boost)
+    add_library(Boost::boost INTERFACE IMPORTED)
+    if(Boost_INCLUDE_DIRS)
+      set_target_properties(Boost::boost PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
+    endif()
+  endif()
+
+  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+    if(_Boost_IMPORTED_TARGETS AND NOT TARGET Boost::${COMPONENT})
+      string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+      if(Boost_${UPPERCOMPONENT}_FOUND)
+        if(Boost_USE_STATIC_LIBS)
+          add_library(Boost::${COMPONENT} STATIC IMPORTED)
+        else()
+          # Even if Boost_USE_STATIC_LIBS is OFF, we might have static
+          # libraries as a result.
+          add_library(Boost::${COMPONENT} UNKNOWN IMPORTED)
+        endif()
+        if(Boost_INCLUDE_DIRS)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
+        endif()
+        if(EXISTS "${Boost_${UPPERCOMPONENT}_LIBRARY}")
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+            IMPORTED_LOCATION "${Boost_${UPPERCOMPONENT}_LIBRARY}")
+        endif()
+        if(EXISTS "${Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE}")
+          set_property(TARGET Boost::${COMPONENT} APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS RELEASE)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
+            IMPORTED_LOCATION_RELEASE "${Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE}")
+        endif()
+        if(EXISTS "${Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG}")
+          set_property(TARGET Boost::${COMPONENT} APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS DEBUG)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
+            IMPORTED_LOCATION_DEBUG "${Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG}")
+        endif()
+        if(_Boost_${UPPERCOMPONENT}_DEPENDENCIES)
+          unset(_Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES)
+          foreach(dep ${_Boost_${UPPERCOMPONENT}_DEPENDENCIES})
+            list(APPEND _Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES Boost::${dep})
+          endforeach()
+          if(COMPONENT STREQUAL "thread")
+            list(APPEND _Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES Threads::Threads)
+          endif()
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${_Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES}")
+        endif()
+        if(_Boost_${UPPERCOMPONENT}_COMPILER_FEATURES)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            INTERFACE_COMPILE_FEATURES "${_Boost_${UPPERCOMPONENT}_COMPILER_FEATURES}")
+        endif()
+      endif()
+    endif()
+  endforeach()
+endif()
+
+# ------------------------------------------------------------------------
+#  Notification to end user about what was found
+# ------------------------------------------------------------------------
+
+set(Boost_LIBRARIES "")
+if(Boost_FOUND)
+  if(NOT Boost_FIND_QUIETLY)
+    message(STATUS "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+    if(Boost_FIND_COMPONENTS)
+      message(STATUS "Found the following Boost libraries:")
+    endif()
+  endif()
+  foreach( COMPONENT  ${Boost_FIND_COMPONENTS} )
+    string( TOUPPER ${COMPONENT} UPPERCOMPONENT )
+    if( Boost_${UPPERCOMPONENT}_FOUND )
+      if(NOT Boost_FIND_QUIETLY)
+        message (STATUS "  ${COMPONENT}")
+      endif()
+      list(APPEND Boost_LIBRARIES ${Boost_${UPPERCOMPONENT}_LIBRARY})
+    endif()
+  endforeach()
+else()
+  if(Boost_FIND_REQUIRED)
+    message(SEND_ERROR "Unable to find the requested Boost libraries.\n${Boost_ERROR_REASON}")
+  else()
+    if(NOT Boost_FIND_QUIETLY)
+      # we opt not to automatically output Boost_ERROR_REASON here as
+      # it could be quite lengthy and somewhat imposing in its requests
+      # Since Boost is not always a required dependency we'll leave this
+      # up to the end-user.
+      if(Boost_DEBUG OR Boost_DETAILED_FAILURE_MSG)
+        message(STATUS "Could NOT find Boost\n${Boost_ERROR_REASON}")
+      else()
+        message(STATUS "Could NOT find Boost")
+      endif()
+    endif()
+  endif()
+endif()
+
+# Configure display of cache entries in GUI.
+foreach(v BOOSTROOT BOOST_ROOT ${_Boost_VARS_INC} ${_Boost_VARS_LIB})
+  get_property(_type CACHE ${v} PROPERTY TYPE)
+  if(_type)
+    set_property(CACHE ${v} PROPERTY ADVANCED 1)
+    if("x${_type}" STREQUAL "xUNINITIALIZED")
+      if("x${v}" STREQUAL "xBoost_ADDITIONAL_VERSIONS")
+        set_property(CACHE ${v} PROPERTY TYPE STRING)
+      else()
+        set_property(CACHE ${v} PROPERTY TYPE PATH)
+      endif()
+    endif()
+  endif()
+endforeach()
+
+# Record last used values of input variables so we can
+# detect on the next run if the user changed them.
+foreach(v
+    ${_Boost_VARS_INC} ${_Boost_VARS_LIB}
+    ${_Boost_VARS_DIR} ${_Boost_VARS_NAME}
+    )
+  if(DEFINED ${v})
+    set(_${v}_LAST "${${v}}" CACHE INTERNAL "Last used ${v} value.")
+  else()
+    unset(_${v}_LAST CACHE)
+  endif()
+endforeach()
+
+# Maintain a persistent list of components requested anywhere since
+# the last flush.
+set(_Boost_COMPONENTS_SEARCHED "${_Boost_COMPONENTS_SEARCHED}")
+list(APPEND _Boost_COMPONENTS_SEARCHED ${Boost_FIND_COMPONENTS})
+list(REMOVE_DUPLICATES _Boost_COMPONENTS_SEARCHED)
+list(SORT _Boost_COMPONENTS_SEARCHED)
+set(_Boost_COMPONENTS_SEARCHED "${_Boost_COMPONENTS_SEARCHED}"
+  CACHE INTERNAL "Components requested for this build tree.")
+
+# Restore project's policies
+cmake_policy(POP)

--- a/cmake/checkclang.cpp
+++ b/cmake/checkclang.cpp
@@ -1,1 +1,0 @@
-#include "math.h"

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Meta target that depends on all drivers
+add_custom_target(drivers)
+
+# Minimal visibility to avoid name clashes among plugins
+#set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+#set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
 add_subdirectory(audioDrivers)
 add_subdirectory(videoDrivers)
 if(RTTR_BUNDLE AND APPLE)

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -2,8 +2,8 @@
 add_custom_target(drivers)
 
 # Minimal visibility to avoid name clashes among plugins
-#set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-#set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 add_subdirectory(audioDrivers)
 add_subdirectory(videoDrivers)

--- a/extras/audioDrivers/SDL/AudioSDL.cpp
+++ b/extras/audioDrivers/SDL/AudioSDL.cpp
@@ -22,6 +22,7 @@
 #include "driver/AudioInterface.h"
 #include "driver/IAudioDriverCallback.h"
 #include "driver/Interface.h"
+#include "helpers/CIUtils.h"
 #include "helpers/LSANUtils.h"
 #include <SDL.h>
 #include <SDL_mixer.h>
@@ -79,10 +80,10 @@ const char* AudioSDL::GetName() const
  */
 bool AudioSDL::Initialize()
 {
+    initialized = false;
     if(SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
     {
         std::cerr << SDL_GetError() << std::endl;
-        initialized = false;
         return false;
     }
 
@@ -92,8 +93,12 @@ bool AudioSDL::Initialize()
         // stereo audio, using 1024 byte chunks
         if(Mix_OpenAudio(44100, AUDIO_S16LSB, 2, 4096) < 0)
         {
+            if(rttr::isRunningOnCI())
+            {
+                initialized = true;
+                return true;
+            }
             std::cerr << Mix_GetError() << std::endl;
-            initialized = false;
             return false;
         }
     }

--- a/extras/audioDrivers/SDL/CMakeLists.txt
+++ b/extras/audioDrivers/SDL/CMakeLists.txt
@@ -19,4 +19,5 @@ ELSE()
 		RUNTIME DESTINATION ${RTTR_DRIVERDIR}/audio
 		LIBRARY DESTINATION ${RTTR_DRIVERDIR}/audio
 	)
+	add_dependencies(drivers audioSDL)
 ENDIF ()

--- a/extras/videoDrivers/SDL/CMakeLists.txt
+++ b/extras/videoDrivers/SDL/CMakeLists.txt
@@ -7,7 +7,7 @@ IF (SDL_FOUND)
 	CORRECT_LIB(SDL_LIBRARY SDL)
 
 	ADD_LIBRARY(videoSDL SHARED ${RTTR_DRIVER_INTERFACE} VideoSDL.cpp VideoSDL.h)
-	target_link_libraries(videoSDL PRIVATE videodrv s25util ${SDL_LIBRARY} Boost::boost nowide::static)
+	target_link_libraries(videoSDL PRIVATE videodrv ${SDL_LIBRARY} nowide::static)
 	target_include_directories(videoSDL PRIVATE ${SDL_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/data/win32)
 
 	IF (WIN32)
@@ -22,6 +22,7 @@ IF (SDL_FOUND)
 		RUNTIME DESTINATION ${RTTR_DRIVERDIR}/video
 		LIBRARY DESTINATION ${RTTR_DRIVERDIR}/video
 	)
+	add_dependencies(drivers videoSDL)
 ELSE ()
 	MESSAGE(WARNING ": SDL library not found: Not building SDL videodriver")
 ENDIF ()

--- a/extras/videoDrivers/SDL/VideoSDL.cpp
+++ b/extras/videoDrivers/SDL/VideoSDL.cpp
@@ -118,7 +118,10 @@ VideoSDL::VideoSDL(VideoDriverLoaderInterface* CallBack) : VideoDriver(CallBack)
 VideoSDL::~VideoSDL()
 {
     if(initialized)
+    {
         SDL_QuitSubSystem(SDL_INIT_VIDEO);
+        SDL_Quit();
+    }
 }
 
 /**

--- a/extras/videoDrivers/SDL/VideoSDL.cpp
+++ b/extras/videoDrivers/SDL/VideoSDL.cpp
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "commonDefines.h" // IWYU pragma: keep
 #include "VideoSDL.h"
 #include "driver/Interface.h"
 #include "driver/VideoDriverLoaderInterface.h"
@@ -24,6 +23,7 @@
 #include <boost/nowide/iostream.hpp>
 #include <SDL.h>
 #include <algorithm>
+#include <helpers/LSANUtils.h>
 
 #ifdef _WIN32
 #include "makeException.h"
@@ -138,6 +138,7 @@ const char* VideoSDL::GetName() const
  */
 bool VideoSDL::Initialize()
 {
+    rttr::ScopedLeakDisabler _;
     if(SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
     {
         fprintf(stderr, "%s\n", SDL_GetError());
@@ -152,7 +153,6 @@ bool VideoSDL::Initialize()
 
     // Key-Repeat einschalten
     SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
-
     return initialized;
 }
 
@@ -309,7 +309,7 @@ bool VideoSDL::SetVideoMode(const VideoMode& newSize, bool fullscreen)
 
 void VideoSDL::PrintError(const std::string& msg)
 {
-    bnw::cerr << msg << std::endl;
+    boost::nowide::cerr << msg << std::endl;
 }
 
 void VideoSDL::HandlePaste()

--- a/extras/videoDrivers/SDL2/CMakeLists.txt
+++ b/extras/videoDrivers/SDL2/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SDL2_BUILDING_LIBRARY ON)
-find_package(SDL2 2.0.4)
+find_package(SDL2 2.0.2)
 
 if(SDL2_FOUND)
   add_library(videoSDL2 SHARED ${RTTR_DRIVER_INTERFACE} VideoSDL2.cpp VideoSDL2.h icon.h icon.cpp)

--- a/extras/videoDrivers/SDL2/CMakeLists.txt
+++ b/extras/videoDrivers/SDL2/CMakeLists.txt
@@ -14,4 +14,5 @@ if(SDL2_FOUND)
     RUNTIME DESTINATION ${RTTR_DRIVERDIR}/video
     LIBRARY DESTINATION ${RTTR_DRIVERDIR}/video
   )
+  add_dependencies(drivers videoSDL2)
 endif()

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -184,7 +184,9 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, bool fullscreen)
         isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
         if(!isFullscreen_)
         {
+#if SDL_VERSION_ATLEAST(2, 0, 5)
             SDL_SetWindowResizable(window, SDL_TRUE);
+#endif
             MoveWindowToCenter();
         }
     }
@@ -386,11 +388,11 @@ bool VideoSDL2::MessageLoop()
                     CallBack->Msg_RightUp(mouse_xy);
                 }
                 break;
-            case SDL_MOUSEWHEEL:
-            {
-                int y = ev.wheel.y;
+            case SDL_MOUSEWHEEL: { int y = ev.wheel.y;
+#if SDL_VERSION_ATLEAST(2, 0, 4)
                 if(ev.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
                     y = -y;
+#endif
                 if(y > 0)
                     CallBack->Msg_WheelUp(mouse_xy);
                 else if(y < 0)
@@ -472,11 +474,18 @@ void* VideoSDL2::GetMapPointer() const
 void VideoSDL2::MoveWindowToCenter()
 {
     SDL_Rect usableBounds;
+#if SDL_VERSION_ATLEAST(2, 0, 5)
     CHECK_SDL(SDL_GetDisplayUsableBounds(SDL_GetWindowDisplayIndex(window), &usableBounds));
     int top, left, bottom, right;
     CHECK_SDL(SDL_GetWindowBordersSize(window, &top, &left, &bottom, &right));
     usableBounds.w -= left + right;
     usableBounds.h -= top + bottom;
+#else
+    CHECK_SDL(SDL_GetDisplayBounds(SDL_GetWindowDisplayIndex(window), &usableBounds));
+    // rough estimates
+    usableBounds.w -= 10;
+    usableBounds.h -= 30;
+#endif
     if(usableBounds.w < GetWindowSize().width || usableBounds.h < GetWindowSize().height)
     {
         SDL_SetWindowSize(window, usableBounds.w, usableBounds.h);

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -20,6 +20,7 @@
 #include "driver/Interface.h"
 #include "driver/VideoDriverLoaderInterface.h"
 #include "driver/VideoInterface.h"
+#include "helpers/LSANUtils.h"
 #include "helpers/containerUtils.h"
 #include "icon.h"
 #include "openglCfg.hpp"
@@ -70,6 +71,7 @@ const char* VideoSDL2::GetName() const
 bool VideoSDL2::Initialize()
 {
     initialized = false;
+    rttr::ScopedLeakDisabler _;
     if(SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
     {
         PrintError(SDL_GetError());
@@ -90,6 +92,7 @@ void VideoSDL2::CleanUp()
     if(window)
         SDL_DestroyWindow(window);
     SDL_QuitSubSystem(SDL_INIT_VIDEO);
+    SDL_Quit();
     initialized = false;
 }
 

--- a/extras/videoDrivers/WinAPI/CMakeLists.txt
+++ b/extras/videoDrivers/WinAPI/CMakeLists.txt
@@ -7,4 +7,5 @@ IF (WIN32)
     target_include_directories(videoWinAPI SYSTEM PRIVATE ${OPENGL_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/data/win32)
 
 	INSTALL(TARGETS videoWinAPI RUNTIME DESTINATION ${RTTR_DRIVERDIR}/video)
+	add_dependencies(drivers videoWinAPI)
 ENDIF ()

--- a/libs/common/include/RTTR_Assert.h
+++ b/libs/common/include/RTTR_Assert.h
@@ -42,11 +42,11 @@ extern void __cdecl __debugbreak();
 #endif
 
 [[noreturn]] void RTTR_AssertFailure(const char* condition, const char* file, int line, const char* function);
-bool RTTR_IsBreakOnAssertFailureEnabled();
 /// If true(default), a breakpoint is triggered on assert (if available)
 /// Note: This breakpoint can be globally disabled by setting the environment variable
 ///       RTTR_DISABLE_ASSERT_BREAKPOINT to "1" or "yes" which overrides this setting
-extern bool RTTR_AssertEnableBreak;
+bool RTTR_IsBreakOnAssertFailureEnabled();
+bool RTTR_SetBreakOnAssertFailure(bool enabled);
 
 /* Some aspects about RTTR_Assert:
     - do-while(false) so it can be used in conditions: if(foo) RTTR_Assert(bar);

--- a/libs/common/include/helpers/CIUtils.h
+++ b/libs/common/include/helpers/CIUtils.h
@@ -15,34 +15,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef LSAN_Utils_h__
-#define LSAN_Utils_h__
+#ifndef CI_Utils_h__
+#define CI_Utils_h__
 
-#ifdef __has_feature
-#define RTTR_HAS_ASAN __has_feature(address_sanitizer)
-#elif defined(__SANITIZE_ADDRESS__)
-#define RTTR_HAS_ASAN __SANITIZE_ADDRESS__
-#else
-#define RTTR_HAS_ASAN 0
-#endif
+#include <cstdlib>
+#include <string>
 
-#if RTTR_HAS_ASAN
-#include <sanitizer/lsan_interface.h>
 namespace rttr {
-/// Record all leaks in the current context as expected
-using ScopedLeakDisabler = __lsan::ScopedDisabler;
-} // namespace rttr
-#else
-namespace rttr {
-struct ScopedLeakDisabler
+inline bool isRunningOnCI()
 {
-    static void suppressDefaultCtorWarning() {}
-    ScopedLeakDisabler()
-    { // Pretent to be a RAII class to avoid unused variable warnings
-        suppressDefaultCtorWarning();
-    };
-};
+    const auto* ciPtr = std::getenv("CI");
+    if(!ciPtr)
+        return false;
+    const std::string ci = ciPtr;
+    return ci == "true" || ci == "True";
+}
 } // namespace rttr
-#endif
 
-#endif // LSAN_Utils_h__
+#endif // CI_Utils_h__

--- a/libs/common/include/helpers/LSANUtils.h
+++ b/libs/common/include/helpers/LSANUtils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2018 - 2019 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -15,24 +15,32 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef PactTypes_h__
-#define PactTypes_h__
+#ifndef LSAN_Utils_h__
+#define LSAN_Utils_h__
 
-#include "helpers/MaxEnumValue.h"
-#include <array>
+#ifdef __has_feature
+#define RTTR_HAS_ASAN __has_feature(address_sanitizer)
+#elif defined(__SANITIZE_ADDRESS__)
+#define RTTR_HAS_ASAN __SANITIZE_ADDRESS__
+#else
+#define RTTR_HAS_ASAN 0
+#endif
 
-/// Types of pacts
-enum PactType
+#if RTTR_HAS_ASAN
+#include <sanitizer/lsan_interface.h>
+namespace rttr {
+/// Record all leaks in the current context as expected
+using ScopedLeakDisabler = __lsan::ScopedDisabler;
+} // namespace rttr
+#else
+namespace rttr {
+struct ScopedLeakDisabler
 {
-    TREATY_OF_ALLIANCE = 0,
-    NON_AGGRESSION_PACT
+    ScopedLeakDisabler(){
+      // Pretent to be a RAII class to avoid unused variable warnings
+    };
 };
+} // namespace rttr
+#endif
 
-/// Number of the various pacts
-const unsigned NUM_PACTS = 2;
-DEFINE_MAX_ENUM_VALUE(PactType, NUM_PACTS)
-
-/// Names of the possible pacts
-extern const std::array<const char*, NUM_PACTS> PACT_NAMES;
-
-#endif // PactTypes_h__
+#endif // LSAN_Utils_h__

--- a/libs/common/include/helpers/MaxEnumValue.h
+++ b/libs/common/include/helpers/MaxEnumValue.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2015 - 2019 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef MaxEnumValue_h__
+#define MaxEnumValue_h__
+
+namespace helpers {
+/// Trait to specify the maximum enum value
+template<class T_Enum>
+struct MaxEnumValue;
+
+template<class T_Enum>
+constexpr unsigned MaxEnumValue_v = MaxEnumValue<T_Enum>::value;
+} // namespace helpers
+
+// Helper macro to specialize the trait
+#define DEFINE_MAX_ENUM_VALUE(enum, maxValue)             \
+    namespace helpers {                                   \
+        template<>                                        \
+        struct MaxEnumValue<enum>                         \
+        {                                                 \
+            static constexpr unsigned value = (maxValue); \
+        };                                                \
+    } // namespace helpers
+
+#endif // MaxEnumValue_h__

--- a/libs/common/src/RTTR_Assert.cpp
+++ b/libs/common/src/RTTR_Assert.cpp
@@ -26,11 +26,18 @@
 #include <windows.h>
 #endif
 
-bool RTTR_AssertEnableBreak = true;
+static bool breakOnAssertFailureEnabled = true;
+
+bool RTTR_SetBreakOnAssertFailure(bool enabled)
+{
+    const bool old = breakOnAssertFailureEnabled;
+    breakOnAssertFailureEnabled = enabled;
+    return old;
+}
 
 bool RTTR_IsBreakOnAssertFailureEnabled()
 {
-    if(!RTTR_AssertEnableBreak)
+    if(!breakOnAssertFailureEnabled)
         return false;
     try
     {

--- a/libs/driver/include/driver/AudioInterface.h
+++ b/libs/driver/include/driver/AudioInterface.h
@@ -25,7 +25,7 @@
 #include <vector>
 
 /// Interface for audio drivers (required for use across DLL boundaries)
-class IAudioDriver
+class BOOST_SYMBOL_VISIBLE IAudioDriver
 {
 public:
     virtual ~IAudioDriver() = 0;

--- a/libs/driver/include/driver/IAudioDriverCallback.h
+++ b/libs/driver/include/driver/IAudioDriverCallback.h
@@ -17,7 +17,9 @@
 #ifndef AUDIODRIVERLOADERINTERFACE_H_INCLUDED
 #define AUDIODRIVERLOADERINTERFACE_H_INCLUDED
 
-class IAudioDriverCallback
+#include <boost/config.hpp>
+
+class BOOST_SYMBOL_VISIBLE IAudioDriverCallback
 {
 public:
     virtual ~IAudioDriverCallback() = default;

--- a/libs/driver/include/driver/Interface.h
+++ b/libs/driver/include/driver/Interface.h
@@ -24,4 +24,7 @@
 RTTR_DECL unsigned GetDriverAPIVersion();
 RTTR_DECL const char* GetDriverName();
 
+using GetDriverAPIVersion_t = decltype(GetDriverAPIVersion);
+using GetDriverName_t = decltype(GetDriverName);
+
 #endif // !INTERFACE_H_INCLUDED

--- a/libs/driver/include/driver/VideoDriverLoaderInterface.h
+++ b/libs/driver/include/driver/VideoDriverLoaderInterface.h
@@ -21,8 +21,9 @@
 
 #include "KeyEvent.h"
 #include "MouseCoords.h"
+#include <boost/config.hpp>
 
-class VideoDriverLoaderInterface
+class BOOST_SYMBOL_VISIBLE VideoDriverLoaderInterface
 {
 public:
     virtual ~VideoDriverLoaderInterface() = default;

--- a/libs/driver/include/driver/VideoInterface.h
+++ b/libs/driver/include/driver/VideoInterface.h
@@ -29,7 +29,7 @@
 /// Function type for loading OpenGL methods
 using OpenGL_Loader_Proc = void* (*)(const char*);
 
-class IVideoDriver
+class BOOST_SYMBOL_VISIBLE IVideoDriver
 {
 public:
     virtual ~IVideoDriver() = 0;
@@ -94,5 +94,8 @@ class VideoDriverLoaderInterface;
 /// Instanzierungsfunktion der Treiber.
 RTTR_DECL IVideoDriver* CreateVideoInstance(VideoDriverLoaderInterface* CallBack);
 RTTR_DECL void FreeVideoInstance(IVideoDriver* driver);
+
+using CreateVideoInstance_t = decltype(CreateVideoInstance);
+using FreeVideoInstance_t = decltype(FreeVideoInstance);
 
 #endif // !VIDEOINTERFACE_H_INCLUDED

--- a/libs/driver/src/AudioType.h
+++ b/libs/driver/src/AudioType.h
@@ -18,6 +18,8 @@
 #ifndef AudioType_h__
 #define AudioType_h__
 
+#include <cassert>
+
 struct AudioType
 {
     enum Type

--- a/libs/driver/src/VideoDriver.cpp
+++ b/libs/driver/src/VideoDriver.cpp
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "commonDefines.h" // IWYU pragma: keep
+#include "commonDefines.h"
 #include "driver/VideoDriver.h"
 #include <algorithm>
 #include <stdexcept>

--- a/libs/libsamplerate/include/samplerate.hpp
+++ b/libs/libsamplerate/include/samplerate.hpp
@@ -55,11 +55,13 @@ namespace detail {
 
     template<class T, class = void>
     struct has_src_clone : std::false_type
-    {};
+    {
+    };
 
     template<class T>
     struct has_src_clone<T, void_t<decltype(src_clone(std::declval<T>(), nullptr))>> : std::true_type
-    {};
+    {
+    };
 
     template<typename T, bool = has_src_clone<T*>::value>
     class State

--- a/libs/s25client/CMakeLists.txt
+++ b/libs/s25client/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(Boost REQUIRED program_options)
 
 add_executable(s25client s25client.cpp ${s25client_RC})
 target_link_libraries(s25client PRIVATE s25Main Boost::program_options nowide::static)
+add_dependencies(s25client drivers)
 
 if(APPLE)
     set(SDL_BUILDING_LIBRARY OFF)

--- a/libs/s25main/GameManager.cpp
+++ b/libs/s25main/GameManager.cpp
@@ -51,7 +51,7 @@ bool GameManager::Start()
     SETTINGS.Load();
 
     /// Videotreiber laden
-    if(!VIDEODRIVER.LoadDriver())
+    if(!VIDEODRIVER.LoadDriver(SETTINGS.driver.video))
     {
         s25util::error(_("Video driver couldn't be loaded!\n"));
         return false;
@@ -61,9 +61,11 @@ bool GameManager::Start()
     const auto screenSize = SETTINGS.video.fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize; //-V807
     if(!VIDEODRIVER.CreateScreen(screenSize, SETTINGS.video.fullscreen))
         return false;
+    VIDEODRIVER.setTargetFramerate(SETTINGS.video.vsync);
+    VIDEODRIVER.SetMouseWarping(SETTINGS.global.smartCursor);
 
     /// Audiodriver laden
-    if(!AUDIODRIVER.LoadDriver())
+    if(!AUDIODRIVER.LoadDriver(SETTINGS.driver.audio))
     {
         s25util::warning(_("Audio driver couldn't be loaded!\n"));
         // return false;
@@ -197,7 +199,7 @@ bool GameManager::ShowMenu()
 
 void GameManager::ResetAverageGFPS()
 {
-    gfCounter_ = FrameCounter(std::chrono::hours::max()); // Never update
+    gfCounter_ = FrameCounter(FrameCounter::clock::duration::max()); // Never update
 }
 
 /**

--- a/libs/s25main/GlobalVars.h
+++ b/libs/s25main/GlobalVars.h
@@ -25,11 +25,7 @@
 class GlobalVars : public Singleton<GlobalVars>
 {
 public:
-    GlobalVars() : notdone(true), hasVSync(false) {}
-
-public:
-    bool notdone;
-    bool hasVSync;
+    bool notdone = true;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/s25main/IngameMinimap.cpp
+++ b/libs/s25main/IngameMinimap.cpp
@@ -23,7 +23,7 @@
 #include "world/GameWorldViewer.h"
 #include "gameData/MinimapConsts.h"
 #include "gameData/TerrainDesc.h"
-#include "libsiedler2/ColorARGB.h"
+#include "libsiedler2/ColorBGRA.h"
 
 IngameMinimap::IngameMinimap(const GameWorldViewer& gwv)
     : Minimap(gwv.GetWorld().GetSize()), gwv(gwv), nodes_updated(GetMapSize().x * GetMapSize().y, false),
@@ -230,7 +230,7 @@ void IngameMinimap::BeforeDrawing()
                 {
                     unsigned color = CalcPixelColor(it, t);
                     DrawPoint texPos((it.x * 2 + t + (it.y & 1)) % (GetMapSize().x * 2), it.y);
-                    map.updatePixel(texPos, libsiedler2::ColorARGB(color));
+                    map.updatePixel(texPos, libsiedler2::ColorBGRA(color));
                 }
                 nodes_updated[GetMMIdx(it)] = false;
             }
@@ -268,7 +268,7 @@ void IngameMinimap::UpdateAll(const DrawnObject drawn_object)
             {
                 unsigned color = CalcPixelColor(pt, t);
                 DrawPoint texPos((pt.x * 2 + t + (pt.y & 1)) % (GetMapSize().x * 2), pt.y);
-                map.updatePixel(texPos, libsiedler2::ColorARGB(color));
+                map.updatePixel(texPos, libsiedler2::ColorBGRA(color));
             }
         }
     }

--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -42,7 +42,7 @@
 #include "libsiedler2/ArchivItem_PaletteAnimation.h"
 #include "libsiedler2/ArchivItem_Text.h"
 #include "libsiedler2/ErrorCodes.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include "libsiedler2/PixelBufferPaletted.h"
 #include "libsiedler2/libsiedler2.h"
 #include "libutil/Log.h"
@@ -283,14 +283,14 @@ void Loader::LoadDummyGUIFiles()
     for(unsigned id = 4; id < 36; id++)
     {
         auto bmp = std::make_unique<glArchivItem_Bitmap_RLE>();
-        libsiedler2::PixelBufferARGB buffer(1, 1);
+        libsiedler2::PixelBufferBGRA buffer(1, 1);
         bmp->create(buffer);
         resource.set(id, std::move(bmp));
     }
     for(unsigned id = 36; id < 57; id++)
     {
         auto bmp = std::make_unique<glArchivItem_Bitmap_Raw>();
-        libsiedler2::PixelBufferARGB buffer(1, 1);
+        libsiedler2::PixelBufferBGRA buffer(1, 1);
         bmp->create(buffer);
         resource.set(id, std::move(bmp));
     }
@@ -298,7 +298,7 @@ void Loader::LoadDummyGUIFiles()
     for(unsigned id = 0; id < 264; id++)
     {
         auto bmp = std::make_unique<glArchivItem_Bitmap_Raw>();
-        libsiedler2::PixelBufferARGB buffer(1, 1);
+        libsiedler2::PixelBufferBGRA buffer(1, 1);
         bmp->create(buffer);
         io.push(std::move(bmp));
     }
@@ -306,7 +306,7 @@ void Loader::LoadDummyGUIFiles()
     libsiedler2::Archiv& fonts = files_["outline_fonts"].archiv;
     auto* palette = GetPaletteN("colors");
     fonts.alloc(3);
-    libsiedler2::PixelBufferARGB buffer(15, 16);
+    libsiedler2::PixelBufferBGRA buffer(15, 16);
     for(unsigned i = 0; i < 3; i++)
     {
         auto font = std::make_unique<glArchivItem_Font>();

--- a/libs/s25main/Loader.h
+++ b/libs/s25main/Loader.h
@@ -73,7 +73,7 @@ public:
     static constexpr unsigned Longevity = 19;
 
     Loader();
-    ~Loader() override;
+    ~Loader();
 
     /// Add a folder to the list of folders containing overrides. Files in folders added last will override prior ones
     /// Paths with macros will be resolved

--- a/libs/s25main/Minimap.cpp
+++ b/libs/s25main/Minimap.cpp
@@ -17,7 +17,7 @@
 
 #include "rttrDefines.h" // IWYU pragma: keep
 #include "Minimap.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 
 Minimap::Minimap(const MapExtent& mapSize) : mapSize(mapSize) {}
 
@@ -26,14 +26,14 @@ void Minimap::CreateMapTexture()
     map.DeleteTexture();
 
     /// Buffer für die Daten erzeugen
-    libsiedler2::PixelBufferARGB buffer(mapSize.x * 2, mapSize.y);
+    libsiedler2::PixelBufferBGRA buffer(mapSize.x * 2, mapSize.y);
 
     RTTR_FOREACH_PT(MapPoint, mapSize)
     {
         // Die 2. Terraindreiecke durchgehen
         for(unsigned t = 0; t < 2; ++t)
         {
-            libsiedler2::ColorARGB color(CalcPixelColor(pt, t));
+            libsiedler2::ColorBGRA color(CalcPixelColor(pt, t));
             unsigned xCoord = (pt.x * 2 + t + (pt.y & 1)) % buffer.getWidth();
             buffer.set(xCoord, pt.y, color);
         }

--- a/libs/s25main/SerializedGameData.h
+++ b/libs/s25main/SerializedGameData.h
@@ -25,6 +25,7 @@
 #include "gameTypes/GO_Type.h"
 #include "gameTypes/MapCoordinates.h"
 #include "libutil/Serializer.h"
+#include "libutil/warningSuppression.h"
 #include <map>
 #include <memory>
 #include <set>
@@ -95,8 +96,12 @@ public:
     // Read methods
     //////////////////////////////////////////////////////////////////////////
 
+    /* FIXME: This function may be used to pop and cast incomplete objects due to a dependency cycle.
+     Example: Builder->Building->Builder
+     In this case Builder cannot be complete when it is stored into Building */
     /// Read a GameObject
     template<typename T>
+    RTTR_ATTRIBUTE_NO_UBSAN(vptr)
     T* PopObject(GO_Type got)
     {
         return static_cast<T*>(PopObject_(got));

--- a/libs/s25main/SoundManager.h
+++ b/libs/s25main/SoundManager.h
@@ -56,7 +56,7 @@ public:
     static constexpr unsigned Longevity = 29;
 
     SoundManager();
-    ~SoundManager() override;
+    ~SoundManager();
 
     /// Versucht ggf. Objekt-Sound abzuspielen
     void PlayNOSound(unsigned sound_lst_id, noBase* obj, unsigned id, unsigned char volume = 255);

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -34,7 +34,7 @@
 #include "ogl/glArchivItem_Font.h"
 #include "ogl/saveBitmap.h"
 #include "gameData/const_gui_ids.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include "libutil/Log.h"
 #include "libutil/MyTime.h"
 #include <algorithm>
@@ -784,7 +784,7 @@ void WindowManager::SetActiveWindow(Window& wnd)
 
 void WindowManager::TakeScreenshot()
 {
-    libsiedler2::PixelBufferARGB buffer(curRenderSize.x, curRenderSize.y);
+    libsiedler2::PixelBufferBGRA buffer(curRenderSize.x, curRenderSize.y);
     glReadPixels(0, 0, curRenderSize.x, curRenderSize.y, GL_BGRA, GL_UNSIGNED_BYTE, buffer.getPixelPtr());
     bfs::path outFilepath = bfs::path(RTTRCONFIG.ExpandPath(FILE_PATHS[100])) / (s25util::Time::FormatTime("%Y-%m-%d_%H-%i-%s") + ".bmp");
     try

--- a/libs/s25main/WindowManager.h
+++ b/libs/s25main/WindowManager.h
@@ -42,7 +42,7 @@ public:
     using MouseMsgHandler = bool (Window::*)(const MouseCoords&);
 
     WindowManager();
-    ~WindowManager() override;
+    ~WindowManager();
     void CleanUp();
 
     /// Zeichnet Desktop und alle Fenster.

--- a/libs/s25main/animation/MoveAnimation.cpp
+++ b/libs/s25main/animation/MoveAnimation.cpp
@@ -26,6 +26,7 @@ MoveAnimation::MoveAnimation(Window* element, DrawPoint newPos, unsigned animTim
     : Animation(element, 2, animTime, repeat), origPos_(element->GetPos()), newPos_(newPos)
 {
     Point<double> diff(newPos_ - origPos_);
+    diff = elMax(Point<double>::all(1), diff); // Avoid division by zero
     Point<double> msPerPixel(static_cast<double>(animTime) / diff);
     double frameRate = std::max(1., std::floor(std::min(msPerPixel.x, msPerPixel.y)));
     setFrameRate(static_cast<unsigned>(frameRate));

--- a/libs/s25main/controls/ctrlChat.h
+++ b/libs/s25main/controls/ctrlChat.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Window.h"
+#include <boost/variant.hpp>
 #include <vector>
 class MouseCoords;
 class glArchivItem_Font;
@@ -56,15 +57,13 @@ protected:
 
 private:
     // Struktur für eine Chatzeile.
-    struct ChatLine
+    struct RawChatLine
     {
-        /// Handelt es sich bei dieser Zeile um eine sekundäre (also den >1-Teil einer umbrochenen Zeile)
-        bool secondary;
-        /// Zeitangabe (optional, 0 wenn nicht benutzt)
+        /// Zeitangabe (optional)
         std::string time_string;
-        /// Spielername
+        /// Spielername (optional)
         std::string player;
-        /// Farbe des Spieler(namens) (optional, 0 wenn nicht benutzt)
+        /// Farbe des Spieler(namens) (optional)
         unsigned player_color;
         /// Chatnachricht
         std::string msg;
@@ -72,12 +71,21 @@ private:
         unsigned msg_color;
     };
 
+    using PrimaryChatLine = RawChatLine;
+    struct SecondaryChatLine
+    {
+        std::string msg;
+        /// Farbe der Chatnachricht
+        unsigned msg_color;
+    };
+    using ChatLine = boost::variant<PrimaryChatLine, SecondaryChatLine>;
+
 private:
     TextureColor tc;         /// Hintergrundtextur.
     glArchivItem_Font* font; /// Schriftart.
 
-    std::vector<ChatLine> raw_chat_lines; /// Chatzeilen, noch nicht umgebrochen
-    std::vector<ChatLine> chat_lines;     /// Chatzeilen
+    std::vector<RawChatLine> raw_chat_lines; /// Chatzeilen, noch nicht umgebrochen
+    std::vector<ChatLine> chat_lines;        /// Chatzeilen
 
     unsigned page_size;  /// Chatzeilen pro Seite
     unsigned time_color; /// Farbe der Zeitangaben

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -28,6 +28,7 @@
 #include "controls/ctrlGroup.h"
 #include "controls/ctrlOptionGroup.h"
 #include "controls/ctrlProgress.h"
+#include "driver/VideoDriver.h"
 #include "drivers/AudioDriverWrapper.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "dskMainMenu.h"
@@ -278,7 +279,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 
     // "Limit Framerate" füllen
     auto* cbFrameRate = groupGrafik->GetCtrl<ctrlComboBox>(51);
-    if(GLOBALVARS.hasVSync)
+    if(VIDEODRIVER.HasVSync())
         cbFrameRate->AddString(_("Dynamic (Limits to display refresh rate, works with most drivers)"));
     for(int framerate : Settings::SCREEN_REFRESH_RATES)
     {
@@ -381,7 +382,7 @@ void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsign
             SETTINGS.video.fullscreenSize = video_modes[selection];
             break;
         case 51: // Limit Framerate
-            if(GLOBALVARS.hasVSync)
+            if(VIDEODRIVER.HasVSync())
             {
                 if(selection == 0)
                     SETTINGS.video.vsync = 0;
@@ -489,6 +490,7 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
                 case 10102: SETTINGS.global.smartCursor = true; break;
                 case 10103: SETTINGS.global.smartCursor = false; break;
             }
+            VIDEODRIVER.SetMouseWarping(SETTINGS.global.smartCursor);
         }
         break;
     }

--- a/libs/s25main/drivers/AudioDriverWrapper.cpp
+++ b/libs/s25main/drivers/AudioDriverWrapper.cpp
@@ -99,7 +99,7 @@ bool AudioDriverWrapper::Init()
 /// Lädt den Treiber
 bool AudioDriverWrapper::LoadDriver(IAudioDriver* audioDriver)
 {
-    audiodriver_ = Handle(audioDriver, [](auto* p) { delete p; });
+    audiodriver_ = Handle(audioDriver, [](IAudioDriver* p) { delete p; });
     return Init();
 }
 

--- a/libs/s25main/drivers/AudioDriverWrapper.h
+++ b/libs/s25main/drivers/AudioDriverWrapper.h
@@ -21,6 +21,7 @@
 #include "driver/EffectPlayId.h"
 #include "driver/IAudioDriverCallback.h"
 #include "libutil/Singleton.h"
+#include <memory>
 
 class IAudioDriver;
 class SoundHandle;
@@ -37,10 +38,11 @@ public:
     static constexpr unsigned Longevity = 30;
 
     AudioDriverWrapper();
-    ~AudioDriverWrapper() override;
+    ~AudioDriverWrapper();
 
-    /// Loads the driver. If audioDriver is nullptr then the dll directory is checked
-    bool LoadDriver(IAudioDriver* audioDriver = nullptr);
+    /// Loads the driver
+    bool LoadDriver(IAudioDriver* audioDriver);
+    bool LoadDriver(std::string& preference);
     /// Unloads the driver resetting all open handles
     void UnloadDriver();
 
@@ -73,12 +75,12 @@ public:
     std::string GetName() const;
 
 private:
+    using Handle = std::unique_ptr<IAudioDriver, void (*)(IAudioDriver*)>;
+    bool Init();
     void Msg_MusicFinished() override;
 
-private:
     drivers::DriverWrapper driver_wrapper;
-    IAudioDriver* audiodriver_;
-    bool loadedFromDll; /// If true then free must just dll free function else delete
+    Handle audiodriver_;
 };
 
 #define AUDIODRIVER AudioDriverWrapper::inst()

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -71,7 +71,7 @@ bool VideoDriverWrapper::Initialize()
 bool VideoDriverWrapper::LoadDriver(IVideoDriver* existingDriver)
 {
     UnloadDriver();
-    videodriver = Handle(existingDriver, [](auto* p) { delete p; });
+    videodriver = Handle(existingDriver, [](IVideoDriver* p) { delete p; });
     return Initialize();
 }
 

--- a/libs/s25main/drivers/VideoDriverWrapper.h
+++ b/libs/s25main/drivers/VideoDriverWrapper.h
@@ -38,13 +38,14 @@ public:
     static constexpr unsigned Longevity = 30;
 
     VideoDriverWrapper();
-    ~VideoDriverWrapper() override;
+    ~VideoDriverWrapper();
 
-    /// Loads a new driver. Takes the existing one, if given
+    /// Loads a new driver.
     /// Do not use this class unless this returned true!
-    bool LoadDriver(IVideoDriver* existingDriver = nullptr);
+    bool LoadDriver(IVideoDriver* existingDriver);
+    bool LoadDriver(std::string& preference);
     void UnloadDriver();
-    IVideoDriver* GetDriver() const { return videodriver; }
+    IVideoDriver* GetDriver() const { return videodriver.get(); }
 
     /// Erstellt das Fenster.
     bool CreateScreen(VideoMode size, bool fullscreen);
@@ -72,6 +73,7 @@ public:
 
     /// Listet verfügbare Videomodi auf
     void ListVideoModes(std::vector<VideoMode>& video_modes) const;
+    bool HasVSync() const;
 
     /// Gibt Pointer auf ein Fenster zurück (device-dependent!), HWND unter Windows
     void* GetMapPointer() const;
@@ -85,6 +87,7 @@ public:
     bool IsRightDown();
     // setzt den Mausstatus
     void SetMousePos(const Position& newPos);
+    void SetMouseWarping(bool enabled) { enableMouseWarping = enabled; }
     /// Get state of the modifier keys
     KeyEvent GetModKeyState() const;
 
@@ -104,7 +107,6 @@ public:
     Extent calcPreferredTextureSize(const Extent& minSize) const;
 
 private:
-    // Viewpoint und Co initialisieren
     bool Initialize();
     bool setHwVSync(bool enabled);
 
@@ -115,12 +117,14 @@ private:
     bool LoadAllExtensions();
 
 private:
+    using Handle = std::unique_ptr<IVideoDriver, void (*)(IVideoDriver*)>;
+
     drivers::DriverWrapper driver_wrapper;
-    IVideoDriver* videodriver;
+    Handle videodriver;
     std::unique_ptr<IRenderer> renderer_;
     std::unique_ptr<FrameCounter> frameCtr_;
     std::unique_ptr<FrameLimiter> frameLimiter_;
-    bool loadedFromDll;
+    bool enableMouseWarping;
 
     std::vector<unsigned> texture_list;
     unsigned texture_current;

--- a/libs/s25main/factories/JobFactory.cpp
+++ b/libs/s25main/factories/JobFactory.cpp
@@ -67,11 +67,11 @@ noFigure* JobFactory::CreateJob(const Job job_id, const MapPoint pt, const unsig
     {
         case JOB_BUILDER:
             if(!goal)
-                return new nofBuilder(pt, player, goal);
-            else if(goal->GetGOT() == GOT_NOB_HARBORBUILDING)
+                return new nofBuilder(pt, player, nullptr);
+            else if(goal->GetGOT() != GOT_BUILDINGSITE)
                 return new nofPassiveWorker(JOB_BUILDER, pt, player, goal);
             else
-                return new nofBuilder(pt, player, goal);
+                return new nofBuilder(pt, player, static_cast<noBuildingSite*>(goal));
         case JOB_PLANER:
             RTTR_Assert(dynamic_cast<noBuildingSite*>(goal));
             return new nofPlaner(pt, player, static_cast<noBuildingSite*>(goal));

--- a/libs/s25main/figures/nofBuilder.cpp
+++ b/libs/s25main/figures/nofBuilder.cpp
@@ -35,9 +35,8 @@
 #include "gameData/BuildingConsts.h"
 #include "gameData/BuildingProperties.h"
 
-nofBuilder::nofBuilder(const MapPoint pos, const unsigned char player, noRoadNode* building_site)
-    : noFigure(JOB_BUILDER, pos, player, building_site), state(STATE_FIGUREWORK),
-      building_site(static_cast<noBuildingSite*>(building_site)), building_steps_available(0)
+nofBuilder::nofBuilder(const MapPoint pos, const unsigned char player, noBuildingSite* building_site)
+    : noFigure(JOB_BUILDER, pos, player, building_site), state(STATE_FIGUREWORK), building_site(building_site), building_steps_available(0)
 {
     // Sind wir schon an unsere Baustelle gleich hingesetzt worden (bei Häfen)?
     if(building_site)

--- a/libs/s25main/figures/nofBuilder.h
+++ b/libs/s25main/figures/nofBuilder.h
@@ -22,7 +22,6 @@
 
 class noBuildingSite;
 class SerializedGameData;
-class noRoadNode;
 
 class nofBuilder final : public noFigure
 {
@@ -66,7 +65,7 @@ private:
     bool ChooseWare();
 
 public:
-    nofBuilder(MapPoint pos, unsigned char player, noRoadNode* building_site);
+    nofBuilder(MapPoint pos, unsigned char player, noBuildingSite* building_site);
     nofBuilder(SerializedGameData& sgd, unsigned obj_id);
 
     void Destroy() override

--- a/libs/s25main/gameTypes/BuildingType.h
+++ b/libs/s25main/gameTypes/BuildingType.h
@@ -20,6 +20,8 @@
 #ifndef BuildingType_h__
 #define BuildingType_h__
 
+#include "helpers/MaxEnumValue.h"
+
 enum BuildingType
 {
     BLD_HEADQUARTERS = 0,    // ----
@@ -67,6 +69,8 @@ enum BuildingType
 
 /// Number of building types
 const unsigned NUM_BUILDING_TYPES = BLD_NOTHING;
+DEFINE_MAX_ENUM_VALUE(BuildingType, NUM_BUILDING_TYPES - 1)
+
 /// Number of NOTHING entries (currently unused buildings)
 const unsigned NUM_UNUSED_BLD_TYPES = 7;
 /// First usual building (building that produces something)

--- a/libs/s25main/gameTypes/GoodTypes.h
+++ b/libs/s25main/gameTypes/GoodTypes.h
@@ -18,6 +18,7 @@
 #ifndef GoodTypes_h__
 #define GoodTypes_h__
 
+#include "helpers/MaxEnumValue.h"
 #include "mygettext/mygettext.h"
 
 // Warentypen
@@ -63,6 +64,7 @@ enum GoodType
 };
 // Anzahl an unterschiedlichen Warentypen
 const unsigned NUM_WARE_TYPES = GD_NOTHING;
+DEFINE_MAX_ENUM_VALUE(GoodType, NUM_WARE_TYPES - 1)
 // Number of tools
 const unsigned NUM_TOOLS = 12;
 

--- a/libs/s25main/gameTypes/JobTypes.h
+++ b/libs/s25main/gameTypes/JobTypes.h
@@ -18,6 +18,7 @@
 #ifndef JobTypes_h__
 #define JobTypes_h__
 
+#include "helpers/MaxEnumValue.h"
 #include <libutil/warningSuppression.h>
 #include <array>
 
@@ -60,6 +61,8 @@ enum Job
 
 // Anzahl an unterschiedlichen Berufstypen
 const unsigned NUM_JOB_TYPES = JOB_NOTHING;
+DEFINE_MAX_ENUM_VALUE(Job, NUM_JOB_TYPES - 1)
+
 /// Job types of soldiers, weak ones first
 static const std::array<Job, 5> SUPPRESS_UNUSED SOLDIER_JOBS = {
   {JOB_PRIVATE, JOB_PRIVATEFIRSTCLASS, JOB_SERGEANT, JOB_OFFICER, JOB_GENERAL}};

--- a/libs/s25main/ingameWindows/iwMissionStatement.cpp
+++ b/libs/s25main/ingameWindows/iwMissionStatement.cpp
@@ -46,6 +46,7 @@ iwMissionStatement::iwMissionStatement(const std::string& title, const std::stri
 
     // set window width to our determined max width
     Extent newIwSize = text->GetSize() + Extent::all(textSpace) + Extent(imgSize.x + imgSpace, buttonSize.y + 2);
+    newIwSize = elMax(newIwSize, buttonSize);
     newIwSize.y = std::max(newIwSize.y, imgSize.y + minImgSpaceTop) + buttonSpace;
     SetIwSize(newIwSize);
 

--- a/libs/s25main/ingameWindows/iwMissionStatement.h
+++ b/libs/s25main/ingameWindows/iwMissionStatement.h
@@ -25,7 +25,8 @@ class iwMissionStatement : public IngameWindow
 {
 public:
     /// Image shown in bottom right corner
-    enum HelpImage
+    using HelpImage = int;
+    enum HelpImageConsts // enum used
     {
         /// No image
         IM_NONE,

--- a/libs/s25main/lua/LuaInterfaceGame.cpp
+++ b/libs/s25main/lua/LuaInterfaceGame.cpp
@@ -23,6 +23,7 @@
 #include "ai/AIInterface.h"
 #include "ai/AIPlayer.h"
 #include "ingameWindows/iwMissionStatement.h"
+#include "lua/LuaHelpers.h"
 #include "lua/LuaPlayer.h"
 #include "lua/LuaWorld.h"
 #include "network/GameClient.h"
@@ -281,22 +282,23 @@ void LuaInterfaceGame::SetMissionGoal(int playerIdx, const std::string& newGoal)
 }
 
 // Must not be PostMessage as this is a windows define :(
-void LuaInterfaceGame::PostMessageLua(unsigned playerIdx, const std::string& msg)
+void LuaInterfaceGame::PostMessageLua(int playerIdx, const std::string& msg)
 {
-    gw.GetPostMgr().SendMsg(playerIdx, new PostMsg(gw.GetEvMgr().GetCurrentGF(), msg, PostCategory::General));
+    lua::assertTrue(playerIdx >= 0, "Invalid player idx");
+    gw.GetPostMgr().SendMsg(static_cast<unsigned>(playerIdx), new PostMsg(gw.GetEvMgr().GetCurrentGF(), msg, PostCategory::General));
 }
 
-void LuaInterfaceGame::PostMessageWithLocation(unsigned playerIdx, const std::string& msg, int x, int y)
+void LuaInterfaceGame::PostMessageWithLocation(int playerIdx, const std::string& msg, int x, int y)
 {
-    gw.GetPostMgr().SendMsg(playerIdx,
+    lua::assertTrue(playerIdx >= 0, "Invalid player idx");
+    gw.GetPostMgr().SendMsg(static_cast<unsigned>(playerIdx),
                             new PostMsg(gw.GetEvMgr().GetCurrentGF(), msg, PostCategory::General, gw.MakeMapPoint(Position(x, y))));
 }
 
-LuaPlayer LuaInterfaceGame::GetPlayer(unsigned playerIdx)
+LuaPlayer LuaInterfaceGame::GetPlayer(int playerIdx)
 {
-    if(playerIdx >= gw.GetNumPlayers())
-        throw LuaExecutionError("Invalid player idx");
-    return LuaPlayer(game, gw.GetPlayer(playerIdx));
+    lua::assertTrue(playerIdx >= 0 && static_cast<unsigned>(playerIdx) < gw.GetNumPlayers(), "Invalid player idx");
+    return LuaPlayer(game, gw.GetPlayer(static_cast<unsigned>(playerIdx)));
 }
 
 LuaWorld LuaInterfaceGame::GetWorld()

--- a/libs/s25main/lua/LuaInterfaceGame.h
+++ b/libs/s25main/lua/LuaInterfaceGame.h
@@ -63,13 +63,13 @@ public:
     void MissionStatement2(int playerIdx, const std::string& title, const std::string& msg, unsigned imgIdx);
     void MissionStatement3(int playerIdx, const std::string& title, const std::string& msg, unsigned imgIdx, bool pause);
     void SetMissionGoal(int playerIdx, const std::string& newGoal = "");
-    void PostMessageLua(unsigned playerIdx, const std::string& msg);
-    void PostMessageWithLocation(unsigned playerIdx, const std::string& msg, int x, int y);
+    void PostMessageLua(int playerIdx, const std::string& msg);
+    void PostMessageWithLocation(int playerIdx, const std::string& msg, int x, int y);
 
 private:
     GameWorldGame& gw;
     std::weak_ptr<Game> game;
-    LuaPlayer GetPlayer(unsigned playerIdx);
+    LuaPlayer GetPlayer(int playerIdx);
     LuaWorld GetWorld();
 };
 

--- a/libs/s25main/lua/LuaInterfaceSettings.cpp
+++ b/libs/s25main/lua/LuaInterfaceSettings.cpp
@@ -93,10 +93,10 @@ unsigned LuaInterfaceSettings::GetNumPlayers() const
     return lobbyServerController_.GetMaxNumPlayers();
 }
 
-LuaServerPlayer LuaInterfaceSettings::GetPlayer(unsigned idx)
+LuaServerPlayer LuaInterfaceSettings::GetPlayer(int idx)
 {
-    lua::assertTrue(idx < GetNumPlayers(), "Invalid player idx");
-    return LuaServerPlayer(lobbyServerController_, idx);
+    lua::assertTrue(idx >= 0 && static_cast<unsigned>(idx) < GetNumPlayers(), "Invalid player idx");
+    return LuaServerPlayer(lobbyServerController_, static_cast<unsigned>(idx));
 }
 
 void LuaInterfaceSettings::SetAddon(AddonIdWrapper id, unsigned value)

--- a/libs/s25main/lua/LuaInterfaceSettings.h
+++ b/libs/s25main/lua/LuaInterfaceSettings.h
@@ -55,7 +55,7 @@ private:
 
     // Callable from Lua
     unsigned GetNumPlayers() const;
-    LuaServerPlayer GetPlayer(unsigned idx);
+    LuaServerPlayer GetPlayer(int idx);
     void SetAddon(AddonIdWrapper id, unsigned value);
     void SetBoolAddon(AddonIdWrapper id, bool value); // Alias
     void ResetAddons();

--- a/libs/s25main/lua/LuaPlayer.cpp
+++ b/libs/s25main/lua/LuaPlayer.cpp
@@ -73,7 +73,7 @@ void LuaPlayer::Register(kaguya::State& state)
                                .addFunction("GetPeopleCount", &LuaPlayer::GetNumPeople));
 }
 
-void LuaPlayer::EnableBuilding(BuildingType bld, bool notify)
+void LuaPlayer::EnableBuilding(lua::SafeEnum<BuildingType> bld, bool notify)
 {
     lua::assertTrue(unsigned(bld) < NUM_BUILDING_TYPES, "Invalid building type");
     player.EnableBuilding(bld);
@@ -85,7 +85,7 @@ void LuaPlayer::EnableBuilding(BuildingType bld, bool notify)
     }
 }
 
-void LuaPlayer::DisableBuilding(BuildingType bld)
+void LuaPlayer::DisableBuilding(lua::SafeEnum<BuildingType> bld)
 {
     lua::assertTrue(unsigned(bld) < NUM_BUILDING_TYPES, "Invalid building type");
     player.DisableBuilding(bld);
@@ -193,7 +193,7 @@ void LuaPlayer::ClearResources()
         warehouse->Clear();
 }
 
-bool LuaPlayer::AddWares(const std::map<GoodType, unsigned>& wares)
+bool LuaPlayer::AddWares(const std::map<lua::SafeEnum<GoodType, NUM_WARE_TYPES - 1>, unsigned>& wares)
 {
     nobBaseWarehouse* warehouse = player.GetFirstWH();
 
@@ -214,7 +214,7 @@ bool LuaPlayer::AddWares(const std::map<GoodType, unsigned>& wares)
     return true;
 }
 
-bool LuaPlayer::AddPeople(const std::map<Job, unsigned>& people)
+bool LuaPlayer::AddPeople(const std::map<lua::SafeEnum<Job>, unsigned>& people)
 {
     nobBaseWarehouse* warehouse = player.GetFirstWH();
 
@@ -235,33 +235,33 @@ bool LuaPlayer::AddPeople(const std::map<Job, unsigned>& people)
     return true;
 }
 
-unsigned LuaPlayer::GetNumBuildings(BuildingType bld) const
+unsigned LuaPlayer::GetNumBuildings(lua::SafeEnum<BuildingType> bld) const
 {
     lua::assertTrue(unsigned(bld) < NUM_BUILDING_TYPES, "Invalid building type");
 
     return player.GetBuildingRegister().GetBuildingNums().buildings[bld];
 }
 
-unsigned LuaPlayer::GetNumBuildingSites(BuildingType bld) const
+unsigned LuaPlayer::GetNumBuildingSites(lua::SafeEnum<BuildingType> bld) const
 {
     lua::assertTrue(unsigned(bld) < NUM_BUILDING_TYPES, "Invalid building type");
 
     return player.GetBuildingRegister().GetBuildingNums().buildingSites[bld];
 }
 
-unsigned LuaPlayer::GetNumWares(GoodType ware) const
+unsigned LuaPlayer::GetNumWares(lua::SafeEnum<GoodType> ware) const
 {
     lua::assertTrue(unsigned(ware) < NUM_WARE_TYPES, "Invalid ware");
     return player.GetInventory().goods[ware];
 }
 
-unsigned LuaPlayer::GetNumPeople(Job job) const
+unsigned LuaPlayer::GetNumPeople(lua::SafeEnum<Job> job) const
 {
     lua::assertTrue(unsigned(job) < NUM_JOB_TYPES, "Invalid ware");
     return player.GetInventory().people[job];
 }
 
-bool LuaPlayer::AIConstructionOrder(unsigned x, unsigned y, BuildingType bld)
+bool LuaPlayer::AIConstructionOrder(unsigned x, unsigned y, lua::SafeEnum<BuildingType> bld)
 {
     // Only for actual AIs
     if(!player.isUsed() || player.isHuman())
@@ -312,7 +312,7 @@ bool LuaPlayer::IsAttackable(unsigned char otherPlayerId)
     return player.IsAttackable(otherPlayerId);
 }
 
-void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const PactType pt, const unsigned duration)
+void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const lua::SafeEnum<PactType> pt, const unsigned duration)
 {
     auto gameInst = game.lock();
     if(!gameInst)
@@ -325,7 +325,7 @@ void LuaPlayer::SuggestPact(unsigned char otherPlayerId, const PactType pt, cons
     }
 }
 
-void LuaPlayer::CancelPact(const PactType pt, unsigned char otherPlayerId)
+void LuaPlayer::CancelPact(const lua::SafeEnum<PactType> pt, unsigned char otherPlayerId)
 {
     auto gameInst = game.lock();
     if(!gameInst)

--- a/libs/s25main/lua/LuaPlayer.h
+++ b/libs/s25main/lua/LuaPlayer.h
@@ -19,6 +19,7 @@
 #define LuaPlayer_h__
 
 #include "LuaPlayerBase.h"
+#include "lua/SafeEnum.h"
 #include "gameTypes/BuildingType.h"
 #include "gameTypes/GoodTypes.h"
 #include "gameTypes/JobTypes.h"
@@ -46,28 +47,28 @@ public:
     LuaPlayer(std::weak_ptr<Game> game, GamePlayer& player) : game(std::move(game)), player(player) {}
     static void Register(kaguya::State& state);
 
-    void EnableBuilding(BuildingType bld, bool notify);
-    void DisableBuilding(BuildingType bld);
+    void EnableBuilding(lua::SafeEnum<BuildingType> bld, bool notify);
+    void DisableBuilding(lua::SafeEnum<BuildingType> bld);
     void EnableAllBuildings();
     void DisableAllBuildings();
     void SetRestrictedArea(kaguya::VariadicArgType inPoints);
     bool IsInRestrictedArea(unsigned x, unsigned y) const;
     void ClearResources();
-    bool AddWares(const std::map<GoodType, unsigned>& wares);
-    bool AddPeople(const std::map<Job, unsigned>& people);
-    unsigned GetNumBuildings(BuildingType bld) const;
-    unsigned GetNumBuildingSites(BuildingType bld) const;
-    unsigned GetNumWares(GoodType ware) const;
-    unsigned GetNumPeople(Job job) const;
-    bool AIConstructionOrder(unsigned x, unsigned y, BuildingType bld);
+    bool AddWares(const std::map<lua::SafeEnum<GoodType>, unsigned>& wares);
+    bool AddPeople(const std::map<lua::SafeEnum<Job>, unsigned>& people);
+    unsigned GetNumBuildings(lua::SafeEnum<BuildingType> bld) const;
+    unsigned GetNumBuildingSites(lua::SafeEnum<BuildingType> bld) const;
+    unsigned GetNumWares(lua::SafeEnum<GoodType> ware) const;
+    unsigned GetNumPeople(lua::SafeEnum<Job> job) const;
+    bool AIConstructionOrder(unsigned x, unsigned y, lua::SafeEnum<BuildingType> bld);
     void ModifyHQ(bool isTent);
     bool IsDefeated() const;
     void Surrender(bool destroyBlds);
     std::tuple<unsigned, unsigned> GetHQPos() const;
     bool IsAlly(unsigned char otherPlayerId);
     bool IsAttackable(unsigned char otherPlayerId);
-    void SuggestPact(unsigned char otherPlayerId, PactType pt, unsigned duration);
-    void CancelPact(PactType pt, unsigned char otherPlayerId);
+    void SuggestPact(unsigned char otherPlayerId, lua::SafeEnum<PactType> pt, unsigned duration);
+    void CancelPact(lua::SafeEnum<PactType> pt, unsigned char otherPlayerId);
 };
 
 #endif // LuaPlayer_h__

--- a/libs/s25main/lua/SafeEnum.h
+++ b/libs/s25main/lua/SafeEnum.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 - 2019 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef SafeEnum_h__
+#define SafeEnum_h__
+
+#include "helpers/MaxEnumValue.h"
+#include <stdexcept>
+#include <type_traits>
+
+namespace lua {
+/// Wrapper around an enum which checks the int passed on ctor to be in range of the enum
+template<class T_Enum, unsigned maxValue = helpers::MaxEnumValue_v<T_Enum>>
+struct SafeEnum
+{
+    static constexpr T_Enum cast(int value)
+    {
+        return (value < 0 || static_cast<unsigned>(value) > maxValue) ? throw std::out_of_range("Enum value is out of range") :
+                                                                        static_cast<T_Enum>(value);
+    }
+    T_Enum value_;
+    SafeEnum(int value) : value_(cast(value)) {}
+    constexpr operator T_Enum() const noexcept { return value_; };
+};
+} // namespace lua
+
+namespace std {
+template<class T, unsigned m>
+struct is_enum<lua::SafeEnum<T, m>> : std::true_type
+{
+};
+template<class T, unsigned m>
+struct underlying_type<lua::SafeEnum<T, m>> : std::underlying_type<T>
+{
+};
+} // namespace std
+
+#endif // SafeEnum_h__

--- a/libs/s25main/network/GameClient.h
+++ b/libs/s25main/network/GameClient.h
@@ -67,7 +67,7 @@ public:
     };
 
     GameClient();
-    ~GameClient() override;
+    ~GameClient();
 
     void SetInterface(ClientInterface* ci) { this->ci = ci; }
     /// Removes the given interface (if it is not yet overwritten by another one)

--- a/libs/s25main/network/GameServer.h
+++ b/libs/s25main/network/GameServer.h
@@ -48,7 +48,7 @@ public:
     using SteadyClock = std::chrono::steady_clock;
 
     GameServer();
-    ~GameServer() override;
+    ~GameServer();
 
     /// Starts the server
     bool Start(const CreateServerInfo& csi, const std::string& map_path, MapType map_type, const std::string& hostPw);

--- a/libs/s25main/ogl/glArchivItem_Bitmap.cpp
+++ b/libs/s25main/ogl/glArchivItem_Bitmap.cpp
@@ -19,7 +19,7 @@
 #include "glArchivItem_Bitmap.h"
 #include "Point.h"
 #include "drivers/VideoDriverWrapper.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include <glad/glad.h>
 
 glArchivItem_Bitmap::glArchivItem_Bitmap() = default;
@@ -112,7 +112,7 @@ void glArchivItem_Bitmap::FillTexture()
     int iformat = GetInternalFormat(), dformat = GL_BGRA;
 
     const Extent texSize = GetTexSize();
-    libsiedler2::PixelBufferARGB buffer(texSize.x, texSize.y);
+    libsiedler2::PixelBufferBGRA buffer(texSize.x, texSize.y);
     print(buffer);
     glTexImage2D(GL_TEXTURE_2D, 0, iformat, texSize.x, texSize.y, 0, dformat, GL_UNSIGNED_BYTE, buffer.getPixelPtr());
 }

--- a/libs/s25main/ogl/glArchivItem_Bitmap_Direct.cpp
+++ b/libs/s25main/ogl/glArchivItem_Bitmap_Direct.cpp
@@ -18,7 +18,7 @@
 #include "rttrDefines.h" // IWYU pragma: keep
 #include "glArchivItem_Bitmap_Direct.h"
 #include "drivers/VideoDriverWrapper.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include <glad/glad.h>
 #include <stdexcept>
 
@@ -45,7 +45,7 @@ void glArchivItem_Bitmap_Direct::endUpdate()
     if(prodOfComponents(areaToUpdate_.getSize()) == 0 || !GetTexNoCreate())
         return;
 
-    libsiedler2::PixelBufferARGB buffer(areaToUpdate_.getSize().x, areaToUpdate_.getSize().y);
+    libsiedler2::PixelBufferBGRA buffer(areaToUpdate_.getSize().x, areaToUpdate_.getSize().y);
     Position origin = areaToUpdate_.getOrigin();
     int ec = print(buffer, nullptr, 0, 0, origin.x, origin.y);
     RTTR_Assert(ec == 0);
@@ -54,7 +54,7 @@ void glArchivItem_Bitmap_Direct::endUpdate()
                     buffer.getPixelPtr());
 }
 
-void glArchivItem_Bitmap_Direct::updatePixel(const DrawPoint& pos, const libsiedler2::ColorARGB& clr)
+void glArchivItem_Bitmap_Direct::updatePixel(const DrawPoint& pos, const libsiedler2::ColorBGRA& clr)
 {
     RTTR_Assert(isUpdating_);
     RTTR_Assert(pos.x >= 0 && pos.y >= 0);

--- a/libs/s25main/ogl/glArchivItem_Bitmap_Direct.h
+++ b/libs/s25main/ogl/glArchivItem_Bitmap_Direct.h
@@ -23,7 +23,7 @@
 #include "glArchivItem_Bitmap.h"
 
 namespace libsiedler2 {
-struct ColorARGB;
+struct ColorBGRA;
 }
 
 /// Klasse für GL-Direct-Bitmaps.
@@ -39,7 +39,7 @@ public:
     /// Call after updating texture
     void endUpdate();
     /// Updates a pixels color
-    void updatePixel(const DrawPoint& pos, const libsiedler2::ColorARGB& clr);
+    void updatePixel(const DrawPoint& pos, const libsiedler2::ColorBGRA& clr);
 
     /// lädt die Bilddaten aus einer Datei.
     int load(std::istream& /*file*/, const libsiedler2::ArchivItem_Palette* /*palette*/) override { return 254; }

--- a/libs/s25main/ogl/glArchivItem_Bitmap_Player.cpp
+++ b/libs/s25main/ogl/glArchivItem_Bitmap_Player.cpp
@@ -20,7 +20,7 @@
 #include "Loader.h"
 #include "Point.h"
 #include "drivers/VideoDriverWrapper.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include <glad/glad.h>
 
 namespace {
@@ -122,7 +122,7 @@ void glArchivItem_Bitmap_Player::FillTexture()
     int iformat = GetInternalFormat(), dformat = GL_BGRA; // GL_BGRA_EXT;
 
     Extent texSize = GetTexSize();
-    libsiedler2::PixelBufferARGB buffer(texSize.x, texSize.y);
+    libsiedler2::PixelBufferBGRA buffer(texSize.x, texSize.y);
 
     print(buffer, palette, 128, 0, 0, 0, 0, 0, 0, false);
     print(buffer, palette, 128, texSize.x / 2u, 0, 0, 0, 0, 0, true);

--- a/libs/s25main/ogl/glArchivItem_Font.cpp
+++ b/libs/s25main/ogl/glArchivItem_Font.cpp
@@ -24,7 +24,7 @@
 #include "helpers/containerUtils.h"
 #include "libsiedler2/ArchivItem_Bitmap_Player.h"
 #include "libsiedler2/IAllocator.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include "libsiedler2/libsiedler2.h"
 #include "libutil/Log.h"
 #include <utf8.h>
@@ -568,8 +568,8 @@ void glArchivItem_Font::initFont()
 
     constexpr Extent spacing(1, 1);
     Extent texSize = (Extent(dx, dy) + spacing * 2u) * Extent(numCharsPerLine, numLines) + spacing * 2u;
-    libsiedler2::PixelBufferARGB bufferWithOutline(texSize.x, texSize.y);
-    libsiedler2::PixelBufferARGB bufferNoOutline(texSize.x, texSize.y);
+    libsiedler2::PixelBufferBGRA bufferWithOutline(texSize.x, texSize.y);
+    libsiedler2::PixelBufferBGRA bufferNoOutline(texSize.x, texSize.y);
 
     const libsiedler2::ArchivItem_Palette* const palette = LOADER.GetPaletteN("colors");
     Position curPos(spacing);

--- a/libs/s25main/ogl/glSmartBitmap.cpp
+++ b/libs/s25main/ogl/glSmartBitmap.cpp
@@ -22,7 +22,7 @@
 #include "ogl/glBitmapItem.h"
 #include "libsiedler2/ArchivItem_Bitmap.h"
 #include "libsiedler2/ArchivItem_Bitmap_Player.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include "libutil/colors.h"
 #include <glad/glad.h>
 #include <limits>
@@ -113,7 +113,7 @@ void glSmartBitmap::calcDimensions()
     size_ = Extent(origin_ + maxPos);
 }
 
-void glSmartBitmap::drawTo(libsiedler2::PixelBufferARGB& buffer, const Extent& bufOffset) const
+void glSmartBitmap::drawTo(libsiedler2::PixelBufferBGRA& buffer, const Extent& bufOffset) const
 {
     libsiedler2::ArchivItem_Palette* p_colors = LOADER.GetPaletteN("colors");
     libsiedler2::ArchivItem_Palette* p_5 = LOADER.GetPaletteN("pal5");
@@ -127,7 +127,7 @@ void glSmartBitmap::drawTo(libsiedler2::PixelBufferARGB& buffer, const Extent& b
 
         if(bmpItem.type == TYPE_ARCHIVITEM_BITMAP_SHADOW)
         {
-            libsiedler2::PixelBufferARGB tmp(size_.x, size_.y);
+            libsiedler2::PixelBufferBGRA tmp(size_.x, size_.y);
 
             dynamic_cast<libsiedler2::baseArchivItem_Bitmap*>(bmpItem.bmp) //-V522
               ->print(tmp, p_5, offset.x, offset.y, bmpItem.pos.x, bmpItem.pos.y, bmpItem.size.x, bmpItem.size.y);
@@ -139,7 +139,7 @@ void glSmartBitmap::drawTo(libsiedler2::PixelBufferARGB& buffer, const Extent& b
                 for(unsigned x = 0; x < size_.x; ++x)
                 {
                     if(tmp.get(tmpIdx).getAlpha() != 0x00 && buffer.get(idx).getAlpha() == 0x00)
-                        buffer.set(idx, libsiedler2::ColorARGB(0x40, 0, 0, 0));
+                        buffer.set(idx, libsiedler2::ColorBGRA(0, 0, 0, 0x40));
                     idx++;
                     tmpIdx++;
                 }
@@ -154,7 +154,7 @@ void glSmartBitmap::drawTo(libsiedler2::PixelBufferARGB& buffer, const Extent& b
         } else
         {
             // There is a player bitmap -> First write to temp buffer
-            libsiedler2::PixelBufferARGB tmp(size_.x, size_.y);
+            libsiedler2::PixelBufferBGRA tmp(size_.x, size_.y);
             if(bmpItem.type == TYPE_ARCHIVITEM_BITMAP)
             {
                 dynamic_cast<libsiedler2::baseArchivItem_Bitmap*>(bmpItem.bmp)
@@ -180,7 +180,7 @@ void glSmartBitmap::drawTo(libsiedler2::PixelBufferARGB& buffer, const Extent& b
                         // Copy to buffer
                         buffer.set(idx, tmp.get(tmpIdx));
                         // Reset player color to transparent
-                        buffer.set(idx + size_.x, libsiedler2::ColorARGB(0));
+                        buffer.set(idx + size_.x, libsiedler2::ColorBGRA());
                     }
                     ++idx;
                     ++tmpIdx;
@@ -212,7 +212,7 @@ void glSmartBitmap::generateTexture()
 
     const Extent bufSize = VIDEODRIVER.calcPreferredTextureSize(getRequiredTexSize());
 
-    libsiedler2::PixelBufferARGB buffer(bufSize.x, bufSize.y);
+    libsiedler2::PixelBufferBGRA buffer(bufSize.x, bufSize.y);
     drawTo(buffer);
 
     VIDEODRIVER.BindTexture(texture);

--- a/libs/s25main/ogl/glSmartBitmap.h
+++ b/libs/s25main/ogl/glSmartBitmap.h
@@ -28,7 +28,7 @@
 namespace libsiedler2 {
 class baseArchivItem_Bitmap;
 class ArchivItem_Bitmap_Player;
-class PixelBufferARGB;
+class PixelBufferBGRA;
 } // namespace libsiedler2
 
 class glBitmapItem;
@@ -77,7 +77,7 @@ public:
     void draw(DrawPoint drawPt, unsigned color = 0xFFFFFFFF, unsigned player_color = 0);
     void drawPercent(DrawPoint drawPt, unsigned percent, unsigned color = 0xFFFFFFFF, unsigned player_color = 0);
     /// Draw the bitmap(s) to the specified buffer at the position starting at bufOffset (must be positive)
-    void drawTo(libsiedler2::PixelBufferARGB& buffer, const Extent& bufOffset = Extent(0, 0)) const;
+    void drawTo(libsiedler2::PixelBufferBGRA& buffer, const Extent& bufOffset = Extent(0, 0)) const;
 
     void add(libsiedler2::baseArchivItem_Bitmap* bmp, bool transferOwnership = false);
     void add(libsiedler2::ArchivItem_Bitmap_Player* bmp, bool transferOwnership = false);

--- a/libs/s25main/ogl/glTexturePacker.cpp
+++ b/libs/s25main/ogl/glTexturePacker.cpp
@@ -21,7 +21,7 @@
 #include "ogl/glSmartBitmap.h"
 #include "ogl/glTexturePackerNode.h"
 #include "ogl/saveBitmap.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include <glad/glad.h>
 #include <algorithm>
 #include <utility>
@@ -74,7 +74,7 @@ bool glTexturePacker::packHelper(std::vector<glSmartBitmap*>& list)
             // list to store bitmaps we could not fit in our current texture
             std::vector<glSmartBitmap*> left;
 
-            libsiedler2::PixelBufferARGB buffer(curSize.x, curSize.y);
+            libsiedler2::PixelBufferBGRA buffer(curSize.x, curSize.y);
 
             // try storing bitmaps in the big texture
             for(glSmartBitmap* bmp : list)
@@ -186,7 +186,7 @@ bool glTexture::checkSize(const Extent& size)
     return resultWidth > 0;
 }
 
-bool glTexture::uploadData(const libsiedler2::PixelBufferARGB& buffer)
+bool glTexture::uploadData(const libsiedler2::PixelBufferBGRA& buffer)
 {
     if(!handle)
         return false;

--- a/libs/s25main/ogl/glTexturePacker.h
+++ b/libs/s25main/ogl/glTexturePacker.h
@@ -24,7 +24,7 @@
 class glSmartBitmap;
 
 namespace libsiedler2 {
-class PixelBufferARGB;
+class PixelBufferBGRA;
 }
 
 class glTexture
@@ -46,7 +46,7 @@ public:
 
     void bind();
     bool checkSize(const Extent&);
-    bool uploadData(const libsiedler2::PixelBufferARGB&);
+    bool uploadData(const libsiedler2::PixelBufferBGRA&);
 };
 
 class glTexturePacker

--- a/libs/s25main/ogl/glTexturePackerNode.cpp
+++ b/libs/s25main/ogl/glTexturePackerNode.cpp
@@ -18,9 +18,9 @@
 #include "rttrDefines.h" // IWYU pragma: keep
 #include "glTexturePackerNode.h"
 #include "ogl/glSmartBitmap.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 
-bool glTexturePackerNode::insert(glSmartBitmap* b, libsiedler2::PixelBufferARGB& buffer, std::vector<glTexturePackerNode*>& todo)
+bool glTexturePackerNode::insert(glSmartBitmap* b, libsiedler2::PixelBufferBGRA& buffer, std::vector<glTexturePackerNode*>& todo)
 {
     todo.clear();
 

--- a/libs/s25main/ogl/glTexturePackerNode.h
+++ b/libs/s25main/ogl/glTexturePackerNode.h
@@ -23,7 +23,7 @@
 
 class glSmartBitmap;
 namespace libsiedler2 {
-class PixelBufferARGB;
+class PixelBufferBGRA;
 } // namespace libsiedler2
 
 class glTexturePackerNode
@@ -41,7 +41,7 @@ public:
     glTexturePackerNode(const Extent& size) : pos(0, 0), size(size), bmp(nullptr) { child[0] = child[1] = nullptr; }
     /// Find a position in the buffer to draw the bitmap starting at this node
     /// todo list is cleared and used to avoid frequent allocations
-    bool insert(glSmartBitmap* b, libsiedler2::PixelBufferARGB& buffer, std::vector<glTexturePackerNode*>& todo);
+    bool insert(glSmartBitmap* b, libsiedler2::PixelBufferBGRA& buffer, std::vector<glTexturePackerNode*>& todo);
     void destroy(unsigned reserve = 0);
 };
 

--- a/libs/s25main/ogl/saveBitmap.cpp
+++ b/libs/s25main/ogl/saveBitmap.cpp
@@ -22,7 +22,7 @@
 #include "libsiedler2/libsiedler2.h"
 #include <stdexcept>
 
-void saveBitmap(const libsiedler2::PixelBufferARGB& buffer, const boost::filesystem::path& path)
+void saveBitmap(const libsiedler2::PixelBufferBGRA& buffer, const boost::filesystem::path& path)
 {
     auto bmp = std::make_unique<libsiedler2::ArchivItem_Bitmap_Raw>();
     bmp->create(buffer);

--- a/libs/s25main/ogl/saveBitmap.h
+++ b/libs/s25main/ogl/saveBitmap.h
@@ -18,9 +18,9 @@
 #ifndef SAVE_BITMAP_H__
 #define SAVE_BITMAP_H__
 
-#include <libsiedler2/PixelBufferARGB.h>
+#include <libsiedler2/PixelBufferBGRA.h>
 #include <boost/filesystem/path.hpp>
 
-void saveBitmap(const libsiedler2::PixelBufferARGB&, const boost::filesystem::path&);
+void saveBitmap(const libsiedler2::PixelBufferBGRA&, const boost::filesystem::path&);
 
 #endif

--- a/tests/s25Main/CMakeLists.txt
+++ b/tests/s25Main/CMakeLists.txt
@@ -27,6 +27,7 @@ target_include_directories(testWorldFixtures PUBLIC .)
 include(AddMacros)
 
 add_subdirectory(audio)
+add_subdirectory(drivers)
 add_subdirectory(integration)
 add_subdirectory(IO)
 add_subdirectory(locale)

--- a/tests/s25Main/UI/testTexturePacker.cpp
+++ b/tests/s25Main/UI/testTexturePacker.cpp
@@ -20,7 +20,7 @@
 #include "ogl/glTexturePacker.h"
 #include "uiHelper/uiHelpers.hpp"
 #include "libsiedler2/ArchivItem_Bitmap_Raw.h"
-#include "libsiedler2/PixelBufferARGB.h"
+#include "libsiedler2/PixelBufferBGRA.h"
 #include <boost/test/unit_test.hpp>
 #include <Rect.h>
 #include <array>
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(SizeAndPosCorrect)
     glTexturePacker packer;
     for(unsigned i = 0; i < bmps.size(); ++i)
     {
-        libsiedler2::PixelBufferARGB buffer(5 + i, 11 + i * 3, libsiedler2::ColorARGB(0xFFFFFFFF));
+        libsiedler2::PixelBufferBGRA buffer(5 + i, 11 + i * 3, libsiedler2::ColorBGRA(0xFFFFFFFF));
         bmps[i].create(buffer);
         smartBmps[i].add(&bmps[i]);
         packer.add(smartBmps[i]);

--- a/tests/s25Main/drivers/CMakeLists.txt
+++ b/tests/s25Main/drivers/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Testing driver system
+add_testcase(NAME drivers
+    LIBS s25Main testHelpers
+)
+
+add_dependencies(Test_drivers drivers)

--- a/tests/s25Main/drivers/main.cpp
+++ b/tests/s25Main/drivers/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2016 - 2017 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -15,24 +15,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef PactTypes_h__
-#define PactTypes_h__
+#define BOOST_TEST_MODULE RTTR_Simple
 
-#include "helpers/MaxEnumValue.h"
-#include <array>
+#include <rttr/test/Fixture.hpp>
+#include <boost/test/unit_test.hpp>
 
-/// Types of pacts
-enum PactType
-{
-    TREATY_OF_ALLIANCE = 0,
-    NON_AGGRESSION_PACT
-};
+//#include <vld.h>
 
-/// Number of the various pacts
-const unsigned NUM_PACTS = 2;
-DEFINE_MAX_ENUM_VALUE(PactType, NUM_PACTS)
+using Fixture = rttr::test::Fixture;
 
-/// Names of the possible pacts
-extern const std::array<const char*, NUM_PACTS> PACT_NAMES;
-
-#endif // PactTypes_h__
+BOOST_GLOBAL_FIXTURE(Fixture);

--- a/tests/s25Main/drivers/testDriverWrapper.cpp
+++ b/tests/s25Main/drivers/testDriverWrapper.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2016 - 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "drivers/AudioDriverWrapper.h"
+#include "drivers/VideoDriverWrapper.h"
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(GetDriverList)
+{
+    for(auto type : {drivers::DriverType::Video, drivers::DriverType::Audio})
+    {
+        const auto drivers = drivers::DriverWrapper::LoadDriverList(type);
+        BOOST_TEST(!drivers.empty());
+        for(const auto& driver : drivers)
+        {
+            BOOST_TEST(!driver.GetName().empty());
+            BOOST_TEST(bfs::exists(driver.GetFile()));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(AllAudioDriversAreLoadable)
+{
+    const auto drivers = drivers::DriverWrapper::LoadDriverList(drivers::DriverType::Audio);
+    for(const auto& driver : drivers)
+    {
+        std::string preference = driver.GetName();
+        BOOST_TEST_REQUIRE(AUDIODRIVER.LoadDriver(preference));
+        BOOST_TEST(preference == driver.GetName());
+        BOOST_TEST(AUDIODRIVER.GetName() == driver.GetName());
+        AUDIODRIVER.UnloadDriver();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(AllVideoDriversAreLoadable)
+{
+    const auto drivers = drivers::DriverWrapper::LoadDriverList(drivers::DriverType::Video);
+    for(const auto& driver : drivers)
+    {
+        std::string preference = driver.GetName();
+        BOOST_TEST_REQUIRE(VIDEODRIVER.LoadDriver(preference));
+        BOOST_TEST(preference == driver.GetName());
+        BOOST_TEST(VIDEODRIVER.GetName() == driver.GetName());
+        BOOST_TEST(VIDEODRIVER.GetDriver());
+        VIDEODRIVER.UnloadDriver();
+    }
+}

--- a/tests/s25Main/integration/testBaseWarehouse.cpp
+++ b/tests/s25Main/integration/testBaseWarehouse.cpp
@@ -131,14 +131,12 @@ BOOST_FIXTURE_TEST_CASE(AddGoods, AddGoodsFixture)
     testNumGoodsPlayer();
 
 #if RTTR_ENABLE_ASSERTS
-    RTTR_AssertEnableBreak = false;
     newGoods.clear();
     newGoods.Add(JOB_BOATCARRIER);
     RTTR_REQUIRE_ASSERT(hq.AddGoods(newGoods, false));
     newGoods.clear();
     newGoods.Add(GD_SHIELDAFRICANS);
     RTTR_REQUIRE_ASSERT(hq.AddGoods(newGoods, false));
-    RTTR_AssertEnableBreak = true;
 #endif
 }
 

--- a/tests/s25Main/integration/testGameEvents.cpp
+++ b/tests/s25Main/integration/testGameEvents.cpp
@@ -227,7 +227,6 @@ BOOST_AUTO_TEST_CASE(InvalidEvent)
 {
     rttr::test::LogAccessor logAcc;
 #if RTTR_ENABLE_ASSERTS
-    RTTR_AssertEnableBreak = false;
     EventManager evMgr(100);
     TestEventHandler obj;
     // Need object
@@ -238,7 +237,6 @@ BOOST_AUTO_TEST_CASE(InvalidEvent)
     RTTR_REQUIRE_ASSERT(evMgr.AddEvent(nullptr, 50, 0, 50));
     // continued event cannot start before the game
     RTTR_REQUIRE_ASSERT(evMgr.AddEvent(nullptr, 200, 0, 150));
-    RTTR_AssertEnableBreak = true;
 #endif
 }
 

--- a/tests/s25Main/integration/testGamePlayer.cpp
+++ b/tests/s25Main/integration/testGamePlayer.cpp
@@ -32,7 +32,7 @@ BOOST_FIXTURE_TEST_CASE(Defeat, WorldFixtureEmpty2P)
     BOOST_REQUIRE(!world.GetPlayer(0).IsDefeated());
     BOOST_REQUIRE(!world.GetPlayer(1).IsDefeated());
     // Destroy HQ -> defeated
-    world.GetPlayer(1).GetFirstWH()->Destroy(); //-V522
+    world.DestroyNO(world.GetPlayer(1).GetHQPos()); //-V522
     BOOST_REQUIRE(!world.GetPlayer(0).IsDefeated());
     BOOST_REQUIRE(world.GetPlayer(1).IsDefeated());
     // Destroy HQ but leave a military bld
@@ -42,9 +42,9 @@ BOOST_FIXTURE_TEST_CASE(Defeat, WorldFixtureEmpty2P)
     world.AddFigure(milBldPos, sld);
     milBld->GotWorker(JOB_PRIVATE, sld);
     sld->WalkToGoal();
-    world.GetPlayer(0).GetFirstWH()->Destroy();
+    world.DestroyNO(world.GetPlayer(0).GetHQPos());
     BOOST_REQUIRE(!world.GetPlayer(0).IsDefeated());
     // Destroy this -> defeated
-    milBld->Destroy();
+    world.DestroyNO(milBldPos);
     BOOST_REQUIRE(world.GetPlayer(0).IsDefeated());
 }

--- a/tests/s25Main/integration/testSeaWorldCreation.cpp
+++ b/tests/s25Main/integration/testSeaWorldCreation.cpp
@@ -105,9 +105,7 @@ BOOST_FIXTURE_TEST_CASE(HarborSpotCreation, SeaWorldWithGCExecution<>)
     BOOST_REQUIRE_EQUAL(world.GetNumSeas(), 2u);
 // Harbor ID 0 is means invalid harbor
 #if RTTR_ENABLE_ASSERTS
-    RTTR_AssertEnableBreak = false;
     RTTR_REQUIRE_ASSERT(world.GetHarborPoint(0));
-    RTTR_AssertEnableBreak = true;
 #else
     BOOST_REQUIRE(!world.GetHarborPoint(0).isValid());
 #endif

--- a/tests/s25Main/integration/testTrading.cpp
+++ b/tests/s25Main/integration/testTrading.cpp
@@ -97,11 +97,9 @@ struct TradeFixture : public WorldWithGCExecution3P
 BOOST_FIXTURE_TEST_CASE(TradeBothOrNone, TradeFixture)
 {
     rttr::test::LogAccessor logAcc;
-    RTTR_AssertEnableBreak = false;
     // It has to be either-or
     RTTR_REQUIRE_ASSERT(this->TradeOverLand(players[0]->GetHQPos(), GD_BOARDS, JOB_WOODCUTTER, 2));
     RTTR_REQUIRE_ASSERT(this->TradeOverLand(players[0]->GetHQPos(), GD_NOTHING, JOB_NOTHING, 2));
-    RTTR_AssertEnableBreak = true;
 }
 #endif
 

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -247,7 +247,8 @@ BOOST_AUTO_TEST_CASE(GameFunctions)
     const PostBox& postBox = *world.GetPostMgr().GetPostBox(1);
     // Send to other player or invalid
     executeLua("rttr:PostMessage(0, 'Hello World')");
-    executeLua("rttr:PostMessage(-1, 'Hello World')");
+    BOOST_REQUIRE_THROW(executeLua("rttr:PostMessage(-1, 'Hello World')"), LuaExecutionError);
+    BOOST_REQUIRE_NE(getLog(), "");
     BOOST_REQUIRE_EQUAL(postBox.GetNumMsgs(), 0u);
     // Send to this player
     executeLua("rttr:PostMessage(1, 'Hello World')");

--- a/tests/testHelpers/rttr/test/LogAccessor.hpp
+++ b/tests/testHelpers/rttr/test/LogAccessor.hpp
@@ -75,7 +75,9 @@ namespace rttr { namespace test {
 #define RTTR_REQUIRE_ASSERT(stmt)                              \
     do                                                         \
     {                                                          \
+        const bool old = RTTR_SetBreakOnAssertFailure(false);  \
         BOOST_CHECK_THROW(stmt, RTTR_AssertError);             \
+        RTTR_SetBreakOnAssertFailure(old);                     \
         RTTR_REQUIRE_LOG_CONTAINS("Assertion failure", false); \
     } while(false)
 

--- a/tools/ci/travisBuild.sh
+++ b/tools/ci/travisBuild.sh
@@ -40,6 +40,7 @@ export LD_LIBRARY_PATH="${boostLibDir}:${LD_LIBRARY_PATH:-}"
 
 # Execute tests
 export RTTR_DISABLE_ASSERT_BREAKPOINT=1
+export UBSAN_OPTIONS=print_stacktrace=1
 if ! ctest --output-on-failure -j2; then
     cat CMakeCache.txt
     echo "LD:${LD_LIBRARY_PATH:-}"

--- a/tools/ci/travisBuild.sh
+++ b/tools/ci/travisBuild.sh
@@ -17,12 +17,16 @@ fi
 INSTALL_DIR="${TRAVIS_BUILD_DIR}/installed"
 rm -rf "${INSTALL_DIR}"
 mkdir -p build && cd build
-cmake .. -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-    -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
-    -DRTTR_ENABLE_WERROR=ON \
-    -DRTTR_EDITOR_ADMINMODE=ON \
-    -DRTTR_BUNDLE="${RTTR_BUNDLE}" \
-    -G "Unix Makefiles" ${ADDITIONAL_CMAKE_FLAGS}
+if ! cmake .. -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+        -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+        -DRTTR_ENABLE_WERROR=ON \
+        -DRTTR_EDITOR_ADMINMODE=ON \
+        -DRTTR_BUNDLE="${RTTR_BUNDLE}" \
+        -G "Unix Makefiles" ${ADDITIONAL_CMAKE_FLAGS}; then
+    cat CMakeFiles/CMakeOutput.log
+    cat CMakeFiles/CMakeError.log
+    exit 1
+fi
 
 # Travis uses 2 cores
 make -j2 ${MAKE_TARGET}


### PR DESCRIPTION
Undefined behavior and memory violation can cause hard to find bugs. Those sanitizers make this easier as they can be run with the code and tests.

It adds the potential for adding fuzzers (fuzzy testing) via `-fsanitize=fuzzing` for Clang to find even more problems.

Solution for now:
- Enable with `-DRTTR_ENABLE_SANITIZERS=ON`
- build and run (tests and/or exe)

Other changes:
- Removed some obsolete workaround
- Added FindBoost of CMake 3.11 if lower version cmake is used. This allows to use targets of newer boost versions avoiding the need to upgrade cmake when upgrading boost which eases development