### PR TITLE
Fix Samplerate tests

### DIFF
--- a/tests/s25Main/UI/testSmartBitmap.cpp
+++ b/tests/s25Main/UI/testSmartBitmap.cpp
@@ -18,6 +18,7 @@
 #include "Loader.h"
 #include "PointOutput.h"
 #include "macros.h"
+#include "uiHelper/uiHelpers.hpp"
 #include <libsiedler2/ArchivItem_Bitmap_Player.h>
 #include <libsiedler2/ArchivItem_Bitmap_Raw.h>
 #include <libsiedler2/ArchivItem_Palette.h>
@@ -80,6 +81,8 @@ std::unique_ptr<ArchivItem_Bitmap_Player> createRandPlayerBmp(unsigned percentTr
     return bmp;
 }
 } // namespace
+
+BOOST_FIXTURE_TEST_SUITE(SmartBmpSuite, uiHelper::Fixture)
 
 BOOST_AUTO_TEST_CASE(CreateRandBmp_Works)
 {
@@ -271,3 +274,5 @@ BOOST_AUTO_TEST_CASE(MultiPlayerBitmap)
         BOOST_TEST(buffer.get(pt.x, pt.y) == expectedColor);
     }
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/UI/testVideoDriver.cpp
+++ b/tests/s25Main/UI/testVideoDriver.cpp
@@ -71,7 +71,7 @@ void APIENTRY glDeleteTextures(GLsizei n, const GLuint* textures)
 RTTR_POP_DIAGNOSTIC
 } // namespace rttrOglMock2
 
-BOOST_AUTO_TEST_CASE(CreateAndDestroyTextures)
+BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
 {
     // Fresh start
     VIDEODRIVER.DestroyScreen();


### PR DESCRIPTION
On 0.1.9 returning NULL as the data pointer is not allowed even if the
size is zero and the pointer never used.

Fixes #1090