### PR TITLE
Readme.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ Coverage:
 - libsdl1.2-dev
 - libsdl-mixer1.2-dev
 - libsdl2-dev (optional)
-- libsdl-mixer2-dev (optional)
+- libsdl2-mixer-dev (optional)
 - licurl-dev (in libcurl4-openssl-dev)
 - libbz2-dev
 - libminiupnpc-dev (linux)
-Most of them can be installed with the package manager.
+
+All of them can be installed with the package manager.
 
 ### Prerequisite MacOSX:
 - cmake
@@ -56,6 +57,7 @@ Most of them can be installed with the package manager.
 - sdl_mixer
 - gettext (make sure it is in your path with e.g. `brew link --force gettext`)
 - miniupnpc
+
 All of them can be installed via homebrew
 
 ### Prerequesites with Nix

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Coverage:
 - C++14 compatible compiler (e.g. GCC-6)
 - cmake
 - git
-- boost / libboost1.64-dev (i.e http://www.boost.org/)
+- libboost-dev (at least v1.64.0, i.e http://www.boost.org/)
+- libboost-locale-dev, libboost-iostreams-dev, libboost-filesystem-dev, libbost-program-options-dev (at least v1.64.0)
 - libsdl1.2-dev
 - libsdl-mixer1.2-dev
 - libsdl2-dev (optional)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Coverage:
 - libsdl2-mixer-dev (optional)
 - licurl-dev (in libcurl4-openssl-dev)
 - libbz2-dev
-- libminiupnpc-dev (linux)
+- lua5.2-dev
+- gettext
+- libminiupnpc-dev
 
 All of them can be installed with the package manager.
 


### PR DESCRIPTION
I took the instructions literally, and it turned out that libboost-dev doesn't provide the libraries and their specific headers. 

One typo fixed, lua5.2 and gettext added. 