### PR TITLE
Always create gui for controls in Addons window

### DIFF
--- a/libs/s25main/addons/AddonBool.cpp
+++ b/libs/s25main/addons/AddonBool.cpp
@@ -44,8 +44,6 @@ void AddonBool::createGui(Window* window, unsigned id, unsigned short& y, bool r
 
     check->SetVisible(true);
     check->SetPos(cbPos);
-
-    y += 30;
 }
 
 void AddonBool::setGuiStatus(Window* window, unsigned id, unsigned status) const

--- a/libs/s25main/addons/AddonList.cpp
+++ b/libs/s25main/addons/AddonList.cpp
@@ -48,8 +48,6 @@ void AddonList::createGui(Window* window, unsigned id, unsigned short& y, bool r
 
     combo->SetVisible(true);
     combo->SetPos(cbPos);
-
-    y += 30;
 }
 
 void AddonList::setGuiStatus(Window* window, unsigned id, unsigned status) const

--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -155,18 +155,22 @@ void iwAddons::UpdateView(const unsigned short selection)
             continue;
         unsigned groups = addon->getGroups();
 
+        bool isReadOnly = policy == READONLY || (policy == HOSTGAME_WHITELIST && !helpers::contains(addonIds, addon->getId()));
+        addon->createGui(this, id, y, isReadOnly, status);
+
         if((groups & selection) == selection)
             ++numAddonsInCurCategory;
+
         // hide addon's gui if addon is beyond selected group or is beyond current page scope
         if(((groups & selection) != selection) || numAddonsInCurCategory < scrollbar->GetScrollPos() + 1
            || numAddonsInCurCategory > (unsigned)(scrollbar->GetScrollPos() + scrollbar->GetPageSize()) + 1)
         {
             addon->hideGui(this, id);
-            continue;
+        } else
+        {
+            // if current button is displayed make sure next one will be below
+            y += 30;
         }
-
-        bool isReadOnly = policy == READONLY || (policy == HOSTGAME_WHITELIST && !helpers::contains(addonIds, addon->getId()));
-        addon->createGui(this, id, y, isReadOnly, status);
     }
     if(numAddonsInCurCategory_ != numAddonsInCurCategory)
     {


### PR DESCRIPTION
Always create gui for all addon controls to allow resetting to default values. Move shifting `y` position from `createGui` to `UpdateView`. Fixes #1001.