### PR TITLE
Fix Crash on jump to next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: trusty
+dist: xenial
 if: branch = master
 
 addons:

--- a/libs/common/include/helpers/mathFuncs.h
+++ b/libs/common/include/helpers/mathFuncs.h
@@ -29,7 +29,7 @@ int gcd(int a, int b) noexcept;
 unsigned roundedDiv(unsigned dividend, unsigned divisor) noexcept;
 /// Clamp the value into [min, max]
 template<typename T>
-constexpr T clamp(T val, T min, T max) noexcept
+T clamp(T val, T min, T max) noexcept
 {
     if(val <= min)
         return min;
@@ -39,7 +39,7 @@ constexpr T clamp(T val, T min, T max) noexcept
         return val;
 }
 template<typename T, typename U>
-constexpr U clamp(T val, U min, U max) noexcept
+U clamp(T val, U min, U max) noexcept
 {
     using Common = std::common_type_t<T, U>;
     if(std::is_signed<T>::value && !std::is_signed<U>::value)

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -179,7 +179,7 @@ IngameWindow& WindowManager::DoShow(std::unique_ptr<IngameWindow> window, bool m
     // All windows are inserted before the first modal window (shown behind)
     auto itModal = helpers::find_if(windows, [](const auto& curWnd) { return curWnd->IsModal(); });
     // Note that if there is no other modal window it will be put at the back which is what we want
-    auto& result = *windows.emplace(itModal, std::move(window))->get();
+    auto& result = **windows.emplace(itModal, std::move(window));
 
     // Make the new window active (special cases handled in the function)
     SetActiveWindow(result);

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -177,28 +177,6 @@ IngameWindow* WindowManager::DoShow(std::unique_ptr<IngameWindow> window, bool m
     if(!curDesktop)
         return nullptr;
 
-    // Non-Modal windows can only be opened once
-    if(!window->IsModal())
-    {
-        // Check for already open windows with same ID (ignoring to-be-closed windows)
-        auto itOther = helpers::find_if(windows, [wndId = window->GetID()](const auto& curWnd) {
-            return !curWnd->ShouldBeClosed() && !curWnd->IsModal() && curWnd->GetID() == wndId;
-        });
-        if(itOther != windows.end())
-        {
-            // Special case:
-            // Help windows simply replace other help windows
-            if(window->GetID() == CGI_HELP)
-                (*itOther)->Close();
-            else
-            {
-                // Same ID -> Close and don't open again
-                (*itOther)->Close();
-                return nullptr;
-            }
-        }
-    }
-
     // All windows are inserted before the first modal window (shown behind)
     auto itModal = helpers::find_if(windows, [](const auto& curWnd) { return curWnd->IsModal(); });
     // Note that if there is no other modal window it will be put at the back which is what we want
@@ -251,6 +229,13 @@ IngameWindow* WindowManager::FindWindowAtPos(const Position& pos) const
             return window.get();
     }
     return nullptr;
+}
+
+IngameWindow* WindowManager::FindNonModalWindow(unsigned id) const
+{
+    auto itWnd =
+      helpers::find_if(windows, [id](const auto& wnd) { return !wnd->ShouldBeClosed() && !wnd->IsModal() && wnd->GetID() == id; });
+    return itWnd == windows.end() ? nullptr : itWnd->get();
 }
 
 /**

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -166,24 +166,23 @@ void WindowManager::RelayMouseMessage(MouseMsgHandler msg, const MouseCoords& mc
 /**
  *  Öffnet ein IngameWindow und fügt es zur Fensterliste hinzu.
  */
-IngameWindow* WindowManager::DoShow(std::unique_ptr<IngameWindow> window, bool mouse)
+IngameWindow& WindowManager::DoShow(std::unique_ptr<IngameWindow> window, bool mouse)
 {
     RTTR_Assert(window);
     RTTR_Assert(!helpers::contains(windows, window));
-
-    SetToolTip(nullptr, "");
-
     // No desktop -> Out
     if(!curDesktop)
-        return nullptr;
+        throw std::runtime_error("No desktop active for window to be shown on");
+
+    SetToolTip(nullptr, "");
 
     // All windows are inserted before the first modal window (shown behind)
     auto itModal = helpers::find_if(windows, [](const auto& curWnd) { return curWnd->IsModal(); });
     // Note that if there is no other modal window it will be put at the back which is what we want
-    auto* result = windows.emplace(itModal, std::move(window))->get();
+    auto& result = *windows.emplace(itModal, std::move(window))->get();
 
     // Make the new window active (special cases handled in the function)
-    SetActiveWindow(*result);
+    SetActiveWindow(result);
 
     // Maus deaktivieren, bis sie losgelassen wurde (Fix des Switch-Anschließend-Drück-Bugs)
     disable_mouse = mouse;

--- a/libs/s25main/WindowManager.h
+++ b/libs/s25main/WindowManager.h
@@ -63,6 +63,25 @@ public:
     {
         return static_cast<T*>(DoShow(std::move(window), mouse));
     }
+    template<typename T>
+    T* ReplaceWindow(std::unique_ptr<T> window)
+    {
+        auto* oldWnd = FindNonModalWindow(window->GetID());
+        if(oldWnd)
+            oldWnd->Close();
+        return Show(std::move(window));
+    }
+    template<typename T>
+    T* ToggleWindow(std::unique_ptr<T> window)
+    {
+        auto* oldWnd = FindNonModalWindow(window->GetID());
+        if(oldWnd)
+        {
+            oldWnd->Close();
+            return nullptr;
+        } else
+            return Show(std::move(window));
+    }
     /// Registers a window to be shown after a desktop switch
     IngameWindow* ShowAfterSwitch(std::unique_ptr<IngameWindow> window);
     /// schliesst ein IngameWindow und entfernt es aus der Fensterliste.
@@ -99,6 +118,7 @@ public:
     /// Return the window currently on the top (probably active)
     const IngameWindow* GetTopMostWindow() const;
     IngameWindow* FindWindowAtPos(const Position& pos) const;
+    IngameWindow* FindNonModalWindow(unsigned id) const;
 
     Desktop* GetCurrentDesktop() { return curDesktop.get(); }
 

--- a/libs/s25main/WindowManager.h
+++ b/libs/s25main/WindowManager.h
@@ -57,14 +57,14 @@ public:
     void RelayMouseMessage(MouseMsgHandler msg, const MouseCoords& mc);
 
     /// Öffnet ein IngameWindow und fügt es zur Fensterliste hinzu.
-    IngameWindow* DoShow(std::unique_ptr<IngameWindow> window, bool mouse = false);
+    IngameWindow& DoShow(std::unique_ptr<IngameWindow> window, bool mouse = false);
     template<typename T>
-    T* Show(std::unique_ptr<T> window, bool mouse = false)
+    T& Show(std::unique_ptr<T> window, bool mouse = false)
     {
-        return static_cast<T*>(DoShow(std::move(window), mouse));
+        return static_cast<T&>(DoShow(std::move(window), mouse));
     }
     template<typename T>
-    T* ReplaceWindow(std::unique_ptr<T> window)
+    T& ReplaceWindow(std::unique_ptr<T> window)
     {
         auto* oldWnd = FindNonModalWindow(window->GetID());
         if(oldWnd)
@@ -80,7 +80,7 @@ public:
             oldWnd->Close();
             return nullptr;
         } else
-            return Show(std::move(window));
+            return &Show(std::move(window));
     }
     /// Registers a window to be shown after a desktop switch
     IngameWindow* ShowAfterSwitch(std::unique_ptr<IngameWindow> window);

--- a/libs/s25main/desktops/dskDirectIP.cpp
+++ b/libs/s25main/desktops/dskDirectIP.cpp
@@ -50,12 +50,12 @@ void dskDirectIP::Msg_ButtonClick(const unsigned ctrl_id)
                   _("Sorry!"), _("You can't create a game while a proxy server is active\nDisable the use of a proxy server first!"), this,
                   MSB_OK, MSB_EXCLAMATIONGREEN, 1));
             else
-                WINDOWMANAGER.Show(std::make_unique<iwDirectIPCreate>(ServerType::DIRECT));
+                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwDirectIPCreate>(ServerType::DIRECT));
         }
         break;
         case 4: // "Verbinden"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwDirectIPConnect>(ServerType::DIRECT));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwDirectIPConnect>(ServerType::DIRECT));
         }
         break;
         case 5: // "Zurück"

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -989,7 +989,7 @@ unsigned dskGameInterface::GetIdInCurBuildRoad(const MapPoint pt)
 
 void dskGameInterface::ShowRoadWindow(const Position& mousePos)
 {
-    roadwindow = WINDOWMANAGER.Show(std::make_unique<iwRoadWindow>(*this, worldViewer.GetBQ(road.point) != BQ_NOTHING, mousePos), true);
+    roadwindow = &WINDOWMANAGER.Show(std::make_unique<iwRoadWindow>(*this, worldViewer.GetBQ(road.point) != BQ_NOTHING, mousePos), true);
 }
 
 void dskGameInterface::ShowActionWindow(const iwAction::Tabs& action_tabs, MapPoint cSel, const DrawPoint& mousePos,
@@ -1026,7 +1026,7 @@ void dskGameInterface::ShowActionWindow(const iwAction::Tabs& action_tabs, MapPo
     }
 
     actionwindow =
-      WINDOWMANAGER.Show(std::make_unique<iwAction>(*this, gwv, action_tabs, cSel, mousePos, params, enable_military_buildings), true);
+      &WINDOWMANAGER.Show(std::make_unique<iwAction>(*this, gwv, action_tabs, cSel, mousePos, params, enable_military_buildings), true);
 }
 
 void dskGameInterface::OnChatCommand(const std::string& cmd)

--- a/libs/s25main/desktops/dskHostGame.cpp
+++ b/libs/s25main/desktops/dskHostGame.cpp
@@ -662,14 +662,19 @@ void dskHostGame::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 22: // Addons
         {
-            std::unique_ptr<iwAddons> w;
-            if(allowAddonChange && (!lua || lua->IsChangeAllowed("addonsAll")))
-                w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::HOSTGAME);
-            else if(allowAddonChange)
-                w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::HOSTGAME_WHITELIST, lua->GetAllowedAddons());
+            if(auto* wnd = WINDOWMANAGER.FindNonModalWindow(CGI_ADDONS))
+                wnd->Close();
             else
-                w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::READONLY);
-            WINDOWMANAGER.Show(std::move(w));
+            {
+                std::unique_ptr<iwAddons> w;
+                if(allowAddonChange && (!lua || lua->IsChangeAllowed("addonsAll")))
+                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::HOSTGAME);
+                else if(allowAddonChange)
+                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::HOSTGAME_WHITELIST, lua->GetAllowedAddons());
+                else
+                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::READONLY);
+                WINDOWMANAGER.Show(std::move(w));
+            }
         }
         break;
     }

--- a/libs/s25main/desktops/dskLAN.cpp
+++ b/libs/s25main/desktops/dskLAN.cpp
@@ -92,7 +92,7 @@ void dskLAN::Msg_ButtonClick(const unsigned ctrl_id)
                   MSB_OK, MSB_EXCLAMATIONGREEN, 1));
             else
             {
-                WINDOWMANAGER.Show(std::make_unique<iwDirectIPCreate>(ServerType::LAN), true);
+                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwDirectIPCreate>(ServerType::LAN));
             }
     }
 }
@@ -160,7 +160,7 @@ bool dskLAN::ConnectToSelectedGame()
     {
         auto connect = std::make_unique<iwDirectIPConnect>(ServerType::LAN);
         connect->Connect(game.ip, game.info.port, game.info.isIPv6, game.info.hasPwd);
-        WINDOWMANAGER.Show(std::move(connect));
+        WINDOWMANAGER.ReplaceWindow(std::move(connect));
         return true;
     } else
     {

--- a/libs/s25main/desktops/dskLobby.cpp
+++ b/libs/s25main/desktops/dskLobby.cpp
@@ -126,7 +126,7 @@ void dskLobby::Msg_ButtonClick(const unsigned ctrl_id)
         case 5: // Ranking - Button
         {
             LOBBYCLIENT.SendRankingListRequest();
-            lobbyRankingWnd = WINDOWMANAGER.Show(std::make_unique<iwLobbyRanking>(), true);
+            lobbyRankingWnd = WINDOWMANAGER.ReplaceWindow(std::make_unique<iwLobbyRanking>());
         }
         break;
         case 6: // GameServer hinzufügen
@@ -137,7 +137,7 @@ void dskLobby::Msg_ButtonClick(const unsigned ctrl_id)
                   MSB_OK, MSB_EXCLAMATIONGREEN, 1));
             else
             {
-                createServerWnd = WINDOWMANAGER.Show(std::make_unique<iwDirectIPCreate>(ServerType::LOBBY), true);
+                createServerWnd = WINDOWMANAGER.ReplaceWindow(std::make_unique<iwDirectIPCreate>(ServerType::LOBBY));
             }
         }
         break;
@@ -177,7 +177,8 @@ void dskLobby::Msg_TableRightButton(const unsigned ctrl_id, const int selection)
                     WINDOWMANAGER.Close(serverInfoWnd);
                 }
 
-                serverInfoWnd = WINDOWMANAGER.Show(std::make_unique<iwLobbyServerInfo>(boost::lexical_cast<unsigned>(item.c_str())), true);
+                serverInfoWnd =
+                  WINDOWMANAGER.ReplaceWindow(std::make_unique<iwLobbyServerInfo>(boost::lexical_cast<unsigned>(item.c_str())));
                 serverInfoWnd->SetTitle(table->GetItemText(selection, 1));
             }
         }
@@ -231,7 +232,7 @@ bool dskLobby::ConnectToSelectedGame()
         {
             auto connect = std::make_unique<iwDirectIPConnect>(ServerType::LOBBY);
             connect->Connect(server.getHost(), server.getPort(), false, server.hasPassword());
-            WINDOWMANAGER.Show(std::move(connect));
+            WINDOWMANAGER.ReplaceWindow(std::move(connect));
             return true;
         } else
             WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Sorry!"), _("You can't join that game with your version!"), this, MSB_OK,

--- a/libs/s25main/desktops/dskLobby.cpp
+++ b/libs/s25main/desktops/dskLobby.cpp
@@ -126,7 +126,7 @@ void dskLobby::Msg_ButtonClick(const unsigned ctrl_id)
         case 5: // Ranking - Button
         {
             LOBBYCLIENT.SendRankingListRequest();
-            lobbyRankingWnd = WINDOWMANAGER.ReplaceWindow(std::make_unique<iwLobbyRanking>());
+            lobbyRankingWnd = &WINDOWMANAGER.ReplaceWindow(std::make_unique<iwLobbyRanking>());
         }
         break;
         case 6: // GameServer hinzufügen
@@ -137,7 +137,7 @@ void dskLobby::Msg_ButtonClick(const unsigned ctrl_id)
                   MSB_OK, MSB_EXCLAMATIONGREEN, 1));
             else
             {
-                createServerWnd = WINDOWMANAGER.ReplaceWindow(std::make_unique<iwDirectIPCreate>(ServerType::LOBBY));
+                createServerWnd = &WINDOWMANAGER.ReplaceWindow(std::make_unique<iwDirectIPCreate>(ServerType::LOBBY));
             }
         }
         break;
@@ -178,7 +178,7 @@ void dskLobby::Msg_TableRightButton(const unsigned ctrl_id, const int selection)
                 }
 
                 serverInfoWnd =
-                  WINDOWMANAGER.ReplaceWindow(std::make_unique<iwLobbyServerInfo>(boost::lexical_cast<unsigned>(item.c_str())));
+                  &WINDOWMANAGER.ReplaceWindow(std::make_unique<iwLobbyServerInfo>(boost::lexical_cast<unsigned>(item.c_str())));
                 serverInfoWnd->SetTitle(table->GetItemText(selection, 1));
             }
         }

--- a/libs/s25main/desktops/dskMainMenu.cpp
+++ b/libs/s25main/desktops/dskMainMenu.cpp
@@ -134,7 +134,7 @@ void dskMainMenu::Msg_ButtonClick(const unsigned ctrl_id)
             GLOBALVARS.notdone = false;
             break;
         case ID_btReadme: // "Readme"
-            WINDOWMANAGER.Show(std::make_unique<iwTextfile>("readme.txt", _("Readme!")));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwTextfile>("readme.txt", _("Readme!")));
             break;
     }
 }

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -566,7 +566,7 @@ void dskOptions::Msg_ButtonClick(const unsigned ctrl_id)
         }
         break;
         case 14: // Addons
-            WINDOWMANAGER.Show(std::make_unique<iwAddons>(ggs));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwAddons>(ggs));
             break;
     }
 }
@@ -578,12 +578,12 @@ void dskOptions::Msg_Group_ButtonClick(const unsigned /*group_id*/, const unsign
         default: break;
         case 71: // "Music player"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwMusicPlayer>());
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwMusicPlayer>());
         }
         break;
         case 35: // "Keyboard Readme"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwTextfile>("keyboardlayout.txt", _("Keyboard layout")));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwTextfile>("keyboardlayout.txt", _("Keyboard layout")));
         }
         break;
     }

--- a/libs/s25main/desktops/dskSelectMap.cpp
+++ b/libs/s25main/desktops/dskSelectMap.cpp
@@ -259,7 +259,7 @@ void dskSelectMap::Msg_ButtonClick(const unsigned ctrl_id)
             if(!mapGenThread)
             {
                 newRandMapPath.clear();
-                waitWnd = WINDOWMANAGER.Show(std::make_unique<iwPleaseWait>());
+                waitWnd = &WINDOWMANAGER.Show(std::make_unique<iwPleaseWait>());
                 // mapGenThread = new boost::thread(boost::bind(&dskSelectMap::CreateRandomMap, this));
                 CreateRandomMap();
             }

--- a/libs/s25main/desktops/dskSelectMap.cpp
+++ b/libs/s25main/desktops/dskSelectMap.cpp
@@ -181,7 +181,7 @@ void dskSelectMap::Msg_TableSelectItem(const unsigned ctrl_id, const int selecti
     if(ctrl_id != 1)
         return;
     ctrlTable& table = *GetCtrl<ctrlTable>(1);
-    const std::string path = table.GetItemText(selection, 5);
+    const std::string& path = table.GetItemText(selection, 5);
 
     ctrlPreviewMinimap& preview = *GetCtrl<ctrlPreviewMinimap>(11);
     ctrlText& txtMapName = *GetCtrl<ctrlText>(12);
@@ -446,8 +446,8 @@ void dskSelectMap::FillTable(const std::vector<std::string>& files)
 void dskSelectMap::MarkMapAsBroken(const int tableIdx, const std::string& reason)
 {
     ctrlTable& table = *GetCtrl<ctrlTable>(1);
-    const std::string path = table.GetItemText(tableIdx, 5);
-    brokenMapPaths.emplace_back(std::move(path));
+    const std::string& path = table.GetItemText(tableIdx, 5);
+    brokenMapPaths.emplace_back(path);
     std::string errorTxt = _("Could not load map:\n") + path + '\n' + reason;
     WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Error"), errorTxt, this, MSB_OK, MSB_EXCLAMATIONRED, 1));
     table.RemoveRow(tableIdx);

--- a/libs/s25main/desktops/dskSelectMap.h
+++ b/libs/s25main/desktops/dskSelectMap.h
@@ -69,6 +69,7 @@ private:
     void CreateRandomMap();
 
     void OnMapCreated(const std::string& mapPath);
+    void MarkMapAsBroken(int tableIdx, const std::string& reason);
 
     CreateServerInfo csi;
     MapSettings rndMapSettings;

--- a/libs/s25main/desktops/dskSinglePlayer.cpp
+++ b/libs/s25main/desktops/dskSinglePlayer.cpp
@@ -118,7 +118,7 @@ void dskSinglePlayer::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 4: // "Replay abspielen"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwPlayReplay>());
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwPlayReplay>());
         }
         break;
         case 5: // "Kampagne"

--- a/libs/s25main/gameData/MapConsts.h
+++ b/libs/s25main/gameData/MapConsts.h
@@ -26,4 +26,7 @@ constexpr int TR_H = 28;
 /// Number of pixels the node is adjusted in y per altitude step
 constexpr int HEIGHT_FACTOR = 5;
 
+/// Maximum supported width or height of the map
+constexpr unsigned MAX_MAP_SIZE = 2048;
+
 #endif // !MAPCONSTS_H_INCLUDED

--- a/libs/s25main/gameData/const_gui_ids.h
+++ b/libs/s25main/gameData/const_gui_ids.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#include "MapConsts.h"
+
+constexpr unsigned MAX_OBSERVATION_WINDOWS = 50;
+
 enum GUI_ID
 {
     CGI_ACTION = 0,
@@ -34,7 +38,6 @@ enum GUI_ID
     CGI_OPTIONSWINDOW,
     CGI_POSTOFFICE,
     CGI_ROADWINDOW,
-    CGI_VIEWER,
     CGI_LOBBYSERVERINFO,
     CGI_README,
     CGI_DISTRIBUTION,
@@ -65,7 +68,9 @@ enum GUI_ID
     CGI_AI_DEBUG,
     CGI_MAP_GENERATOR,
     CGI_VICTORY,
-    CGI_NEXT = CGI_MAP_GENERATOR + 40
+    CGI_OBSERVATION,
+    CGI_BUILDING, /// Building windows use this as the base ID and add a unique number for each building
+    CGI_NEXT = CGI_BUILDING + MAX_MAP_SIZE * MAX_MAP_SIZE
 };
 
 #endif // !CONST_GUI_IDS_H_INCLUDED

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -30,7 +30,7 @@ struct Point;
 
 class IngameWindow : public Window
 {
-    /// For each id we save the last posistion of the window
+    /// For each id we save the last position of the window
     static std::vector<DrawPoint> last_pos;
 
 public:

--- a/libs/s25main/ingameWindows/iwAction.cpp
+++ b/libs/s25main/ingameWindows/iwAction.cpp
@@ -553,9 +553,7 @@ void iwAction::Msg_ButtonClick_TabAttack(const unsigned ctrl_id)
         case 4: // Angriff!
         {
             auto* ogroup = GetCtrl<ctrlTab>(0)->GetGroup(TAB_ATTACK)->GetCtrl<ctrlOptionGroup>(3);
-
             GAMECLIENT.Attack(selectedPt, selected_soldiers_count, (ogroup->GetSelection() == 1));
-
             Close();
         }
         break;
@@ -592,9 +590,7 @@ void iwAction::Msg_ButtonClick_TabSeaAttack(const unsigned ctrl_id)
         case 4: // Angriff!
         {
             auto* ogroup = GetCtrl<ctrlTab>(0)->GetGroup(TAB_SEAATTACK)->GetCtrl<ctrlOptionGroup>(3);
-
             GAMECLIENT.SeaAttack(selectedPt, selected_soldiers_count_sea, (ogroup->GetSelection() == 1));
-
             Close();
         }
         break;
@@ -625,7 +621,6 @@ void iwAction::Msg_ButtonClick_TabFlag(const unsigned ctrl_id)
             if(nop == NOP_BUILDING || nop == NOP_BUILDINGSITE)
             {
                 // Abreißen?
-                Close();
                 const auto* building = world.GetSpecObj<noBaseBuilding>(world.GetNeighbour(selectedPt, Direction::NORTHWEST));
 
                 // Militärgebäude?
@@ -641,6 +636,8 @@ void iwAction::Msg_ButtonClick_TabFlag(const unsigned ctrl_id)
                 }
 
                 WINDOWMANAGER.Show(std::make_unique<iwDemolishBuilding>(gwv, building, true));
+                DisableMousePosResetOnClose();
+                Close();
             } else
             {
                 GAMECLIENT.DestroyFlag(selectedPt);
@@ -679,15 +676,11 @@ void iwAction::Msg_ButtonClick_TabSetFlag(const unsigned ctrl_id)
     switch(ctrl_id)
     {
         case 1: // Flagge setzen
-        {
             GAMECLIENT.SetFlag(selectedPt);
-        }
-        break;
+            break;
         case 2: // Weg aufwerten
-        {
             DoUpgradeRoad();
-        }
-        break;
+            break;
     }
 
     Close();
@@ -706,10 +699,8 @@ void iwAction::Msg_ButtonClick_TabCutRoad(const unsigned ctrl_id)
         }
         break;
         case 2: // Straße aufwerten
-        {
             DoUpgradeRoad();
-        }
-        break;
+            break;
     }
 
     Close();
@@ -722,17 +713,22 @@ void iwAction::Msg_ButtonClick_TabWatch(const unsigned ctrl_id)
         case 1:
             // TODO: bestimen, was an der position selected ist
             WINDOWMANAGER.Show(std::make_unique<iwObservate>(gwv, selectedPt));
-            mousePosAtOpen_ = DrawPoint::Invalid();
+            DisableMousePosResetOnClose();
             break;
         case 2: // Häusernamen/Prozent anmachen
             gwv.ToggleShowNamesAndProductivity();
             break;
         case 3: // zum HQ
             gwv.MoveToMapPt(gwv.GetViewer().GetPlayer().GetHQPos());
-            mousePosAtOpen_ = DrawPoint::Invalid();
+            DisableMousePosResetOnClose();
             break;
         case 4: GAMECLIENT.NotifyAlliesOfLocation(selectedPt); break;
     }
 
     Close();
+}
+
+void iwAction::DisableMousePosResetOnClose()
+{
+    mousePosAtOpen_ = DrawPoint::Invalid();
 }

--- a/libs/s25main/ingameWindows/iwAction.h
+++ b/libs/s25main/ingameWindows/iwAction.h
@@ -99,6 +99,8 @@ private:
     inline void Msg_ButtonClick_TabSetFlag(unsigned ctrl_id);
     inline void Msg_ButtonClick_TabWatch(unsigned ctrl_id);
 
+    void DisableMousePosResetOnClose();
+
     /// Fügt Angriffs-Steuerelemente für bestimmte Gruppe hinzu
     void AddAttackControls(ctrlGroup* group, unsigned attackers_count);
     void AddUpgradeRoad(ctrlGroup* group, unsigned& x, unsigned& width);

--- a/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
@@ -36,6 +36,7 @@
 #include "world/GameWorldBase.h"
 #include "world/GameWorldView.h"
 #include "gameData/BuildingConsts.h"
+#include "gameData/const_gui_ids.h"
 #include <stdexcept>
 
 namespace {
@@ -57,8 +58,8 @@ enum
 }
 
 iwBaseWarehouse::iwBaseWarehouse(GameWorldView& gwv, GameCommandFactory& gcFactory, nobBaseWarehouse* wh)
-    : iwWares(wh->CreateGUIID(), IngameWindow::posAtMouse, Extent(167, 416), _(BUILDING_NAMES[wh->GetBuildingType()]), true, NormalFont,
-              wh->GetInventory(), gwv.GetWorld().GetPlayer(wh->GetPlayer())),
+    : iwWares(CGI_BUILDING + MapBase::CreateGUIID(wh->GetPos()), IngameWindow::posAtMouse, Extent(167, 416),
+              _(BUILDING_NAMES[wh->GetBuildingType()]), true, NormalFont, wh->GetInventory(), gwv.GetWorld().GetPlayer(wh->GetPlayer())),
       gwv(gwv), gcFactory(gcFactory), wh(wh)
 {
     wh->AddListener(this);
@@ -204,7 +205,7 @@ void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case ID_HELP: // "Hilfe"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _(BUILDING_HELP_STRINGS[wh->GetBuildingType()])));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_(BUILDING_HELP_STRINGS[wh->GetBuildingType()])));
         }
         break;
         case ID_GOTO: // "Gehe Zu Ort"
@@ -229,14 +230,14 @@ void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
                 gwv.MoveToMapPt((*it)->GetPos());
                 if((*it)->GetBuildingType() == BLD_HEADQUARTERS)
                 {
-                    WINDOWMANAGER.Show(std::make_unique<iwHQ>(gwv, gcFactory, *it))->SetPos(GetPos());
+                    WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHQ>(gwv, gcFactory, *it))->SetPos(GetPos());
                 } else if((*it)->GetBuildingType() == BLD_HARBORBUILDING)
                 {
-                    WINDOWMANAGER.Show(std::make_unique<iwHarborBuilding>(gwv, gcFactory, dynamic_cast<nobHarborBuilding*>(*it)))
+                    WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHarborBuilding>(gwv, gcFactory, dynamic_cast<nobHarborBuilding*>(*it)))
                       ->SetPos(GetPos());
                 } else if((*it)->GetBuildingType() == BLD_STOREHOUSE)
                 {
-                    WINDOWMANAGER.Show(std::make_unique<iwBaseWarehouse>(gwv, gcFactory, dynamic_cast<nobStorehouse*>(*it)))
+                    WINDOWMANAGER.ReplaceWindow(std::make_unique<iwBaseWarehouse>(gwv, gcFactory, dynamic_cast<nobStorehouse*>(*it)))
                       ->SetPos(GetPos());
                 }
                 break;

--- a/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
@@ -230,15 +230,15 @@ void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
                 gwv.MoveToMapPt((*it)->GetPos());
                 if((*it)->GetBuildingType() == BLD_HEADQUARTERS)
                 {
-                    WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHQ>(gwv, gcFactory, *it))->SetPos(GetPos());
+                    WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHQ>(gwv, gcFactory, *it)).SetPos(GetPos());
                 } else if((*it)->GetBuildingType() == BLD_HARBORBUILDING)
                 {
                     WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHarborBuilding>(gwv, gcFactory, dynamic_cast<nobHarborBuilding*>(*it)))
-                      ->SetPos(GetPos());
+                      .SetPos(GetPos());
                 } else if((*it)->GetBuildingType() == BLD_STOREHOUSE)
                 {
                     WINDOWMANAGER.ReplaceWindow(std::make_unique<iwBaseWarehouse>(gwv, gcFactory, dynamic_cast<nobStorehouse*>(*it)))
-                      ->SetPos(GetPos());
+                      .SetPos(GetPos());
                 }
                 break;
             }

--- a/libs/s25main/ingameWindows/iwBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwBuilding.cpp
@@ -35,6 +35,7 @@
 #include "world/GameWorldView.h"
 #include "gameData/BuildingConsts.h"
 #include "gameData/BuildingProperties.h"
+#include "gameData/const_gui_ids.h"
 #include <sstream>
 
 /// IDs in der IO_DAT von Boot und Schiffs-Bild für den Umschaltebutton beim Schiffsbauer
@@ -42,8 +43,8 @@ const unsigned IODAT_BOAT_ID = 219;
 const unsigned IODAT_SHIP_ID = 218;
 
 iwBuilding::iwBuilding(GameWorldView& gwv, GameCommandFactory& gcFactory, nobUsual* const building)
-    : IngameWindow(building->CreateGUIID(), IngameWindow::posAtMouse, Extent(226, 194), _(BUILDING_NAMES[building->GetBuildingType()]),
-                   LOADER.GetImageN("resource", 41)),
+    : IngameWindow(CGI_BUILDING + MapBase::CreateGUIID(building->GetPos()), IngameWindow::posAtMouse, Extent(226, 194),
+                   _(BUILDING_NAMES[building->GetBuildingType()]), LOADER.GetImageN("resource", 41)),
       gwv(gwv), gcFactory(gcFactory), building(building)
 {
     // Arbeitersymbol
@@ -169,7 +170,7 @@ void iwBuilding::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 4: // Hilfe
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _(BUILDING_HELP_STRINGS[building->GetBuildingType()])));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_(BUILDING_HELP_STRINGS[building->GetBuildingType()])));
         }
         break;
         case 5: // Gebäude abbrennen
@@ -234,7 +235,7 @@ void iwBuilding::Msg_ButtonClick(const unsigned ctrl_id)
                 if(it == buildings.end()) // was last entry in list -> goto first
                     it = buildings.begin();
                 gwv.MoveToMapPt((*it)->GetPos());
-                WINDOWMANAGER.Show(std::make_unique<iwBuilding>(gwv, gcFactory, *it))->SetPos(GetPos());
+                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwBuilding>(gwv, gcFactory, *it))->SetPos(GetPos());
                 break;
             }
         }

--- a/libs/s25main/ingameWindows/iwBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwBuilding.cpp
@@ -235,7 +235,7 @@ void iwBuilding::Msg_ButtonClick(const unsigned ctrl_id)
                 if(it == buildings.end()) // was last entry in list -> goto first
                     it = buildings.begin();
                 gwv.MoveToMapPt((*it)->GetPos());
-                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwBuilding>(gwv, gcFactory, *it))->SetPos(GetPos());
+                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwBuilding>(gwv, gcFactory, *it)).SetPos(GetPos());
                 break;
             }
         }

--- a/libs/s25main/ingameWindows/iwBuildingSite.cpp
+++ b/libs/s25main/ingameWindows/iwBuildingSite.cpp
@@ -25,10 +25,12 @@
 #include "ogl/FontStyle.h"
 #include "ogl/glArchivItem_Bitmap.h"
 #include "world/GameWorldView.h"
+#include "world/MapBase.h"
 #include "gameData/BuildingConsts.h"
+#include "gameData/const_gui_ids.h"
 
 iwBuildingSite::iwBuildingSite(GameWorldView& gwv, const noBuildingSite* const buildingsite)
-    : IngameWindow(buildingsite->CreateGUIID(), IngameWindow::posAtMouse, Extent(226, 194),
+    : IngameWindow(CGI_BUILDING + MapBase::CreateGUIID(buildingsite->GetPos()), IngameWindow::posAtMouse, Extent(226, 194),
                    _(BUILDING_NAMES[buildingsite->GetBuildingType()]), LOADER.GetImageN("resource", 41)),
       gwv(gwv), buildingsite(buildingsite)
 {
@@ -52,7 +54,7 @@ void iwBuildingSite::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 2: // Hilfe
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _(BUILDING_HELP_STRINGS[buildingsite->GetBuildingType()])));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_(BUILDING_HELP_STRINGS[buildingsite->GetBuildingType()])));
         }
         break;
         case 3: // Gebäude abbrennen

--- a/libs/s25main/ingameWindows/iwBuildings.cpp
+++ b/libs/s25main/ingameWindows/iwBuildings.cpp
@@ -114,11 +114,11 @@ void iwBuildings::Msg_ButtonClick(const unsigned ctrl_id)
 {
     if(ctrl_id == 32) // Help button
     {
-        WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("The building statistics window gives you an insight into "
-                                                                        "the number of buildings you have, by type. The number on "
-                                                                        "the left is the total number of this type of building "
-                                                                        "completed, the number on the right shows how many are "
-                                                                        "currently under construction.")));
+        WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_("The building statistics window gives you an insight into "
+                                                               "the number of buildings you have, by type. The number on "
+                                                               "the left is the total number of this type of building "
+                                                               "completed, the number on the right shows how many are "
+                                                               "currently under construction.")));
         return;
     }
 
@@ -147,7 +147,7 @@ void iwBuildings::GoToFirstMatching(BuildingType bldType, const std::list<T_Buil
             gwv.MoveToMapPt(bld->GetPos());
             auto nextscrn = std::make_unique<T_Window>(gwv, gcFactory, static_cast<T_Building*>(bld));
             nextscrn->SetPos(GetPos());
-            WINDOWMANAGER.Show(std::move(nextscrn));
+            WINDOWMANAGER.ReplaceWindow(std::move(nextscrn));
             return;
         }
     }

--- a/libs/s25main/ingameWindows/iwDemolishBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwDemolishBuilding.cpp
@@ -23,10 +23,13 @@
 #include "ogl/FontStyle.h"
 #include "world/GameWorldView.h"
 #include "world/GameWorldViewer.h"
+#include "world/MapBase.h"
 #include "gameData/BuildingConsts.h"
+#include "gameData/const_gui_ids.h"
 
 iwDemolishBuilding::iwDemolishBuilding(GameWorldView& gwv, const noBaseBuilding* building, const bool flag)
-    : IngameWindow(building->CreateGUIID(), IngameWindow::posAtMouse, Extent(200, 200), _("Demolish?"), LOADER.GetImageN("resource", 41)),
+    : IngameWindow(CGI_BUILDING + MapBase::CreateGUIID(building->GetPos()), IngameWindow::posAtMouse, Extent(200, 200), _("Demolish?"),
+                   LOADER.GetImageN("resource", 41)),
       gwv(gwv), building(building), flag(flag)
 {
     // Ja

--- a/libs/s25main/ingameWindows/iwDiplomacy.cpp
+++ b/libs/s25main/ingameWindows/iwDiplomacy.cpp
@@ -176,7 +176,7 @@ void iwDiplomacy::Msg_ButtonClick(const unsigned ctrl_id)
         // Noch kein Bündnis abgeschlossen?
         if(gwv.GetPlayer().GetPactState(TREATY_OF_ALLIANCE, playerId) == GamePlayer::NO_PACT)
             // Dann neues Bündnis vorschlagen
-            WINDOWMANAGER.Show(std::make_unique<iwSuggestPact>(TREATY_OF_ALLIANCE, gwv.GetWorld().GetPlayer(playerId), gcFactory));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwSuggestPact>(TREATY_OF_ALLIANCE, gwv.GetWorld().GetPlayer(playerId), gcFactory));
         else
             // ansonsten Vertrag versuchen abzubrechen
             gcFactory.CancelPact(TREATY_OF_ALLIANCE, playerId);
@@ -188,7 +188,8 @@ void iwDiplomacy::Msg_ButtonClick(const unsigned ctrl_id)
         // Noch kein Bündnis abgeschlossen?
         if(gwv.GetPlayer().GetPactState(NON_AGGRESSION_PACT, playerId) == GamePlayer::NO_PACT)
             // Dann neues Bündnis vorschlagen
-            WINDOWMANAGER.Show(std::make_unique<iwSuggestPact>(NON_AGGRESSION_PACT, gwv.GetWorld().GetPlayer(playerId), gcFactory));
+            WINDOWMANAGER.ReplaceWindow(
+              std::make_unique<iwSuggestPact>(NON_AGGRESSION_PACT, gwv.GetWorld().GetPlayer(playerId), gcFactory));
         else
             // ansonsten Vertrag versuchen abzubrechen
             gcFactory.CancelPact(NON_AGGRESSION_PACT, playerId);

--- a/libs/s25main/ingameWindows/iwDistribution.cpp
+++ b/libs/s25main/ingameWindows/iwDistribution.cpp
@@ -167,10 +167,9 @@ void iwDistribution::Msg_ButtonClick(const unsigned ctrl_id)
 
         case 2:
         {
-            WINDOWMANAGER.Show(
-              std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("The priority of goods for the individual buildings can be set here. "
-                                                           "The higher the value, the quicker the required goods are delivered "
-                                                           "to the building concerned.")));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_("The priority of goods for the individual buildings can be set here. "
+                                                                   "The higher the value, the quicker the required goods are delivered "
+                                                                   "to the building concerned.")));
         }
         break;
         // Default button

--- a/libs/s25main/ingameWindows/iwEndgame.cpp
+++ b/libs/s25main/ingameWindows/iwEndgame.cpp
@@ -50,7 +50,7 @@ void iwEndgame::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 2: // OK + Speichern
         {
-            WINDOWMANAGER.Show(std::make_unique<iwSave>());
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwSave>());
         }
         break;
     }

--- a/libs/s25main/ingameWindows/iwHelp.cpp
+++ b/libs/s25main/ingameWindows/iwHelp.cpp
@@ -19,6 +19,7 @@
 #include "iwHelp.h"
 #include "Loader.h"
 #include "controls/ctrlMultiline.h"
+#include "gameData/const_gui_ids.h"
 
 /// Breite des Fensters
 const unsigned short HELP_WINDOW_WIDTH = 280;
@@ -26,8 +27,8 @@ const unsigned short HELP_WINDOW_WIDTH = 280;
 /// Maximale Anzahl von Zeilen, bis Scrollbar eingesetzt wird
 const unsigned MAX_LINES = 15;
 
-iwHelp::iwHelp(const GUI_ID gui_id, const std::string& content)
-    : IngameWindow(gui_id, IngameWindow::posAtMouse, Extent(HELP_WINDOW_WIDTH, 480), _("What is this?"), LOADER.GetImageN("io", 1))
+iwHelp::iwHelp(const std::string& content)
+    : IngameWindow(CGI_HELP, IngameWindow::posAtMouse, Extent(HELP_WINDOW_WIDTH, 480), _("What is this?"), LOADER.GetImageN("io", 1))
 {
     // Größe des Fensters und des Controls nach der Anzahl der Zeilen
     ctrlMultiline* text = AddMultiline(2, DrawPoint(contentOffset), GetIwSize(), TC_GREEN1, NormalFont);

--- a/libs/s25main/ingameWindows/iwHelp.h
+++ b/libs/s25main/ingameWindows/iwHelp.h
@@ -20,14 +20,13 @@
 #pragma once
 
 #include "IngameWindow.h"
-#include "gameData/const_gui_ids.h"
 #include <string>
 
 /// Soforthilfe-Fenster
 class iwHelp : public IngameWindow
 {
 public:
-    iwHelp(GUI_ID gui_id, const std::string& content);
+    explicit iwHelp(const std::string& content);
 };
 
 #endif // iwHELP_H_INCLUDED

--- a/libs/s25main/ingameWindows/iwMainMenu.cpp
+++ b/libs/s25main/ingameWindows/iwMainMenu.cpp
@@ -97,68 +97,70 @@ void iwMainMenu::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 0: // Verteilung
         {
-            WINDOWMANAGER.Show(std::make_unique<iwDistribution>(gwv.GetViewer(), gcFactory));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwDistribution>(gwv.GetViewer(), gcFactory));
         }
         break;
         case 1: // Transport
         {
-            WINDOWMANAGER.Show(std::make_unique<iwTransport>(gwv.GetViewer(), gcFactory));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwTransport>(gwv.GetViewer(), gcFactory));
         }
         break;
         case 2: // Werkzeugproduktion
         {
-            WINDOWMANAGER.Show(std::make_unique<iwTools>(gwv.GetViewer(), gcFactory));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwTools>(gwv.GetViewer(), gcFactory));
         }
         break;
         case 3: // Statistik
         {
-            WINDOWMANAGER.Show(std::make_unique<iwStatistics>(gwv.GetViewer()));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwStatistics>(gwv.GetViewer()));
         }
         break;
         case 4: // Warenstatistik
         {
-            WINDOWMANAGER.Show(std::make_unique<iwMerchandiseStatistics>(gwv.GetViewer().GetPlayer()));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwMerchandiseStatistics>(gwv.GetViewer().GetPlayer()));
         }
         break;
         case 5: // Gebäudestatistik
         {
-            WINDOWMANAGER.Show(std::make_unique<iwBuildings>(gwv, gcFactory));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwBuildings>(gwv, gcFactory));
         }
         break;
         case 6: // Inventur
         {
-            WINDOWMANAGER.Show(std::make_unique<iwInventory>(gwv.GetViewer().GetPlayer()));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwInventory>(gwv.GetViewer().GetPlayer()));
         }
         break;
         case 7: // Produktivitäten
         {
-            WINDOWMANAGER.Show(std::make_unique<iwBuildingProductivities>(gwv.GetViewer().GetPlayer()));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwBuildingProductivities>(gwv.GetViewer().GetPlayer()));
         }
         break;
         case 8: // Militär
         {
-            WINDOWMANAGER.Show(std::make_unique<iwMilitary>(gwv.GetViewer(), gcFactory));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwMilitary>(gwv.GetViewer(), gcFactory));
         }
         break;
         case 9: // Schiffe
         {
-            WINDOWMANAGER.Show(
+            WINDOWMANAGER.ToggleWindow(
               std::make_unique<iwShip>(gwv, gcFactory, gwv.GetViewer().GetPlayer().GetShipByID(0), IngameWindow::posCenter));
         }
         break;
         case 10: // Baureihenfolge
         {
-            WINDOWMANAGER.Show(std::make_unique<iwBuildOrder>(gwv.GetViewer()));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwBuildOrder>(gwv.GetViewer()));
         }
         break;
         case 11: // Diplomatie
         {
-            WINDOWMANAGER.Show(std::make_unique<iwDiplomacy>(gwv.GetViewer(), gcFactory));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwDiplomacy>(gwv.GetViewer(), gcFactory));
         }
         break;
         case 13: // AI Debug
         {
-            if(gwv.GetViewer().GetPlayer().isHost)
+            if(auto* wnd = WINDOWMANAGER.FindNonModalWindow(CGI_AI_DEBUG))
+                wnd->Close();
+            else if(gwv.GetViewer().GetPlayer().isHost)
             {
                 std::vector<const AIPlayer*> ais;
                 for(unsigned i = 0; i < gwv.GetViewer().GetNumPlayers(); ++i)
@@ -173,7 +175,7 @@ void iwMainMenu::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 30: // Optionen
         {
-            WINDOWMANAGER.Show(std::make_unique<iwOptionsWindow>());
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwOptionsWindow>());
         }
         break;
     }

--- a/libs/s25main/ingameWindows/iwMerchandiseStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwMerchandiseStatistics.cpp
@@ -108,11 +108,11 @@ void iwMerchandiseStatistics::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 16: // Hilfe
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(
-              GUI_ID(CGI_HELP), _("The merchandise statistics window allows you to check the quantities "
-                                  "of your merchandise. By clicking the left mouse button you can switch "
-                                  "the display of individual goods on and off. These can displayed over "
-                                  "four different time periods. To delete all displays, click on the wastebasket button.")));
+            WINDOWMANAGER.ReplaceWindow(
+              std::make_unique<iwHelp>(_("The merchandise statistics window allows you to check the quantities "
+                                         "of your merchandise. By clicking the left mouse button you can switch "
+                                         "the display of individual goods on and off. These can displayed over "
+                                         "four different time periods. To delete all displays, click on the wastebasket button.")));
         }
         break;
         case 17: // Alle abwählen

--- a/libs/s25main/ingameWindows/iwMilitary.cpp
+++ b/libs/s25main/ingameWindows/iwMilitary.cpp
@@ -132,17 +132,16 @@ void iwMilitary::Msg_ButtonClick(const unsigned ctrl_id)
         // Default button
         case 20:
         {
-            WINDOWMANAGER.Show(
-              std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("This is where you can make adjustments to all military matters. "
-                                                           "The upper value corresponds to the recruiting rate of your army. "
-                                                           "The higher it is, the more inhabitants are recruited as soldiers. "
-                                                           "Below this is the setting to protect your huts. If this value is "
-                                                           "set at maximum, your huts are defended by the strongest unit. To "
-                                                           "raise the number of attackers leaving your huts per attack, choose "
-                                                           "the next setting. The number of defenders who counter the enemy in "
-                                                           "the event of an attack is shown by the fourth display. The final "
-                                                           "three values correspond to the occupation of your huts in the "
-                                                           "interior, in the center of the country and on its borders.")));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_("This is where you can make adjustments to all military matters. "
+                                                                   "The upper value corresponds to the recruiting rate of your army. "
+                                                                   "The higher it is, the more inhabitants are recruited as soldiers. "
+                                                                   "Below this is the setting to protect your huts. If this value is "
+                                                                   "set at maximum, your huts are defended by the strongest unit. To "
+                                                                   "raise the number of attackers leaving your huts per attack, choose "
+                                                                   "the next setting. The number of defenders who counter the enemy in "
+                                                                   "the event of an attack is shown by the fourth display. The final "
+                                                                   "three values correspond to the occupation of your huts in the "
+                                                                   "interior, in the center of the country and on its borders.")));
         }
         break;
         case 21:

--- a/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
@@ -208,7 +208,7 @@ void iwMilitaryBuilding::Msg_ButtonClick(const unsigned ctrl_id)
                 if(it == militaryBuildings.end()) // was last entry in list -> goto first
                     it = militaryBuildings.begin();
                 gwv.MoveToMapPt((*it)->GetPos());
-                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwMilitaryBuilding>(gwv, gcFactory, *it))->SetPos(GetPos());
+                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwMilitaryBuilding>(gwv, gcFactory, *it)).SetPos(GetPos());
                 break;
             }
         }

--- a/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
@@ -38,10 +38,12 @@
 #include "world/GameWorldView.h"
 #include "gameData/BuildingConsts.h"
 #include "gameData/MilitaryConsts.h"
+#include "gameData/const_gui_ids.h"
 #include <set>
+
 iwMilitaryBuilding::iwMilitaryBuilding(GameWorldView& gwv, GameCommandFactory& gcFactory, nobMilitary* const building)
-    : IngameWindow(building->CreateGUIID(), IngameWindow::posAtMouse, Extent(226, 194), _(BUILDING_NAMES[building->GetBuildingType()]),
-                   LOADER.GetImageN("resource", 41)),
+    : IngameWindow(CGI_BUILDING + MapBase::CreateGUIID(building->GetPos()), IngameWindow::posAtMouse, Extent(226, 194),
+                   _(BUILDING_NAMES[building->GetBuildingType()]), LOADER.GetImageN("resource", 41)),
       gwv(gwv), gcFactory(gcFactory), building(building)
 {
     // Schwert
@@ -151,7 +153,7 @@ void iwMilitaryBuilding::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 4: // Hilfe
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _(BUILDING_HELP_STRINGS[building->GetBuildingType()])));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_(BUILDING_HELP_STRINGS[building->GetBuildingType()])));
         }
         break;
         case 5: // Gebäude abbrennen
@@ -206,9 +208,7 @@ void iwMilitaryBuilding::Msg_ButtonClick(const unsigned ctrl_id)
                 if(it == militaryBuildings.end()) // was last entry in list -> goto first
                     it = militaryBuildings.begin();
                 gwv.MoveToMapPt((*it)->GetPos());
-                auto nextscrn = std::make_unique<iwMilitaryBuilding>(gwv, gcFactory, *it);
-                nextscrn->SetPos(GetPos());
-                WINDOWMANAGER.Show(std::move(nextscrn));
+                WINDOWMANAGER.ReplaceWindow(std::make_unique<iwMilitaryBuilding>(gwv, gcFactory, *it))->SetPos(GetPos());
                 break;
             }
         }

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -207,14 +207,14 @@ void iwMusicPlayer::Msg_ButtonClick(const unsigned ctrl_id)
         // Add Track
         case 7:
         {
-            WINDOWMANAGER.Show(std::make_unique<InputWindow>(*this, 0, _("Add track")));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<InputWindow>(*this, 0, _("Add track")));
             changed = true;
         }
         break;
         // Add Directory of tracks
         case 8:
         {
-            WINDOWMANAGER.Show(std::make_unique<InputWindow>(*this, 2, _("Add directory of tracks")));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<InputWindow>(*this, 2, _("Add directory of tracks")));
             changed = true;
         }
         break;

--- a/libs/s25main/ingameWindows/iwObservate.cpp
+++ b/libs/s25main/ingameWindows/iwObservate.cpp
@@ -30,6 +30,7 @@
 #include "world/GameWorldViewer.h"
 #include "nodeObjs/noMovable.h"
 #include "gameTypes/RoadBuildState.h"
+#include "gameData/const_gui_ids.h"
 #include <cmath>
 
 const Extent SmallWndSize(260, 190);
@@ -37,8 +38,7 @@ const Extent MediumWndSize(300, 250);
 const Extent BigWndSize(340, 310);
 
 iwObservate::iwObservate(GameWorldView& gwv, const MapPoint selectedPt)
-    : IngameWindow(gwv.GetWorld().CreateGUIID(selectedPt), IngameWindow::posAtMouse, SmallWndSize, _("Observation window"), nullptr, false,
-                   false),
+    : IngameWindow(CGI_OBSERVATION, IngameWindow::posAtMouse, SmallWndSize, _("Observation window"), nullptr, false, false),
       parentView(gwv), view(new GameWorldView(gwv.GetViewer(), Position(GetDrawPos() * DrawPoint(10, 15)), GetSize() - Extent::all(20))),
       selectedPt(selectedPt), lastWindowPos(Point<unsigned short>::Invalid()), isScrolling(false), zoomLvl(0), followMovableId(0)
 {

--- a/libs/s25main/ingameWindows/iwOptionsWindow.cpp
+++ b/libs/s25main/ingameWindows/iwOptionsWindow.cpp
@@ -99,23 +99,23 @@ void iwOptionsWindow::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 0: // "Spiel beenden"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwEndgame>());
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwEndgame>());
             Close();
         }
         break;
         case 4: // "Tastaturbelegung laden"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwTextfile>("keyboardlayout.txt", _("Keyboard layout")));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwTextfile>("keyboardlayout.txt", _("Keyboard layout")));
         }
         break;
         case 6: // "'Lies mich'-Datei laden"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwTextfile>("readme.txt", _("Readme!")));
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwTextfile>("readme.txt", _("Readme!")));
         }
         break;
         case 10: // "Spiel speichern"
         {
-            WINDOWMANAGER.Show(std::make_unique<iwSave>());
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwSave>());
         }
         break;
 
@@ -141,18 +141,18 @@ void iwOptionsWindow::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 16: // Music player
         {
-            WINDOWMANAGER.Show(std::make_unique<iwMusicPlayer>());
+            WINDOWMANAGER.ToggleWindow(std::make_unique<iwMusicPlayer>());
         }
         break;
         case 17: // Aufgeben
         {
-            WINDOWMANAGER.Show(std::make_unique<iwSurrender>());
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwSurrender>());
             Close();
         }
         break;
         case 18: // Advanced
         {
-            WINDOWMANAGER.Show(std::make_unique<iwSettings>());
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwSettings>());
             Close();
         }
         break;

--- a/libs/s25main/ingameWindows/iwPostWindow.cpp
+++ b/libs/s25main/ingameWindows/iwPostWindow.cpp
@@ -110,10 +110,10 @@ void iwPostWindow::Msg_ButtonClick(const unsigned ctrl_id)
     switch(ctrl_id)
     {
         case ID_HELP:
-            WINDOWMANAGER.Show(
-              std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("All important messages are collected in this window and "
-                                                           "sorted into groups. If this window is not open, the dove "
-                                                           "symbol at the bottom of the screen indicates the arrival of a new message.")));
+            WINDOWMANAGER.ReplaceWindow(
+              std::make_unique<iwHelp>(_("All important messages are collected in this window and "
+                                         "sorted into groups. If this window is not open, the dove "
+                                         "symbol at the bottom of the screen indicates the arrival of a new message.")));
             break;
         case ID_SHOW_ALL:
             showAll = true;

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -17,14 +17,15 @@
 
 #include "rttrDefines.h" // IWYU pragma: keep
 #include "iwSettings.h"
-
 #include "Loader.h"
 #include "Settings.h"
+#include "WindowManager.h"
 #include "controls/ctrlCheck.h"
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlOptionGroup.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "helpers/format.hpp"
+#include "iwMsgbox.h"
 #include "gameData/const_gui_ids.h"
 #include "libutil/colors.h"
 
@@ -81,9 +82,8 @@ iwSettings::~iwSettings()
             const auto screenSize = SETTINGS.video.fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
             if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.fullscreen))
             {
-                // WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Sorry!"), _("You need to restart your game to change the screen
-                // resolution!"), this,
-                //     MSB_OK, MSB_EXCLAMATIONGREEN, 1));
+                WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
+                  _("Sorry!"), _("You need to restart your game to change the screen resolution!"), this, MSB_OK, MSB_EXCLAMATIONGREEN, 1));
             }
         }
     } catch(...)

--- a/libs/s25main/ingameWindows/iwShip.cpp
+++ b/libs/s25main/ingameWindows/iwShip.cpp
@@ -121,10 +121,10 @@ void iwShip::Msg_ButtonClick(const unsigned ctrl_id)
 {
     if(ctrl_id == 2) // Hilfe
     {
-        WINDOWMANAGER.Show(
-          std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("The ship register contains all the ships in your fleet. Here you can monitor "
-                                                       "the loading and destinations of individual ships. Ships on an expedition are "
-                                                       "controlled from here as well.")));
+        WINDOWMANAGER.ReplaceWindow(
+          std::make_unique<iwHelp>(_("The ship register contains all the ships in your fleet. Here you can monitor "
+                                     "the loading and destinations of individual ships. Ships on an expedition are "
+                                     "controlled from here as well.")));
         return;
     }
 

--- a/libs/s25main/ingameWindows/iwStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwStatistics.cpp
@@ -190,10 +190,10 @@ void iwStatistics::Msg_ButtonClick(const unsigned ctrl_id)
             break;
         case 25: // Hilfe
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("This window allows a direct comparison with the enemies. "
-                                                                            "Factors such as the wealth, territorial area, inhabitants, "
-                                                                            "etc. of all parties can be compared. This data can be shown "
-                                                                            "over four different time periods.")));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_("This window allows a direct comparison with the enemies. "
+                                                                   "Factors such as the wealth, territorial area, inhabitants, "
+                                                                   "etc. of all parties can be compared. This data can be shown "
+                                                                   "over four different time periods.")));
         }
         break;
     }

--- a/libs/s25main/ingameWindows/iwTools.cpp
+++ b/libs/s25main/ingameWindows/iwTools.cpp
@@ -189,9 +189,9 @@ void iwTools::Msg_ButtonClick(const unsigned ctrl_id)
         {
             default: return;
             case 12:
-                WINDOWMANAGER.Show(
-                  std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("These settings control the tool production of your metalworks. "
-                                                               "The higher the value, the more likely this tool is to be produced.")));
+                WINDOWMANAGER.ReplaceWindow(
+                  std::make_unique<iwHelp>(_("These settings control the tool production of your metalworks. "
+                                             "The higher the value, the more likely this tool is to be produced.")));
                 break;
             case 13: // Standard
                 GAMECLIENT.visual_settings.tools_settings = GAMECLIENT.default_settings.tools_settings;

--- a/libs/s25main/ingameWindows/iwTrade.cpp
+++ b/libs/s25main/ingameWindows/iwTrade.cpp
@@ -27,16 +27,18 @@
 #include "factories/GameCommandFactory.h"
 #include "helpers/strUtils.h"
 #include "helpers/toString.h"
+#include "ogl/FontStyle.h"
+#include "ogl/glArchivItem_Bitmap.h"
 #include "world/GameWorldBase.h"
 #include "world/GameWorldViewer.h"
 #include "gameData/JobConsts.h"
 #include "gameData/ShieldConsts.h"
+#include "gameData/const_gui_ids.h"
 
-#include "ogl/FontStyle.h"
-#include "ogl/glArchivItem_Bitmap.h"
 iwTrade::iwTrade(const nobBaseWarehouse& wh, const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
-    : IngameWindow(wh.CreateGUIID(), IngameWindow::posAtMouse, Extent(400, 194), _("Trade"), LOADER.GetImageN("resource", 41)), wh(wh),
-      gwv(gwv), gcFactory(gcFactory), possibleSrcWarehouses(gwv.GetPlayer().GetWarehousesForTrading(wh))
+    : IngameWindow(CGI_BUILDING + MapBase::CreateGUIID(wh.GetPos()), IngameWindow::posAtMouse, Extent(400, 194), _("Trade"),
+                   LOADER.GetImageN("resource", 41)),
+      wh(wh), gwv(gwv), gcFactory(gcFactory), possibleSrcWarehouses(gwv.GetPlayer().GetWarehousesForTrading(wh))
 {
     // Get title of the player
     SetTitle((boost::format(_("Trade with %s")) % gwv.GetWorld().GetPlayer(wh.GetPlayer()).name).str());

--- a/libs/s25main/ingameWindows/iwTransport.cpp
+++ b/libs/s25main/ingameWindows/iwTransport.cpp
@@ -121,9 +121,9 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 0:
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("The transport priority of a type of merchandise can "
-                                                                            "be determined here.The higher the priority of an item "
-                                                                            "in the list, the quicker it is transported by helpers.")));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_("The transport priority of a type of merchandise can "
+                                                                   "be determined here.The higher the priority of an item "
+                                                                   "in the list, the quicker it is transported by helpers.")));
         }
         break;
         case 1: // Standardbelegung

--- a/libs/s25main/ingameWindows/iwVictory.cpp
+++ b/libs/s25main/ingameWindows/iwVictory.cpp
@@ -62,7 +62,7 @@ void iwVictory::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case ID_CONTINUE: Close(); break;
         case ID_END_GAME:
-            WINDOWMANAGER.Show(std::make_unique<iwEndgame>());
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwEndgame>());
             Close();
             break;
     }

--- a/libs/s25main/ingameWindows/iwWares.cpp
+++ b/libs/s25main/ingameWindows/iwWares.cpp
@@ -176,8 +176,8 @@ void iwWares::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 12: // Hilfe
         {
-            WINDOWMANAGER.Show(std::make_unique<iwHelp>(GUI_ID(CGI_HELP), _("Here you will find a list of your entire stores of "
-                                                                            "merchandise and all the inhabitants of your realm.")));
+            WINDOWMANAGER.ReplaceWindow(std::make_unique<iwHelp>(_("Here you will find a list of your entire stores of "
+                                                                   "merchandise and all the inhabitants of your realm.")));
         }
         break;
     }

--- a/libs/s25main/nodeObjs/noCoordBase.cpp
+++ b/libs/s25main/nodeObjs/noCoordBase.cpp
@@ -19,6 +19,7 @@
 #include "noCoordBase.h"
 #include "SerializedGameData.h"
 #include "world/GameWorldGame.h"
+#include "gameData/MapConsts.h"
 
 void noCoordBase::Serialize_noCoordBase(SerializedGameData& sgd) const
 {
@@ -28,8 +29,3 @@ void noCoordBase::Serialize_noCoordBase(SerializedGameData& sgd) const
 }
 
 noCoordBase::noCoordBase(SerializedGameData& sgd, const unsigned obj_id) : noBase(sgd, obj_id), pos(sgd.PopMapPoint()) {}
-
-unsigned noCoordBase::CreateGUIID() const
-{
-    return gwg->CreateGUIID(pos);
-}

--- a/libs/s25main/nodeObjs/noCoordBase.h
+++ b/libs/s25main/nodeObjs/noCoordBase.h
@@ -51,9 +51,6 @@ public:
     /// Returns position
     MapPoint GetPos() const { return pos; }
 
-    /// Liefert GUI-ID zurück für die Fenster
-    unsigned CreateGUIID() const;
-
 protected:
     MapPoint pos;
 };

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -103,9 +103,6 @@ public:
     noFlag* GetRoadFlag(MapPoint pt, Direction& dir, unsigned prevDir = 255);
     const noFlag* GetRoadFlag(MapPoint pt, Direction& dir, unsigned prevDir = 255) const;
 
-    /// Erzeugt eine GUI-ID für die Fenster von Map-Objekten
-    unsigned CreateGUIID(const MapPoint pt) const { return 1000 + GetIdx(pt); }
-
     /// Gets the (height adjusted) global coordinates of the node (e.g. for drawing)
     Position GetNodePos(MapPoint pt) const;
 

--- a/libs/s25main/world/MapBase.cpp
+++ b/libs/s25main/world/MapBase.cpp
@@ -15,10 +15,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "rttrDefines.h" // IWYU pragma: keep
+#include "commonDefines.h"
 #include "world/MapBase.h"
 #include "world/MapGeometry.h"
+#include "gameData/MapConsts.h"
 #include <stdexcept>
+#include <string>
+
+unsigned MapBase::CreateGUIID(MapPoint pt)
+{
+    return pt.y * MAX_MAP_SIZE + pt.x;
+}
 
 MapBase::MapBase() : size_(MapExtent::all(0)) {}
 
@@ -30,6 +37,8 @@ void MapBase::Resize(const MapExtent& newSize)
     // For width it is technically possible to have odd sizes so we don't check this
     if(newSize.y & 1)
         throw std::invalid_argument("The map height must be even!");
+    if(newSize.x > MAX_MAP_SIZE || newSize.y > MAX_MAP_SIZE)
+        throw std::invalid_argument("Can't load a map bigger than " + std::to_string(MAX_MAP_SIZE) + " nodes per direction");
     size_ = newSize;
 }
 

--- a/libs/s25main/world/MapBase.h
+++ b/libs/s25main/world/MapBase.h
@@ -32,6 +32,8 @@ class MapBase
     MapExtent size_;
 
 public:
+    static unsigned CreateGUIID(MapPoint pt);
+
     MapBase();
     ~MapBase();
 

--- a/tests/common/testPoint.cpp
+++ b/tests/common/testPoint.cpp
@@ -22,6 +22,7 @@
 #include <boost/test/unit_test.hpp>
 #include <type_traits>
 
+using boost::test_tools::tolerance;
 using rttr::test::randomPoint;
 using rttr::test::randomValue;
 
@@ -229,20 +230,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unscale_point, T, SignedTypes)
     SignedPoint pt(x, y);
     const auto scale = randomValue<U>(1, 100);
 
+    constexpr auto epsilon = std::conditional_t<std::is_same<T, float>::value, float, double>(0.001);
+
     const auto result = pt / scale;
     static_assert(std::is_same<decltype(result.x), T>::value, "Result must be signed");
-    BOOST_TEST(result == pt / SignedPoint::all(scale));
+    BOOST_TEST(result == pt / SignedPoint::all(scale), epsilon % tolerance());
 
     const auto resultSigned = pt / T(scale);
     static_assert(std::is_same<decltype(resultSigned.x), T>::value, "Result must be signed");
-    BOOST_TEST(resultSigned == result);
+    BOOST_TEST(resultSigned == result, epsilon % tolerance());
 
     x = abs(x);
     y = abs(y);
     UnsignedPoint pt2(x, y);
     const auto resultUnsigned = pt2 / scale;
     static_assert(std::is_same<decltype(resultUnsigned.x), U>::value, "Result must be unsigned");
-    BOOST_TEST(resultUnsigned == pt2 / UnsignedPoint::all(scale));
+    BOOST_TEST(resultUnsigned == pt2 / UnsignedPoint::all(scale), epsilon % tolerance());
 
     pt /= scale;
     BOOST_TEST(pt == result);
@@ -256,7 +259,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unscale_point, T, SignedTypes)
     pt = SignedPoint(x, y);
     const auto resultPt = scale2 / pt;
     static_assert(std::is_same<decltype(resultPt.x), T>::value, "Result must be signed");
-    BOOST_TEST(resultPt == SignedPoint::all(scale2) / pt);
+    BOOST_TEST(resultPt == SignedPoint::all(scale2) / pt, epsilon % tolerance());
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(symetric_operators, T, SignedTypes)

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -24,7 +24,7 @@
 BOOST_AUTO_TEST_CASE(IngameWnd)
 {
     uiHelper::initGUITests();
-    iwHelp wnd(CGI_HELP, "Foo barFoo barFoo barFoo bar\n\n\n\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\n");
+    iwHelp wnd("Foo barFoo barFoo barFoo bar\n\n\n\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\n");
     const Extent oldSize = wnd.GetSize();
     BOOST_REQUIRE_GT(oldSize.x, 50u);
     BOOST_REQUIRE_GT(oldSize.y, 50u);

--- a/tests/s25Main/UI/testSmartBitmap.cpp
+++ b/tests/s25Main/UI/testSmartBitmap.cpp
@@ -82,7 +82,14 @@ std::unique_ptr<ArchivItem_Bitmap_Player> createRandPlayerBmp(unsigned percentTr
 }
 } // namespace
 
-BOOST_FIXTURE_TEST_SUITE(SmartBmpSuite, uiHelper::Fixture)
+BOOST_AUTO_TEST_CASE(PrintColor)
+{
+    std::stringstream s;
+    boost_test_print_type(s, ColorBGRA(0x42, 0x13, 0x37, 0x99));
+    BOOST_TEST(s.str() == "99371342");
+}
+
+BOOST_FIXTURE_TEST_SUITE(SmartBitmapTestSuite, uiHelper::Fixture)
 
 BOOST_AUTO_TEST_CASE(CreateRandBmp_Works)
 {
@@ -92,13 +99,6 @@ BOOST_AUTO_TEST_CASE(CreateRandBmp_Works)
     const auto bmpPl = createRandPlayerBmp(50);
     BOOST_TEST(bmpPl->getWidth() > 0);
     BOOST_TEST(bmpPl->getHeight() > 0);
-}
-
-BOOST_AUTO_TEST_CASE(PrintColor)
-{
-    std::stringstream s;
-    boost_test_print_type(s, ColorBGRA(0x42, 0x13, 0x37, 0x99));
-    BOOST_TEST(s.str() == "99371342");
 }
 
 BOOST_AUTO_TEST_CASE(RegularBitmap)

--- a/tests/s25Main/UI/testVideoDriver.cpp
+++ b/tests/s25Main/UI/testVideoDriver.cpp
@@ -73,6 +73,7 @@ RTTR_POP_DIAGNOSTIC
 
 BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
 {
+    uiHelper::initGUITests();
     // Fresh start
     VIDEODRIVER.DestroyScreen();
     VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);

--- a/tests/s25Main/drivers/main.cpp
+++ b/tests/s25Main/drivers/main.cpp
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#define BOOST_TEST_MODULE RTTR_Simple
+#define BOOST_TEST_MODULE RTTR_Drivers
 
 #include <rttr/test/Fixture.hpp>
 #include <boost/test/unit_test.hpp>

--- a/tests/s25Main/drivers/testDriverWrapper.cpp
+++ b/tests/s25Main/drivers/testDriverWrapper.cpp
@@ -40,6 +40,7 @@ BOOST_AUTO_TEST_CASE(AllAudioDriversAreLoadable)
     for(const auto& driver : drivers)
     {
         std::string preference = driver.GetName();
+        BOOST_TEST_CHECKPOINT("Loading " << preference);
         BOOST_TEST_REQUIRE(AUDIODRIVER.LoadDriver(preference));
         BOOST_TEST(preference == driver.GetName());
         BOOST_TEST(AUDIODRIVER.GetName() == driver.GetName());
@@ -53,6 +54,7 @@ BOOST_AUTO_TEST_CASE(AllVideoDriversAreLoadable)
     for(const auto& driver : drivers)
     {
         std::string preference = driver.GetName();
+        BOOST_TEST_CHECKPOINT("Loading " << preference);
         BOOST_TEST_REQUIRE(VIDEODRIVER.LoadDriver(preference));
         BOOST_TEST(preference == driver.GetName());
         BOOST_TEST(VIDEODRIVER.GetName() == driver.GetName());

--- a/tests/s25Main/simple/testMapBase.cpp
+++ b/tests/s25Main/simple/testMapBase.cpp
@@ -19,6 +19,7 @@
 #include "PointOutput.h"
 #include "world/MapBase.h"
 #include "world/MapGeometry.h"
+#include "gameData/MapConsts.h"
 #include <boost/assign/std/vector.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -117,14 +118,13 @@ BOOST_AUTO_TEST_CASE(GetIdx)
     BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(0, 1)), 100u);
     BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(1, 1)), 101u);
     BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(99, 49)), 50u * 100u - 1u);
-    // Big world. Index will exceed uint16_t
-    world.Resize(MapExtent(0xFF00, 0xEEEE));
+    // Big world.
+    world.Resize(MapExtent(MAX_MAP_SIZE, MAX_MAP_SIZE - 2));
     BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(0, 0)), 0u);
-    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(0xFF00u - 1, 0)), 0xFF00u - 1);
-    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(0, 1)), 0xFF00u);
-    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(1, 1)), 0xFF01u);
-    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(0x100, 1)), 0x10000u);
-    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(0xFF00 - 1, 0xEEEE - 1)), 0xFF00u * 0xEEEEu - 1u);
+    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(MAX_MAP_SIZE - 1, 0)), MAX_MAP_SIZE - 1);
+    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(0, 1)), MAX_MAP_SIZE);
+    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(1, 1)), MAX_MAP_SIZE + 1u);
+    BOOST_REQUIRE_EQUAL(world.GetIdx(MapPoint(MAX_MAP_SIZE - 1, MAX_MAP_SIZE - 3)), MAX_MAP_SIZE * (MAX_MAP_SIZE - 2u) - 1u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tools/ci/travisBuild.sh
+++ b/tools/ci/travisBuild.sh
@@ -46,6 +46,7 @@ export LD_LIBRARY_PATH="${boostLibDir}:${LD_LIBRARY_PATH:-}"
 export RTTR_DISABLE_ASSERT_BREAKPOINT=1
 export UBSAN_OPTIONS=print_stacktrace=1
 export AUDIODEV=null # Avoid errors like: ALSA lib confmisc.c:768:(parse_card) cannot find card '0'
+export SDL_VIDEODRIVER=dummy # Avoid crash on travis
 if ! ctest --output-on-failure -j2; then
     cat CMakeCache.txt
     echo "LD:${LD_LIBRARY_PATH:-}"

--- a/tools/ci/travisBuild.sh
+++ b/tools/ci/travisBuild.sh
@@ -45,6 +45,7 @@ export LD_LIBRARY_PATH="${boostLibDir}:${LD_LIBRARY_PATH:-}"
 # Execute tests
 export RTTR_DISABLE_ASSERT_BREAKPOINT=1
 export UBSAN_OPTIONS=print_stacktrace=1
+export AUDIODEV=null # Avoid errors like: ALSA lib confmisc.c:768:(parse_card) cannot find card '0'
 if ! ctest --output-on-failure -j2; then
     cat CMakeCache.txt
     echo "LD:${LD_LIBRARY_PATH:-}"


### PR DESCRIPTION
Introduce ToggleWindow and ReplaceWindow to define behavior for existing (non-modal) windows at the call site explicitly.

Avoids unexpected nullptr returns when a window exists
This then fixes #1105