### PR TITLE
Fix crash on chat input of format strings

### DIFF
--- a/libs/common/src/RTTR_Assert.cpp
+++ b/libs/common/src/RTTR_Assert.cpp
@@ -72,7 +72,7 @@ void RTTR_AssertFailure(const char* condition, const char* file, const int line,
         std::string msg = sMsg.str();
         try
         {
-            LOG.write(msg + "\n", LogTarget::Stderr);
+            LOG.write("%1%\n", LogTarget::Stderr) % msg;
         } catch(...)
         {
             std::cerr << msg << std::endl;

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -152,7 +152,7 @@ void showCrashMessage()
         s25util::ClassicImbuedStream<std::stringstream> ss;
         for(void* p : stacktrace)
             ss << p << "\n";
-        LOG.write(ss.str(), target);
+        LOG.write("%1%", target) % ss.str();
     } catch(...)
     { //-V565
       // Could not write stacktrace. Ignore errors

--- a/libs/s25main/Messenger.cpp
+++ b/libs/s25main/Messenger.cpp
@@ -70,8 +70,8 @@ void Messenger::AddMessage(const std::string& author, const unsigned color_autho
 {
     if(!author.empty())
         LOG.writeColored("%1% ", color_author) % author;
-    LOG.writeColored(CD_STRINGS[cd], CD_COLORS[cd]);
-    LOG.write(msg + "\n");
+    LOG.writeColored("%1%", CD_COLORS[cd]) % CD_STRINGS[cd];
+    LOG.write("%1%\n") % msg;
 
     // in Zeilen aufteilen, damit alles auf den Bildschirm passt
     glFont::WrapInfo wi = LargeFont->GetWrapInfo(msg,

--- a/libs/s25main/controls/ctrlChat.cpp
+++ b/libs/s25main/controls/ctrlChat.cpp
@@ -212,9 +212,9 @@ void ctrlChat::AddMessage(const std::string& time_string, const std::string& pla
 
     // Loggen
     LOG.write("%s <") % time_string;
-    LOG.writeColored(player, player_color);
+    LOG.writeColored("%1%", player_color) % player;
     LOG.write(">: ");
-    LOG.writeColored(msg, msg_color);
+    LOG.writeColored("%1%", msg_color) % msg;
     LOG.write("\n");
 
     // Umbrechen

--- a/libs/s25main/controls/ctrlEdit.h
+++ b/libs/s25main/controls/ctrlEdit.h
@@ -64,18 +64,18 @@ private:
     ctrlTextDeepening* txtCtrl;
     bool isPassword_;
     bool isDisabled_;
-    bool focus_;
-    bool newFocus_;
+    bool focus_ = false;
+    bool newFocus_ = false;
     bool notify_;
 
     std::u32string text_;
     /// Position of cursor in text (in UTF32 chars)
-    unsigned cursorPos_;
+    unsigned cursorPos_ = 0;
     /// Offset of the cursor from the start of the text start position
     unsigned cursorOffsetX_ = 0;
-    unsigned viewStart_;
+    unsigned viewStart_ = 0;
 
-    bool numberOnly_;
+    bool numberOnly_ = false;
 };
 
 #endif // !CTRLEDIT_H_INCLUDED

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -122,11 +122,8 @@ BOOST_AUTO_TEST_CASE(BaseFunctions)
     GAMECLIENT.SetIsHost(false);
     BOOST_CHECK(isLuaEqual("rttr:IsHost()", "false"));
     BOOST_CHECK(isLuaEqual("rttr:GetNumPlayers()", "3"));
-    std::string oldLog = getLog();
     // Set Player ID
     GAMECLIENT.SetTestPlayerId(1);
-    clearLog();
-    LOG.write(oldLog, LogTarget::Stdout);
     BOOST_CHECK(isLuaEqual("rttr:GetLocalPlayerIdx()", "1"));
 }
 


### PR DESCRIPTION
The LOG class expects a format string, so do not pass a user-provided string to it which may or may not contain a format specifier/special char.

Also fix misbehaving edit on clearing where the internal string was not kept in sync with the actual text so clearing it still showed the old text.