### PR TITLE
Update MapGenerator back button texture, fixes #985

### DIFF
--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -55,7 +55,7 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
         return;
     }
 
-    AddTextButton(0, DrawPoint(20, 360), Extent(100, 20), TC_RED2, _("Back"), NormalFont);
+    AddTextButton(0, DrawPoint(20, 360), Extent(100, 20), TC_RED1, _("Back"), NormalFont);
     AddTextButton(1, DrawPoint(130, 360), Extent(100, 20), TC_GREEN2, _("Apply"), NormalFont);
 
     ctrlComboBox* combo = AddComboBox(CTRL_PLAYER_NUMBER, DrawPoint(20, 30), Extent(210, 20), TC_GREY, NormalFont, 100);


### PR DESCRIPTION
This changes the texture of the back button in the mapgenerator settings window to the default red used for all buttons. Fixes #985 