### PR TITLE
Store password as hash

### DIFF
--- a/libs/s25main/controls/ctrlEdit.cpp
+++ b/libs/s25main/controls/ctrlEdit.cpp
@@ -66,6 +66,15 @@ std::string ctrlEdit::GetText() const
     return utf8::utf32to8(text_);
 }
 
+void ctrlEdit::SetFocus(bool focus)
+{
+    if(focus_ != focus)
+    {
+        focus_ = focus;
+        txtCtrl->SetTextColor(focus_ ? 0xFFFFA000 : COLOR_YELLOW);
+    }
+}
+
 static void removeFirstCharFromString(std::string& str)
 {
     auto it = str.begin();
@@ -209,25 +218,13 @@ void ctrlEdit::Resize(const Extent& newSize)
     UpdateInternalText();
 }
 
-void ctrlEdit::Msg_PaintAfter()
-{
-    if(focus_ != newFocus_)
-    {
-        focus_ = newFocus_;
-        txtCtrl->SetTextColor(focus_ ? 0xFFFFA000 : COLOR_YELLOW);
-    }
-    Window::Msg_PaintAfter();
-}
-
 /**
  *  Maustaste-gedrückt Callback
  */
 bool ctrlEdit::Msg_LeftDown(const MouseCoords& mc)
 {
-    if((newFocus_ = IsPointInRect(mc.GetPos(), GetDrawRect())))
-        return false; /// vorläufig, um Fokus zu für andere Edit-Felder zu kriegen, damit es zu keinen Doppelfokus kommt
-    else
-        return false;
+    SetFocus(IsPointInRect(mc.GetPos(), GetDrawRect()));
+    return false; // "Unhandled" so other edits can handle this too and set their focus accordingly
 }
 
 /**

--- a/libs/s25main/controls/ctrlEdit.h
+++ b/libs/s25main/controls/ctrlEdit.h
@@ -36,14 +36,14 @@ public:
     void SetText(unsigned text);
 
     std::string GetText() const;
-    void SetFocus(bool focus = true) { newFocus_ = focus; }
+    void SetFocus(bool focus = true);
+    bool HasFocus() const { return focus_; }
     void SetDisabled(bool disabled = true) { this->isDisabled_ = disabled; }
     void SetNotify(bool notify = true) { this->notify_ = notify; }
     void SetNumberOnly(const bool activated) { this->numberOnly_ = activated; }
 
     void Resize(const Extent& newSize) override;
 
-    void Msg_PaintAfter() override;
     bool Msg_LeftDown(const MouseCoords& mc) override;
     bool Msg_KeyDown(const KeyEvent& ke) override;
 
@@ -65,7 +65,6 @@ private:
     bool isPassword_;
     bool isDisabled_;
     bool focus_ = false;
-    bool newFocus_ = false;
     bool notify_;
 
     std::u32string text_;

--- a/libs/s25main/ingameWindows/iwLobbyConnect.cpp
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.cpp
@@ -247,6 +247,30 @@ void iwLobbyConnect::Msg_OptionGroupChange(const unsigned ctrl_id, const int sel
     }
 }
 
+bool iwLobbyConnect::Msg_KeyDown(const KeyEvent& ev)
+{
+    if(ev.kt != KT_TAB)
+        return false;
+    auto* user = GetCtrl<ctrlEdit>(ID_edtUser);
+    auto* pass = GetCtrl<ctrlEdit>(ID_edtPw);
+    auto* email = GetCtrl<ctrlEdit>(ID_edtEmail);
+    if(user->HasFocus())
+    {
+        user->SetFocus(false);
+        pass->SetFocus();
+    } else if(pass->HasFocus())
+    {
+        pass->SetFocus(false);
+        email->SetFocus();
+    } else if(email->HasFocus())
+    {
+        email->SetFocus(false);
+        user->SetFocus();
+    } else
+        return false;
+    return true;
+}
+
 /**
  *  Setzt den Text und Schriftfarbe vom Textfeld und den Status des
  *  Buttons.

--- a/libs/s25main/ingameWindows/iwLobbyConnect.h
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.h
@@ -39,6 +39,7 @@ protected:
     void Msg_EditEnter(unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    bool Msg_KeyDown(const KeyEvent&) override;
 
 private:
     void SetText(const std::string& text, unsigned color, bool button);


### PR DESCRIPTION
This will store the password as a hash only in the INI file instead of in plaintext.

On reading this will be detected and the password field will be filled in with the hash instead. This results in 32 stars (*) showing, but IMO this is OK. Otherwise we would need a flag to change when the edit changed or risk false positives (user pw detected as hash although it is a plain text pw)

Additionally I implemented TAB in addition to ENTER to switch between fields in that dialog as this is what I'm always trying to use :/