### PR TITLE
Add support for SDL2_mixer using the same driver code as SDL_mixer

### DIFF
--- a/cmake/Modules/FindSDL_mixer.cmake
+++ b/cmake/Modules/FindSDL_mixer.cmake
@@ -11,7 +11,7 @@ This module defines:
 
 ::
 
-  SDL_Mixer::SDL_Mixer target to link to
+  SDL{1,2}_Mixer::SDL_Mixer target to link to
   SDL_MIXER_FOUND, if false, do not try to link against
   SDL_MIXER_VERSION - human-readable string containing the
                              version of SDL_mixer
@@ -26,13 +26,16 @@ module, but with modifications to recognize OS X frameworks and
 additional Unix paths (FreeBSD, etc).
 #]=======================================================================]
 
+unset(SDL_MIXER_LIBRARY CACHE)
+unset(SDL_MIXER_INCLUDE_DIR CACHE)
+
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(VC_LIB_PATH_SUFFIX lib/x64)
 else()
   set(VC_LIB_PATH_SUFFIX lib/x86)
 endif()
 
-if(PACKAGE_FIND_VERSION_MAJOR EQUAL "2")
+if(SDL_mixer_FIND_VERSION VERSION_GREATER_EQUAL 2)
   set(libName SDL2_mixer)
   set(pathSuffixes SDL2 include/SDL2 include)
 else()
@@ -80,7 +83,6 @@ if(SDL_MIXER_INCLUDE_DIR AND EXISTS "${SDL_MIXER_INCLUDE_DIR}/SDL_mixer.h")
   unset(SDL_MIXER_VERSION_MAJOR_LINE)
   unset(SDL_MIXER_VERSION_MINOR_LINE)
   unset(SDL_MIXER_VERSION_PATCH_LINE)
-  unset(SDL_MIXER_VERSION_MAJOR)
   unset(SDL_MIXER_VERSION_MINOR)
   unset(SDL_MIXER_VERSION_PATCH)
 else()
@@ -104,21 +106,22 @@ find_package_handle_standard_args(SDL_mixer
                                   REQUIRED_VARS SDL_MIXER_LIBRARY SDL_MIXER_INCLUDE_DIR ${additionalVars}
                                   VERSION_VAR SDL_MIXER_VERSION)
 
-if(NOT TARGET SDL_mixer::SDL_mixer)
-  add_library(SDL_mixer-SDL_mixer INTERFACE)
-  add_library(SDL_mixer::SDL_mixer ALIAS SDL_mixer-SDL_mixer)
-  target_link_libraries(SDL_mixer-SDL_mixer INTERFACE ${SDL_MIXER_LIBRARY})
-  target_include_directories(SDL_mixer-SDL_mixer SYSTEM INTERFACE ${SDL_MIXER_INCLUDE_DIR})
+if(NOT TARGET SDL${SDL_MIXER_VERSION_MAJOR}_mixer::SDL_mixer)
+  add_library(SDL${SDL_MIXER_VERSION_MAJOR}_mixer-SDL_mixer INTERFACE)
+  add_library(SDL${SDL_MIXER_VERSION_MAJOR}_mixer::SDL_mixer ALIAS SDL${SDL_MIXER_VERSION_MAJOR}_mixer-SDL_mixer)
+  target_link_libraries(SDL${SDL_MIXER_VERSION_MAJOR}_mixer-SDL_mixer INTERFACE ${SDL_MIXER_LIBRARY})
+  target_include_directories(SDL${SDL_MIXER_VERSION_MAJOR}_mixer-SDL_mixer SYSTEM INTERFACE ${SDL_MIXER_INCLUDE_DIR})
   # Add correct SDL dependency
   if(SDL_MIXER_VERSION VERSION_LESS "2")
     if(NOT SDL_VERSION_STRING VERSION_LESS "2")
       message(FATAL_ERROR "SDL_Mixer ${SDL_MIXER_VERSION} not compatible with SDL ${SDL_VERSION_STRING}")
     endif()
-    target_link_libraries(SDL_mixer-SDL_mixer INTERFACE ${SDL_LIBRARY})
-    target_include_directories(SDL_mixer-SDL_mixer SYSTEM INTERFACE ${SDL_INCLUDE_DIR})
+    target_link_libraries(SDL${SDL_MIXER_VERSION_MAJOR}_mixer-SDL_mixer INTERFACE ${SDL_LIBRARY})
+    target_include_directories(SDL${SDL_MIXER_VERSION_MAJOR}_mixer-SDL_mixer SYSTEM INTERFACE ${SDL_INCLUDE_DIR})
   else()
-    target_link_libraries(SDL_mixer-SDL_mixer INTERFACE SDL2::SDL2)
+    target_link_libraries(SDL${SDL_MIXER_VERSION_MAJOR}_mixer-SDL_mixer INTERFACE SDL2::SDL2)
   endif()
 endif()
 
 mark_as_advanced(SDL_MIXER_LIBRARY SDL_MIXER_INCLUDE_DIR)
+unset(SDL_MIXER_VERSION_MAJOR)

--- a/extras/audioDrivers/SDL/AudioSDL.cpp
+++ b/extras/audioDrivers/SDL/AudioSDL.cpp
@@ -48,7 +48,11 @@ void FreeAudioInstance(IAudioDriver* driver)
 
 const char* GetDriverName()
 {
+#if SDL_MIXER_MAJOR_VERSION == 1
     return "(SDL) Audio via SDL_mixer-Library";
+#else
+    return "(SDL2) Audio via SDL2_mixer-Library";
+#endif
 }
 
 /** @class AudioSDL
@@ -182,7 +186,11 @@ SoundHandle AudioSDL::LoadMusic(const std::vector<char>& data, const std::string
     // Need to copy data as it is used by SDL
     auto* handle = new SoundSDL_Music(data);
     SDL_RWops* rwOps = SDL_RWFromConstMem(&handle->data[0], static_cast<int>(data.size()));
+#if SDL_MIXER_MAJOR_VERSION == 1
     Mix_Music* music = Mix_LoadMUS_RW(rwOps);
+#else
+    Mix_Music* music = Mix_LoadMUS_RW(rwOps, 0);
+#endif
     if(music == nullptr)
     {
         SDL_FreeRW(rwOps);

--- a/extras/audioDrivers/SDL/CMakeLists.txt
+++ b/extras/audioDrivers/SDL/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SDL_BUILDING_LIBRARY ON)
-find_package(SDL_mixer)
+find_package(SDL_mixer 1)
 
 if(NOT SDL_MIXER_FOUND)
   message(WARNING "SDL_mixer library not found: Not building SDL audiodriver")
@@ -13,11 +13,35 @@ else()
   endif()
 
   add_library(audioSDL SHARED ${RTTR_DRIVER_INTERFACE} AudioSDL.cpp AudioSDL.h SoundSDL_Effect.h SoundSDL_Music.h)
-  target_link_libraries(audioSDL PRIVATE audiodrv SDL_mixer::SDL_mixer)
+  target_link_libraries(audioSDL PRIVATE audiodrv SDL1_mixer::SDL_mixer)
 
   install(TARGETS audioSDL
     RUNTIME DESTINATION ${RTTR_DRIVERDIR}/audio
     LIBRARY DESTINATION ${RTTR_DRIVERDIR}/audio
   )
   add_dependencies(drivers audioSDL)
+endif()
+
+set(SDL2_BUILDING_LIBRARY ON)
+find_package(SDL_mixer 2)
+
+if(NOT SDL_MIXER_FOUND)
+  message(WARNING "SDL2_mixer library not found: Not building SDL audiodriver")
+else()
+  if(WIN32)
+    include(GatherDll)
+    gather_dll(SDL2_MIXER)
+    gather_dll_by_name(VORBIS libvorbis-0.dll)
+    gather_dll_by_name(VORBISFILE libvorbisfile-3.dll)
+    gather_dll_by_name(OGG libogg-0.dll)
+  endif()
+
+  add_library(audioSDL2 SHARED ${RTTR_DRIVER_INTERFACE} AudioSDL.cpp AudioSDL.h SoundSDL_Effect.h SoundSDL_Music.h)
+  target_link_libraries(audioSDL2 PRIVATE audiodrv SDL2_mixer::SDL_mixer)
+
+  install(TARGETS audioSDL2
+    RUNTIME DESTINATION ${RTTR_DRIVERDIR}/audio
+    LIBRARY DESTINATION ${RTTR_DRIVERDIR}/audio
+  )
+  add_dependencies(drivers audioSDL2)
 endif()


### PR DESCRIPTION
Only one line actually required an #if macro to support both versions.

Supporting both versions in AudioSDL.cpp was easy. Supporting both versions in CMake was much trickier. This isn't because the same source files are being used but because of how CMake stores the variables resulting from `find_package(SDL_mixer)`. Perhaps you can think of a better approach.