### PR TITLE
Addon changes

### DIFF
--- a/libs/s25main/GlobalGameSettings.cpp
+++ b/libs/s25main/GlobalGameSettings.cpp
@@ -61,73 +61,58 @@ GlobalGameSettings& GlobalGameSettings::operator=(const GlobalGameSettings& ggs)
     return *this;
 }
 
-GlobalGameSettings::~GlobalGameSettings()
-{
-    // clear memory and dont register addons again
-    clearAddons();
-}
-
-/**
- *  clears the addon memory.
- */
-void GlobalGameSettings::clearAddons()
-{
-    for(auto& addon : addons)
-        delete addon.addon;
-
-    addons.clear();
-}
+GlobalGameSettings::~GlobalGameSettings() = default;
 
 void GlobalGameSettings::registerAllAddons()
 {
-    registerAddon(new AddonLimitCatapults);
-    registerAddon(new AddonInexhaustibleMines);
-    registerAddon(new AddonRefundMaterials);
-    registerAddon(new AddonExhaustibleWater);
-    registerAddon(new AddonRefundOnEmergency);
-    registerAddon(new AddonManualRoadEnlargement);
-    registerAddon(new AddonCatapultGraphics);
-    registerAddon(new AddonMetalworksBehaviorOnZero);
+    registerAddon(std::make_unique<AddonLimitCatapults>());
+    registerAddon(std::make_unique<AddonInexhaustibleMines>());
+    registerAddon(std::make_unique<AddonRefundMaterials>());
+    registerAddon(std::make_unique<AddonExhaustibleWater>());
+    registerAddon(std::make_unique<AddonRefundOnEmergency>());
+    registerAddon(std::make_unique<AddonManualRoadEnlargement>());
+    registerAddon(std::make_unique<AddonCatapultGraphics>());
+    registerAddon(std::make_unique<AddonMetalworksBehaviorOnZero>());
 
-    registerAddon(new AddonDemolitionProhibition);
-    registerAddon(new AddonCharburner);
-    registerAddon(new AddonTrade);
+    registerAddon(std::make_unique<AddonDemolitionProhibition>());
+    registerAddon(std::make_unique<AddonCharburner>());
+    registerAddon(std::make_unique<AddonTrade>());
 
-    registerAddon(new AddonChangeGoldDeposits);
-    registerAddon(new AddonMaxWaterwayLength);
-    registerAddon(new AddonCustomBuildSequence);
-    registerAddon(new AddonStatisticsVisibility);
+    registerAddon(std::make_unique<AddonChangeGoldDeposits>());
+    registerAddon(std::make_unique<AddonMaxWaterwayLength>());
+    registerAddon(std::make_unique<AddonCustomBuildSequence>());
+    registerAddon(std::make_unique<AddonStatisticsVisibility>());
 
-    registerAddon(new AddonDefenderBehavior);
-    registerAddon(new AddonAIDebugWindow);
+    registerAddon(std::make_unique<AddonDefenderBehavior>());
+    registerAddon(std::make_unique<AddonAIDebugWindow>());
 
-    registerAddon(new AddonNoCoinsDefault);
+    registerAddon(std::make_unique<AddonNoCoinsDefault>());
 
-    registerAddon(new AddonAdjustMilitaryStrength);
+    registerAddon(std::make_unique<AddonAdjustMilitaryStrength>());
 
-    registerAddon(new AddonToolOrdering);
+    registerAddon(std::make_unique<AddonToolOrdering>());
 
-    registerAddon(new AddonMilitaryAid);
-    registerAddon(new AddonInexhaustibleGraniteMines);
-    registerAddon(new AddonMaxRank);
-    registerAddon(new AddonSeaAttack);
-    registerAddon(new AddonInexhaustibleFish);
+    registerAddon(std::make_unique<AddonMilitaryAid>());
+    registerAddon(std::make_unique<AddonInexhaustibleGraniteMines>());
+    registerAddon(std::make_unique<AddonMaxRank>());
+    registerAddon(std::make_unique<AddonSeaAttack>());
+    registerAddon(std::make_unique<AddonInexhaustibleFish>());
 
-    registerAddon(new AddonShipSpeed);
-    registerAddon(new AddonMoreAnimals);
-    registerAddon(new AddonBurnDuration);
-    registerAddon(new AddonNoAlliedPush);
-    registerAddon(new AddonBattlefieldPromotion);
-    registerAddon(new AddonHalfCostMilEquip);
-    registerAddon(new AddonMilitaryControl);
+    registerAddon(std::make_unique<AddonShipSpeed>());
+    registerAddon(std::make_unique<AddonMoreAnimals>());
+    registerAddon(std::make_unique<AddonBurnDuration>());
+    registerAddon(std::make_unique<AddonNoAlliedPush>());
+    registerAddon(std::make_unique<AddonBattlefieldPromotion>());
+    registerAddon(std::make_unique<AddonHalfCostMilEquip>());
+    registerAddon(std::make_unique<AddonMilitaryControl>());
 
-    registerAddon(new AddonMilitaryHitpoints);
+    registerAddon(std::make_unique<AddonMilitaryHitpoints>());
 
-    registerAddon(new AddonNumScoutsExploration);
+    registerAddon(std::make_unique<AddonNumScoutsExploration>());
 
-    registerAddon(new AddonFrontierDistanceReachable);
-    registerAddon(new AddonCoinsCapturedBld);
-    registerAddon(new AddonDemolishBldWORes);
+    registerAddon(std::make_unique<AddonFrontierDistanceReachable>());
+    registerAddon(std::make_unique<AddonCoinsCapturedBld>());
+    registerAddon(std::make_unique<AddonDemolishBldWORes>());
 }
 
 void GlobalGameSettings::resetAddons()
@@ -136,49 +121,60 @@ void GlobalGameSettings::resetAddons()
         addon.status = addon.addon->getDefaultStatus();
 }
 
-const Addon* GlobalGameSettings::getAddon(unsigned nr, unsigned& status) const
+const Addon* GlobalGameSettings::getAddon(unsigned idx, unsigned& status) const
 {
-    const Addon* addon = getAddon(nr);
-    if(!addon)
-        return nullptr;
-
-    status = addons[nr].status;
+    const Addon* addon = getAddon(idx);
+    if(addon)
+        status = addons[idx].status;
     return addon;
 }
 
-const Addon* GlobalGameSettings::getAddon(unsigned nr) const
+const Addon* GlobalGameSettings::getAddon(unsigned idx) const
 {
-    if(nr >= addons.size())
+    if(idx >= addons.size())
         return nullptr;
     else
-        return addons[nr].addon;
+        return addons[idx].addon.get();
+}
+
+GlobalGameSettings::AddonWithState* GlobalGameSettings::getAddon(AddonId id)
+{
+    auto it = helpers::find_if(addons, [id](const AddonWithState& cur) { return cur.addon->getId() == id; });
+    return it != addons.end() ? &*it : nullptr;
+}
+
+const GlobalGameSettings::AddonWithState* GlobalGameSettings::getAddon(AddonId id) const
+{
+    auto it = helpers::find_if(addons, [id](const AddonWithState& cur) { return cur.addon->getId() == id; });
+    return it != addons.end() ? &*it : nullptr;
 }
 
 bool GlobalGameSettings::isEnabled(AddonId id) const
 {
-    auto it = std::find(addons.begin(), addons.end(), id);
-    return it != addons.end() && it->status != it->addon->getDefaultStatus();
+    const auto* addon = getAddon(id);
+    return addon && addon->status != addon->addon->getDefaultStatus();
 }
 
 unsigned GlobalGameSettings::getSelection(AddonId id) const
 {
-    auto it = std::find(addons.begin(), addons.end(), id);
-    if(it == addons.end())
-        return 0;
-    return it->status;
+    const auto* addon = getAddon(id);
+    return addon ? addon->status : 0;
 }
 
-void GlobalGameSettings::registerAddon(Addon* addon)
+void GlobalGameSettings::registerAddon(std::unique_ptr<Addon> addon)
 {
     if(!addon)
         return;
 
-    if(helpers::contains(addons, addon->getId()))
+    if(getAddon(addon->getId()))
         throw std::runtime_error("Addon already registered");
 
     // Insert sorted
-    AddonWithState newItem(addon);
-    addons.insert(std::upper_bound(addons.begin(), addons.end(), newItem), newItem);
+    AddonWithState newItem(std::move(addon));
+    const auto cmpByName = [](const AddonWithState& lhs, const AddonWithState& rhs) {
+        return lhs.addon->getName().compare(rhs.addon->getName()) < 0;
+    };
+    addons.insert(std::upper_bound(addons.begin(), addons.end(), newItem, cmpByName), std::move(newItem));
 }
 
 /**
@@ -258,11 +254,11 @@ void GlobalGameSettings::Deserialize(Serializer& ser)
 
 void GlobalGameSettings::setSelection(AddonId id, unsigned selection)
 {
-    auto it = std::find(addons.begin(), addons.end(), id);
-    if(it == addons.end())
+    auto* addon = getAddon(id);
+    if(!addon)
         LOG.write(_("Addon %1$#x not found!\n"), LogTarget::FileAndStderr) % static_cast<unsigned>(id);
     else
-        it->status = selection;
+        addon->status = selection;
 }
 
 unsigned GlobalGameSettings::GetMaxMilitaryRank() const
@@ -277,14 +273,6 @@ unsigned GlobalGameSettings::GetNumScoutsExedition() const
     return selection + 1;
 }
 
-GlobalGameSettings::AddonWithState::AddonWithState(Addon* addon) : addon(addon), status(addon->getDefaultStatus()) {}
-
-bool GlobalGameSettings::AddonWithState::operator<(const AddonWithState& rhs) const
-{
-    return addon->getName().compare(rhs.addon->getName()) < 0;
-}
-
-bool GlobalGameSettings::AddonWithState::operator==(const AddonId& rhs) const
-{
-    return addon->getId() == rhs;
-}
+GlobalGameSettings::AddonWithState::AddonWithState(std::unique_ptr<Addon> addon)
+    : addon(std::move(addon)), status(this->addon->getDefaultStatus())
+{}

--- a/libs/s25main/GlobalGameSettings.h
+++ b/libs/s25main/GlobalGameSettings.h
@@ -19,6 +19,7 @@
 #define GlobalGameSettings_H_INCLUDED
 
 #include "gameTypes/GameSettingTypes.h"
+#include <memory>
 #include <vector>
 
 class Serializer;
@@ -48,10 +49,8 @@ public:
     bool randomStartPosition;
 
     unsigned getNumAddons() const { return addons.size(); }
-    const Addon* getAddon(unsigned nr, unsigned& status) const;
-    const Addon* getAddon(unsigned nr) const;
-    /// clears the addon memory.
-    void clearAddons();
+    const Addon* getAddon(unsigned idx, unsigned& status) const;
+    const Addon* getAddon(unsigned idx) const;
 
     void registerAllAddons();
 
@@ -74,19 +73,17 @@ public:
     unsigned GetNumScoutsExedition() const;
 
 private:
-    void registerAddon(Addon* addon);
-
     struct AddonWithState
     {
-        AddonWithState() : addon(nullptr), status(0) {}
-        explicit AddonWithState(Addon* addon);
+        explicit AddonWithState(std::unique_ptr<Addon> addon);
 
-        Addon* addon;
+        std::unique_ptr<Addon> addon;
         unsigned status;
-
-        inline bool operator==(const AddonId& rhs) const;
-        inline bool operator<(const AddonWithState& rhs) const;
     };
+
+    void registerAddon(std::unique_ptr<Addon> addon);
+    const AddonWithState* getAddon(AddonId id) const;
+    AddonWithState* getAddon(AddonId id);
 
     std::vector<AddonWithState> addons;
 };

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -233,7 +233,7 @@ public:
     virtual void Msg_ProgressChange(unsigned /*ctrl_id*/, unsigned short /*position*/) {}
     virtual void Msg_ScrollChange(unsigned /*ctrl_id*/, unsigned short /*position*/) {}
     virtual void Msg_ScrollShow(unsigned /*ctrl_id*/, bool /*visible*/) {}
-    virtual void Msg_OptionGroupChange(unsigned /*ctrl_id*/, int /*selection*/) {}
+    virtual void Msg_OptionGroupChange(unsigned /*ctrl_id*/, unsigned /*selection*/) {}
     virtual void Msg_Timer(unsigned /*ctrl_id*/) {}
     virtual void Msg_TableSelectItem(unsigned /*ctrl_id*/, int /*selection*/) {}
     virtual void Msg_TableChooseItem(unsigned /*ctrl_id*/, unsigned /*selection*/) {}
@@ -253,7 +253,7 @@ public:
     virtual void Msg_Group_CheckboxChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, bool /*checked*/) {}
     virtual void Msg_Group_ProgressChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, unsigned short /*position*/) {}
     virtual void Msg_Group_ScrollShow(unsigned /*group_id*/, unsigned /*ctrl_id*/, bool /*visible*/) {}
-    virtual void Msg_Group_OptionGroupChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}
+    virtual void Msg_Group_OptionGroupChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, unsigned /*selection*/) {}
     virtual void Msg_Group_Timer(unsigned /*group_id*/, unsigned /*ctrl_id*/) {}
     virtual void Msg_Group_TableSelectItem(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}
     virtual void Msg_Group_TableRightButton(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}

--- a/libs/s25main/addons/Addon.cpp
+++ b/libs/s25main/addons/Addon.cpp
@@ -37,23 +37,17 @@ void Addon::hideGui(Window* window, unsigned id) const
 void Addon::createGui(Window* window, unsigned id, unsigned short& y, bool /*readonly*/, unsigned /*status*/) const //-V669
 {
     DrawPoint btPos(20, y), txtPos(52, y + 4);
-    auto* button = window->GetCtrl<ctrlButton>(id + 1);
-    if(!button)
-        button = window->AddImageButton(id + 1, btPos, Extent(22, 22), TC_GREY, LOADER.GetImageN("io", 21), description_);
-
-    button->SetVisible(true);
-    button->SetPos(btPos);
-
     auto* text = window->GetCtrl<ctrlText>(id);
     if(!text)
         text = window->AddText(id, txtPos, name_, COLOR_YELLOW, FontStyle{}, NormalFont);
 
     text->SetVisible(true);
     text->SetPos(txtPos);
-}
 
-unsigned Addon::getGuiStatus(Window* /*window*/, unsigned /*id*/, bool& failed) const
-{
-    failed = false;
-    return getDefaultStatus();
+    auto* button = window->GetCtrl<ctrlButton>(id + 1);
+    if(!button)
+        button = window->AddImageButton(id + 1, btPos, Extent(22, 22), TC_GREY, LOADER.GetImageN("io", 21), description_);
+
+    button->SetVisible(true);
+    button->SetPos(btPos);
 }

--- a/libs/s25main/addons/Addon.cpp
+++ b/libs/s25main/addons/Addon.cpp
@@ -15,39 +15,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "rttrDefines.h" // IWYU pragma: keep
 #include "Addon.h"
 #include "Loader.h"
 #include "Window.h"
-#include "controls/ctrlButton.h"
-#include "controls/ctrlText.h"
 #include "s25util/colors.h"
 
-void Addon::hideGui(Window* window, unsigned id) const
+AddonGui::AddonGui(const Addon& addon, Window& window, bool /*readonly*/)
 {
-    auto* text = window->GetCtrl<ctrlText>(id);
-    if(text)
-        text->SetVisible(false);
-
-    auto* button = window->GetCtrl<ctrlButton>(id + 1);
-    if(button)
-        button->SetVisible(false);
-}
-
-void Addon::createGui(Window* window, unsigned id, unsigned short& y, bool /*readonly*/, unsigned /*status*/) const //-V669
-{
-    DrawPoint btPos(20, y), txtPos(52, y + 4);
-    auto* text = window->GetCtrl<ctrlText>(id);
-    if(!text)
-        text = window->AddText(id, txtPos, name_, COLOR_YELLOW, FontStyle{}, NormalFont);
-
-    text->SetVisible(true);
-    text->SetPos(txtPos);
-
-    auto* button = window->GetCtrl<ctrlButton>(id + 1);
-    if(!button)
-        button = window->AddImageButton(id + 1, btPos, Extent(22, 22), TC_GREY, LOADER.GetImageN("io", 21), description_);
-
-    button->SetVisible(true);
-    button->SetPos(btPos);
+    DrawPoint btPos(20, 0), txtPos(52, 4);
+    window.AddText(0, txtPos, addon.getName(), COLOR_YELLOW, FontStyle{}, NormalFont);
+    window.AddImageButton(1, btPos, Extent(22, 22), TC_GREY, LOADER.GetImageN("io", 21), addon.getDescription());
 }

--- a/libs/s25main/addons/Addon.h
+++ b/libs/s25main/addons/Addon.h
@@ -21,10 +21,20 @@
 #define ADDON_H_INCLUDED
 
 #include "const_addons.h"
+#include <memory>
 #include <string>
-#include <utility>
 
 class Window;
+class Addon;
+
+class AddonGui
+{
+public:
+    AddonGui(const Addon& addon, Window& window, bool readonly);
+    virtual ~AddonGui() = default;
+    virtual void setStatus(Window& window, unsigned status) = 0;
+    virtual unsigned getStatus(const Window& window) = 0;
+};
 
 /**
  *  Addon baseclass
@@ -37,10 +47,7 @@ public:
     {}
     virtual ~Addon() = default;
 
-    virtual void hideGui(Window* window, unsigned id) const;
-    virtual void createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const;
-    virtual void setGuiStatus(Window* /*window*/, unsigned /*id*/, unsigned /*status*/) const = 0;
-    virtual unsigned getGuiStatus(Window* /*window*/, unsigned /*id*/, bool& failed) const = 0;
+    virtual std::unique_ptr<AddonGui> createGui(Window& window, bool readonly) const = 0;
 
     AddonId getId() const { return id_; }
     AddonGroup getGroups() const { return groups_; }

--- a/libs/s25main/addons/Addon.h
+++ b/libs/s25main/addons/Addon.h
@@ -32,7 +32,7 @@ class Window;
 class Addon
 {
 public:
-    Addon(const AddonId id, unsigned groups, std::string name, std::string description, unsigned default_status)
+    Addon(const AddonId id, AddonGroup groups, std::string name, std::string description, unsigned default_status)
         : id_(id), groups_(groups), name_(std::move(name)), description_(std::move(description)), defaultStatus_(default_status)
     {}
     virtual ~Addon() = default;
@@ -40,11 +40,10 @@ public:
     virtual void hideGui(Window* window, unsigned id) const;
     virtual void createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const;
     virtual void setGuiStatus(Window* /*window*/, unsigned /*id*/, unsigned /*status*/) const = 0;
-
-    virtual unsigned getGuiStatus(Window* /*window*/, unsigned /*id*/, bool& failed) const;
+    virtual unsigned getGuiStatus(Window* /*window*/, unsigned /*id*/, bool& failed) const = 0;
 
     AddonId getId() const { return id_; }
-    unsigned getGroups() const { return (ADDONGROUP_ALL | groups_); }
+    AddonGroup getGroups() const { return groups_; }
     std::string getName() const { return name_; }
     std::string getDescription() const { return description_; }
     unsigned getDefaultStatus() const { return defaultStatus_; }
@@ -52,7 +51,7 @@ public:
 
 private:
     AddonId id_;
-    unsigned groups_;
+    AddonGroup groups_;
     std::string name_;
     std::string description_;
     unsigned defaultStatus_;

--- a/libs/s25main/addons/AddonAIDebugWindow.h
+++ b/libs/s25main/addons/AddonAIDebugWindow.h
@@ -30,10 +30,9 @@ class AddonAIDebugWindow : public AddonBool
 {
 public:
     AddonAIDebugWindow()
-        : AddonBool(AddonId::AI_DEBUG_WINDOW, ADDONGROUP_OTHER, _("AI Debugging Window"),
+        : AddonBool(AddonId::AI_DEBUG_WINDOW, AddonGroup::Other, _("AI Debugging Window"),
                     _("Enable AI Debugging Window\n"
-                      "(possible cheating)"),
-                    0)
+                      "(possible cheating)"))
     {}
 };
 

--- a/libs/s25main/addons/AddonAdjustMilitaryStrength.h
+++ b/libs/s25main/addons/AddonAdjustMilitaryStrength.h
@@ -41,13 +41,15 @@ class AddonAdjustMilitaryStrength : public AddonList
 {
 public:
     AddonAdjustMilitaryStrength()
-        : AddonList(AddonId::ADJUST_MILITARY_STRENGTH, ADDONGROUP_MILITARY, _("Adjust military strength"),
-                    _("Modify the strength increase of military ranks"), 1)
-    {
-        addOption(_("Maximum strength"));
-        addOption(_("Medium strength"));
-        addOption(_("Minimum strength"));
-    }
+        : AddonList(AddonId::ADJUST_MILITARY_STRENGTH, AddonGroup::Military, _("Adjust military strength"),
+                    _("Modify the strength increase of military ranks"),
+                    {
+                      _("Maximum strength"),
+                      _("Medium strength"),
+                      _("Minimum strength"),
+                    },
+                    1)
+    {}
 };
 
 #endif // !ADDONADJUSTMILITARYSTRENGTH_H_INCLUDED

--- a/libs/s25main/addons/AddonAsyncDebug.h
+++ b/libs/s25main/addons/AddonAsyncDebug.h
@@ -26,8 +26,8 @@ class AddonAsyncDebug : public AddonBool
 {
 public:
     AddonAsyncDebug()
-        : AddonBool(AddonId::ASYNC_DEBUG, ADDONGROUP_OTHER, _("Async debugging (REALLY SLOW!)"),
-                    _("Enables extra stuff to debug asyncs. Do not enable unless you know what you are doing!"), 0)
+        : AddonBool(AddonId::ASYNC_DEBUG, AddonGroup::Other, _("Async debugging (REALLY SLOW!)"),
+                    _("Enables extra stuff to debug asyncs. Do not enable unless you know what you are doing!"))
     {}
 };
 

--- a/libs/s25main/addons/AddonBattlefieldPromotion.h
+++ b/libs/s25main/addons/AddonBattlefieldPromotion.h
@@ -26,8 +26,8 @@ class AddonBattlefieldPromotion : public AddonBool
 {
 public:
     AddonBattlefieldPromotion()
-        : AddonBool(AddonId::BATTLEFIELD_PROMOTION, ADDONGROUP_MILITARY, _("Enable battlefield promotions"),
-                    _("Soldiers winning a fight increase in rank."), 0)
+        : AddonBool(AddonId::BATTLEFIELD_PROMOTION, AddonGroup::Military, _("Enable battlefield promotions"),
+                    _("Soldiers winning a fight increase in rank."))
     {}
 };
 

--- a/libs/s25main/addons/AddonBool.cpp
+++ b/libs/s25main/addons/AddonBool.cpp
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "rttrDefines.h" // IWYU pragma: keep
 #include "AddonBool.h"
 #include "Loader.h"
 #include "Window.h"
@@ -25,54 +24,32 @@ AddonBool::AddonBool(const AddonId id, AddonGroup groups, const std::string& nam
     : Addon(id, groups, name, description, 0)
 {}
 
-void AddonBool::hideGui(Window* window, unsigned id) const
+std::unique_ptr<AddonGui> AddonBool::createGui(Window& window, bool readonly) const
 {
-    Addon::hideGui(window, id);
-    auto* check = window->GetCtrl<ctrlCheck>(id + 2);
-    if(check)
-        check->SetVisible(false);
-}
-
-void AddonBool::createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const
-{
-    Addon::createGui(window, id, y, readonly, status);
-    DrawPoint cbPos(430, y);
-
-    auto* check = window->GetCtrl<ctrlCheck>(id + 2);
-    if(!check)
-    {
-        check = window->AddCheckBox(id + 2, DrawPoint(0, 0), Extent(220, 20), TC_GREY, _("Use"), NormalFont, readonly);
-        setGuiStatus(window, id, status);
-    }
-
-    check->SetVisible(true);
-    check->SetPos(cbPos);
-
-    y += 30;
-}
-
-void AddonBool::setGuiStatus(Window* window, unsigned id, unsigned status) const
-{
-    auto* check = window->GetCtrl<ctrlCheck>(id + 2);
-
-    if(check)
-        check->SetCheck(status != 0);
-}
-
-unsigned AddonBool::getGuiStatus(Window* window, unsigned id, bool& failed) const
-{
-    auto* check = window->GetCtrl<ctrlCheck>(id + 2);
-    if(!check)
-    {
-        failed = true;
-        return getDefaultStatus();
-    }
-    failed = false;
-
-    return (check->GetCheck() ? 1 : 0);
+    return std::make_unique<Gui>(*this, window, readonly);
 }
 
 unsigned AddonBool::getNumOptions() const
 {
     return 2;
+}
+
+AddonBool::Gui::Gui(const Addon& addon, Window& window, bool readonly) : AddonGui(addon, window, readonly)
+{
+    DrawPoint cbPos(430, 0);
+    window.AddCheckBox(2, cbPos, Extent(220, 20), TC_GREY, _("Use"), NormalFont, readonly);
+}
+
+void AddonBool::Gui::setStatus(Window& window, unsigned status)
+{
+    auto* cb = window.GetCtrl<ctrlCheck>(2);
+    RTTR_Assert(cb);
+    cb->SetCheck(status != 0);
+}
+
+unsigned AddonBool::Gui::getStatus(const Window& window)
+{
+    const auto* cb = window.GetCtrl<ctrlCheck>(2);
+    RTTR_Assert(cb);
+    return cb->GetCheck() ? 1 : 0;
 }

--- a/libs/s25main/addons/AddonBool.cpp
+++ b/libs/s25main/addons/AddonBool.cpp
@@ -20,7 +20,10 @@
 #include "Loader.h"
 #include "Window.h"
 #include "controls/ctrlCheck.h"
-#include "mygettext/mygettext.h"
+
+AddonBool::AddonBool(const AddonId id, AddonGroup groups, const std::string& name, const std::string& description)
+    : Addon(id, groups, name, description, 0)
+{}
 
 void AddonBool::hideGui(Window* window, unsigned id) const
 {
@@ -53,7 +56,7 @@ void AddonBool::setGuiStatus(Window* window, unsigned id, unsigned status) const
     auto* check = window->GetCtrl<ctrlCheck>(id + 2);
 
     if(check)
-        check->SetCheck((status != 0));
+        check->SetCheck(status != 0);
 }
 
 unsigned AddonBool::getGuiStatus(Window* window, unsigned id, bool& failed) const

--- a/libs/s25main/addons/AddonBool.h
+++ b/libs/s25main/addons/AddonBool.h
@@ -28,9 +28,7 @@
 class AddonBool : public Addon
 {
 public:
-    AddonBool(const AddonId id, unsigned groups, const std::string& name, const std::string& description, const unsigned default_status)
-        : Addon(id, groups, name, description, default_status)
-    {}
+    AddonBool(const AddonId id, AddonGroup groups, const std::string& name, const std::string& description);
 
     void hideGui(Window* window, unsigned id) const override;
     void createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const override;

--- a/libs/s25main/addons/AddonBool.h
+++ b/libs/s25main/addons/AddonBool.h
@@ -27,15 +27,20 @@
  */
 class AddonBool : public Addon
 {
-public:
-    AddonBool(const AddonId id, AddonGroup groups, const std::string& name, const std::string& description);
+    class Gui : public AddonGui
+    {
+    public:
+        Gui(const Addon& addon, Window& window, bool readonly);
+        void setStatus(Window& window, unsigned status) override;
+        unsigned getStatus(const Window& window) override;
+    };
 
-    void hideGui(Window* window, unsigned id) const override;
-    void createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const override;
-    void setGuiStatus(Window* window, unsigned id, unsigned status) const override;
-    unsigned getGuiStatus(Window* window, unsigned id, bool& failed) const override;
+public:
+    AddonBool(AddonId id, AddonGroup groups, const std::string& name, const std::string& description);
 
     unsigned getNumOptions() const override;
+
+    std::unique_ptr<AddonGui> createGui(Window& window, bool readonly) const override;
 };
 
 #endif // AddonBool_h__

--- a/libs/s25main/addons/AddonBurnDuration.h
+++ b/libs/s25main/addons/AddonBurnDuration.h
@@ -28,17 +28,18 @@ class AddonBurnDuration : public AddonList
 {
 public:
     AddonBurnDuration()
-        : AddonList(AddonId::BURN_DURATION, ADDONGROUP_GAMEPLAY, _("Set duration fires burn"),
-                    _("Adjusts how long a building will burn for when it is destroyed"), 0)
-    {
-        addOption(_("Default"));
-        addOption(_("-25%"));
-        addOption(_("-50%"));
-        addOption(_("-75%"));
-        addOption(_("-90%"));
-        addOption(_("+50%"));
-        addOption(_("+100%"));
-    }
+        : AddonList(AddonId::BURN_DURATION, AddonGroup::GamePlay, _("Set duration fires burn"),
+                    _("Adjusts how long a building will burn for when it is destroyed"),
+                    {
+                      _("Default"),
+                      _("-25%"),
+                      _("-50%"),
+                      _("-75%"),
+                      _("-90%"),
+                      _("+50%"),
+                      _("+100%"),
+                    })
+    {}
 };
 
 #endif

--- a/libs/s25main/addons/AddonCatapultGraphics.h
+++ b/libs/s25main/addons/AddonCatapultGraphics.h
@@ -31,8 +31,8 @@ class AddonCatapultGraphics : public AddonBool
 {
 public:
     AddonCatapultGraphics()
-        : AddonBool(AddonId::CATAPULT_GRAPHICS, ADDONGROUP_GAMEPLAY, _("Race specific catapult graphics"),
-                    _("Adds new race-specific graphics for catapults to the game."), 0)
+        : AddonBool(AddonId::CATAPULT_GRAPHICS, AddonGroup::GamePlay, _("Race specific catapult graphics"),
+                    _("Adds new race-specific graphics for catapults to the game."))
     {}
 };
 

--- a/libs/s25main/addons/AddonChangeGoldDeposits.h
+++ b/libs/s25main/addons/AddonChangeGoldDeposits.h
@@ -30,18 +30,18 @@ class AddonChangeGoldDeposits : public AddonList
 {
 public:
     AddonChangeGoldDeposits()
-        : AddonList(AddonId::CHANGE_GOLD_DEPOSITS, ADDONGROUP_MILITARY | ADDONGROUP_ECONOMY, _("Change gold deposits"),
+        : AddonList(AddonId::CHANGE_GOLD_DEPOSITS, AddonGroup::Military | AddonGroup::Economy, _("Change gold deposits"),
                     _("You can remove gold resources completely or convert them into iron ore, coal or granite.\n\n"
                       "You'll probably want to convert gold to iron ore, as this (on most maps)\n"
                       "allows you to utilize the additional coal not needed for minting anymore."),
-                    0)
-    {
-        addOption(_("No change"));
-        addOption(_("Remove gold completely"));
-        addOption(_("Convert to iron ore"));
-        addOption(_("Convert to coal"));
-        addOption(_("Convert to granite"));
-    }
+                    {
+                      _("No change"),
+                      _("Remove gold completely"),
+                      _("Convert to iron ore"),
+                      _("Convert to coal"),
+                      _("Convert to granite"),
+                    })
+    {}
 };
 
 #endif // !ADDONCHANGEGOLDDEPOSITS_H_INCLUDED

--- a/libs/s25main/addons/AddonCharburner.h
+++ b/libs/s25main/addons/AddonCharburner.h
@@ -26,8 +26,7 @@
 class AddonCharburner : public AddonBool
 {
 public:
-    AddonCharburner() : AddonBool(AddonId::CHARBURNER, ADDONGROUP_ECONOMY, _("Enable charburner"), _("Allows to build the charburner."), 0)
-    {}
+    AddonCharburner() : AddonBool(AddonId::CHARBURNER, AddonGroup::Economy, _("Enable charburner"), _("Allows to build the charburner.")) {}
 };
 
 #endif // !ADDONEXHAUSTIBLEWELLS_H_INCLUDED

--- a/libs/s25main/addons/AddonCoinsCapturedBld.h
+++ b/libs/s25main/addons/AddonCoinsCapturedBld.h
@@ -30,13 +30,14 @@ class AddonCoinsCapturedBld : public AddonList
 {
 public:
     AddonCoinsCapturedBld()
-        : AddonList(AddonId::COINS_CAPTURED_BLD, ADDONGROUP_MILITARY, _("Coins on captured buildings"),
-                    _("Change the coin setting for captured military buildings."), 0)
-    {
-        this->addOption(_("Keep setting"));
-        this->addOption(_("Enable"));
-        this->addOption(_("Disable"));
-    }
+        : AddonList(AddonId::COINS_CAPTURED_BLD, AddonGroup::Military, _("Coins on captured buildings"),
+                    _("Change the coin setting for captured military buildings."),
+                    {
+                      _("Keep setting"),
+                      _("Enable"),
+                      _("Disable"),
+                    })
+    {}
 };
 
 #endif // !COINSCAPTUREDBLD_H_INCLUDED

--- a/libs/s25main/addons/AddonCustomBuildSequence.h
+++ b/libs/s25main/addons/AddonCustomBuildSequence.h
@@ -29,10 +29,9 @@ class AddonCustomBuildSequence : public AddonBool
 {
 public:
     AddonCustomBuildSequence()
-        : AddonBool(AddonId::CUSTOM_BUILD_SEQUENCE, ADDONGROUP_ECONOMY | ADDONGROUP_GAMEPLAY, _("Custom build sequence"),
+        : AddonBool(AddonId::CUSTOM_BUILD_SEQUENCE, AddonGroup::Economy | AddonGroup::GamePlay, _("Custom build sequence"),
                     _("Allows every player to control whether building sites should be supplied "
-                      "in sequence of given order or in a definable sequence based on the building type."),
-                    0)
+                      "in sequence of given order or in a definable sequence based on the building type."))
     {}
 };
 

--- a/libs/s25main/addons/AddonDefenderBehavior.h
+++ b/libs/s25main/addons/AddonDefenderBehavior.h
@@ -30,17 +30,17 @@ class AddonDefenderBehavior : public AddonList
 {
 public:
     AddonDefenderBehavior()
-        : AddonList(AddonId::DEFENDER_BEHAVIOR, ADDONGROUP_MILITARY, _("Change defender behavior"),
+        : AddonList(AddonId::DEFENDER_BEHAVIOR, AddonGroup::Military, _("Change defender behavior"),
                     _("Change the military setting 'defender'.\n\n"
                       "You can choose to disallow any changes to that setting "
                       "or you can limit the amount of reoccupying troops "
                       "(during an attack) according to the defender setting."),
-                    0)
-    {
-        addOption(_("No change"));
-        addOption(_("Disallow change"));
-        addOption(_("Reduce reoccupying troops accordingly"));
-    }
+                    {
+                      _("No change"),
+                      _("Disallow change"),
+                      _("Reduce reoccupying troops accordingly"),
+                    })
+    {}
 };
 
 #endif // !ADDONDEFENDERBEHAVIOR_H_INCLUDED

--- a/libs/s25main/addons/AddonDemolishBldWORes.h
+++ b/libs/s25main/addons/AddonDemolishBldWORes.h
@@ -26,8 +26,8 @@ class AddonDemolishBldWORes : public AddonBool
 {
 public:
     AddonDemolishBldWORes()
-        : AddonBool(AddonId::DEMOLISH_BLD_WO_RES, ADDONGROUP_GAMEPLAY | ADDONGROUP_ECONOMY, _("Demolish building when out of resources"),
-                    _("Automatically demolish a resource gathering building, like a mine, if it runs permanently out of resources."), 0)
+        : AddonBool(AddonId::DEMOLISH_BLD_WO_RES, AddonGroup::GamePlay | AddonGroup::Economy, _("Demolish building when out of resources"),
+                    _("Automatically demolish a resource gathering building, like a mine, if it runs permanently out of resources."))
     {}
 };
 

--- a/libs/s25main/addons/AddonDemolitionProhibition.h
+++ b/libs/s25main/addons/AddonDemolitionProhibition.h
@@ -29,13 +29,14 @@ class AddonDemolitionProhibition : public AddonList
 {
 public:
     AddonDemolitionProhibition()
-        : AddonList(AddonId::DEMOLITION_PROHIBITION, ADDONGROUP_MILITARY, _("Disable Demolition of military buildings"),
-                    _("Disable the demolition of military buildings under attack or near frontiers."), 0)
-    {
-        addOption(_("Off"));
-        addOption(_("Active if attacked"));
-        addOption(_("Active near frontiers"));
-    }
+        : AddonList(AddonId::DEMOLITION_PROHIBITION, AddonGroup::Military, _("Disable Demolition of military buildings"),
+                    _("Disable the demolition of military buildings under attack or near frontiers."),
+                    {
+                      _("Off"),
+                      _("Active if attacked"),
+                      _("Active near frontiers"),
+                    })
+    {}
 };
 
 #endif // !ADDONDEMOLITIONPROHIBITION_H_INCLUDED

--- a/libs/s25main/addons/AddonExhaustibleWater.h
+++ b/libs/s25main/addons/AddonExhaustibleWater.h
@@ -30,13 +30,14 @@ class AddonExhaustibleWater : public AddonList
 public:
     AddonExhaustibleWater()
         : AddonList(
-            AddonId::EXHAUSTIBLE_WATER, ADDONGROUP_ECONOMY, _("Exhaustible Water"),
-            _("If Water is exhaustible wells will now dry out. If water everywhere is enabled, a geologist will not notify for water"), 0)
-    {
-        addOption(_("Inexhaustible"));
-        addOption(_("Inexhaustible and water everywhere"));
-        addOption(_("Exhaustible"));
-    }
+            AddonId::EXHAUSTIBLE_WATER, AddonGroup::Economy, _("Exhaustible Water"),
+            _("If Water is exhaustible wells will now dry out. If water everywhere is enabled, a geologist will not notify for water"),
+            {
+              _("Inexhaustible"),
+              _("Inexhaustible and water everywhere"),
+              _("Exhaustible"),
+            })
+    {}
 };
 
 #endif // !ADDONEXHAUSTIBLEWELLS_H_INCLUDED

--- a/libs/s25main/addons/AddonFrontierDistanceReachable.h
+++ b/libs/s25main/addons/AddonFrontierDistanceReachable.h
@@ -26,11 +26,10 @@ class AddonFrontierDistanceReachable : public AddonBool
 {
 public:
     AddonFrontierDistanceReachable()
-        : AddonBool(AddonId::FRONTIER_DISTANCE_REACHABLE, ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY,
+        : AddonBool(AddonId::FRONTIER_DISTANCE_REACHABLE, AddonGroup::GamePlay | AddonGroup::Military,
                     _("Frontier Distance checks reachability"),
                     _("Military building counts as interior if an attack is permanently impossible. (Path blocked by terrain like sea, "
-                      "lava, etc.)"),
-                    0)
+                      "lava, etc.)"))
     {}
 };
 

--- a/libs/s25main/addons/AddonHalfCostMilEquip.h
+++ b/libs/s25main/addons/AddonHalfCostMilEquip.h
@@ -28,10 +28,9 @@ class AddonHalfCostMilEquip : public AddonBool
 {
 public:
     AddonHalfCostMilEquip()
-        : AddonBool(AddonId::HALF_COST_MIL_EQUIP, ADDONGROUP_ECONOMY, _("Half cost recruits"),
+        : AddonBool(AddonId::HALF_COST_MIL_EQUIP, AddonGroup::Economy, _("Half cost recruits"),
                     _("Smith can create 1 shield & 1 sword "
-                      "for 1 iron + 1 coal instead of 2 iron + 2 coal"),
-                    0)
+                      "for 1 iron + 1 coal instead of 2 iron + 2 coal"))
     {}
 };
 

--- a/libs/s25main/addons/AddonInexhaustibleFish.h
+++ b/libs/s25main/addons/AddonInexhaustibleFish.h
@@ -13,8 +13,8 @@ class AddonInexhaustibleFish : public AddonBool
 {
 public:
     AddonInexhaustibleFish()
-        : AddonBool(AddonId::INEXHAUSTIBLE_FISH, ADDONGROUP_ECONOMY, _("Inexhaustible Fish"),
-                    _("Deactivates reduction of fish population."), 0)
+        : AddonBool(AddonId::INEXHAUSTIBLE_FISH, AddonGroup::Economy, _("Inexhaustible Fish"),
+                    _("Deactivates reduction of fish population."))
     {}
 };
 

--- a/libs/s25main/addons/AddonInexhaustibleGraniteMines.h
+++ b/libs/s25main/addons/AddonInexhaustibleGraniteMines.h
@@ -13,8 +13,8 @@ class AddonInexhaustibleGraniteMines : public AddonBool
 {
 public:
     AddonInexhaustibleGraniteMines()
-        : AddonBool(AddonId::INEXHAUSTIBLE_GRANITEMINES, ADDONGROUP_ECONOMY, _("Inexhaustible Granite Mines"),
-                    _("Granite mines will never be depleted."), 0)
+        : AddonBool(AddonId::INEXHAUSTIBLE_GRANITEMINES, AddonGroup::Economy, _("Inexhaustible Granite Mines"),
+                    _("Granite mines will never be depleted."))
     {}
 };
 

--- a/libs/s25main/addons/AddonInexhaustibleMines.h
+++ b/libs/s25main/addons/AddonInexhaustibleMines.h
@@ -29,7 +29,7 @@ class AddonInexhaustibleMines : public AddonBool
 {
 public:
     AddonInexhaustibleMines()
-        : AddonBool(AddonId::INEXHAUSTIBLE_MINES, ADDONGROUP_ECONOMY, _("Inexhaustible Mines"), _("Mines will never be depleted."), 0)
+        : AddonBool(AddonId::INEXHAUSTIBLE_MINES, AddonGroup::Economy, _("Inexhaustible Mines"), _("Mines will never be depleted."))
     {}
 };
 

--- a/libs/s25main/addons/AddonLimitCatapults.h
+++ b/libs/s25main/addons/AddonLimitCatapults.h
@@ -29,24 +29,24 @@ class AddonLimitCatapults : public AddonList
 {
 public:
     AddonLimitCatapults()
-        : AddonList(AddonId::LIMIT_CATAPULTS, ADDONGROUP_MILITARY, _("Limit number of catapults"),
+        : AddonList(AddonId::LIMIT_CATAPULTS, AddonGroup::Military, _("Limit number of catapults"),
                     _("Limits the number of catapults per player.\n\n"
                       "Proportional uses the following ratios of military buildings to catapults:\n"
                       "Barracks: 8\n"
                       "Guardhouse: 4\n"
                       "Watchtower: 2\n"
                       "Fortress: 1"),
-                    0)
-    {
-        addOption(_("Unlimited"));
-        addOption(_("Proportional"));
-        addOption(_("No catapults"));
-        addOption(_("3 catapults"));
-        addOption(_("5 catapults"));
-        addOption(_("10 catapults"));
-        addOption(_("20 catapults"));
-        addOption(_("30 catapults"));
-    }
+                    {
+                      _("Unlimited"),
+                      _("Proportional"),
+                      _("No catapults"),
+                      _("3 catapults"),
+                      _("5 catapults"),
+                      _("10 catapults"),
+                      _("20 catapults"),
+                      _("30 catapults"),
+                    })
+    {}
 };
 
 #endif // !ADDONLIMITCATAPULTS_H_INCLUDED

--- a/libs/s25main/addons/AddonList.cpp
+++ b/libs/s25main/addons/AddonList.cpp
@@ -20,7 +20,15 @@
 #include "Loader.h"
 #include "Window.h"
 #include "controls/ctrlComboBox.h"
-#include "helpers/containerUtils.h"
+#include <stdexcept>
+
+AddonList::AddonList(const AddonId id, AddonGroup groups, const std::string& name, const std::string& description,
+                     std::vector<std::string> options, unsigned defaultStatus /*=0*/)
+    : Addon(id, groups, name, description, defaultStatus), options(std::move(options))
+{
+    if(defaultStatus >= this->options.size())
+        throw std::logic_error("Invalid default option");
+}
 
 void AddonList::hideGui(Window* window, unsigned id) const
 {
@@ -76,15 +84,4 @@ unsigned AddonList::getGuiStatus(Window* window, unsigned id, bool& failed) cons
 unsigned AddonList::getNumOptions() const
 {
     return options.size();
-}
-
-void AddonList::removeOptions()
-{
-    options.clear();
-}
-
-void AddonList::addOption(const std::string& name)
-{
-    if(!helpers::contains(options, name))
-        options.push_back(name);
 }

--- a/libs/s25main/addons/AddonList.cpp
+++ b/libs/s25main/addons/AddonList.cpp
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "rttrDefines.h" // IWYU pragma: keep
 #include "AddonList.h"
 #include "Loader.h"
 #include "Window.h"
@@ -30,58 +29,35 @@ AddonList::AddonList(const AddonId id, AddonGroup groups, const std::string& nam
         throw std::logic_error("Invalid default option");
 }
 
-void AddonList::hideGui(Window* window, unsigned id) const
+std::unique_ptr<AddonGui> AddonList::createGui(Window& window, bool readonly) const
 {
-    Addon::hideGui(window, id);
-
-    auto* combo = window->GetCtrl<ctrlComboBox>(id + 2);
-    if(combo)
-        combo->SetVisible(false);
-}
-
-void AddonList::createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const
-{
-    Addon::createGui(window, id, y, readonly, status);
-    DrawPoint cbPos(430, y);
-
-    auto* combo = window->GetCtrl<ctrlComboBox>(id + 2);
-    if(!combo)
-    {
-        combo = window->AddComboBox(id + 2, DrawPoint(0, 0), Extent(220, 20), TC_GREY, NormalFont, 100, readonly);
-        for(const auto& option : options)
-            combo->AddString(option);
-
-        setGuiStatus(window, id, status);
-    }
-
-    combo->SetVisible(true);
-    combo->SetPos(cbPos);
-
-    y += 30;
-}
-
-void AddonList::setGuiStatus(Window* window, unsigned id, unsigned status) const
-{
-    auto* combo = window->GetCtrl<ctrlComboBox>(id + 2);
-
-    if(combo)
-        combo->SetSelection(status);
-}
-
-unsigned AddonList::getGuiStatus(Window* window, unsigned id, bool& failed) const
-{
-    auto* combo = window->GetCtrl<ctrlComboBox>(id + 2);
-    if(!combo)
-    {
-        failed = true;
-        return getDefaultStatus();
-    }
-    failed = false;
-
-    return combo->GetSelection();
+    return std::make_unique<Gui>(*this, window, readonly);
 }
 
 unsigned AddonList::getNumOptions() const
 {
     return options.size();
+}
+
+AddonList::Gui::Gui(const AddonList& addon, Window& window, bool readonly) : AddonGui(addon, window, readonly)
+{
+    DrawPoint cbPos(430, 0);
+
+    auto* cb = window.AddComboBox(2, cbPos, Extent(220, 20), TC_GREY, NormalFont, 100, readonly);
+    for(const auto& option : addon.options)
+        cb->AddString(option);
+}
+
+void AddonList::Gui::setStatus(Window& window, unsigned status)
+{
+    auto* cb = window.GetCtrl<ctrlComboBox>(2);
+    RTTR_Assert(cb);
+    cb->SetSelection(status);
+}
+
+unsigned AddonList::Gui::getStatus(const Window& window)
+{
+    const auto* cb = window.GetCtrl<ctrlComboBox>(2);
+    RTTR_Assert(cb);
+    return cb->GetSelection();
 }

--- a/libs/s25main/addons/AddonList.h
+++ b/libs/s25main/addons/AddonList.h
@@ -25,14 +25,12 @@
 
 /**
  *  Addon baseclass for option-list addons
- *  first option added will be the default one
  */
 class AddonList : public Addon
 {
 public:
-    AddonList(const AddonId id, unsigned groups, const std::string& name, const std::string& description, const unsigned default_status)
-        : Addon(id, groups, name, description, default_status)
-    {}
+    AddonList(const AddonId id, AddonGroup groups, const std::string& name, const std::string& description,
+              std::vector<std::string> options, unsigned defaultStatus = 0);
 
     void hideGui(Window* window, unsigned id) const override;
     void createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const override;
@@ -40,10 +38,6 @@ public:
     unsigned getGuiStatus(Window* window, unsigned id, bool& failed) const override;
 
     unsigned getNumOptions() const override;
-
-protected:
-    void removeOptions();
-    void addOption(const std::string& name);
 
 private:
     std::vector<std::string> options;

--- a/libs/s25main/addons/AddonList.h
+++ b/libs/s25main/addons/AddonList.h
@@ -28,16 +28,21 @@
  */
 class AddonList : public Addon
 {
-public:
-    AddonList(const AddonId id, AddonGroup groups, const std::string& name, const std::string& description,
-              std::vector<std::string> options, unsigned defaultStatus = 0);
+    class Gui : public AddonGui
+    {
+    public:
+        Gui(const AddonList& addon, Window& window, bool readonly);
+        void setStatus(Window& window, unsigned status) override;
+        unsigned getStatus(const Window& window) override;
+    };
 
-    void hideGui(Window* window, unsigned id) const override;
-    void createGui(Window* window, unsigned id, unsigned short& y, bool readonly, unsigned status) const override;
-    void setGuiStatus(Window* window, unsigned id, unsigned status) const override;
-    unsigned getGuiStatus(Window* window, unsigned id, bool& failed) const override;
+public:
+    AddonList(AddonId id, AddonGroup groups, const std::string& name, const std::string& description, std::vector<std::string> options,
+              unsigned defaultStatus = 0);
 
     unsigned getNumOptions() const override;
+
+    std::unique_ptr<AddonGui> createGui(Window& window, bool readonly) const override;
 
 private:
     std::vector<std::string> options;

--- a/libs/s25main/addons/AddonManualRoadEnlargement.h
+++ b/libs/s25main/addons/AddonManualRoadEnlargement.h
@@ -29,8 +29,8 @@ class AddonManualRoadEnlargement : public AddonBool
 {
 public:
     AddonManualRoadEnlargement()
-        : AddonBool(AddonId::MANUAL_ROAD_ENLARGEMENT, ADDONGROUP_ECONOMY, _("Manual road enlargement"),
-                    _("Manually upgrade your roads and directly build donkey roads."), 0)
+        : AddonBool(AddonId::MANUAL_ROAD_ENLARGEMENT, AddonGroup::Economy, _("Manual road enlargement"),
+                    _("Manually upgrade your roads and directly build donkey roads."))
     {}
 };
 

--- a/libs/s25main/addons/AddonMaxRank.h
+++ b/libs/s25main/addons/AddonMaxRank.h
@@ -38,14 +38,16 @@
 class AddonMaxRank : public AddonList
 {
 public:
-    AddonMaxRank() : AddonList(AddonId::MAX_RANK, ADDONGROUP_MILITARY, _("Set max rank"), _("Limit the rank for soldiers"), 0)
-    {
-        addOption(_("General (4)"));
-        addOption(_("Officer (3)"));
-        addOption(_("Sergeant (2)"));
-        addOption(_("Privatefc (1)"));
-        addOption(_("Private (0)"));
-    }
+    AddonMaxRank()
+        : AddonList(AddonId::MAX_RANK, AddonGroup::Military, _("Set max rank"), _("Limit the rank for soldiers"),
+                    {
+                      _("General (4)"),
+                      _("Officer (3)"),
+                      _("Sergeant (2)"),
+                      _("Privatefc (1)"),
+                      _("Private (0)"),
+                    })
+    {}
 };
 
 #endif

--- a/libs/s25main/addons/AddonMaxWaterwayLength.h
+++ b/libs/s25main/addons/AddonMaxWaterwayLength.h
@@ -32,7 +32,7 @@ class AddonMaxWaterwayLength : public AddonList
 {
 public:
     AddonMaxWaterwayLength()
-        : AddonList(AddonId::MAX_WATERWAY_LENGTH, ADDONGROUP_GAMEPLAY, _("Set maximum waterway length"),
+        : AddonList(AddonId::MAX_WATERWAY_LENGTH, AddonGroup::GamePlay, _("Set maximum waterway length"),
                     _("Limits the distance settlers may travel per boat.\n\n"
                       "Possible values are:\n"
                       "Short: 3 tiles\n"
@@ -41,15 +41,16 @@ public:
                       "Longer: 13 tiles\n"
                       "Very long: 21 tiles\n"
                       "and Unlimited."),
+                    {
+                      _("Short"),
+                      _("Default"),
+                      _("Long"),
+                      _("Longer"),
+                      _("Very long"),
+                      _("Unlimited"),
+                    },
                     1)
-    {
-        addOption(_("Short"));
-        addOption(_("Default"));
-        addOption(_("Long"));
-        addOption(_("Longer"));
-        addOption(_("Very long"));
-        addOption(_("Unlimited"));
-    }
+    {}
 };
 
 #endif // !ADDONMAXWATERWAYLENGTH_H_INCLUDED

--- a/libs/s25main/addons/AddonMetalworksBehaviorOnZero.h
+++ b/libs/s25main/addons/AddonMetalworksBehaviorOnZero.h
@@ -1,21 +1,21 @@
 #ifndef ADDONSTOPMETALWORKSONZERO_H_INCLUDED
 #define ADDONSTOPMETALWORKSONZERO_H_INCLUDED
 
-#include "AddonBool.h"
+#include "AddonList.h"
 
 class AddonMetalworksBehaviorOnZero : public AddonList
 {
 public:
     AddonMetalworksBehaviorOnZero()
-        : AddonList(AddonId::METALWORKSBEHAVIORONZERO, ADDONGROUP_GAMEPLAY | ADDONGROUP_ECONOMY, _("Change metalworks behavior on zero"),
+        : AddonList(AddonId::METALWORKSBEHAVIORONZERO, AddonGroup::GamePlay | AddonGroup::Economy, _("Change metalworks behavior on zero"),
                     _("Change the working behavior of metalworks if all sliders in the tools window are set to zero.\n"
                       "Produce random ware: S2-Default\n"
                       "Produce nothing: RttR-Default"),
-                    0)
-    {
-        addOption(_("Produce random ware"));
-        addOption(_("Produce nothing"));
-    }
+                    {
+                      _("Produce random ware"),
+                      _("Produce nothing"),
+                    })
+    {}
 };
 
 #endif

--- a/libs/s25main/addons/AddonMilitaryAid.h
+++ b/libs/s25main/addons/AddonMilitaryAid.h
@@ -31,8 +31,8 @@ class AddonMilitaryAid : public AddonBool
 {
 public:
     AddonMilitaryAid()
-        : AddonBool(AddonId::MILITARY_AID, ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY, _("Military Aid"),
-                    _("Adds military building indicators in construction aid mode."), 0)
+        : AddonBool(AddonId::MILITARY_AID, AddonGroup::GamePlay | AddonGroup::Military, _("Military Aid"),
+                    _("Adds military building indicators in construction aid mode."))
     {}
 };
 

--- a/libs/s25main/addons/AddonMilitaryControl.h
+++ b/libs/s25main/addons/AddonMilitaryControl.h
@@ -30,11 +30,10 @@ class AddonMilitaryControl : public AddonBool
 {
 public:
     AddonMilitaryControl()
-        : AddonBool(AddonId::MILITARY_CONTROL, ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY, _("Military Control"),
+        : AddonBool(AddonId::MILITARY_CONTROL, AddonGroup::GamePlay | AddonGroup::Military, _("Military Control"),
                     _("Adds the 'send home' button to military buildings.\n"
                       "Pressing this button will send all soldiers of the highest available rank to a warehouse (at least 1 Soldier will "
-                      "remain in the building)"),
-                    0)
+                      "remain in the building)"))
     {}
 };
 

--- a/libs/s25main/addons/AddonMilitaryHitpoints.h
+++ b/libs/s25main/addons/AddonMilitaryHitpoints.h
@@ -28,8 +28,8 @@ class AddonMilitaryHitpoints : public AddonBool
 {
 public:
     AddonMilitaryHitpoints()
-        : AddonBool(AddonId::MILITARY_HITPOINTS, ADDONGROUP_GAMEPLAY | ADDONGROUP_MILITARY, _("Military Hitpoints"),
-                    _("Display the hitpoints of units in military buildings."), 0)
+        : AddonBool(AddonId::MILITARY_HITPOINTS, AddonGroup::GamePlay | AddonGroup::Military, _("Military Hitpoints"),
+                    _("Display the hitpoints of units in military buildings."))
     {}
 };
 

--- a/libs/s25main/addons/AddonMoreAnimals.h
+++ b/libs/s25main/addons/AddonMoreAnimals.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "AddonBool.h"
+#include "AddonList.h"
 #include "mygettext/mygettext.h"
 
 /**
@@ -29,16 +29,17 @@ class AddonMoreAnimals : public AddonList
 {
 public:
     AddonMoreAnimals()
-        : AddonList(AddonId::MORE_ANIMALS, ADDONGROUP_ECONOMY, _("More trees spawn animals"),
-                    _("Adjust the fraction of trees that spawn animals."), 0)
-    {
-        addOption(_("default"));
-        addOption(_("+50%"));
-        addOption(_("+100%"));
-        addOption(_("+200%"));
-        addOption(_("+500%"));
-        addOption(_("+1000%"));
-    }
+        : AddonList(AddonId::MORE_ANIMALS, AddonGroup::Economy, _("More trees spawn animals"),
+                    _("Adjust the fraction of trees that spawn animals."),
+                    {
+                      _("default"),
+                      _("+50%"),
+                      _("+100%"),
+                      _("+200%"),
+                      _("+500%"),
+                      _("+1000%"),
+                    })
+    {}
 };
 
 #endif // !ADDONREFUNDMATERIALS_H_INCLUDED

--- a/libs/s25main/addons/AddonNoAlliedPush.h
+++ b/libs/s25main/addons/AddonNoAlliedPush.h
@@ -12,8 +12,8 @@ class AddonNoAlliedPush : public AddonBool
 {
 public:
     AddonNoAlliedPush()
-        : AddonBool(AddonId::NO_ALLIED_PUSH, ADDONGROUP_MILITARY, _("Improved Alliance"),
-                    _("Allied players can no longer push your borders back with new buildings."), 0)
+        : AddonBool(AddonId::NO_ALLIED_PUSH, AddonGroup::Military, _("Improved Alliance"),
+                    _("Allied players can no longer push your borders back with new buildings."))
     {}
 };
 

--- a/libs/s25main/addons/AddonNoCoinsDefault.h
+++ b/libs/s25main/addons/AddonNoCoinsDefault.h
@@ -13,8 +13,8 @@ class AddonNoCoinsDefault : public AddonBool
 {
 public:
     AddonNoCoinsDefault()
-        : AddonBool(AddonId::NO_COINS_DEFAULT, ADDONGROUP_MILITARY, _("Disable coins by default"),
-                    _("Receiving coins is disabled for military buildings by default."), 0)
+        : AddonBool(AddonId::NO_COINS_DEFAULT, AddonGroup::Military, _("Disable coins by default"),
+                    _("Receiving coins is disabled for military buildings by default."))
     {}
 };
 

--- a/libs/s25main/addons/AddonNumScoutsExploration.h
+++ b/libs/s25main/addons/AddonNumScoutsExploration.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "AddonBool.h"
+#include "AddonList.h"
 #include "mygettext/mygettext.h"
 
 /**
@@ -30,17 +30,19 @@ class AddonNumScoutsExploration : public AddonList
 {
 public:
     AddonNumScoutsExploration()
-        : AddonList(AddonId::NUM_SCOUTS_EXPLORATION, ADDONGROUP_ECONOMY, _("Number of scouts required for exploration expedition"),
+        : AddonList(AddonId::NUM_SCOUTS_EXPLORATION, AddonGroup::Economy, _("Number of scouts required for exploration expedition"),
                     _("Change the required number of scouts for an exploration via ship\n"
                       "Note: Setting this to low might make some maps imbalanced!"),
+
+                    {
+                      _("Minimal"),
+                      _("Fewer"),
+                      _("Normal"),
+                      _("More"),
+                      _("Maximal"),
+                    },
                     2)
-    {
-        addOption(_("Minimal"));
-        addOption(_("Fewer"));
-        addOption(_("Normal"));
-        addOption(_("More"));
-        addOption(_("Maximal"));
-    }
+    {}
 };
 
 #endif // AddonNumScoutsExploration_h__

--- a/libs/s25main/addons/AddonRefundMaterials.h
+++ b/libs/s25main/addons/AddonRefundMaterials.h
@@ -29,15 +29,16 @@ class AddonRefundMaterials : public AddonList
 {
 public:
     AddonRefundMaterials()
-        : AddonList(AddonId::REFUND_MATERIALS, ADDONGROUP_ECONOMY, _("Refund materials for destroyed buildings"),
-                    _("Get building materials back when a building is destroyed."), 0)
-    {
-        addOption(_("No refund"));
-        addOption(_("Refund 25%"));
-        addOption(_("Refund 50%"));
-        addOption(_("Refund 75%"));
-        addOption(_("Get all back"));
-    }
+        : AddonList(AddonId::REFUND_MATERIALS, AddonGroup::Economy, _("Refund materials for destroyed buildings"),
+                    _("Get building materials back when a building is destroyed."),
+                    {
+                      _("No refund"),
+                      _("Refund 25%"),
+                      _("Refund 50%"),
+                      _("Refund 75%"),
+                      _("Get all back"),
+                    })
+    {}
 };
 
 #endif // !ADDONREFUNDMATERIALS_H_INCLUDED

--- a/libs/s25main/addons/AddonRefundOnEmergency.h
+++ b/libs/s25main/addons/AddonRefundOnEmergency.h
@@ -30,10 +30,9 @@ class AddonRefundOnEmergency : public AddonBool
 {
 public:
     AddonRefundOnEmergency()
-        : AddonBool(AddonId::REFUND_ON_EMERGENCY, ADDONGROUP_ECONOMY, _("Refund materials in emergency program"),
+        : AddonBool(AddonId::REFUND_ON_EMERGENCY, AddonGroup::Economy, _("Refund materials in emergency program"),
                     _("Get building materials back when a building is destroyed "
-                      "and your emergency program is active."),
-                    0)
+                      "and your emergency program is active."))
     {}
 };
 

--- a/libs/s25main/addons/AddonSeaAttack.h
+++ b/libs/s25main/addons/AddonSeaAttack.h
@@ -35,12 +35,14 @@ class AddonSeaAttack : public AddonList
 {
 public:
     AddonSeaAttack()
-        : AddonList(AddonId::SEA_ATTACK, ADDONGROUP_MILITARY, _("Sea attack settings"), _("Set restriction level for sea attacks"), 2)
-    {
-        addOption(_("Enemy harbors don't block"));
-        addOption(_("Enemy harbors block"));
-        addOption(_("No sea attacks"));
-    }
+        : AddonList(AddonId::SEA_ATTACK, AddonGroup::Military, _("Sea attack settings"), _("Set restriction level for sea attacks"),
+                    {
+                      _("Enemy harbors don't block"),
+                      _("Enemy harbors block"),
+                      _("No sea attacks"),
+                    },
+                    2)
+    {}
 };
 
 #endif

--- a/libs/s25main/addons/AddonShipSpeed.h
+++ b/libs/s25main/addons/AddonShipSpeed.h
@@ -28,14 +28,17 @@
 class AddonShipSpeed : public AddonList
 {
 public:
-    AddonShipSpeed() : AddonList(AddonId::SHIP_SPEED, ADDONGROUP_ECONOMY, _("Set ship speed"), _("Changes the ship movement speed"), 2)
-    {
-        addOption(_("Very slow"));
-        addOption(_("Slow"));
-        addOption(_("Normal"));
-        addOption(_("Fast"));
-        addOption(_("Very fast"));
-    }
+    AddonShipSpeed()
+        : AddonList(AddonId::SHIP_SPEED, AddonGroup::Economy, _("Set ship speed"), _("Changes the ship movement speed"),
+                    {
+                      _("Very slow"),
+                      _("Slow"),
+                      _("Normal"),
+                      _("Fast"),
+                      _("Very fast"),
+                    },
+                    2)
+    {}
 };
 
 #endif

--- a/libs/s25main/addons/AddonStatisticsVisibility.h
+++ b/libs/s25main/addons/AddonStatisticsVisibility.h
@@ -29,15 +29,15 @@ class AddonStatisticsVisibility : public AddonList
 {
 public:
     AddonStatisticsVisibility()
-        : AddonList(AddonId::STATISTICS_VISIBILITY, ADDONGROUP_OTHER, _("Change the visibility of your ingame statistics"),
+        : AddonList(AddonId::STATISTICS_VISIBILITY, AddonGroup::Other, _("Change the visibility of your ingame statistics"),
                     _("Decides to whom your statistics are visible.\n\n"
                       "\"Allies\" applies to team members as well as to allies by treaty."),
-                    0)
-    {
-        addOption(_("Everyone"));
-        addOption(_("Allies"));
-        addOption(_("Nobody else but you"));
-    }
+                    {
+                      _("Everyone"),
+                      _("Allies"),
+                      _("Nobody else but you"),
+                    })
+    {}
 };
 
 #endif // !ADDONSTATISTICSVISIBILITY_H_INCLUDED

--- a/libs/s25main/addons/AddonToolOrdering.h
+++ b/libs/s25main/addons/AddonToolOrdering.h
@@ -7,8 +7,8 @@ class AddonToolOrdering : public AddonBool
 {
 public:
     AddonToolOrdering()
-        : AddonBool(AddonId::TOOL_ORDERING, ADDONGROUP_GAMEPLAY, _("Tool ordering"),
-                    _("Allows to order a specific amount of tools for priority production."), 0)
+        : AddonBool(AddonId::TOOL_ORDERING, AddonGroup::GamePlay, _("Tool ordering"),
+                    _("Allows to order a specific amount of tools for priority production."))
     {}
 };
 

--- a/libs/s25main/addons/AddonTrade.h
+++ b/libs/s25main/addons/AddonTrade.h
@@ -23,7 +23,7 @@
 class AddonTrade : public AddonBool
 {
 public:
-    AddonTrade() : AddonBool(AddonId::TRADE, ADDONGROUP_ECONOMY, _("Trade"), _("Allows to send wares/figures to allied warehouses"), 0) {}
+    AddonTrade() : AddonBool(AddonId::TRADE, AddonGroup::Economy, _("Trade"), _("Allows to send wares/figures to allied warehouses")) {}
 };
 
 #endif // !ADDONEXHAUSTIBLEWELLS_H_INCLUDED

--- a/libs/s25main/addons/const_addons.h
+++ b/libs/s25main/addons/const_addons.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "helpers/EnumWithString.h"
+#include "s25util/enumUtils.h"
 
 // Addon Author List
 //
@@ -81,13 +82,15 @@ ENUM_WITH_STRING(AddonId, LIMIT_CATAPULTS = 0x00000000, INEXHAUSTIBLE_MINES = 0x
                  FRONTIER_DISTANCE_REACHABLE = 0x00D0000, COINS_CAPTURED_BLD = 0x00D0001, DEMOLISH_BLD_WO_RES = 0x00D0002)
 //-V:AddonId:801
 
-enum AddonGroup
+enum class AddonGroup : unsigned
 {
-    ADDONGROUP_ALL = 1,
-    ADDONGROUP_MILITARY = 2,
-    ADDONGROUP_ECONOMY = 4,
-    ADDONGROUP_GAMEPLAY = 8,
-    ADDONGROUP_OTHER = 16
+    Military = 1,
+    Economy = 2,
+    GamePlay = 4,
+    Other = 8,
+    All = 0xFFFFFFFF
 };
+
+MAKE_BITSET_STRONG(AddonGroup);
 
 #endif // !CONST_ADDONS_H_INCLUDED

--- a/libs/s25main/controls/ctrlGroup.cpp
+++ b/libs/s25main/controls/ctrlGroup.cpp
@@ -68,7 +68,7 @@ void ctrlGroup::Msg_ScrollShow(const unsigned ctrl_id, const bool visible)
     GetParent()->Msg_Group_ScrollShow(this->GetID(), ctrl_id, visible);
 }
 
-void ctrlGroup::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     GetParent()->Msg_Group_OptionGroupChange(this->GetID(), ctrl_id, selection);
 }
@@ -178,7 +178,7 @@ void ctrlGroup::Msg_Group_ScrollShow(const unsigned /*group_id*/, const unsigned
     GetParent()->Msg_Group_ScrollShow(this->GetID(), ctrl_id, visible);
 }
 
-void ctrlGroup::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const unsigned ctrl_id, unsigned selection)
 {
     GetParent()->Msg_Group_OptionGroupChange(this->GetID(), ctrl_id, selection);
 }

--- a/libs/s25main/controls/ctrlGroup.h
+++ b/libs/s25main/controls/ctrlGroup.h
@@ -37,7 +37,7 @@ public:
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
     void Msg_ProgressChange(unsigned ctrl_id, unsigned short position) override;
     void Msg_ScrollShow(unsigned ctrl_id, bool visible) override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_Timer(unsigned ctrl_id) override;
     void Msg_TableSelectItem(unsigned ctrl_id, int selection) override;
     void Msg_TableRightButton(unsigned ctrl_id, int selection) override;
@@ -52,7 +52,7 @@ public:
     void Msg_Group_CheckboxChange(unsigned group_id, unsigned ctrl_id, bool checked) override;
     void Msg_Group_ProgressChange(unsigned group_id, unsigned ctrl_id, unsigned short position) override;
     void Msg_Group_ScrollShow(unsigned group_id, unsigned ctrl_id, bool visible) override;
-    void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_Group_Timer(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_TableSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
     void Msg_Group_TableRightButton(unsigned group_id, unsigned ctrl_id, int selection) override;

--- a/libs/s25main/controls/ctrlMultiSelectGroup.cpp
+++ b/libs/s25main/controls/ctrlMultiSelectGroup.cpp
@@ -19,14 +19,13 @@
 #include "ctrlMultiSelectGroup.h"
 class MouseCoords;
 
-ctrlMultiSelectGroup::ctrlMultiSelectGroup(Window* parent, unsigned id, int select_type)
-    : ctrlGroup(parent, id), selectedItems_(std::set<unsigned short>()), select_type(select_type)
+ctrlMultiSelectGroup::ctrlMultiSelectGroup(Window* parent, unsigned id, int select_type) : ctrlGroup(parent, id), select_type(select_type)
 {}
 
 /**
  *  Selektiert einen neuen Button aus der Gruppe.
  */
-void ctrlMultiSelectGroup::AddSelection(unsigned short selection, bool notify)
+void ctrlMultiSelectGroup::AddSelection(unsigned selection, bool notify)
 {
     // Neuen Button auswählen
     auto* button = GetCtrl<ctrlButton>(selection);
@@ -47,7 +46,7 @@ void ctrlMultiSelectGroup::AddSelection(unsigned short selection, bool notify)
 /**
  *  Entfernt die Selektion eines Buttons aus der Gruppe.
  */
-void ctrlMultiSelectGroup::RemoveSelection(unsigned short selection, bool notify)
+void ctrlMultiSelectGroup::RemoveSelection(unsigned selection, bool notify)
 {
     // Neuen Button auswählen
     auto* button = GetCtrl<ctrlButton>(selection);
@@ -68,7 +67,7 @@ void ctrlMultiSelectGroup::RemoveSelection(unsigned short selection, bool notify
 /**
  *  Wechselt zwischen selektiert/nicht selektiert
  */
-void ctrlMultiSelectGroup::ToggleSelection(unsigned short selection, bool notify)
+void ctrlMultiSelectGroup::ToggleSelection(unsigned selection, bool notify)
 {
     if(IsSelected(selection))
         RemoveSelection(selection, notify);
@@ -76,7 +75,7 @@ void ctrlMultiSelectGroup::ToggleSelection(unsigned short selection, bool notify
         AddSelection(selection, notify);
 }
 
-bool ctrlMultiSelectGroup::IsSelected(unsigned short selection) const
+bool ctrlMultiSelectGroup::IsSelected(unsigned selection) const
 {
     return (this->selectedItems_.count(selection) == 1);
 }

--- a/libs/s25main/controls/ctrlMultiSelectGroup.h
+++ b/libs/s25main/controls/ctrlMultiSelectGroup.h
@@ -40,15 +40,15 @@ public:
     ctrlMultiSelectGroup(Window* parent, unsigned id, int select_type);
 
     /// Selektiert einen neuen Button
-    void AddSelection(unsigned short selection, bool notify = false);
+    void AddSelection(unsigned selection, bool notify = false);
     /// Entfernt einen selektierten Button aus der Selektion
-    void RemoveSelection(unsigned short selection, bool notify = false);
+    void RemoveSelection(unsigned selection, bool notify = false);
     /// Wechselt zwischen selektiert/nicht selektiert
-    void ToggleSelection(unsigned short selection, bool notify = false);
+    void ToggleSelection(unsigned selection, bool notify = false);
     /// Gibt Liste der aktuell selektierten Buttons zurück
-    const std::set<unsigned short>& GetSelection() const { return selectedItems_; }
+    const std::set<unsigned>& GetSelection() const { return selectedItems_; }
     /// Prüft ob ein Button ausgewählt ist
-    bool IsSelected(unsigned short selection) const;
+    bool IsSelected(unsigned selection) const;
     // Gibt einen Button aus der Gruppe zurück zum direkten Bearbeiten
     ctrlButton* GetButton(unsigned id) { return GetCtrl<ctrlButton>(id); }
 
@@ -60,8 +60,8 @@ public:
     bool Msg_MouseMove(const MouseCoords& mc) override;
 
 private:
-    std::set<unsigned short> selectedItems_; /// aktuell ausgewählte Buttons
-    int select_type;                         /// Typ der Selektierung
+    std::set<unsigned> selectedItems_; /// aktuell ausgewählte Buttons
+    int select_type;                   /// Typ der Selektierung
 };
 
 #endif // !CTRLMULTISELECTGROUP_H_INCLUDED

--- a/libs/s25main/controls/ctrlOptionGroup.h
+++ b/libs/s25main/controls/ctrlOptionGroup.h
@@ -21,6 +21,7 @@
 
 #include "ctrlButton.h"
 #include "ctrlGroup.h"
+#include <boost/optional.hpp>
 class MouseCoords;
 class Window;
 
@@ -39,9 +40,9 @@ public:
     ctrlOptionGroup(Window* parent, unsigned id, int select_type);
 
     /// Selektiert einen neuen Button
-    void SetSelection(unsigned short selection, bool notify = false);
+    void SetSelection(unsigned selection, bool notify = false);
     /// Gibt den aktuell selektierten Button zurück
-    unsigned short GetSelection() const { return selection_; }
+    unsigned GetSelection() const;
     // Gibt einen Button aus der Gruppe zurück zum direkten Bearbeiten
     ctrlButton* GetButton(unsigned id) { return GetCtrl<ctrlButton>(id); }
 
@@ -53,8 +54,8 @@ public:
     bool Msg_MouseMove(const MouseCoords& mc) override;
 
 private:
-    unsigned short selection_; /// aktuell ausgewählter Button ( @p 0xFFFF = nicht selektiert )
-    int select_type;           /// Typ der Selektierung
+    boost::optional<unsigned> selection_; /// Currently selected button ID, must be set via SetSelection after initialization
+    int select_type;                      /// Typ der Selektierung
 };
 
 #endif // !CTRLOPTIONGROUP_H_INCLUDED

--- a/libs/s25main/controls/ctrlScrollBar.cpp
+++ b/libs/s25main/controls/ctrlScrollBar.cpp
@@ -139,8 +139,11 @@ void ctrlScrollBar::Msg_ButtonClick(const unsigned ctrl_id)
  */
 void ctrlScrollBar::SetScrollPos(unsigned short scroll_pos)
 {
-    this->scroll_pos = scroll_pos;
-    UpdateSliderFromPos();
+    if(this->scroll_pos != scroll_pos)
+    {
+        this->scroll_pos = scroll_pos;
+        UpdateSliderFromPos();
+    }
 }
 
 /**
@@ -148,8 +151,11 @@ void ctrlScrollBar::SetScrollPos(unsigned short scroll_pos)
  */
 void ctrlScrollBar::SetRange(unsigned short scroll_range)
 {
-    this->scroll_range = scroll_range;
-    RecalculateSizes();
+    if(this->scroll_range != scroll_range)
+    {
+        this->scroll_range = scroll_range;
+        RecalculateSizes();
+    }
 }
 
 /**
@@ -157,8 +163,11 @@ void ctrlScrollBar::SetRange(unsigned short scroll_range)
  */
 void ctrlScrollBar::SetPageSize(unsigned short pagesize)
 {
-    this->pagesize = pagesize;
-    RecalculateSizes();
+    if(this->pagesize != pagesize)
+    {
+        this->pagesize = pagesize;
+        RecalculateSizes();
+    }
 }
 
 void ctrlScrollBar::Resize(const Extent& newSize)

--- a/libs/s25main/controls/ctrlTab.cpp
+++ b/libs/s25main/controls/ctrlTab.cpp
@@ -195,7 +195,7 @@ void ctrlTab::Msg_Group_ScrollShow(const unsigned /*group_id*/, const unsigned c
     GetParent()->Msg_Group_ScrollShow(this->GetID(), ctrl_id, visible);
 }
 
-void ctrlTab::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlTab::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const unsigned ctrl_id, const unsigned selection)
 {
     GetParent()->Msg_Group_OptionGroupChange(this->GetID(), ctrl_id, selection);
 }

--- a/libs/s25main/controls/ctrlTab.h
+++ b/libs/s25main/controls/ctrlTab.h
@@ -53,7 +53,7 @@ public:
     void Msg_Group_CheckboxChange(unsigned group_id, unsigned ctrl_id, bool checked) override;
     void Msg_Group_ProgressChange(unsigned group_id, unsigned ctrl_id, unsigned short position) override;
     void Msg_Group_ScrollShow(unsigned group_id, unsigned ctrl_id, bool visible) override;
-    void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_Group_Timer(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_TableSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
     void Msg_Group_TableRightButton(unsigned group_id, unsigned ctrl_id, int selection) override;

--- a/libs/s25main/desktops/dskHostGame.cpp
+++ b/libs/s25main/desktops/dskHostGame.cpp
@@ -668,11 +668,12 @@ void dskHostGame::Msg_ButtonClick(const unsigned ctrl_id)
             {
                 std::unique_ptr<iwAddons> w;
                 if(allowAddonChange && (!lua || lua->IsChangeAllowed("addonsAll")))
-                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::HOSTGAME);
+                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, AddonChangeAllowed::All);
                 else if(allowAddonChange)
-                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::HOSTGAME_WHITELIST, lua->GetAllowedAddons());
+                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, AddonChangeAllowed::WhitelistOnly,
+                                                   lua->GetAllowedAddons());
                 else
-                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, iwAddons::READONLY);
+                    w = std::make_unique<iwAddons>(gameLobby->getSettings(), this, AddonChangeAllowed::None);
                 WINDOWMANAGER.Show(std::move(w));
             }
         }

--- a/libs/s25main/desktops/dskHostGame.cpp
+++ b/libs/s25main/desktops/dskHostGame.cpp
@@ -800,7 +800,7 @@ void dskHostGame::Msg_CheckboxChange(const unsigned ctrl_id, const bool /*checke
     }
 }
 
-void dskHostGame::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void dskHostGame::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     if(ctrl_id == ID_CHAT_TAB)
     {

--- a/libs/s25main/desktops/dskHostGame.h
+++ b/libs/s25main/desktops/dskHostGame.h
@@ -66,7 +66,7 @@ private:
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
     void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
 
     void LC_RankingInfo(const LobbyPlayerInfo& player) override;
 

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -402,7 +402,7 @@ void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsign
     }
 }
 
-void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {
@@ -496,7 +496,7 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
     }
 }
 
-void dskOptions::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void dskOptions::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/desktops/dskOptions.h
+++ b/libs/s25main/desktops/dskOptions.h
@@ -31,14 +31,14 @@ public:
     ~dskOptions() override;
 
 private:
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
 
     void Msg_Group_ButtonClick(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_ProgressChange(unsigned group_id, unsigned ctrl_id, unsigned short position) override;
     void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
-    void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
 
 private:
     GlobalGameSettings ggs;

--- a/libs/s25main/desktops/dskSelectMap.cpp
+++ b/libs/s25main/desktops/dskSelectMap.cpp
@@ -149,7 +149,7 @@ dskSelectMap::~dskSelectMap()
     GAMECLIENT.RemoveInterface(this);
 }
 
-void dskSelectMap::Msg_OptionGroupChange(const unsigned /*ctrl_id*/, const int selection)
+void dskSelectMap::Msg_OptionGroupChange(const unsigned /*ctrl_id*/, unsigned selection)
 {
     auto* table = GetCtrl<ctrlTable>(1);
 

--- a/libs/s25main/desktops/dskSelectMap.h
+++ b/libs/s25main/desktops/dskSelectMap.h
@@ -42,7 +42,7 @@ private:
 
     void FillTable(const std::vector<std::string>& files);
 
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
     void Msg_TableSelectItem(unsigned ctrl_id, int selection) override;

--- a/libs/s25main/gameTypes/InventorySetting.h
+++ b/libs/s25main/gameTypes/InventorySetting.h
@@ -21,27 +21,16 @@
 #include <array>
 
 /// Setting for each item in a warehouses inventory
-struct EInventorySetting
+enum class EInventorySetting : unsigned
 {
-    enum Type
-    {
-        STOP = 0,
-        SEND = 1,
-        COLLECT = 2
-    };
-    static const int COUNT = COLLECT + 1;
-
-    Type t_;
-    EInventorySetting() : t_(STOP) {}
-    EInventorySetting(Type t) : t_(t) { RTTR_Assert(t_ >= STOP && t_ < COUNT); }
-    operator Type() const { return t_; }
+    STOP = 0,
+    SEND = 1,
+    COLLECT = 2
 };
-//-V:EInventorySetting:801
 
 struct InventorySetting
 {
     InventorySetting() : state(0) {}
-    InventorySetting(const EInventorySetting::Type setting) : state(MakeBitField(setting)) {}
     InventorySetting(const EInventorySetting setting) : state(MakeBitField(setting)) {}
     explicit InventorySetting(unsigned char state) : state(state) { MakeValid(); }
     inline bool IsSet(EInventorySetting setting) const;

--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "rttrDefines.h" // IWYU pragma: keep
 #include "iwAddons.h"
-
-#include <utility>
-
 #include "GlobalGameSettings.h"
 #include "Loader.h"
 #include "addons/Addon.h"
@@ -28,25 +24,43 @@
 #include "helpers/containerUtils.h"
 #include "gameData/const_gui_ids.h"
 #include "s25util/colors.h"
+#include <utility>
 
-iwAddons::iwAddons(GlobalGameSettings& ggs, Window* parent, ChangePolicy policy, std::vector<AddonId> addonIds)
+namespace {
+enum
+{
+    ID_txtAddFeatures,
+    ID_btApply,
+    ID_btAbort,
+    ID_btS2Defaults,
+    ID_grpAddonGroup,
+    ID_scroll,
+    ID_grpAddonsStart
+};
+/// Breite der Scrollbar
+constexpr unsigned SCROLLBAR_WIDTH = 20;
+constexpr unsigned AddonGuiLineHeight = 30;
+
+} // namespace
+
+iwAddons::iwAddons(GlobalGameSettings& ggs, Window* parent, AddonChangeAllowed policy, std::vector<AddonId> whitelistedAddons)
     : IngameWindow(CGI_ADDONS, IngameWindow::posLastOrCenter, Extent(700, 500), _("Addon Settings"), LOADER.GetImageN("resource", 41), true,
                    false, parent),
-      ggs(ggs), policy(policy), addonIds(std::move(addonIds))
+      ggs(ggs), policy_(policy), whitelistedAddons_(std::move(whitelistedAddons))
 {
-    AddText(0, DrawPoint(20, 30), _("Additional features:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddText(ID_txtAddFeatures, DrawPoint(20, 30), _("Additional features:"), COLOR_YELLOW, FontStyle{}, NormalFont);
 
     Extent btSize(200, 22);
-    if(policy != READONLY)
-        AddTextButton(1, DrawPoint(20, GetSize().y - 40), btSize, TC_GREEN2, _("Apply"), NormalFont, _("Apply Changes"));
+    if(policy != AddonChangeAllowed::None)
+        AddTextButton(ID_btApply, DrawPoint(20, GetSize().y - 40), btSize, TC_GREEN2, _("Apply"), NormalFont, _("Apply Changes"));
 
-    AddTextButton(2, DrawPoint(250, GetSize().y - 40), btSize, TC_RED1, _("Abort"), NormalFont, _("Close Without Saving"));
+    AddTextButton(ID_btAbort, DrawPoint(250, GetSize().y - 40), btSize, TC_RED1, _("Abort"), NormalFont, _("Close Without Saving"));
 
-    if(policy != READONLY)
-        AddTextButton(3, DrawPoint(480, GetSize().y - 40), btSize, TC_GREY, _("Default"), NormalFont, _("Use S2 Defaults"));
+    if(policy != AddonChangeAllowed::None)
+        AddTextButton(ID_btS2Defaults, DrawPoint(480, GetSize().y - 40), btSize, TC_GREY, _("Default"), NormalFont, _("Use S2 Defaults"));
 
     // Kategorien
-    ctrlOptionGroup* optiongroup = AddOptionGroup(5, ctrlOptionGroup::CHECK);
+    ctrlOptionGroup* optiongroup = AddOptionGroup(ID_grpAddonGroup, ctrlOptionGroup::CHECK);
     btSize = Extent(120, 22);
     // "Alle"
     optiongroup->AddTextButton(static_cast<unsigned>(AddonGroup::All), DrawPoint(20, 50), btSize, TC_GREEN2, _("All"), NormalFont);
@@ -61,10 +75,19 @@ iwAddons::iwAddons(GlobalGameSettings& ggs, Window* parent, ChangePolicy policy,
     // "Sonstiges"
     optiongroup->AddTextButton(static_cast<unsigned>(AddonGroup::Other), DrawPoint(560, 50), btSize, TC_GREEN2, _("Other"), NormalFont);
 
-    ctrlScrollBar* scrollbar =
-      AddScrollBar(6, DrawPoint(GetSize().x - SCROLLBAR_WIDTH - 20, 90), Extent(SCROLLBAR_WIDTH, GetSize().y - 140), SCROLLBAR_WIDTH,
-                   TC_GREEN2, (GetSize().y - 140) / 30 - 1);
-    scrollbar->SetRange(ggs.getNumAddons());
+    ctrlScrollBar* scrollbar = AddScrollBar(ID_scroll, DrawPoint(GetSize().x - SCROLLBAR_WIDTH - 20, 90),
+                                            Extent(SCROLLBAR_WIDTH, GetSize().y - 140), SCROLLBAR_WIDTH, TC_GREEN2, 1);
+    scrollbar->SetPageSize(scrollbar->GetSize().y / AddonGuiLineHeight);
+
+    for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+    {
+        const unsigned id = ID_grpAddonsStart + i;
+        const Addon* addon = ggs.getAddon(i);
+        RTTR_Assert(addon);
+        auto& group = *AddGroup(id);
+        addonGuis_.emplace_back(addon->createGui(group, isReadOnly(addon->getId())));
+        addonGuis_.back()->setStatus(group, ggs.getSelection(addon->getId()));
+    }
 
     optiongroup->SetSelection(static_cast<unsigned>(AddonGroup::All), true);
 }
@@ -77,113 +100,89 @@ void iwAddons::Msg_ButtonClick(const unsigned ctrl_id)
     {
         default: break;
 
-        case 1: // Apply changes
+        case ID_btApply:
         {
-            if(policy == READONLY)
-                Close();
-
-            // Einstellungen in ADDONMANAGER übertragen
-            for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+            if(policy_ != AddonChangeAllowed::None)
             {
-                unsigned status;
-                const Addon* addon = ggs.getAddon(i, status);
-
-                if(!addon)
-                    continue;
-
-                bool failed = false;
-                status = addon->getGuiStatus(this, 10 + 20 * i, failed);
-                if(!failed)
-                    ggs.setSelection(addon->getId(), status);
-            }
-
-            switch(policy)
-            {
-                default: break;
-                case SETDEFAULTS: { ggs.SaveSettings();
-                }
-                break;
-                case HOSTGAME:
-                case HOSTGAME_WHITELIST:
+                // Einstellungen in ADDONMANAGER übertragen
+                for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
                 {
-                    // send message via msgboxresult
-                    GetParent()->Msg_MsgBoxResult(GetID(), MSR_YES);
+                    const auto& group = *GetCtrl<ctrlGroup>(ID_grpAddonsStart + i);
+                    ggs.setSelection(ggs.getAddon(i)->getId(), addonGuis_[i]->getStatus(group));
                 }
-                break;
+
+                switch(policy_)
+                {
+                    default: break;
+                    case AddonChangeAllowed::AllAndSaveToConfig: ggs.SaveSettings(); break;
+                    case AddonChangeAllowed::All:
+                    case AddonChangeAllowed::WhitelistOnly:
+                        // send message via msgboxresult
+                        GetParent()->Msg_MsgBoxResult(GetID(), MSR_YES);
+                        break;
+                }
             }
             Close();
         }
         break;
 
-        case 2: // Discard changes
-        {
+        case ID_btAbort: // Discard changes
             Close();
-        }
-        break;
+            break;
 
-        case 3: // Load S2 Defaults
-        {
+        case ID_btS2Defaults: // Load S2 Defaults
             // Standardeinstellungen aufs Fenster übertragen
             for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
             {
-                unsigned status;
-                const Addon* addon = ggs.getAddon(i, status);
-
-                if(!addon)
-                    continue;
-                if(policy == HOSTGAME_WHITELIST && !helpers::contains(addonIds, addon->getId()))
-                    continue;
-
-                addon->setGuiStatus(this, 10 + 20 * i, addon->getDefaultStatus());
+                const Addon* addon = ggs.getAddon(i);
+                if(!isReadOnly(addon->getId()))
+                    addonGuis_[i]->setStatus(*GetCtrl<ctrlGroup>(ID_grpAddonsStart + i), addon->getDefaultStatus());
             }
-        }
-        break;
+            break;
     }
 }
 
 /// Aktualisiert die Addons, die angezeigt werden sollen
 void iwAddons::UpdateView(const AddonGroup selection)
 {
-    auto* scrollbar = GetCtrl<ctrlScrollBar>(6);
+    auto* scrollbar = GetCtrl<ctrlScrollBar>(ID_scroll);
+    const unsigned scrollPos = scrollbar->GetScrollPos();
+    const unsigned scrollPosEnd = scrollPos + scrollbar->GetPageSize();
     unsigned short y = 90;
     unsigned short numAddonsInCurCategory = 0;
     for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
     {
-        unsigned id = 10 + 20 * i;
-        unsigned status;
-        const Addon* addon = ggs.getAddon(i, status);
-
-        if(!addon)
-            continue;
+        const Addon* addon = ggs.getAddon(i);
         const bool isVisible = (addon->getGroups() & selection) != AddonGroup(0);
+        auto* group = GetCtrl<ctrlGroup>(ID_grpAddonsStart + i);
 
+        // Don't show addon's gui if addon is beyond selected group or is beyond current page scope
+        if(isVisible && numAddonsInCurCategory >= scrollPos && numAddonsInCurCategory < scrollPosEnd)
+        {
+            group->SetVisible(true);
+            group->SetPos({group->GetPos().x, y});
+            y += AddonGuiLineHeight;
+        } else
+            group->SetVisible(false);
         if(isVisible)
             ++numAddonsInCurCategory;
-        // hide addon's gui if addon is beyond selected group or is beyond current page scope
-        if(!isVisible || numAddonsInCurCategory < scrollbar->GetScrollPos() + 1
-           || numAddonsInCurCategory > (unsigned)(scrollbar->GetScrollPos() + scrollbar->GetPageSize()) + 1)
-        {
-            addon->hideGui(this, id);
-            continue;
-        }
+    }
+    scrollbar->SetRange(numAddonsInCurCategory);
+}
 
-        bool isReadOnly = policy == READONLY || (policy == HOSTGAME_WHITELIST && !helpers::contains(addonIds, addon->getId()));
-        addon->createGui(this, id, y, isReadOnly, status);
-    }
-    if(numAddonsInCurCategory_ != numAddonsInCurCategory)
-    {
-        numAddonsInCurCategory_ = numAddonsInCurCategory;
-        scrollbar->SetRange(numAddonsInCurCategory);
-    }
+bool iwAddons::isReadOnly(AddonId id) const
+{
+    return policy_ == AddonChangeAllowed::None
+           || (policy_ == AddonChangeAllowed::WhitelistOnly && !helpers::contains(whitelistedAddons_, id));
 }
 
 void iwAddons::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {
-        case 5: // richtige Kategorie anzeigen
+        case ID_grpAddonGroup: // richtige Kategorie anzeigen
         {
-            GetCtrl<ctrlScrollBar>(6)->SetScrollPos(0);
+            GetCtrl<ctrlScrollBar>(ID_scroll)->SetScrollPos(0);
             UpdateView(static_cast<AddonGroup>(selection));
         }
         break;
@@ -195,20 +194,18 @@ void iwAddons::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned sele
  */
 void iwAddons::Msg_ScrollChange(const unsigned /*ctrl_id*/, const unsigned short /*position*/)
 {
-    auto* optiongroup = GetCtrl<ctrlOptionGroup>(5);
+    auto* optiongroup = GetCtrl<ctrlOptionGroup>(ID_grpAddonGroup);
     UpdateView(static_cast<AddonGroup>(optiongroup->GetSelection()));
 }
 
 bool iwAddons::Msg_WheelUp(const MouseCoords& /*mc*/)
 {
-    auto* scrollbar = GetCtrl<ctrlScrollBar>(6);
-    scrollbar->Scroll(-2);
+    GetCtrl<ctrlScrollBar>(ID_scroll)->Scroll(-2);
     return true;
 }
 
 bool iwAddons::Msg_WheelDown(const MouseCoords& /*mc*/)
 {
-    auto* scrollbar = GetCtrl<ctrlScrollBar>(6);
-    scrollbar->Scroll(+2);
+    GetCtrl<ctrlScrollBar>(ID_scroll)->Scroll(+2);
     return true;
 }

--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -49,22 +49,24 @@ iwAddons::iwAddons(GlobalGameSettings& ggs, Window* parent, ChangePolicy policy,
     ctrlOptionGroup* optiongroup = AddOptionGroup(5, ctrlOptionGroup::CHECK);
     btSize = Extent(120, 22);
     // "Alle"
-    optiongroup->AddTextButton(ADDONGROUP_ALL, DrawPoint(20, 50), btSize, TC_GREEN2, _("All"), NormalFont);
+    optiongroup->AddTextButton(static_cast<unsigned>(AddonGroup::All), DrawPoint(20, 50), btSize, TC_GREEN2, _("All"), NormalFont);
     // "Militär"
-    optiongroup->AddTextButton(ADDONGROUP_MILITARY, DrawPoint(150, 50), btSize, TC_GREEN2, _("Military"), NormalFont);
+    optiongroup->AddTextButton(static_cast<unsigned>(AddonGroup::Military), DrawPoint(150, 50), btSize, TC_GREEN2, _("Military"),
+                               NormalFont);
     // "Wirtschaft"
-    optiongroup->AddTextButton(ADDONGROUP_ECONOMY, DrawPoint(290, 50), btSize, TC_GREEN2, _("Economy"), NormalFont);
+    optiongroup->AddTextButton(static_cast<unsigned>(AddonGroup::Economy), DrawPoint(290, 50), btSize, TC_GREEN2, _("Economy"), NormalFont);
     // "Spielverhalten"
-    optiongroup->AddTextButton(ADDONGROUP_GAMEPLAY, DrawPoint(430, 50), btSize, TC_GREEN2, _("Gameplay"), NormalFont);
+    optiongroup->AddTextButton(static_cast<unsigned>(AddonGroup::GamePlay), DrawPoint(430, 50), btSize, TC_GREEN2, _("Gameplay"),
+                               NormalFont);
     // "Sonstiges"
-    optiongroup->AddTextButton(ADDONGROUP_OTHER, DrawPoint(560, 50), btSize, TC_GREEN2, _("Other"), NormalFont);
+    optiongroup->AddTextButton(static_cast<unsigned>(AddonGroup::Other), DrawPoint(560, 50), btSize, TC_GREEN2, _("Other"), NormalFont);
 
     ctrlScrollBar* scrollbar =
       AddScrollBar(6, DrawPoint(GetSize().x - SCROLLBAR_WIDTH - 20, 90), Extent(SCROLLBAR_WIDTH, GetSize().y - 140), SCROLLBAR_WIDTH,
                    TC_GREEN2, (GetSize().y - 140) / 30 - 1);
     scrollbar->SetRange(ggs.getNumAddons());
 
-    optiongroup->SetSelection(ADDONGROUP_ALL, true);
+    optiongroup->SetSelection(static_cast<unsigned>(AddonGroup::All), true);
 }
 
 iwAddons::~iwAddons() = default;
@@ -140,7 +142,7 @@ void iwAddons::Msg_ButtonClick(const unsigned ctrl_id)
 }
 
 /// Aktualisiert die Addons, die angezeigt werden sollen
-void iwAddons::UpdateView(const unsigned short selection)
+void iwAddons::UpdateView(const AddonGroup selection)
 {
     auto* scrollbar = GetCtrl<ctrlScrollBar>(6);
     unsigned short y = 90;
@@ -153,12 +155,12 @@ void iwAddons::UpdateView(const unsigned short selection)
 
         if(!addon)
             continue;
-        unsigned groups = addon->getGroups();
+        const bool isVisible = (addon->getGroups() & selection) != AddonGroup(0);
 
-        if((groups & selection) == selection)
+        if(isVisible)
             ++numAddonsInCurCategory;
         // hide addon's gui if addon is beyond selected group or is beyond current page scope
-        if(((groups & selection) != selection) || numAddonsInCurCategory < scrollbar->GetScrollPos() + 1
+        if(!isVisible || numAddonsInCurCategory < scrollbar->GetScrollPos() + 1
            || numAddonsInCurCategory > (unsigned)(scrollbar->GetScrollPos() + scrollbar->GetPageSize()) + 1)
         {
             addon->hideGui(this, id);
@@ -175,15 +177,14 @@ void iwAddons::UpdateView(const unsigned short selection)
     }
 }
 
-void iwAddons::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void iwAddons::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {
         case 5: // richtige Kategorie anzeigen
         {
-            auto* scrollbar = GetCtrl<ctrlScrollBar>(6);
-            scrollbar->SetScrollPos(0);
-            UpdateView(selection);
+            GetCtrl<ctrlScrollBar>(6)->SetScrollPos(0);
+            UpdateView(static_cast<AddonGroup>(selection));
         }
         break;
     }
@@ -195,7 +196,7 @@ void iwAddons::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection
 void iwAddons::Msg_ScrollChange(const unsigned /*ctrl_id*/, const unsigned short /*position*/)
 {
     auto* optiongroup = GetCtrl<ctrlOptionGroup>(5);
-    UpdateView(optiongroup->GetSelection());
+    UpdateView(static_cast<AddonGroup>(optiongroup->GetSelection()));
 }
 
 bool iwAddons::Msg_WheelUp(const MouseCoords& /*mc*/)

--- a/libs/s25main/ingameWindows/iwAddons.h
+++ b/libs/s25main/ingameWindows/iwAddons.h
@@ -21,29 +21,26 @@
 
 #include "IngameWindow.h"
 #include "addons/const_addons.h"
+#include <memory>
 #include <vector>
 
+class AddonGui;
 class GlobalGameSettings;
 class MouseCoords;
 
+enum class AddonChangeAllowed
+{
+    All,
+    WhitelistOnly,
+    None,
+    AllAndSaveToConfig
+};
+
 class iwAddons : public IngameWindow
 {
-    /// Breite der Scrollbar
-    static const unsigned short SCROLLBAR_WIDTH = 20;
-
 public:
-    enum ChangePolicy
-    {
-        HOSTGAME,
-        /// Allow only whitelisted addons to change
-        HOSTGAME_WHITELIST,
-        READONLY,
-        SETDEFAULTS
-    };
-
-public:
-    iwAddons(GlobalGameSettings& ggs, Window* parent = nullptr, ChangePolicy policy = SETDEFAULTS,
-             std::vector<AddonId> addonIds = std::vector<AddonId>());
+    iwAddons(GlobalGameSettings& ggs, Window* parent = nullptr, AddonChangeAllowed policy = AddonChangeAllowed::AllAndSaveToConfig,
+             std::vector<AddonId> whitelistedAddons = {});
     ~iwAddons() override;
 
 protected:
@@ -56,12 +53,13 @@ protected:
 private:
     /// settings we edit in this window
     GlobalGameSettings& ggs;
-    ChangePolicy policy;
-    std::vector<AddonId> addonIds;
-    unsigned short numAddonsInCurCategory_;
+    AddonChangeAllowed policy_;
+    std::vector<AddonId> whitelistedAddons_;
+    std::vector<std::unique_ptr<AddonGui>> addonGuis_;
 
     /// Aktualisiert die Addons, die angezeigt werden sollen
     void UpdateView(AddonGroup selection);
+    bool isReadOnly(AddonId) const;
 };
 
 #endif // !iwENHANCEMENTS_H_INCLUDED

--- a/libs/s25main/ingameWindows/iwAddons.h
+++ b/libs/s25main/ingameWindows/iwAddons.h
@@ -48,13 +48,10 @@ public:
 
 protected:
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_ScrollChange(unsigned ctrl_id, unsigned short position) override;
     bool Msg_WheelUp(const MouseCoords& mc) override;
     bool Msg_WheelDown(const MouseCoords& mc) override;
-
-    /// Aktualisiert die Addons, die angezeigt werden sollen
-    void UpdateView(unsigned short selection);
 
 private:
     /// settings we edit in this window
@@ -62,6 +59,9 @@ private:
     ChangePolicy policy;
     std::vector<AddonId> addonIds;
     unsigned short numAddonsInCurCategory_;
+
+    /// Aktualisiert die Addons, die angezeigt werden sollen
+    void UpdateView(AddonGroup selection);
 };
 
 #endif // !iwENHANCEMENTS_H_INCLUDED

--- a/libs/s25main/ingameWindows/iwChat.cpp
+++ b/libs/s25main/ingameWindows/iwChat.cpp
@@ -50,7 +50,7 @@ void iwChat::Msg_PaintBefore()
     GetCtrl<ctrlEdit>(0)->SetFocus();
 }
 
-void iwChat::Msg_OptionGroupChange(const unsigned /*ctrl_id*/, const int selection)
+void iwChat::Msg_OptionGroupChange(const unsigned /*ctrl_id*/, unsigned selection)
 {
     chat_dest = static_cast<unsigned char>(selection);
     GetCtrl<ctrlEdit>(0)->SetFocus();

--- a/libs/s25main/ingameWindows/iwChat.h
+++ b/libs/s25main/ingameWindows/iwChat.h
@@ -38,7 +38,7 @@ public:
 
 private:
     void Msg_PaintBefore() override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_EditEnter(unsigned ctrl_id) override;
 };
 

--- a/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
@@ -154,7 +154,7 @@ void iwDirectIPConnect::Msg_ButtonClick(const unsigned ctrl_id)
     }
 }
 
-void iwDirectIPConnect::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void iwDirectIPConnect::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/ingameWindows/iwDirectIPConnect.h
+++ b/libs/s25main/ingameWindows/iwDirectIPConnect.h
@@ -41,7 +41,7 @@ private:
     void Msg_EditChange(unsigned ctrl_id) override;
     void Msg_EditEnter(unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
 
     void CI_Error(ClientError ce) override;
     void CI_NextConnectState(ConnectState cs) override;

--- a/libs/s25main/ingameWindows/iwDirectIPCreate.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPCreate.cpp
@@ -113,7 +113,7 @@ void iwDirectIPCreate::Msg_EditEnter(const unsigned ctrl_id)
     }
 }
 
-void iwDirectIPCreate::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void iwDirectIPCreate::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/ingameWindows/iwDirectIPCreate.h
+++ b/libs/s25main/ingameWindows/iwDirectIPCreate.h
@@ -33,7 +33,7 @@ protected:
     void Msg_EditChange(unsigned ctrl_id) override;
     void Msg_EditEnter(unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
 
 private:
     void SetText(const std::string& text, unsigned color, bool button);

--- a/libs/s25main/ingameWindows/iwLobbyConnect.cpp
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.cpp
@@ -230,7 +230,7 @@ void iwLobbyConnect::Msg_ButtonClick(const unsigned ctrl_id)
     }
 }
 
-void iwLobbyConnect::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void iwLobbyConnect::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/ingameWindows/iwLobbyConnect.h
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.h
@@ -38,7 +38,7 @@ protected:
     void Msg_EditChange(unsigned ctrl_id) override;
     void Msg_EditEnter(unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     bool Msg_KeyDown(const KeyEvent&) override;
 
 private:

--- a/libs/s25main/ingameWindows/iwMerchandiseStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwMerchandiseStatistics.cpp
@@ -117,18 +117,15 @@ void iwMerchandiseStatistics::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 17: // Alle abwählen
         {
-            const std::set<unsigned short>& active = GetCtrl<ctrlMultiSelectGroup>(22)->GetSelection();
-            for(auto it = active.begin(); it != active.end();)
-            {
-                auto curIt = it++;
-                GetCtrl<ctrlMultiSelectGroup>(22)->RemoveSelection(*curIt);
-            }
+            const std::set<unsigned> active = GetCtrl<ctrlMultiSelectGroup>(22)->GetSelection();
+            for(unsigned sel : active)
+                GetCtrl<ctrlMultiSelectGroup>(22)->RemoveSelection(sel);
         }
         break;
     }
 }
 
-void iwMerchandiseStatistics::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void iwMerchandiseStatistics::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {
@@ -162,14 +159,14 @@ void iwMerchandiseStatistics::DrawStatistic()
     const int stepX = sizeX / NUM_STAT_STEPS; // 6
 
     // Aktive Buttons holen (Achtung ID == BarColor + 1)
-    const std::set<unsigned short>& active = GetCtrl<ctrlMultiSelectGroup>(22)->GetSelection();
+    const std::set<unsigned>& active = GetCtrl<ctrlMultiSelectGroup>(22)->GetSelection();
 
     // Statistik holen
     const GamePlayer::Statistic stat = player.GetStatistic(currentTime);
 
     // Maximalwert suchen
     unsigned short max = 1;
-    for(unsigned short it : active)
+    for(unsigned it : active)
     {
         for(unsigned i = 0; i < NUM_STAT_STEPS; ++i)
         {

--- a/libs/s25main/ingameWindows/iwMerchandiseStatistics.h
+++ b/libs/s25main/ingameWindows/iwMerchandiseStatistics.h
@@ -55,7 +55,7 @@ private:
 
     // Durchgereichte Methoden vom Window
     void Draw_() override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
 };
 

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -92,7 +92,7 @@ iwSettings::~iwSettings()
     }
 }
 
-void iwSettings::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void iwSettings::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/ingameWindows/iwSettings.h
+++ b/libs/s25main/ingameWindows/iwSettings.h
@@ -31,7 +31,7 @@ public:
 
 private:
     std::vector<VideoMode> video_modes; /// Vector für die Auflösungen
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
 };
 

--- a/libs/s25main/ingameWindows/iwStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwStatistics.cpp
@@ -199,7 +199,7 @@ void iwStatistics::Msg_ButtonClick(const unsigned ctrl_id)
     }
 }
 
-void iwStatistics::Msg_OptionGroupChange(const unsigned ctrl_id, const int selection)
+void iwStatistics::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/ingameWindows/iwStatistics.h
+++ b/libs/s25main/ingameWindows/iwStatistics.h
@@ -45,7 +45,7 @@ private:
 
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Draw_() override;
-    void Msg_OptionGroupChange(unsigned ctrl_id, int selection) override;
+    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void DrawStatistic(StatisticType type);
     void DrawAxis();
 };


### PR DESCRIPTION
Refactor the addons to fix #1001 in a more complete way than #1110 although it uses the same approach: Create all GUI controls on start of the iwAddons window. Also (same as there) the shifting of the addons is done in the window, not the addon classes). Thanks @iceslab !

Reasoning: The pagesize of the scrollbar assumes a height of 30. Factored that out into a constant.

@Flow86: After the (minor) refactoring of the Addon classes themselves I don't see why we really need to have different classes. My suggestion:
- Only have the `Addon` class and instances of it
- (Opt) Have Addon store its current value (to avoid the stuff with AddonWithStatus) or make a struct `AddonData` (containing the description) and `Addon` containing the AddonData, status and accessors with current interface.
- Store an enum whether this is a bool or list addon (others aren't really possible)
- Create the GUI in iwAddons based on that enum. we have implicit restrictions on height and width anyway so Addon::createGui was never really flexible.
- Create a factory for creating a vector of all addons (currently in GlobalGameSettings) instead of the addons.h to have all addon stuff inside the addon folder. No one needs to know the types that exist, only the AddonId and the status
- Also cut down on the number of required steps to add an addon, currently:
  - Add new (really small file) with just some data
  - Add new AddonId with implicit author
  - Add to addons.h
  - Add to GlobalGameSettings
- Better:
  - Add all "Addons" (basically their data) into a single file which serves as the factory (probably a class)
  - So now you need to add a new AddonId and add a call to `registerAddon(AddonId, data)`, done
  - I'd also add the authors name to the data (although it wouldn't be currently used)
  - Downside: File becomes quite big, but that should be faster to compile than 40 small files. 
- Finally: Add an assert/exception when `isEnabled` is called on a non-bool addon and rework the handling of missing addons. IMO this shouldn't ever happen but currently some fallback returning a default or arbitrary value is implemented.