### PR TITLE
Fix build on travis and update readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
       - sdl_mixer
       - gettext
       - miniupnpc
+      - git-lfs
     update: true
 
 cache:
@@ -33,6 +34,8 @@ before_install:
   - eval "${MATRIX_EVAL}"
   - DEPS_DIR="${HOME}/.cache"
   - mkdir -p "${DEPS_DIR}"
+  - git lfs install
+  - git lfs pull
 
 install:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew link gettext --force; fi

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ see more information on http://www.rttr.info
 
 # Current Build Info
 
-Travis CI: [![Travis CI Build Info](https://travis-ci.org/Return-To-The-Roots/s25client.svg?branch=master)](https://travis-ci.org/Return-To-The-Roots/s25client)
+Travis CI: [![Travis CI Build Info](https://travis-ci.com/Return-To-The-Roots/s25client.svg?branch=master)](https://travis-ci.com/Return-To-The-Roots/s25client)
 
 Appveyor: [![Appveyor CI Build Info](https://ci.appveyor.com/api/projects/status/ufw8v9mi80va1me7/branch/master?svg=true)](https://ci.appveyor.com/project/Flow86/s25client/branch/master)
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ All of them can be installed with the package manager.
 
 ### Prerequisite MacOSX:
 - cmake
-- git
+- git + git-lfs
 - boost
-- sdl(2)
-- sdl_mixer
+- sdl2
+- sdl2_mixer
 - gettext (make sure it is in your path with e.g. `brew link --force gettext`)
 - miniupnpc
 
@@ -70,6 +70,7 @@ Nix users can open a nix-shell to get a development environment with all package
 ```
 git clone --recursive https://github.com/Return-To-The-Roots/s25client s25client
 cd s25client
+git lfs pull
 nix-shell # Optional, for Nix users only
 mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
@@ -77,6 +78,9 @@ make
 ```
 Note: by using the `-G` option of `cmake` you can specify a generator, e.g. `cmake -G Xcode -DCMAKE_BUILD_TYPE=Release ..` will generate an Xcode project. 
 Please check `cmake --help` for more options. 
+
+The `git lfs pull` should not be required if you have properly set up git-lfs before by running `git lfs install`.
+This is recommended to do either before and/or after the clone.
 
 ### Optimizations:
 There are various CMake options to control the build and optimization including ARM (Rasberry PI etc.) related ones. Examples:


### PR DESCRIPTION
This adds the `git lfs` commands to the readme and travis

It also updates the travis badge still pointing to travis.org instead of travis.com