### PR TITLE
set locale before parsing playlist

### DIFF
--- a/libs/s25main/Playlist.cpp
+++ b/libs/s25main/Playlist.cpp
@@ -25,6 +25,7 @@
 #include <boost/nowide/fstream.hpp>
 #include <algorithm>
 #include <random>
+#include <sstream>
 
 namespace bnw = boost::nowide;
 

--- a/libs/s25main/Playlist.cpp
+++ b/libs/s25main/Playlist.cpp
@@ -79,7 +79,7 @@ bool Playlist::SaveAs(const std::string& filename, const bool overwrite)
         }
     }
 
-    bnw::ofstream out(filename.c_str());
+    s25util::ClassicImbuedStream<bnw::ofstream> out(filename.c_str());
     if(!out.good())
         return false;
 

--- a/libs/s25main/Playlist.cpp
+++ b/libs/s25main/Playlist.cpp
@@ -19,12 +19,12 @@
 #include "ingameWindows/iwMusicPlayer.h"
 #include "mygettext/mygettext.h"
 #include "s25util/Log.h"
+#include "s25util/StringConversion.h"
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <algorithm>
 #include <random>
-#include <sstream>
 
 namespace bnw = boost::nowide;
 
@@ -115,8 +115,7 @@ bool Playlist::Load(Log& logger, const std::string& filename)
         return false;
 
     std::string line, random_str;
-    std::stringstream sline;
-    sline.imbue(std::locale("C"));
+    s25util::ClassicImbuedStream<std::stringstream> sline;
 
     if(!std::getline(in, line))
         return false;

--- a/libs/s25main/Playlist.cpp
+++ b/libs/s25main/Playlist.cpp
@@ -116,6 +116,7 @@ bool Playlist::Load(Log& logger, const std::string& filename)
 
     std::string line, random_str;
     std::stringstream sline;
+    sline.imbue(std::locale("C"));
 
     if(!std::getline(in, line))
         return false;


### PR DESCRIPTION
i've got a loading error in Playlist.cpp on my machine. I traced the fault down to Playlist loading with my environment's locale. My suggested fix is to apply "C" locale before starting to parse.

Before applying this patch, it should refuse loading by running
`LC_ALL=nb_NO.UTF-8 bin/s25client`
while running
`LC_ALL=C bin/s25client`
successfully loads
