### PR TITLE
Map load error handling

### DIFF
--- a/libs/s25main/controls/ctrlPreviewMinimap.cpp
+++ b/libs/s25main/controls/ctrlPreviewMinimap.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "rttrDefines.h" // IWYU pragma: keep
 #include "ctrlPreviewMinimap.h"
 #include "ogl/glArchivItem_Map.h"
 #include "libsiedler2/ArchivItem_Map_Header.h"
@@ -33,13 +32,16 @@ ctrlPreviewMinimap::ctrlPreviewMinimap(Window* parent, const unsigned id, const 
  */
 void ctrlPreviewMinimap::Draw_()
 {
+    if(mapSize == Extent::all(0))
+        return;
+
     // Button drumrum zeichnen
     Draw3DBorder(GetBoundaryRect(), TC_GREY, true);
 
     // Map ansich zeichnen
     DrawMap(minimap);
 
-    Extent playerPxlSize(4, 4);
+    const Extent playerPxlSize(4, 4);
     const DrawPoint basePos = GetDrawPos();
     // Startpositionen zeichnen
     for(const Player& player : players)
@@ -67,8 +69,8 @@ void ctrlPreviewMinimap::SetMap(const glArchivItem_Map* const s2map)
         return;
     }
 
-    unsigned short map_width = s2map->getHeader().getWidth();
-    unsigned short map_height = s2map->getHeader().getHeight();
+    const unsigned short map_width = s2map->getHeader().getWidth();
+    const unsigned short map_height = s2map->getHeader().getHeight();
     SetMapSize(Extent(map_width, map_height));
     minimap.SetMap(*s2map);
 
@@ -80,8 +82,8 @@ void ctrlPreviewMinimap::SetMap(const glArchivItem_Map* const s2map)
             // Startposition eines Spielers an dieser Stelle?
             if(s2map->GetMapDataAt(MAP_TYPE, x, y) != 0x80)
                 continue;
-            unsigned player = s2map->GetMapDataAt(MAP_LANDSCAPE, x, y);
-            if(player < MAX_PLAYERS)
+            const unsigned player = s2map->GetMapDataAt(MAP_LANDSCAPE, x, y);
+            if(player < players.size())
             {
                 players[player].pos = MapPoint(x, y);
                 players[player].color = PLAYER_COLORS[player % PLAYER_COLORS.size()];

--- a/libs/s25main/controls/ctrlTable.cpp
+++ b/libs/s25main/controls/ctrlTable.cpp
@@ -242,7 +242,7 @@ const std::string& ctrlTable::GetItemText(unsigned short row, unsigned short col
     if(row >= rows_.size() || column >= columns_.size())
         return empty;
 
-    return rows_.at(row).columns.at(column);
+    return rows_[row].columns[column];
 }
 
 /**

--- a/libs/s25main/controls/ctrlTable.cpp
+++ b/libs/s25main/controls/ctrlTable.cpp
@@ -47,8 +47,12 @@ static int Compare(const std::string& a, const std::string& b, ctrlTable::SortTy
             RTTR_Assert(ss_a);
             RTTR_Assert(ss_b);
             if(x_a * y_a == x_b * y_b)
-                return 0;
-            else
+            {
+                if(x_a == x_b)
+                    return 0;
+                else
+                    return (x_a < x_b) ? -1 : 1;
+            } else
                 return (x_a * y_a < x_b * y_b) ? -1 : 1;
         }
         break;
@@ -115,7 +119,7 @@ static int Compare(const std::string& a, const std::string& b, ctrlTable::SortTy
 }
 
 ctrlTable::ctrlTable(Window* parent, unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font,
-                     std::vector<Column> columns)
+                     Columns columns)
     : Window(parent, id, pos, elMax(size, Extent(20, 30))), tc(tc), font(font), columns_(std::move(columns)), selection_(-1),
       sortColumn_(-1), sortDir_(TableSortDir::Ascending)
 {

--- a/libs/s25main/controls/ctrlTable.h
+++ b/libs/s25main/controls/ctrlTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -21,7 +21,6 @@
 
 #include "Window.h"
 #include "gameTypes/TextureColor.h"
-#include <cstdarg>
 #include <string>
 #include <vector>
 
@@ -36,6 +35,11 @@ enum class TableSortType
     Number,
     Date,
     Default
+};
+enum class TableSortDir
+{
+    Ascending,
+    Descending
 };
 
 struct TableColumn
@@ -64,9 +68,9 @@ public:
     /// liefert den Wert eines Feldes.
     const std::string& GetItemText(unsigned short row, unsigned short column) const;
     /// sortiert die Zeilen.
-    void SortRows(int column, const bool* direction = nullptr);
-    int GetSortColumn() const { return sort_column; }
-    bool GetSortDirection() const { return sort_direction; }
+    void SortRows(unsigned column, TableSortDir sortDir);
+    int GetSortColumn() const { return sortColumn_; }
+    TableSortDir GetSortDirection() const { return sortDir_; }
     unsigned short GetNumRows() const { return static_cast<unsigned short>(rows_.size()); }
     unsigned short GetNumColumns() const { return static_cast<unsigned short>(columns_.size()); }
     int GetSelection() const { return selection_; }
@@ -104,8 +108,8 @@ private:
     /// Selected row. -1 for none
     int selection_;
     /// Column to sort by. -1 for none
-    int sort_column;
-    bool sort_direction;
+    int sortColumn_;
+    TableSortDir sortDir_;
 
     struct Row
     {

--- a/libs/s25main/controls/ctrlTable.h
+++ b/libs/s25main/controls/ctrlTable.h
@@ -56,8 +56,7 @@ public:
     using SortType = TableSortType;
     using Columns = std::vector<Column>;
 
-    ctrlTable(Window* parent, unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font,
-              std::vector<Column> columns);
+    ctrlTable(Window* parent, unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font, Columns columns);
 
     void Resize(const Extent& newSize) override;
     /// löscht alle Items.

--- a/libs/s25main/desktops/dskLAN.cpp
+++ b/libs/s25main/desktops/dskLAN.cpp
@@ -127,13 +127,13 @@ void dskLAN::UpdateServerList()
 
     auto* servertable = GetCtrl<ctrlTable>(ID_tblServer);
 
-    unsigned selection = servertable->GetSelection();
-    if(selection == 0xFFFF)
+    int selection = servertable->GetSelection();
+    if(selection == -1)
         selection = 0;
-    unsigned short column = servertable->GetSortColumn();
-    if(column == 0xFFFF)
-        column = 0;
-    bool direction = servertable->GetSortDirection();
+    int sortColumn = servertable->GetSortColumn();
+    if(sortColumn == -1)
+        sortColumn = 0;
+    const auto direction = servertable->GetSortDirection();
     servertable->DeleteAllItems();
 
     unsigned curId = 0;
@@ -145,7 +145,8 @@ void dskLAN::UpdateServerList()
         servertable->AddRow({id, name, gameInfo.info.map, player, gameInfo.info.version});
     }
 
-    servertable->SortRows(column, &direction);
+    if(sortColumn >= 0)
+        servertable->SortRows(sortColumn, direction);
     servertable->SetSelection(selection);
 }
 

--- a/libs/s25main/desktops/dskLobby.cpp
+++ b/libs/s25main/desktops/dskLobby.cpp
@@ -319,13 +319,13 @@ void dskLobby::LC_ServerList(const LobbyServerList& servers)
     auto* servertable = GetCtrl<ctrlTable>(10);
     bool first = servertable->GetNumRows() == 0;
 
-    unsigned selection = servertable->GetSelection();
-    if(selection == 0xFFFF)
+    int selection = servertable->GetSelection();
+    if(selection == -1)
         selection = 0;
-    unsigned short column = servertable->GetSortColumn();
-    if(column == 0xFFFF)
-        column = 0;
-    bool direction = servertable->GetSortDirection();
+    int sortColumn = servertable->GetSortColumn();
+    if(sortColumn == -1)
+        sortColumn = 0;
+    const auto direction = servertable->GetSortDirection();
     servertable->DeleteAllItems();
 
     std::set<unsigned> ids;
@@ -347,9 +347,9 @@ void dskLobby::LC_ServerList(const LobbyServerList& servers)
         servertable->AddRow({id, name, server.getMap(), player, server.getVersion(), ping});
     }
     if(first)
-        servertable->SortRows(0);
+        servertable->SortRows(0, TableSortDir::Ascending);
     else
-        servertable->SortRows(column, &direction);
+        servertable->SortRows(sortColumn, direction);
     servertable->SetSelection(selection);
 }
 
@@ -363,13 +363,13 @@ void dskLobby::LC_PlayerList(const LobbyPlayerList& players)
         LOADER.GetSoundN("sound", 114)->Play(255, false);
     }
 
-    unsigned selection = playertable->GetSelection();
-    if(selection == 0xFFFF)
+    int selection = playertable->GetSelection();
+    if(selection == -1)
         selection = 0;
-    unsigned short column = playertable->GetSortColumn();
-    if(column == 0xFFFF)
-        column = 0;
-    bool direction = playertable->GetSortDirection();
+    int sortColumn = playertable->GetSortColumn();
+    if(sortColumn == -1)
+        sortColumn = 0;
+    const auto direction = playertable->GetSortDirection();
     playertable->DeleteAllItems();
 
     for(const LobbyPlayerInfo& player : players)
@@ -384,9 +384,9 @@ void dskLobby::LC_PlayerList(const LobbyPlayerList& players)
         }
     }
     if(first)
-        playertable->SortRows(0);
+        playertable->SortRows(0, TableSortDir::Ascending);
     else
-        playertable->SortRows(column, &direction);
+        playertable->SortRows(sortColumn, direction);
     playertable->SetSelection(selection);
 }
 

--- a/libs/s25main/desktops/dskSelectMap.cpp
+++ b/libs/s25main/desktops/dskSelectMap.cpp
@@ -188,7 +188,7 @@ void dskSelectMap::Msg_OptionGroupChange(const unsigned /*ctrl_id*/, unsigned se
     table->SortRows(0, &sortAsc);
 
     // und Auswahl zurücksetzen
-    table->SetSelection(0);
+    table->SetSelection(-1);
 }
 
 /// Load a map, throw on error

--- a/libs/s25main/desktops/dskSelectMap.cpp
+++ b/libs/s25main/desktops/dskSelectMap.cpp
@@ -184,8 +184,7 @@ void dskSelectMap::Msg_OptionGroupChange(const unsigned /*ctrl_id*/, unsigned se
     }
 
     // Dann noch sortieren
-    bool sortAsc = true;
-    table->SortRows(0, &sortAsc);
+    table->SortRows(0, TableSortDir::Ascending);
 
     // und Auswahl zurücksetzen
     table->SetSelection(-1);

--- a/libs/s25main/desktops/dskSelectMap.h
+++ b/libs/s25main/desktops/dskSelectMap.h
@@ -25,6 +25,7 @@
 #include "network/CreateServerInfo.h"
 #include "liblobby/LobbyInterface.h"
 #include <boost/filesystem/path.hpp>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -70,7 +71,6 @@ private:
     void CreateRandomMap();
 
     void OnMapCreated(const std::string& mapPath);
-    void MarkMapAsBroken(int tableIdx, const std::string& reason);
 
     CreateServerInfo csi;
     MapSettings rndMapSettings;
@@ -80,7 +80,7 @@ private:
     /// Mapping of s2 ids to landscape names
     std::map<uint8_t, std::string> landscapeNames;
     /// Maps that we already know are broken
-    std::vector<boost::filesystem::path> brokenMapPaths;
+    std::set<boost::filesystem::path> brokenMapPaths;
 };
 
 #endif //! dskSELECTMAP_H_INCLUDED

--- a/libs/s25main/ingameWindows/iwPlayReplay.cpp
+++ b/libs/s25main/ingameWindows/iwPlayReplay.cpp
@@ -73,8 +73,7 @@ iwPlayReplay::iwPlayReplay()
     PopulateTable();
 
     // Nach Zeit Sortieren
-    bool bFalse = false;
-    GetCtrl<ctrlTable>(0)->SortRows(1, &bFalse);
+    GetCtrl<ctrlTable>(0)->SortRows(1, TableSortDir::Descending);
 }
 
 void iwPlayReplay::PopulateTable()
@@ -82,10 +81,10 @@ void iwPlayReplay::PopulateTable()
     static bool loadedOnce = false;
 
     auto* table = GetCtrl<ctrlTable>(0);
-    unsigned short sortCol = table->GetSortColumn();
-    if(sortCol == 0xFFFF)
+    int sortCol = table->GetSortColumn();
+    if(sortCol == -1)
         sortCol = 0;
-    bool sortDir = table->GetSortDirection();
+    const auto sortDir = table->GetSortDirection();
     table->DeleteAllItems();
 
     unsigned numInvalid = 0;
@@ -132,7 +131,7 @@ void iwPlayReplay::PopulateTable()
     }
 
     // Erst einmal nach Dateiname sortieren
-    table->SortRows(sortCol, &sortDir);
+    table->SortRows(sortCol, sortDir);
 
     auto* btDelInvalid = GetCtrl<ctrlTextButton>(5);
     if(numInvalid == 0)

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -106,8 +106,7 @@ void iwSaveLoad::RefreshTable()
     }
 
     // Nach Zeit Sortieren
-    bool bFalse = false;
-    GetCtrl<ctrlTable>(0)->SortRows(2, &bFalse);
+    GetCtrl<ctrlTable>(0)->SortRows(2, TableSortDir::Descending);
     loadedOnce = true;
 }
 


### PR DESCRIPTION
As explained in https://github.com/Return-To-The-Roots/s25client/issues/1243#issuecomment-636804549 this fixes #1243 by showing an error in the log for completely broken maps (e.g. wrong file format) and a message box when selecting an unsupported map.

To avoid this triggering without the user selecting anything (e.g. when there is only 1 map in a folder) I changed it so no map is selected when changing "folders"

Also some related fixes and refactoring:
- When no map was selected it was still drawn with size zero
- ctrlTable: Sorting behavior has now a better interface instead of some strange bool pointer

I have no idea how to unittest the dskSelectMap but did add some tests for table sorting