### PR TITLE
Add more restrictions to gameData loading and test them

### DIFF
--- a/libs/libGamedata/lua/GameDataLoader.cpp
+++ b/libs/libGamedata/lua/GameDataLoader.cpp
@@ -90,6 +90,8 @@ void GameDataLoader::Include(const std::string& filepath)
         };
         if(helpers::contains_if(filepath, [isAllowedChar](const char c) { return !isAllowedChar(c); }))
             throw LuaIncludeError("It contains disallowed chars. Allowed: alpha-numeric, underscore, slash and dot.");
+        if(bfs::path(filepath).is_absolute())
+            throw LuaIncludeError("Path to file must be relative to current file");
         bfs::path absFilePath = bfs::absolute(filepath, bfs::path(curFile_).parent_path());
         if(!bfs::is_regular_file(absFilePath))
             throw LuaIncludeError("File not found!");

--- a/tests/libGameData/testGameData.cpp
+++ b/tests/libGameData/testGameData.cpp
@@ -165,6 +165,24 @@ BOOST_AUTO_TEST_CASE(DetectFolderEscape)
     RTTR_REQUIRE_LOG_CONTAINS("outside the lua data directory", false);
 }
 
+#ifndef BOOST_WINDOWS_API
+BOOST_AUTO_TEST_CASE(DetectAbsolute)
+{
+    rttr::test::TmpFolder tmp;
+    bfs::path basePath(tmp.get() / "gameData");
+    create_directories(basePath);
+    {
+        bnw::ofstream file(basePath / "default.lua");
+        file << "include(\"/tmp/foo.lua\")\n";
+    }
+    WorldDescription desc;
+    GameDataLoader loader(desc, basePath.string());
+    rttr::test::LogAccessor logAcc;
+    BOOST_TEST(!loader.Load());
+    RTTR_REQUIRE_LOG_CONTAINS("relative", false);
+}
+#endif
+
 BOOST_AUTO_TEST_CASE(TextureCoords)
 {
     rttr::test::TmpFolder tmp;

--- a/tests/testHelpers/rttr/test/TmpFolder.hpp
+++ b/tests/testHelpers/rttr/test/TmpFolder.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2016 - 2020 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include <boost/filesystem.hpp>
+
+namespace rttr { namespace test {
+    class TmpFolder
+    {
+        boost::filesystem::path folder;
+
+    public:
+        explicit TmpFolder(const boost::filesystem::path& parent = boost::filesystem::temp_directory_path(),
+                           const boost::filesystem::path& pattern = "%%%%-%%%%-%%%%-%%%%")
+        {
+            do
+            {
+                folder = unique_path(parent / pattern);
+            } while(exists(folder));
+            create_directories(folder);
+        }
+        ~TmpFolder() { boost::filesystem::remove_all(folder); }
+        boost::filesystem::path get() const { return folder; }
+    };
+}} // namespace rttr::test


### PR DESCRIPTION
This is in preparation for syncing gameData files and adds some restrictions:

- file names must be alpha-numeric + underscore
- they must be relative to current file and not leave the gameData base folder
- they must have `.lua` as the extension

This should be a good barrier to avoid arbitrary file inclusion but it should be evaluated if there are other issues when executing untrusted lua code. @Spikeone  ideas? Anything network or filesystem in lua which is currently possible?