### PR TITLE
Update player inventory with reserve soldiers used on ClearResources

### DIFF
--- a/libs/common/include/helpers/EnumRange.h
+++ b/libs/common/include/helpers/EnumRange.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2015 - 2020 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef RttrEnumRange_h__
+#define RttrEnumRange_h__
+
+#include "MaxEnumValue.h"
+#include <boost/config.hpp>
+#include <type_traits>
+
+namespace helpers {
+/// Can be used in range-based for loops to iterate over each enum value
+/// Requires: T must be an enum with MaxEnumValue trait specialized
+///           T must be simple: Start at zero, no gaps
+template<class T>
+struct EnumRange
+{
+    static_assert(std::is_enum<T>::value, "Must be an enum!");
+    class iterator
+    {
+        unsigned value;
+
+    public:
+        explicit BOOST_FORCEINLINE iterator(unsigned value) : value(value) {}
+        BOOST_FORCEINLINE T operator*() const { return static_cast<T>(value); }
+        BOOST_FORCEINLINE void operator++() { ++value; }
+        BOOST_FORCEINLINE bool operator!=(iterator rhs) const { return value != rhs.value; }
+    };
+
+    BOOST_FORCEINLINE iterator begin() const { return iterator(0); }
+    BOOST_FORCEINLINE iterator end() const { return iterator(MaxEnumValue_v<T> + 1u); }
+};
+} // namespace helpers
+
+#endif // RttrEnumRange_h__

--- a/libs/s25main/buildings/nobBaseWarehouse.h
+++ b/libs/s25main/buildings/nobBaseWarehouse.h
@@ -275,8 +275,8 @@ public:
     void RefreshReserve(unsigned rank);
 
     /// Gibt Zeiger auf dir Reserve zurück für das GUI
-    const unsigned* GetReservePointerAvailable(unsigned rank) const { return &reserve_soldiers_available[rank]; }
-    const unsigned* GetReservePointerClaimed(unsigned rank) const { return &reserve_soldiers_claimed_visual[rank]; }
+    const unsigned* GetReserveAvailablePointer(unsigned rank) const { return &reserve_soldiers_available[rank]; }
+    const unsigned* GetReserveClaimedVisualPointer(unsigned rank) const { return &reserve_soldiers_claimed_visual[rank]; }
     unsigned GetReserveClaimed(unsigned rank) const { return reserve_soldiers_claimed_real[rank]; }
 
     /// Available goods of a specific type that can be used for trading

--- a/libs/s25main/ingameWindows/iwHQ.cpp
+++ b/libs/s25main/ingameWindows/iwHQ.cpp
@@ -51,7 +51,7 @@ iwHQ::iwHQ(GameWorldView& gwv, GameCommandFactory& gcFactory, nobBaseWarehouse* 
                                _("More"));
         // Anzahl-Text
         reserve.AddVarText(21 + i, DrawPoint(100, 117 + Y_DISTANCE * i), _("%u/%u"), 0xFFFFFF00, FontStyle::CENTER, NormalFont, 2,
-                           wh->GetReservePointerAvailable(i), wh->GetReservePointerClaimed(i));
+                           wh->GetReserveAvailablePointer(i), wh->GetReserveClaimedVisualPointer(i));
     }
 }
 

--- a/tests/common/testEnumRange.cpp
+++ b/tests/common/testEnumRange.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2016 - 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "helpers/EnumRange.h"
+#include <boost/test/unit_test.hpp>
+
+enum PlainEnum
+{
+    First,
+    Second,
+    Third
+};
+DEFINE_MAX_ENUM_VALUE(PlainEnum, PlainEnum::Third)
+
+enum class IntEnum : int
+{
+    First,
+    Second,
+    Third,
+    Forth
+};
+DEFINE_MAX_ENUM_VALUE(IntEnum, IntEnum::Forth)
+
+enum class UnsignedEnum : unsigned
+{
+    First,
+    Second
+};
+DEFINE_MAX_ENUM_VALUE(UnsignedEnum, UnsignedEnum::Second)
+
+BOOST_AUTO_TEST_CASE(PlainEnumWorks)
+{
+    std::vector<PlainEnum> result, expected;
+    expected = {First, Second, Third};
+    for(const PlainEnum e : helpers::EnumRange<PlainEnum>{})
+        result.push_back(e);
+    BOOST_TEST(result == expected);
+}
+
+BOOST_AUTO_TEST_CASE(IntEnumWorks)
+{
+    std::vector<IntEnum> result, expected;
+    expected = {IntEnum::First, IntEnum::Second, IntEnum::Third, IntEnum::Forth};
+    for(const IntEnum e : helpers::EnumRange<IntEnum>{})
+        result.push_back(e);
+    BOOST_TEST(result == expected);
+}
+
+BOOST_AUTO_TEST_CASE(UnsignedEnumWorks)
+{
+    std::vector<UnsignedEnum> result, expected;
+    expected = {UnsignedEnum::First, UnsignedEnum::Second};
+    for(const UnsignedEnum e : helpers::EnumRange<UnsignedEnum>{})
+        result.push_back(e);
+    BOOST_TEST(result == expected);
+}

--- a/tests/s25Main/integration/testGameCommands.cpp
+++ b/tests/s25Main/integration/testGameCommands.cpp
@@ -883,7 +883,7 @@ BOOST_FIXTURE_TEST_CASE(ChangeReserveTest, WorldWithGCExecution2P)
     {
         // We already have soldier per rank as reserve
         BOOST_REQUIRE_EQUAL(wh->GetReserveClaimed(i), 1u);
-        BOOST_REQUIRE_EQUAL(*wh->GetReservePointerAvailable(i), 1u);
+        BOOST_REQUIRE_EQUAL(*wh->GetReserveAvailablePointer(i), 1u);
 
         unsigned newVal = i * 5 + 2;
         unsigned numSoldiersAv = wh->GetNumVisualFigures(SOLDIER_JOBS[i]);
@@ -891,7 +891,7 @@ BOOST_FIXTURE_TEST_CASE(ChangeReserveTest, WorldWithGCExecution2P)
         // Update reserve -> Removed from inventory
         this->ChangeReserve(hqPos, i, newVal);
         BOOST_REQUIRE_EQUAL(wh->GetReserveClaimed(i), newVal);
-        BOOST_REQUIRE_EQUAL(*wh->GetReservePointerAvailable(i), newVal);
+        BOOST_REQUIRE_EQUAL(*wh->GetReserveAvailablePointer(i), newVal);
         // Current figure ct should be old figure count minus the new reserve soldiers (currentVal - 1 for old reserve val)
         BOOST_REQUIRE_EQUAL(wh->GetNumVisualFigures(SOLDIER_JOBS[i]), numSoldiersAv - (newVal - 1));
         BOOST_REQUIRE_EQUAL(wh->GetNumRealFigures(SOLDIER_JOBS[i]), numSoldiersAv - (newVal - 1));
@@ -901,11 +901,11 @@ BOOST_FIXTURE_TEST_CASE(ChangeReserveTest, WorldWithGCExecution2P)
     {
         unsigned newVal = i * 3 + 1;
         unsigned numSoldiersAv = wh->GetNumVisualFigures(SOLDIER_JOBS[i]);
-        unsigned numSoldiersReleased = *wh->GetReservePointerAvailable(i) - newVal;
+        unsigned numSoldiersReleased = *wh->GetReserveAvailablePointer(i) - newVal;
         // Release some soldiers from reserve -> Added to inventory
         this->ChangeReserve(hqPos, i, newVal);
         BOOST_REQUIRE_EQUAL(wh->GetReserveClaimed(i), newVal);
-        BOOST_REQUIRE_EQUAL(*wh->GetReservePointerAvailable(i), newVal);
+        BOOST_REQUIRE_EQUAL(*wh->GetReserveAvailablePointer(i), newVal);
         BOOST_REQUIRE_EQUAL(wh->GetNumVisualFigures(SOLDIER_JOBS[i]), numSoldiersAv + numSoldiersReleased);
         BOOST_REQUIRE_EQUAL(wh->GetNumRealFigures(SOLDIER_JOBS[i]), numSoldiersAv + numSoldiersReleased);
     }

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2016 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -15,11 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "rttrDefines.h" // IWYU pragma: keep
 #include "GameWithLuaAccess.h"
 #include "PointOutput.h"
+#include "RttrForeachPt.h"
 #include "buildings/noBuildingSite.h"
 #include "buildings/nobHQ.h"
+#include "helpers/EnumRange.h"
 #include "lua/LuaTraits.h" // IWYU pragma: keep
 #include "network/ClientInterface.h"
 #include "network/GameClient.h"
@@ -401,14 +402,14 @@ BOOST_AUTO_TEST_CASE(IngamePlayer)
 
     executeLua("player:ClearResources()");
     const Inventory& playerInv = player.GetInventory();
-    for(auto gd = GoodType(0); gd < NUM_WARE_TYPES; gd = GoodType(gd + 1))
+    for(const GoodType gd : helpers::EnumRange<GoodType>{})
         BOOST_TEST_CONTEXT("Good: " << gd)
         {
             BOOST_TEST(hq->GetNumRealWares(gd) == 0u);
             BOOST_TEST(hq->GetNumVisualWares(gd) == 0u);
             BOOST_TEST(playerInv[gd] == 0u);
         }
-    for(auto job = Job(0); job < NUM_JOB_TYPES; job = Job(job + 1))
+    for(const Job job : helpers::EnumRange<Job>{})
         BOOST_TEST_CONTEXT("Job: " << job)
         {
             BOOST_TEST(hq->GetNumRealFigures(job) == 0u);


### PR DESCRIPTION
Also don't touch claimed reserve soldiers
Fixes #1253