### PR TITLE
Improve sound conversion

### DIFF
--- a/data/RTTR/sound.scs
+++ b/data/RTTR/sound.scs
@@ -1,63 +1,9 @@
 # Format:
 # <itemnr> <source-frequency>
 #
-# The destination item nr is implicit. So the 3rd uncommented line will refer to the 3rd item.
+# The item at index <itemnr> is converted using <source-frequency> as the frequency
+# All others are left untouched
 #
-# if <itemnr> is "empty", an empty item will be inserted and <source-frequency> is ignored (can be left out),
-# if <source-frequency> is "copy", the item <itemnr> will be copied
-# otherwise the item <itemnr> is converted using <source-frequency> as the frequency
-#
-0 copy
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
-empty
 051 11025
 052 11025
 053 11025
@@ -67,10 +13,10 @@ empty
 057 11025
 058 11025
 059 11025
-empty
+# empty
 061 11025
 062 11025
-empty
+# empty
 064 11025
 065 11025
 066 11025
@@ -78,19 +24,19 @@ empty
 068 11025
 069 11025
 070 11025
-empty
+# empty
 072 11025
-empty
+# empty
 074 11025
-empty
+# empty
 076 11025
 077 11025
 078 6000
-empty
-empty
+# empty
+# empty
 081 11025
 082 9000
-empty
+# empty
 084 11025
 085 11025
 086 11025
@@ -104,7 +50,7 @@ empty
 094 6000
 095 11025
 096 11025
-empty
+# empty
 098 11025
 099 11025
 100 11025
@@ -113,9 +59,9 @@ empty
 103 11025
 104 06500
 105 10025
-empty
+# empty
 107 9000
-empty
+# empty
 109 11025
 110 9000
 111 11025

--- a/libs/s25client/CMakeLists.txt
+++ b/libs/s25client/CMakeLists.txt
@@ -16,7 +16,7 @@ ENDIF()
 
 find_package(Boost REQUIRED program_options)
 
-add_executable(s25client s25client.cpp ${s25client_RC})
+add_executable(s25client s25client.cpp commands.cpp ${s25client_RC})
 target_link_libraries(s25client PRIVATE s25Main Boost::program_options Boost::nowide)
 add_dependencies(s25client drivers)
 

--- a/libs/s25client/commands.cpp
+++ b/libs/s25client/commands.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "commands.h"
+#include "RttrConfig.h"
+#include "convertSounds.h"
+#include "files.h"
+#include "libsiedler2/Archiv.h"
+#include "libsiedler2/ArchivItem_Sound_Wave.h"
+#include "libsiedler2/libsiedler2.h"
+#include <boost/filesystem.hpp>
+#include <boost/nowide/fstream.hpp>
+#include <string>
+
+void convertAndSaveSounds(const RttrConfig& config, const boost::filesystem::path& targetFolder)
+{
+    libsiedler2::Archiv sounds;
+    if(libsiedler2::Load(config.ExpandPath(s25::files::soundOrig), sounds) != 0)
+        throw std::runtime_error("Could not load sounds");
+    convertSounds(sounds, config.ExpandPath(s25::files::soundScript));
+    boost::filesystem::create_directories(targetFolder);
+    for(unsigned i = 0; i < sounds.size(); i++)
+    {
+        const auto* wav = dynamic_cast<const libsiedler2::ArchivItem_Sound_Wave*>(sounds[i]);
+        if(wav)
+        {
+            boost::nowide::ofstream f(targetFolder / (std::to_string(i) + ".wav"));
+            if(wav->write(f) != 0)
+                throw std::runtime_error("Could not write sound" + std::to_string(i));
+        }
+    }
+}

--- a/libs/s25client/commands.h
+++ b/libs/s25client/commands.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef rttr_s25client_commands_h__
+#define rttr_s25client_commands_h__
+
+#include <boost/filesystem/path.hpp>
+
+class RttrConfig;
+
+void convertAndSaveSounds(const RttrConfig& config, const boost::filesystem::path& targetFolder);
+
+#endif // rttr_s25client_commands_h__

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -24,6 +24,7 @@
 #include "Settings.h"
 #include "SignalHandler.h"
 #include "WindowManager.h"
+#include "commands.h"
 #include "drivers/AudioDriverWrapper.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "files.h"
@@ -442,6 +443,19 @@ int RunProgram(po::variables_map& options)
     // Generator verwendet)
     srand(static_cast<unsigned>(std::time(nullptr)));
 
+    if(options.count("convert-sounds"))
+    {
+        try
+        {
+            convertAndSaveSounds(RTTRCONFIG, RTTRCONFIG.ExpandPath("<RTTR_USERDATA>/convertedSoundeffects"));
+            return 0;
+        } catch(const std::runtime_error& e)
+        {
+            bnw::cerr << "Error: " << e.what() << "\n";
+            return 1;
+        }
+    }
+
     SetGlobalInstanceWrapper<GameManager> gameManager(setGlobalGameManager, LOG, SETTINGS, VIDEODRIVER, AUDIODRIVER, WINDOWMANAGER);
     try
     {
@@ -452,6 +466,7 @@ int RunProgram(po::variables_map& options)
             return 1;
 
         // Hauptschleife
+
         while(gameManager.Run())
         {
 #ifndef _WIN32
@@ -497,6 +512,7 @@ int main(int argc, char** argv)
         ("help,h", "Show help")
         ("map,m", po::value<std::string>(),"Map to load")
         ("version", "Show version information and exit")
+        ("convert-sounds", "Convert sounds and exit")
         ;
     // clang-format on
     po::positional_options_description positionalOptions;

--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -259,9 +259,12 @@ bool Loader::LoadSounds()
         return false;
     const Timer timer(true);
     logger_.write(_("Starting sound conversion: "));
-    if(!convertSounds(GetArchive("sound"), config_.ExpandPath(s25::files::soundScript)))
+    try
     {
-        logger_.write(_("failed\n"));
+        convertSounds(GetArchive("sound"), config_.ExpandPath(s25::files::soundScript));
+    } catch(const std::runtime_error& e)
+    {
+        logger_.write(_("failed: %1%\n")) % e.what();
         return false;
     }
     logger_.write(_("done in %ums\n")) % duration_cast<milliseconds>(timer.getElapsed()).count();

--- a/libs/s25main/convertSounds.h
+++ b/libs/s25main/convertSounds.h
@@ -19,11 +19,10 @@
 
 #include <boost/filesystem/path.hpp>
 
-namespace bfs = boost::filesystem;
 namespace libsiedler2 {
 class Archiv;
 }
 
-bool convertSounds(libsiedler2::Archiv& sounds, const bfs::path& scriptPath);
+void convertSounds(libsiedler2::Archiv& sounds, const boost::filesystem::path& scriptPath);
 
 #endif // convertSounds_h__


### PR DESCRIPTION
Use the new loadMapping function from libsiedler2 and adapt the conversion script

Found also a bug: It used the wave header instead of sound.scs for getting the source samplerate.

To help with improving the sounds I added a command line switch `--convert-sounds` which converts the sounds into wave files into `convertedSoundEffects` inside the user settings folder 