### PR TITLE
Make WAV header calculation more explicit

### DIFF
--- a/libs/common/include/helpers/mathFuncs.h
+++ b/libs/common/include/helpers/mathFuncs.h
@@ -27,6 +27,10 @@ namespace helpers {
 int gcd(int a, int b) noexcept;
 /// Returns the result of "dividend / divisor" rounded to the nearest integer value
 unsigned roundedDiv(unsigned dividend, unsigned divisor) noexcept;
+constexpr unsigned divCeil(unsigned dividend, unsigned divisor) noexcept
+{
+    return (dividend + divisor - 1) / divisor; // Standard trick using truncating division for smalish values (no overflow)
+}
 /// Clamp the value into [min, max]
 template<typename T>
 T clamp(T val, T min, T max) noexcept

--- a/libs/s25main/convertSounds.cpp
+++ b/libs/s25main/convertSounds.cpp
@@ -15,6 +15,7 @@
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
 #include "convertSounds.h"
+#include "helpers/mathFuncs.h"
 #include <libsiedler2/Archiv.h>
 #include <libsiedler2/ArchivItem_Sound_Wave.h>
 #include <libsiedler2/loadMapping.h>
@@ -53,10 +54,13 @@ void convertSounds(libsiedler2::Archiv& sounds, const boost::filesystem::path& s
             int converted = std::lrint((value + 1.f) / 2.f * std::numeric_limits<uint8_t>::max());
             return static_cast<uint8_t>(std::min<int>(std::numeric_limits<uint8_t>::max(), std::max(0, converted)));
         });
-        header.samplesPerSec = targetFrequency;
-        header.bytesPerSec = targetFrequency;
-        header.frameSize = 1;
+        // Those 2 are checked above, but for completeness here again
+        header.numChannels = 1;
         header.bitsPerSample = 8;
+
+        header.samplesPerSec = targetFrequency;
+        header.frameSize = header.numChannels * helpers::divCeil(header.bitsPerSample, 8);
+        header.bytesPerSec = header.samplesPerSec * header.frameSize;
         header.dataSize = data.size();
         header.fileSize = data.size() + sizeof(header);
         sound->setHeader(header);

--- a/tests/common/testMathHelpers.cpp
+++ b/tests/common/testMathHelpers.cpp
@@ -111,4 +111,25 @@ BOOST_AUTO_TEST_CASE(SmoothedValue)
     BOOST_REQUIRE_EQUAL(val.get(), (2 + 11 + 102 + 1 + 7) / 5);
 }
 
+BOOST_AUTO_TEST_CASE(DivCeilResults)
+{
+    BOOST_TEST(helpers::divCeil(0, 3) == 0u);
+    BOOST_TEST(helpers::divCeil(1, 3) == 1u);
+    BOOST_TEST(helpers::divCeil(2, 3) == 1u);
+    BOOST_TEST(helpers::divCeil(3, 3) == 1u);
+    BOOST_TEST(helpers::divCeil(4, 3) == 2u);
+    BOOST_TEST(helpers::divCeil(5, 3) == 2u);
+    BOOST_TEST(helpers::divCeil(6, 3) == 2u);
+
+    BOOST_TEST(helpers::divCeil(1, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(2, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(3, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(4, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(5, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(6, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(7, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(8, 8) == 1u);
+    BOOST_TEST(helpers::divCeil(9, 8) == 2u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
From discussion here: https://github.com/Return-To-The-Roots/s25client/pull/1258/files#r439767352

This makes it clear that the values are correct