### PR TITLE
Remove unused online ranking display

### DIFF
--- a/libs/s25main/BasePlayerInfo.h
+++ b/libs/s25main/BasePlayerInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //

--- a/libs/s25main/ILobbyClient.hpp
+++ b/libs/s25main/ILobbyClient.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2016 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -31,7 +31,6 @@ public:
     virtual void AddListener(LobbyInterface* listener) = 0;
     virtual void RemoveListener(LobbyInterface* listener) = 0;
     virtual void SendServerJoinRequest() = 0;
-    virtual void SendRankingInfoRequest(const std::string& name) = 0;
     virtual void SendChat(const std::string& text) = 0;
 };
 

--- a/libs/s25main/JoinPlayerInfo.cpp
+++ b/libs/s25main/JoinPlayerInfo.cpp
@@ -21,21 +21,18 @@
 #include "s25util/Serializer.h"
 #include <boost/format.hpp>
 
-JoinPlayerInfo::JoinPlayerInfo() : rating(0), isReady(false) {}
+JoinPlayerInfo::JoinPlayerInfo() = default;
 
-JoinPlayerInfo::JoinPlayerInfo(const BasePlayerInfo& baseInfo) : PlayerInfo(baseInfo), originName(name), rating(0), isReady(false) {}
+JoinPlayerInfo::JoinPlayerInfo(const BasePlayerInfo& baseInfo) : PlayerInfo(baseInfo), originName(name) {}
 
-JoinPlayerInfo::JoinPlayerInfo(const PlayerInfo& playerInfo) : PlayerInfo(playerInfo), originName(name), rating(0), isReady(false) {}
+JoinPlayerInfo::JoinPlayerInfo(const PlayerInfo& playerInfo) : PlayerInfo(playerInfo), originName(name) {}
 
-JoinPlayerInfo::JoinPlayerInfo(Serializer& ser)
-    : PlayerInfo(ser), originName(ser.PopLongString()), rating(ser.PopUnsignedInt()), isReady(ser.PopBool())
-{}
+JoinPlayerInfo::JoinPlayerInfo(Serializer& ser) : PlayerInfo(ser), originName(ser.PopLongString()), isReady(ser.PopBool()) {}
 
 void JoinPlayerInfo::Serialize(Serializer& ser) const
 {
     PlayerInfo::Serialize(ser);
     ser.PushLongString(originName);
-    ser.PushUnsignedInt(rating);
     ser.PushBool(isReady);
 }
 
@@ -50,26 +47,6 @@ void JoinPlayerInfo::FixSwappedSaveSlot(JoinPlayerInfo& other)
     swap(nation, other.nation);
     swap(color, other.color);
     swap(team, other.team);
-}
-
-void JoinPlayerInfo::InitRating()
-{
-    if(ps == PS_OCCUPIED)
-        rating = 1000;
-    else if(ps == PS_AI)
-    {
-        if(aiInfo.type == AI::DEFAULT)
-        {
-            switch(aiInfo.level)
-            {
-                case AI::EASY: rating = 42; break;
-                case AI::MEDIUM: rating = 666; break;
-                case AI::HARD: rating = 1337; break;
-            }
-        } else
-            rating = 0;
-    } else
-        rating = 0;
 }
 
 void JoinPlayerInfo::SetAIName(unsigned playerId)

--- a/libs/s25main/JoinPlayerInfo.h
+++ b/libs/s25main/JoinPlayerInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -24,8 +24,7 @@
 struct JoinPlayerInfo : public PlayerInfo
 {
     std::string originName;
-    unsigned rating;
-    bool isReady;
+    bool isReady = false;
 
     JoinPlayerInfo();
     explicit JoinPlayerInfo(const BasePlayerInfo& baseInfo);
@@ -35,7 +34,6 @@ struct JoinPlayerInfo : public PlayerInfo
     // Serialize complete struct
     void Serialize(Serializer& ser) const;
 
-    void InitRating();
     void SetAIName(unsigned playerId);
     // Recovers fixed data in savegames after player slots are swapped
     void FixSwappedSaveSlot(JoinPlayerInfo& other);

--- a/libs/s25main/RttrLobbyClient.cpp
+++ b/libs/s25main/RttrLobbyClient.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2018 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -38,11 +38,6 @@ void RttrLobbyClient::RemoveListener(LobbyInterface* listener)
 void RttrLobbyClient::SendServerJoinRequest()
 {
     client_.SendServerJoinRequest();
-}
-
-void RttrLobbyClient::SendRankingInfoRequest(const std::string& name)
-{
-    client_.SendRankingInfoRequest(name);
 }
 
 void RttrLobbyClient::SendChat(const std::string& text)

--- a/libs/s25main/RttrLobbyClient.hpp
+++ b/libs/s25main/RttrLobbyClient.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2016 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -33,7 +33,6 @@ public:
     void AddListener(LobbyInterface* listener) override;
     void RemoveListener(LobbyInterface* listener) override;
     void SendServerJoinRequest() override;
-    void SendRankingInfoRequest(const std::string& name) override;
     void SendChat(const std::string& text) override;
 };
 

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -228,7 +228,7 @@ public:
     virtual void Msg_TabChange(unsigned /*ctrl_id*/, unsigned short /*tab_id*/) {}
     virtual void Msg_ListSelectItem(unsigned /*ctrl_id*/, int /*selection*/) {}
     virtual void Msg_ListChooseItem(unsigned /*ctrl_id*/, unsigned /*selection*/) {}
-    virtual void Msg_ComboSelectItem(unsigned /*ctrl_id*/, int /*selection*/) {}
+    virtual void Msg_ComboSelectItem(unsigned /*ctrl_id*/, unsigned /*selection*/) {}
     virtual void Msg_CheckboxChange(unsigned /*ctrl_id*/, bool /*checked*/) {}
     virtual void Msg_ProgressChange(unsigned /*ctrl_id*/, unsigned short /*position*/) {}
     virtual void Msg_ScrollChange(unsigned /*ctrl_id*/, unsigned short /*position*/) {}
@@ -249,7 +249,7 @@ public:
     virtual void Msg_Group_EditChange(unsigned /*group_id*/, unsigned /*ctrl_id*/) {}
     virtual void Msg_Group_TabChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, unsigned short /*tab_id*/) {}
     virtual void Msg_Group_ListSelectItem(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}
-    virtual void Msg_Group_ComboSelectItem(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}
+    virtual void Msg_Group_ComboSelectItem(unsigned /*group_id*/, unsigned /*ctrl_id*/, unsigned /*selection*/) {}
     virtual void Msg_Group_CheckboxChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, bool /*checked*/) {}
     virtual void Msg_Group_ProgressChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, unsigned short /*position*/) {}
     virtual void Msg_Group_ScrollShow(unsigned /*group_id*/, unsigned /*ctrl_id*/, bool /*visible*/) {}

--- a/libs/s25main/controls/ctrlGroup.cpp
+++ b/libs/s25main/controls/ctrlGroup.cpp
@@ -47,7 +47,7 @@ void ctrlGroup::Msg_ListSelectItem(const unsigned ctrl_id, const int selection)
     GetParent()->Msg_Group_ListSelectItem(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlGroup::Msg_ComboSelectItem(const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selection)
 {
     GetParent()->Msg_Group_ComboSelectItem(this->GetID(), ctrl_id, selection);
 }
@@ -157,7 +157,7 @@ void ctrlGroup::Msg_Group_ListSelectItem(const unsigned /*group_id*/, const unsi
     GetParent()->Msg_Group_ListSelectItem(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlGroup::Msg_Group_ComboSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_Group_ComboSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const unsigned selection)
 {
     GetParent()->Msg_Group_ComboSelectItem(this->GetID(), ctrl_id, selection);
 }

--- a/libs/s25main/controls/ctrlGroup.h
+++ b/libs/s25main/controls/ctrlGroup.h
@@ -33,7 +33,7 @@ public:
     void Msg_EditChange(unsigned ctrl_id) override;
     void Msg_TabChange(unsigned ctrl_id, unsigned short tab_id) override;
     void Msg_ListSelectItem(unsigned ctrl_id, int selection) override;
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
     void Msg_ProgressChange(unsigned ctrl_id, unsigned short position) override;
     void Msg_ScrollShow(unsigned ctrl_id, bool visible) override;
@@ -48,7 +48,7 @@ public:
     void Msg_Group_EditChange(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_TabChange(unsigned group_id, unsigned ctrl_id, unsigned short tab_id) override;
     void Msg_Group_ListSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
-    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_Group_CheckboxChange(unsigned group_id, unsigned ctrl_id, bool checked) override;
     void Msg_Group_ProgressChange(unsigned group_id, unsigned ctrl_id, unsigned short position) override;
     void Msg_Group_ScrollShow(unsigned group_id, unsigned ctrl_id, bool visible) override;

--- a/libs/s25main/controls/ctrlTab.cpp
+++ b/libs/s25main/controls/ctrlTab.cpp
@@ -174,7 +174,7 @@ void ctrlTab::Msg_Group_ListSelectItem(const unsigned /*group_id*/, const unsign
     GetParent()->Msg_Group_ListSelectItem(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlTab::Msg_Group_ComboSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlTab::Msg_Group_ComboSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const unsigned selection)
 {
     GetParent()->Msg_Group_ComboSelectItem(this->GetID(), ctrl_id, selection);
 }

--- a/libs/s25main/controls/ctrlTab.h
+++ b/libs/s25main/controls/ctrlTab.h
@@ -49,7 +49,7 @@ public:
     void Msg_Group_EditChange(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_TabChange(unsigned group_id, unsigned ctrl_id, unsigned short tab_id) override;
     void Msg_Group_ListSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
-    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_Group_CheckboxChange(unsigned group_id, unsigned ctrl_id, bool checked) override;
     void Msg_Group_ProgressChange(unsigned group_id, unsigned ctrl_id, unsigned short position) override;
     void Msg_Group_ScrollShow(unsigned group_id, unsigned ctrl_id, bool visible) override;

--- a/libs/s25main/desktops/dskHostGame.h
+++ b/libs/s25main/desktops/dskHostGame.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -60,15 +60,13 @@ private:
     void Msg_PaintBefore() override;
     void Msg_Group_ButtonClick(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_CheckboxChange(unsigned group_id, unsigned ctrl_id, bool checked) override;
-    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_EditEnter(unsigned ctrl_id) override;
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
     void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
-
-    void LC_RankingInfo(const LobbyPlayerInfo& player) override;
 
     void CI_Error(ClientError ce) override;
 

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -357,7 +357,7 @@ void dskOptions::Msg_Group_ProgressChange(const unsigned /*group_id*/, const uns
     }
 }
 
-void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsigned ctrl_id, const int selection)
+void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsigned ctrl_id, const unsigned selection)
 {
     auto* group = GetCtrl<ctrlGroup>(group_id);
     auto* combo = group->GetCtrl<ctrlComboBox>(ctrl_id);

--- a/libs/s25main/desktops/dskOptions.h
+++ b/libs/s25main/desktops/dskOptions.h
@@ -37,7 +37,7 @@ private:
 
     void Msg_Group_ButtonClick(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_ProgressChange(unsigned group_id, unsigned ctrl_id, unsigned short position) override;
-    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
 
 private:

--- a/libs/s25main/desktops/dskTest.cpp
+++ b/libs/s25main/desktops/dskTest.cpp
@@ -117,7 +117,7 @@ void dskTest::Msg_EditChange(const unsigned ctrl_id)
         GetCtrl<ctrlText>(ID_txtTest)->SetText(GetCtrl<ctrlEdit>(ID_edtTest)->GetText());
 }
 
-void dskTest::Msg_ComboSelectItem(const unsigned ctrl_id, const int selection)
+void dskTest::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selection)
 {
     if(ctrl_id == ID_cbTxtSize)
     {

--- a/libs/s25main/desktops/dskTest.h
+++ b/libs/s25main/desktops/dskTest.h
@@ -29,7 +29,7 @@ public:
     dskTest();
 
     void Msg_EditChange(unsigned ctrl_id) override;
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     bool Msg_RightUp(const MouseCoords& mc) override;
 

--- a/libs/s25main/desktops/dskTextureTest.cpp
+++ b/libs/s25main/desktops/dskTextureTest.cpp
@@ -76,7 +76,7 @@ void dskTextureTest::Load()
     Msg_ComboSelectItem(ID_cbTexture, selection);
 }
 
-void dskTextureTest::Msg_ComboSelectItem(const unsigned ctrl_id, const int selection)
+void dskTextureTest::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selection)
 {
     curTerrainIdx = desc.terrain.getIndex(GetCtrl<ctrlComboBox>(ctrl_id)->GetText(selection));
     if(!curTerrainIdx)

--- a/libs/s25main/desktops/dskTextureTest.h
+++ b/libs/s25main/desktops/dskTextureTest.h
@@ -32,7 +32,7 @@ public:
 
     void Load();
 
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_PaintAfter() override;
     bool Msg_KeyDown(const KeyEvent& ke) override;

--- a/libs/s25main/ingameWindows/iwAIDebug.cpp
+++ b/libs/s25main/ingameWindows/iwAIDebug.cpp
@@ -138,7 +138,7 @@ iwAIDebug::~iwAIDebug()
     }
 }
 
-void iwAIDebug::Msg_ComboSelectItem(const unsigned ctrl_id, const int selection)
+void iwAIDebug::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/ingameWindows/iwAIDebug.h
+++ b/libs/s25main/ingameWindows/iwAIDebug.h
@@ -35,7 +35,7 @@ public:
     ~iwAIDebug() override;
 
 private:
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     // void Msg_ButtonClick(unsigned ctrl_id);
     // void Msg_ProgressChange(unsigned ctrl_id, unsigned short position);
     void Msg_PaintBefore() override;

--- a/libs/s25main/ingameWindows/iwLobbyConnect.cpp
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //

--- a/libs/s25main/ingameWindows/iwMapDebug.cpp
+++ b/libs/s25main/ingameWindows/iwMapDebug.cpp
@@ -223,17 +223,13 @@ iwMapDebug::~iwMapDebug()
     gwv.RemoveDrawNodeCallback(printer.get());
 }
 
-void iwMapDebug::Msg_ComboSelectItem(const unsigned ctrl_id, const int select)
+void iwMapDebug::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned select)
 {
     if(ctrl_id == ID_cbShowWhat)
-    {
-        if(select >= 0)
-            printer->showDataIdx = static_cast<unsigned>(select);
-    } else if(ctrl_id == ID_cbShowForPlayer)
-    {
-        if(select >= 0)
-            printer->playerIdx = static_cast<unsigned>(select);
-    } else if(ctrl_id == ID_cbCheckEventForPlayer)
+        printer->showDataIdx = select;
+    else if(ctrl_id == ID_cbShowForPlayer)
+        printer->playerIdx = select;
+    else if(ctrl_id == ID_cbCheckEventForPlayer)
     {
         if(select == 0)
         {

--- a/libs/s25main/ingameWindows/iwMapDebug.h
+++ b/libs/s25main/ingameWindows/iwMapDebug.h
@@ -33,7 +33,7 @@ private:
     class DebugPrinter;
     class EventChecker;
 
-    void Msg_ComboSelectItem(unsigned ctrl_id, int select) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned select) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
     void Msg_Timer(unsigned ctrl_id) override;
 

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -129,22 +129,19 @@ iwMusicPlayer::~iwMusicPlayer()
     }
 }
 
-void iwMusicPlayer::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const int selection)
+void iwMusicPlayer::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsigned selection)
 {
     // Entsprechende Datei geladen
-    if(selection != 0xFFFF)
+    Playlist pl;
+    if(pl.Load(LOG, GetFullPlaylistPath(GetCtrl<ctrlComboBox>(2)->GetText(selection))))
     {
-        Playlist pl;
-        if(pl.Load(LOG, GetFullPlaylistPath(GetCtrl<ctrlComboBox>(2)->GetText(selection))))
-        {
-            // Das Fenster entsprechend mit den geladenen Werten füllen
-            pl.FillMusicPlayer(this);
-            changed = true;
-        } else
-            // Fehler, konnte nicht geladen werden
-            WINDOWMANAGER.Show(
-              std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be loaded!"), this, MSB_OK, MSB_EXCLAMATIONRED));
-    }
+        // Das Fenster entsprechend mit den geladenen Werten füllen
+        pl.FillMusicPlayer(this);
+        changed = true;
+    } else
+        // Fehler, konnte nicht geladen werden
+        WINDOWMANAGER.Show(
+          std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be loaded!"), this, MSB_OK, MSB_EXCLAMATIONRED));
 }
 
 void iwMusicPlayer::Msg_ListChooseItem(const unsigned /*ctrl_id*/, const unsigned selection)

--- a/libs/s25main/ingameWindows/iwMusicPlayer.h
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.h
@@ -62,7 +62,7 @@ public:
 
 private:
     void Msg_ListChooseItem(unsigned ctrl_id, unsigned selection) override;
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
 
     void Msg_Input(unsigned win_id, const std::string& msg);

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -166,7 +166,7 @@ iwSave::iwSave() : iwSaveLoad(40, _("Save game!"))
     RefreshTable();
 }
 
-void iwSave::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const int selection)
+void iwSave::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsigned selection)
 {
     // Erster Eintrag --> deaktiviert
     if(selection == 0)

--- a/libs/s25main/ingameWindows/iwSave.h
+++ b/libs/s25main/ingameWindows/iwSave.h
@@ -53,7 +53,7 @@ private:
     // Speichert Datei
     void SaveLoad() override;
 
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
 };
 
 class iwLoad : public iwSaveLoad

--- a/libs/s25main/ingameWindows/iwTrade.cpp
+++ b/libs/s25main/ingameWindows/iwTrade.cpp
@@ -119,7 +119,7 @@ void iwTrade::Msg_ButtonClick(const unsigned /*ctrl_id*/)
     }
 }
 
-void iwTrade::Msg_ComboSelectItem(const unsigned ctrl_id, const int selection)
+void iwTrade::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selection)
 {
     switch(ctrl_id)
     {

--- a/libs/s25main/ingameWindows/iwTrade.h
+++ b/libs/s25main/ingameWindows/iwTrade.h
@@ -27,7 +27,7 @@ public:
 private:
     void Msg_PaintBefore() override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_ComboSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     unsigned GetPossibleTradeAmount(Job job) const;
     unsigned GetPossibleTradeAmount(GoodType good) const;
 };

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -461,7 +461,6 @@ bool GameClient::OnGameMessage(const GameMessage_Player_New& msg)
     playerInfo.name = msg.name;
     playerInfo.ps = PS_OCCUPIED;
     playerInfo.ping = 0;
-    playerInfo.InitRating();
 
     if(ci)
         ci->CI_NewPlayer(msg.player);
@@ -506,7 +505,6 @@ bool GameClient::OnGameMessage(const GameMessage_Player_State& msg)
     bool wasUsed = playerInfo.isUsed();
     playerInfo.ps = msg.ps;
     playerInfo.aiInfo = msg.aiInfo;
-    playerInfo.InitRating();
 
     if(ci)
     {

--- a/libs/s25main/network/GameMessages.cpp
+++ b/libs/s25main/network/GameMessages.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -52,8 +52,8 @@ bool GameMessage_Player_List::Run(GameMessageInterface* callback) const
     for(unsigned i = 0; i < playerInfos.size(); ++i)
     {
         const JoinPlayerInfo& playerInfo = playerInfos[i];
-        LOG.writeToFile("    %d: %s %d %d %d %d %d %d %s\n") % i % playerInfo.name % playerInfo.ps % playerInfo.rating % playerInfo.ping
-          % playerInfo.nation % playerInfo.color % playerInfo.team % (playerInfo.isReady ? "true" : "false");
+        LOG.writeToFile("    %d: %s %d %d %d %d %d %s\n") % i % playerInfo.name % playerInfo.ps % playerInfo.ping % playerInfo.nation
+          % playerInfo.color % playerInfo.team % (playerInfo.isReady ? "true" : "false");
     }
     return callback->OnGameMessage(*this);
 }

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -179,7 +179,6 @@ bool GameServer::Start(const CreateServerInfo& csi, const std::string& map_path,
                 // If it was a human we make it free, so someone can join
                 if(playerInfos[i].ps == PS_OCCUPIED)
                     playerInfos[i].ps = PS_FREE;
-                playerInfos[i].InitRating();
             }
 
             ggs_ = save.ggs;

--- a/tests/s25Main/UI/testComboBox.cpp
+++ b/tests/s25Main/UI/testComboBox.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(ControlWithScrollWheel)
     MouseCoords mc{cb->GetPos() + Position(randomValue(0u, cb->GetSize().x - 1u), randomValue(0u, cb->GetSize().y - 1u))};
     for(int i = 0; i < 3; i++)
     {
-        MOCK_EXPECT(wnd.Msg_ComboSelectItem).once().with(cb->GetID(), i).in(s);
+        MOCK_EXPECT(wnd.Msg_ComboSelectItem).once().with(cb->GetID(), static_cast<unsigned>(i)).in(s);
         cb->Msg_WheelDown(mc);
         REQUIRE(cb->GetSelection() == i);
     }
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(ControlWithScrollWheel)
     // Same but up
     for(int i = 1; i >= 0; i--)
     {
-        MOCK_EXPECT(wnd.Msg_ComboSelectItem).once().with(cb->GetID(), i).in(s);
+        MOCK_EXPECT(wnd.Msg_ComboSelectItem).once().with(cb->GetID(), static_cast<unsigned>(i)).in(s);
         cb->Msg_WheelUp(mc);
         REQUIRE(cb->GetSelection() == i);
     }

--- a/tests/s25Main/UI/testDskHostGame.cpp
+++ b/tests/s25Main/UI/testDskHostGame.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 - 2018 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2016 - 2020 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -39,7 +39,6 @@ MOCK_BASE_CLASS(MockLobbyClient, ILobbyClient)
     MOCK_METHOD(AddListener, 1);
     MOCK_METHOD(RemoveListener, 1);
     MOCK_METHOD(SendServerJoinRequest, 0);
-    MOCK_METHOD(SendRankingInfoRequest, 1);
     MOCK_METHOD(SendChat, 1);
 };
 /* clang-format on */
@@ -60,7 +59,6 @@ BOOST_FIXTURE_TEST_CASE(LobbyChat, uiHelper::Fixture)
     MOCK_EXPECT(client->AddListener).exactly(1).in(s);
     MOCK_EXPECT(client->RemoveListener).exactly(1).in(s);
     MOCK_EXPECT(client->SendServerJoinRequest).exactly(1).in(s2);
-    MOCK_EXPECT(client->SendRankingInfoRequest).at_least(1);
     MOCK_EXPECT(client->SendChat).exactly(1);
 
     // TODO: How to trigger through dskHostGame?


### PR DESCRIPTION
Also fix player switching in savegame if multiple players have the same name

Closes #124

Note: The player statistics are still transmitted from the lobby server but changing that is rather hard as the server and client need to agree on a version and deserializing messages with version dependent content is not really possible due to mixing the serializer and the messages in the server code which is a design issue. Workaround would be to introduce a new message type without the statistics. But IMO the server code needs some love and we should merge client and server code (again) in a GH repo