### PR TITLE
Fix visual glitch when hunter is waiting for the animal

### DIFF
--- a/libs/s25main/Loader.h
+++ b/libs/s25main/Loader.h
@@ -175,7 +175,7 @@ public:
     helpers::MultiArray<glSmartBitmap, 2, 6> granite_cache;
     /// Grainfield: Type, Size
     helpers::MultiArray<glSmartBitmap, 2, 4> grainfield_cache;
-    /// Carrier w/ ware: Ware, Direction, Animation, NormalOrFat
+    /// Carrier w/ ware: Ware, NormalOrFat, Direction, Animation
     helpers::MultiArray<FigAnimationSprites, NUM_WARE_TYPES, 2, 6> carrier_cache;
     /// Boundary stones: Nation
     std::array<glSmartBitmap, NUM_NATIONS> boundary_stone_cache;

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -94,6 +94,10 @@
 /// If a format change occurred that can still be handled increase this version and handle it in the loading code.
 /// If the change is to big to handle increase the version in Savegame.cpp  and remove all code referencing GetGameDataVersion. Then reset
 /// this number to 1.
+/// Changelog:
+/// 2: All player buildings together, variable width size for containers and ship names
+/// 3: Landscape and terrain names stored as strings
+/// 4: STATE_HUNTER_WAITING_FOR_ANIMAL_READY introduced as sub-state of STATE_HUNTER_FINDINGSHOOTINGPOINT
 static const unsigned currentGameDataVersion = 4;
 
 GameObject* SerializedGameData::Create_GameObject(const GO_Type got, const unsigned obj_id)

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -94,7 +94,7 @@
 /// If a format change occurred that can still be handled increase this version and handle it in the loading code.
 /// If the change is to big to handle increase the version in Savegame.cpp  and remove all code referencing GetGameDataVersion. Then reset
 /// this number to 1.
-static const unsigned currentGameDataVersion = 3;
+static const unsigned currentGameDataVersion = 4;
 
 GameObject* SerializedGameData::Create_GameObject(const GO_Type got, const unsigned obj_id)
 {

--- a/libs/s25main/SerializedGameData.h
+++ b/libs/s25main/SerializedGameData.h
@@ -57,6 +57,9 @@ public:
     /// Reads the snapshot from the internal buffer
     void ReadSnapshot(const std::shared_ptr<Game>& game);
 
+    /// Get the format version the data is saved in. Deserializing methods can use this to support
+    /// loading data saved in an earlier format.
+    /// See `currentGameDataVersion` in SerializedGameData.cpp for version history
     unsigned GetGameDataVersion() const { return gameDataVersion; }
 
     //////////////////////////////////////////////////////////////////////////

--- a/libs/s25main/figures/nofBuildingWorker.cpp
+++ b/libs/s25main/figures/nofBuildingWorker.cpp
@@ -90,6 +90,7 @@ void nofBuildingWorker::Draw(DrawPoint drawPt)
         case STATE_WORK:
         case STATE_HUNTER_SHOOTING:
         case STATE_HUNTER_EVISCERATING:
+        case STATE_HUNTER_WAITING_FOR_ANIMAL_READY:
         case STATE_CATAPULT_TARGETBUILDING:
         case STATE_CATAPULT_BACKOFF: DrawWorking(drawPt); break;
         case STATE_CARRYOUTWARE: DrawWalkingWithWare(drawPt); break;
@@ -246,6 +247,7 @@ void nofBuildingWorker::LostWork()
         case STATE_WAITFORWARESPACE:
         case STATE_HUNTER_SHOOTING:
         case STATE_HUNTER_EVISCERATING:
+        case STATE_HUNTER_WAITING_FOR_ANIMAL_READY:
         case STATE_CATAPULT_TARGETBUILDING:
         case STATE_CATAPULT_BACKOFF:
         {

--- a/libs/s25main/figures/nofBuildingWorker.h
+++ b/libs/s25main/figures/nofBuildingWorker.h
@@ -48,8 +48,8 @@ public:
         STATE_HUNTER_WALKINGTOCADAVER,              /// Jäger: Zum Kadaver laufen
         STATE_HUNTER_EVISCERATING,                  /// Jäger: Tier ausnehmen
         STATE_CATAPULT_TARGETBUILDING,              /// Katapult: Dreht den Katapult oben auf das Ziel zu und schießt
-        STATE_CATAPULT_BACKOFF                      /// Katapult: beendet schießen und dreht Katapult in die Ausgangsstellung zurück
-
+        STATE_CATAPULT_BACKOFF,                     /// Katapult: beendet schießen und dreht Katapult in die Ausgangsstellung zurück
+        STATE_HUNTER_WAITING_FOR_ANIMAL_READY,      /// Hunter: Arrived at shooting pos and waiting for animal to be ready to be shot
     };
 
 protected:

--- a/libs/s25main/figures/nofHunter.h
+++ b/libs/s25main/figures/nofHunter.h
@@ -55,6 +55,7 @@ private:
     /// Wenn jeweils gelaufen wurde oder ein Event abgelaufen ist, je nach aktuellem Status folgende Funktionen ausführen
     void HandleStateChasing();
     void HandleStateFindingShootingPoint();
+    void HandleStateWaitingForAnimalReady();
     void HandleStateShooting();
     void HandleStateWalkingToCadaver();
     void HandleStateEviscerating();

--- a/libs/s25main/figures/nofHunter.h
+++ b/libs/s25main/figures/nofHunter.h
@@ -47,7 +47,7 @@ private:
     /// Trifft Vorbereitungen fürs nach Hause - Laufen
     void StartWalkingHome();
     /// Läuft wieder zu seiner Hütte zurück
-    void WalkHome();
+    void HandleStateWalkingHome();
 
     /// Prüft, ob der Schießpunkt geeignet ist
     bool IsShootingPointGood(MapPoint pt);

--- a/libs/s25main/ogl/glArchivItem_Bitmap_Player.cpp
+++ b/libs/s25main/ogl/glArchivItem_Bitmap_Player.cpp
@@ -45,6 +45,11 @@ void glArchivItem_Bitmap_Player::DrawFull(const DrawPoint& dst, unsigned color, 
     DrawFull(Rect(dst, GetSize()), color, player_color);
 }
 
+void glArchivItem_Bitmap_Player::drawForPlayer(const DrawPoint& dst, unsigned playerColor)
+{
+    DrawFull(dst, COLOR_WHITE, playerColor);
+}
+
 void glArchivItem_Bitmap_Player::Draw(Rect dstArea, Rect srcArea, unsigned color /*= COLOR_WHITE*/, unsigned player_color /*= COLOR_WHITE*/)
 {
     if(GetTexture() == 0)

--- a/libs/s25main/ogl/glArchivItem_Bitmap_Player.h
+++ b/libs/s25main/ogl/glArchivItem_Bitmap_Player.h
@@ -36,11 +36,13 @@ public:
     RTTR_CLONEABLE(glArchivItem_Bitmap_Player)
 
     /// Draw the texture in the given rect, stretching if required
-    /// equivalent to Draw(origin, w, h, 0, 0, 0, 0, color)
+    /// equivalent to Draw(destArea, {0, 0, 0, 0}, color)
     void DrawFull(const Rect& destArea, unsigned color = COLOR_WHITE, unsigned player_color = COLOR_WHITE);
     /// Draw the texture to the given position with full size
-    /// equivalent to Draw(dst, 0, 0, 0, 0, 0, 0, color, player_color)
+    /// equivalent to Draw({dst, 0, 0}, {0, 0, 0, 0}, color, player_color)
     void DrawFull(const DrawPoint& dst, unsigned color = COLOR_WHITE, unsigned player_color = COLOR_WHITE);
+    /// Draw in player colors
+    void drawForPlayer(const DrawPoint& dst, unsigned playerColor);
 
 protected:
     void Draw(Rect dstArea, Rect srcArea, unsigned color = COLOR_WHITE, unsigned player_color = COLOR_WHITE);


### PR DESCRIPTION
When the hunter arrived at the shooting pos but the animal was not yet
ready, the hunter was still drawn as "walking" making it walk past its
destination point (due to interpolation using the "wait" event) and
warped back once the animal was ready.
This also triggered an assertion checking for walking draw while not
walking

Fixes #1126