### PR TITLE
Fix AI BQ update when placing flag near border

### DIFF
--- a/libs/s25main/ai/aijh/AIConstruction.cpp
+++ b/libs/s25main/ai/aijh/AIConstruction.cpp
@@ -408,7 +408,6 @@ bool AIConstruction::BuildRoad(const noRoadNode* start, const noRoadNode* target
     // Wenn Pfad gefunden, Befehl zum Straße bauen und Flagen setzen geben
     if(foundPath)
     {
-        aii.SetFlag(target->GetPos());
         aii.BuildRoad(start->GetPos(), false, route);
         // set flags along the road just after contruction - todo: handle failed road construction by removing the useless flags!
         /*MapCoord tx=x,ty=y;

--- a/libs/s25main/ai/aijh/AIPlayerJH.h
+++ b/libs/s25main/ai/aijh/AIPlayerJH.h
@@ -41,6 +41,10 @@ class BuildingPlanner;
 class AIConstruction;
 class Job;
 
+/// Create a subscription which records all nodes for which the BQ (may) have changed
+/// Requires arguments to have the same lifetime as the subscription
+Subscription recordBQsToUpdate(const GameWorldBase& gw, std::vector<MapPoint>& bqsToUpdate);
+
 /// Klasse für die besser JH-KI
 class AIPlayerJH : public AIPlayer
 {

--- a/libs/s25main/ingameWindows/iwMapDebug.cpp
+++ b/libs/s25main/ingameWindows/iwMapDebug.cpp
@@ -20,6 +20,7 @@
 #include "Loader.h"
 #include "PointOutput.h"
 #include "RttrForeachPt.h"
+#include "ai/aijh/AIPlayerJH.h"
 #include "controls/ctrlCheck.h"
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlTimer.h"
@@ -114,22 +115,7 @@ public:
             for(const unsigned playerIdx : usedPlayerIdxs)
                 bqMap[pt][playerIdx] = gw.GetBQ(pt, playerIdx);
         }
-        nodeSub = gw.GetNotifications().subscribe<NodeNote>([this](const NodeNote& note) {
-            if(note.type == NodeNote::BQ)
-                pointsToUpdate.push_back(note.pos);
-            else if(note.type == NodeNote::Owner)
-            {
-                // Owner changes border, which changes where buildings can be placed next to it
-                // And as flags are need for buildings we need range 2 (e.g. range 1 is flag, range 2 building)
-                this->gw.CheckPointsInRadius(
-                  note.pos, 2,
-                  [this](const MapPoint pt, unsigned) {
-                      pointsToUpdate.push_back(pt);
-                      return false;
-                  },
-                  true);
-            }
-        });
+        nodeSub = AIJH::recordBQsToUpdate(this->gw, this->pointsToUpdate);
     }
     void check()
     {


### PR DESCRIPTION
Found a regression caused by the previous fix: Setting a flag in distance 2 of the border disallows placing a flag next to the border but doesn't change it's underlying BQ. Previously a changed BQ lead to reevaluation of neighbor BQs via recursive calls which was removed to avoid excessive recalculations when not required but missed the above case. Hence add distance-1-nodes for changed BQs in the event

Also some refactoring to reuse the code in the map debug window and in the test to reproduce this by brute-force setting flags all over the players territory. This also didn't occur previously in the test because if the BQ in the border-neighbour node was castle, placing a flag changed it to BigBuilding hiding the issue. Hence place some trees to reduce BQ to less-than castle in many nodes.