### PR TITLE
Improve docu and tests, add rttr:FormatNumGFs

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,6 +22,12 @@ jobs:
       with:
         source: 'extras libs tests external/libendian external/liblobby external/libsiedler2 external/libutil external/mygettext external/s25edit external/s25update'
         clangFormatVersion: 9
+    - name: Lint markdown files
+      uses: avto-dev/markdown-lint@v1.3.0
+      with:
+        args:  --ignore data/RTTR/MAPS .
+        ignore: external
+
   Clang-Tidy:
     runs-on: ubuntu-latest
     steps:

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,2 @@
+default: true
+line_length: false

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -15,20 +15,20 @@ Check e.g. for `tools/release/debian/s25rttr.png` for an icon.
 
 ## Build type
 
-Option: `CMAKE_BUILD_TYPE`   
+Option: `CMAKE_BUILD_TYPE`
 Optimized ("release") builds are what you want to ship to users.
 Alternatively use `RelWithDebInfo` to include debug info at the expense of a bit less optimization.
 
 ## Version
 
-Option: `RTTR_VERSION`   
+Option: `RTTR_VERSION`
 RttR has 2 version parts: The version and revision.
 The latter is the git commit hash for unique identification and determined from the git tree or a file `revision.txt` in the root folder.
 The version is the human readable identification and defaults to the build date in `YYYYMMDD` format.
 
 ## System libs
 
-Options: `RTTR_USE_SYSTEM_LIBS`, `RTTR_USE_SYSTEM_<lib>`   
+Options: `RTTR_USE_SYSTEM_LIBS`, `RTTR_USE_SYSTEM_<lib>`
 RttR uses some libraries which may be installed system-wide or from other sources.
 To ease development it downloads those at configure time via CMakes [FetchContent](https://cmake.org/cmake/help/v3.14/module/FetchContent.html) module.
 You can force the configure run to use an already installed library by setting the corresponding `RTTR_USE_SYSTEM_<lib>` variable to `ON`.
@@ -37,7 +37,7 @@ So you may set that instead, but that has to be done on the first `cmake` run or
 
 ## FetchContent
 
-Option: `FETCHCONTENT_FULLY_DISCONNECTED`   
+Option: `FETCHCONTENT_FULLY_DISCONNECTED`
 The CMake [FetchContent](https://cmake.org/cmake/help/v3.14/module/FetchContent.html) module allows to download dependencies at configure time.
 To avoid this the above variable can be set to `ON`.
 
@@ -49,6 +49,6 @@ The only exception are library names like `LibFoo` which translate to `LIBFOO`.
 
 ## Tests
 
-Option: `BUILD_TESTING`   
+Option: `BUILD_TESTING`
 By default the tests are build alongside Rttr.
 You can disable this by setting the above (standard) option to `OFF` which e.g. avoids the dependency on Boost.Test.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 "Return To The Roots" is a fan-project, which aims to renew the original The Settlers 2.
 
-We aim to extend new features such as a multiplayer mode via internet as well as the support for modern hardware and several operating systems like Windows XP/Vista/Seven, Linux and MacOS X. Likewise we want to invent some smaller upgrades. Unfortunately it is necessary to rewrite the whole game, but we will stick to the original graphics and sounds, because they are still common and nice to be heard or seen.
+We aim to extend new features such as a multiplayer mode via internet as well as the support for modern hardware and several operating systems like Windows XP/Vista/Seven, Linux and MacOS X.
+Likewise we want to invent some smaller upgrades.
+Unfortunately it is necessary to rewrite the whole game, but we will stick to the original graphics and sounds, because they are still common and nice to be heard or seen.
 So you will still need an original "The Settlers 2 Gold Edition" version to play Return To The Roots.
 
-see more information on http://www.rttr.info
+see more information on <http://www.rttr.info>
 
-# Current Build Info
+## Current Build Info
 
 Travis CI: [![Travis CI Build Info](https://travis-ci.com/Return-To-The-Roots/s25client.svg?branch=master)](https://travis-ci.com/Return-To-The-Roots/s25client)
 
@@ -18,27 +20,29 @@ Coverage:
  /
 [![codecov](https://codecov.io/gh/Return-To-The-Roots/s25client/branch/master/graph/badge.svg)](https://codecov.io/gh/Return-To-The-Roots/s25client)
 
-# How to install
+## How to install
 
 - Download the game for your OS at [Downloads](https://www.rttr.info/index.php?com=dynamic&mod=2)
-    - stable: Usually more stable
-    - nightly: Latest features and bug fixes, but might be broken sometimes
+  - stable: Usually more stable
+  - nightly: Latest features and bug fixes, but might be broken sometimes
 - Extract into a folder of your choice
 - Locate the file `put your S2-Installation in here` in that folder (usually at the root or in S2)
 - Copy the DATA and GFX folder from the original The Settlers II Gold into the folder containing the above file
 - Start `rttr.bat`/`rttr.sh` or the bundle (OSX only) to auto-update and start the game
-    - Alternatively start `s25client` directly, but updates and music might be missing
-- WARNING: Do not use symlinks/junction points/... for subfolders of your installation. Putting RttR in a symlinked folder should work though.
+  - Alternatively start `s25client` directly, but updates and music might be missing
+- WARNING: Do not use symlinks/junction points/... for subfolders of your installation.
+Putting RttR in a symlinked folder should work though.
 
-# How to build
+## How to build
 
-## On Linux or Darwin/MacOSX
+### On Linux or Darwin/MacOSX
 
-### Prerequisite Linux:
+#### Prerequisite Linux
+
 - C++14 compatible compiler (e.g. GCC-6)
 - cmake
 - git
-- libboost-dev (at least v1.64.0, i.e http://www.boost.org/)
+- libboost-dev (at least v1.64.0, i.e <http://www.boost.org/>)
   or only: libboost-test-dev libboost-locale-dev, libboost-iostreams-dev, libboost-filesystem-dev, libboost-program-options-dev (at least v1.64.0)
 - libsdl2-dev
 - libsdl2-mixer-dev
@@ -50,7 +54,8 @@ Coverage:
 
 All of them can be installed with the package manager.
 
-### Prerequisite MacOSX:
+#### Prerequisite MacOSX
+
 - cmake
 - git
 - boost
@@ -61,11 +66,13 @@ All of them can be installed with the package manager.
 
 All of them can be installed via homebrew
 
-### Prerequesites with Nix
+#### Prerequisites with Nix
+
 Nix users can open a nix-shell to get a development environment with all packages ready.
 
-### Steps:
-```
+#### Checkout and build
+
+```bash
 git clone --recursive https://github.com/Return-To-The-Roots/s25client s25client
 cd s25client
 nix-shell # Optional, for Nix users only
@@ -73,11 +80,15 @@ mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make
 ```
-Note: by using the `-G` option of `cmake` you can specify a generator, e.g. `cmake -G Xcode -DCMAKE_BUILD_TYPE=Release ..` will generate an Xcode project. 
-Please check `cmake --help` for more options. 
 
-### Optimizations:
-There are various CMake options to control the build and optimization including ARM (Rasberry PI etc.) related ones. Examples:
+Note: by using the `-G` option of `cmake` you can specify a generator, e.g. `cmake -G Xcode -DCMAKE_BUILD_TYPE=Release ..` will generate an Xcode project.
+Please check `cmake --help` for more options.
+
+#### Optimizations
+
+There are various CMake options to control the build and optimization including ARM (Raspberry PI etc.) related ones.
+Examples:
+
 - RTTR_ENABLE_OPTIMIZATIONS/RTTR_ENABLE_WERROR
 - RTTR_OPTIMIZATION_VECTOR_EXT (Non-Windows x86/x64 only)
 - RTTR_OPTIMIZATION_TUNE (Non-Windows only)
@@ -87,7 +98,8 @@ See the description in CMake-GUI/ccmake for details.
 Note that due to the use of submodules you always need to `git pull && git submodule update --init --recursive` to get the latest version.
 (The `--init` and `--recursive` arguments are only required should we add *new* submodules to the existing set.)
 
-### Tests
+#### Tests
+
 Especially for developing you should build in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`) and run the tests after executing `make` via `make test` or `ctest --output-on-failure`.
 There is also an option to enable checks for undefined behavior (UBSAN) and memory errors (ASAN) like use-after-free or leaks.
 Just pass `-DRTTR_ENABLE_SANITIZERS=ON` to CMake and use a recent GCC or Clang compiler to build.
@@ -95,30 +107,33 @@ Then just run (tests or application) as usual.
 
 **Note**: Boost.Endian < 1.67 is known to have UB so use at least 1.67 when running the sanitizers.
 
-## On Windows
+### On Windows
 
-### Prerequisites:
-- cmake (i.e from http://www.cmake.org/download/)
-- boost (i.e from http://www.boost.org/)
+#### Prerequisites
+
+- cmake (i.e from <http://www.cmake.org/download/>)
+- boost (i.e from <http://www.boost.org/>)
 - Visual Studio (at least 2015, you can get the community edition for free)
 - Git Client (i.e TortoiseGit)
 
-### Steps:
-- Clone GIT Repository from https://github.com/Return-To-The-Roots/s25client
+#### Steps
+
+- Clone GIT Repository from <https://github.com/Return-To-The-Roots/s25client>
   - Using Git bash:
-     ```
+
+     ```bash
      git clone --recursive https://github.com/Return-To-The-Roots/s25client s25client
      ```
 
   - **OR** using TortoiseGit:
-     - Rightclick -> "Git clone..."
-     - Put in https://github.com/Return-To-The-Roots/s25client as URL
-     - Select "Directory" to clone to
-     - press OK
-     - Rightclick on the newly created folder -> TortoiseGit-> Submodule Update
-     - Make sure all modules are selected and "Initialize submodules (--init)" is checked
-     - press OK
-- If you havent installed boost, install boost
+    - Rightclick -> "Git clone..."
+    - Put in <https://github.com/Return-To-The-Roots/s25client> as URL
+    - Select "Directory" to clone to
+    - press OK
+    - Rightclick on the newly created folder -> TortoiseGit-> Submodule Update
+    - Make sure all modules are selected and "Initialize submodules (--init)" is checked
+    - press OK
+- If you haven't installed boost, install boost
   Fast Way:
   - extract boost-1.64.zip (i.e to external/boost, so that external/boost/bootstrap.bat exist)
   - run that "bootstrap.bat"
@@ -143,4 +158,4 @@ Then just run (tests or application) as usual.
 
 --
 
-for advanced info or help see [FAQ in the wiki](https://github.com/Return-To-The-Roots/s25client/wiki/How-to-install-RttR) or http://www.rttr.info
+For advanced info or help see [FAQ in the wiki](https://github.com/Return-To-The-Roots/s25client/wiki/How-to-install-RttR) or <http://www.rttr.info>

--- a/doc/lua/constants.md
+++ b/doc/lua/constants.md
@@ -1,0 +1,148 @@
+# Constants
+
+These are the named constants that must be used to refer to specific instances.
+They are also used when an event is called.
+
+- [Wares / Goods](#Wares-/-Goods)  
+- [Buildings](#Buildings)  
+- [Jobs](#Jobs)  
+- [Resources](#Resources)  
+- [Animals](#Animals)  
+- [Pacts](#Pacts)  
+
+## Wares / Goods
+
+--> [gameTypes/GoodTypes.h](../../libs/s25main/gameTypes/GoodTypes.h)  
+GD_BEER  
+GD_TONGS  
+GD_HAMMER  
+GD_AXE  
+GD_SAW  
+GD_PICKAXE  
+GD_SHOVEL  
+GD_CRUCIBLE  
+GD_RODANDLINE  
+GD_SCYTHE  
+GD_WATER  
+GD_CLEAVER  
+GD_ROLLINGPIN  
+GD_BOW  
+GD_BOAT  
+GD_SWORD  
+GD_IRON  
+GD_FLOUR  
+GD_FISH  
+GD_BREAD  
+GD_SHIELD  
+GD_WOOD  
+GD_BOARDS  
+GD_STONES  
+GD_GRAIN  
+GD_COINS  
+GD_GOLD  
+GD_IRONORE  
+GD_COAL  
+GD_MEAT  
+GD_HAM  
+
+## Buildings
+
+--> [gameTypes/BuildingType.h](../../libs/s25main/gameTypes/BuildingType.h)  
+BLD_HEADQUARTERS  
+BLD_BARRACKS  
+BLD_GUARDHOUSE  
+BLD_WATCHTOWER  
+BLD_FORTRESS  
+BLD_GRANITEMINE  
+BLD_COALMINE  
+BLD_IRONMINE  
+BLD_GOLDMINE  
+BLD_LOOKOUTTOWER  
+BLD_CATAPULT  
+BLD_WOODCUTTER  
+BLD_FISHERY  
+BLD_QUARRY  
+BLD_FORESTER  
+BLD_SLAUGHTERHOUSE  
+BLD_HUNTER  
+BLD_BREWERY  
+BLD_ARMORY  
+BLD_METALWORKS  
+BLD_IRONSMELTER  
+BLD_CHARBURNER  
+BLD_PIGFARM  
+BLD_STOREHOUSE  
+BLD_MILL  
+BLD_BAKERY  
+BLD_SAWMILL  
+BLD_MINT  
+BLD_WELL  
+BLD_SHIPYARD  
+BLD_FARM  
+BLD_DONKEYBREEDER  
+BLD_HARBORBUILDING  
+
+## Jobs
+
+--> [gameTypes/JobTypes.h](../../libs/s25main/gameTypes/JobTypes.h)  
+JOB_HELPER  
+JOB_WOODCUTTER  
+JOB_FISHER  
+JOB_FORESTER  
+JOB_CARPENTER  
+JOB_STONEMASON  
+JOB_HUNTER  
+JOB_FARMER  
+JOB_MILLER  
+JOB_BAKER  
+JOB_BUTCHER  
+JOB_MINER  
+JOB_BREWER  
+JOB_PIGBREEDER  
+JOB_DONKEYBREEDER  
+JOB_IRONFOUNDER  
+JOB_MINTER  
+JOB_METALWORKER  
+JOB_ARMORER  
+JOB_BUILDER  
+JOB_PLANER  
+JOB_PRIVATE  
+JOB_PRIVATEFIRSTCLASS  
+JOB_SERGEANT  
+JOB_OFFICER  
+JOB_GENERAL  
+JOB_GEOLOGIST  
+JOB_SHIPWRIGHT  
+JOB_SCOUT  
+JOB_PACKDONKEY  
+JOB_BOATCARRIER  
+JOB_CHARBURNER  
+JOB_NOTHING  
+
+## Resources
+
+--> [lua/LuaInterfaceGame.cpp](../../libs/s25main/lua/LuaInterfaceGame.cpp)  
+RES_IRON  
+RES_GOLD  
+RES_COAL  
+RES_GRANITE  
+RES_WATER  
+
+## Animals
+
+--> [gameTypes/AnimalTypes.h](../../libs/s25main/gameTypes/AnimalTypes.h)  
+SPEC_POLARBEAR  
+SPEC_RABBITWHITE  
+SPEC_RABBITGREY  
+SPEC_FOX  
+SPEC_STAG  
+SPEC_DEER  
+SPEC_DUCK  
+SPEC_SHEEP  
+
+## Pact
+
+--> [gameTypes/PactTypes.h](../../libs/s25main/gameTypes/PactTypes.h)  
+NON_AGGRESSION_PACT  
+TREATY_OF_ALLIANCE  
+DURATION_INFINITE

--- a/doc/lua/events.md
+++ b/doc/lua/events.md
@@ -1,0 +1,96 @@
+# Events
+
+This lists all events, that is functions your script can implement and which are called at specific times,
+e.g. when something happens.
+
+- [Events during settings stage](#Settings)  
+- [Events during game stage](#Game)  
+
+## Settings
+
+**onSettingsInit(isSinglePlayer, isSavegame)**  
+Called when the game settings screen is entered.
+Can be used to set up some dependent variables.  
+**ONLY** settings event called for all players.
+All other events are called only for host
+
+**onSettingsReady()**  
+Called when the settings screen is initialized and player manipulations are possible
+
+**onPlayerJoined(playerIdx)**  
+Called whenever a player joined.
+
+**onPlayerLeft(playerIdx)**  
+Called when a player has left.
+
+**onPlayerReady(playerIdx)**  
+Called when a player pressed "ready".
+For the host player this means the game is starting (or host tries to).
+
+**getAllowedChanges()**  
+Should return a map with string keys and bool values.
+If the bool is false, the given option cannot be changed.
+If a key does not exist, a default value is used:  
+
+- general(false): Settings like lock teams, team view, ...
+- addonsAll(false): Cannot change any addon
+- addonsSome(false): Can only change addons in list returned by `getAllowedAddons`
+- swapping(false): Swap places
+- playerState(false): Change player slots (add/change AI, ...)
+- ownNation, ownColor, ownTeam (all true): Change values player
+- aiNation, aiColor, aiTeam (all true): Change values of AI  
+
+```lua
+function getAllowedChanges()
+    return { ["general"] = true}
+end
+```
+
+**getAllowedAddons()**  
+Only meaningfull if `addonsAll=false` and `addonsSome=true`:
+Return a list with addonIds that the host can change.
+
+## Game
+
+**onStart(isFirstStart)**  
+Called at the start of the game, after the headquarters are placed.
+`isFirstStart` is true, if the game was just created and false for savegames.
+
+**onSave(serializer)**  
+Called when the game is being saved.
+LUA data can be saved to the passed [`Serializer`](methods.md#Serializer) object.
+Needs to return true on success or false on error.
+
+**onLoad(serializer)**  
+Called when the game is loaded (before onStart).
+LUA data can be loaded from the [`Serializer`](methods.md#Serializer) object in the same order they are saved (FIFO).
+Needs to return true on success or false on error.
+
+**onOccupied(playerIdx, x, y)**  
+Called every time a point on the map gets occupied by a player.
+
+**onExplored(playerIdx, x, y, owner)**  
+Called every time a point on the map becomes visible for a player.
+The owner parameter contains the owner's player id, _nil_ means that there is no owner.
+
+**onGameFrame(gameframeNumber)**  
+Gets called every game frame.
+
+**onResourceFound(playerIdx, x, y, type, quantity)**  
+Given resource (RES_IRON, RES_GOLD, RES_COAL, RES_GRANITE or RES_WATER) was found at x,y.  
+
+**onCancelPactRequest(pactType, fromPlayerIdx, toPlayerIdx)**  
+Only called for AI.
+Called when `fromPlayer` requests to cancel a pact.
+Return false to decline.  
+
+**onSuggestPact(PactType, suggestedByPlayerIdx, targetPlayerIdx, duration)**  
+Only called for AI.
+Player suggests a pact
+Return true to accept or false to decline.
+
+**onPactCanceled(PactType, canceledByPlayerIdx, targetPlayerIdx)**  
+Called when a pact has been canceled.
+
+**onPactCreated(PactType, suggestedByPlayerIdx, targetPlayerIdx, duration)**  
+Called when a pact has been confirmed.

--- a/doc/lua/main.md
+++ b/doc/lua/main.md
@@ -1,0 +1,88 @@
+# Content
+
+[Events](events.md)  
+[Functions](functions.md)  
+[Constants](constants.md)  
+
+## Map scripts
+
+LUA scripts are loaded from `path/to/map.lua` for a map at `path/to/map.swd`.
+The game will look for a file ending in `'.lua'` instead of `'.swd'`.
+Please be aware that case matters for some operating systems.
+The file will be sent to all clients, overwriting files in the user's own rttr MAPS directory.  
+
+## Interface overview
+
+The new LUA interface is object oriented.
+This means all RTTR entities are objects and hence functions must be invoked with `rttr:MyFunc()`.
+
+LUA scripts (can) contain 2 parts:
+One that is used during game creating (e.g. set resources, nations, fixed settings...)
+and one that runs during the game and reacts on events.
+This is important as some functions are only available during the 'Settings' state
+and other only during the 'Game' state.
+Calling an unavailable function will lead to aborting the script and stopping the game,
+but you usually get a descriptive message in the console window and log.
+
+Players are represented in 2 ways:
+Either by their `playerIdx`, a zero-based index into an array of players.
+Or by a player object which has methods to call.
+The interface distinguishes between them by using naming conventions like `playerIdx` and `player`.
+
+## Versioning
+
+The lua interface is versioned according to SemVer (semantic versioning).
+This means there is a version number consisting of a major and minor version, e.g. `1.0`.
+Everytime a feature is added the minor version is increased.
+When a breaking change is made (e.g. a function is removed or changes behavior considerably) the major version is increased and the minor version reset to zero.
+
+Every map script must have 1 function:  
+**getRequiredLuaVersion()**  
+You need to implement this and return the major version your script works with.
+If it does not match the current version an error will be shown and the script will not be used.
+See `rttr:GetVersion()`.
+
+## Example
+
+```lua
+    -- start callback, called after everything is set up
+    function onStart(isFirstStart)
+        if(not isFirstStart) then
+            return
+        end
+        -- add 100 generals and 10 officers for player 0
+        rttr:GetPlayer(0):AddPeople({[JOB_GENERAL] = 100, [JOB_OFFICER] = 10})
+        -- disable barracks (building 1) for player 0
+        rttr:GetPlayer(0):DisableBuilding(BLD_BARRACKS)
+
+        -- restrictions for player 0
+        rttr:GetPlayer(0):SetRestrictedArea(0,42, 255,42, 255,255, 0,255)
+    end
+
+    function onGameFrame(no)
+        -- every 100 gf...
+        if no % 100 == 0 then
+            -- for all players...
+            for player = 1, rttr:GetNumPlayers() do
+                pl = rttr:GetPlayer(player - 1)
+                rttr:Chat(-1, "[Player " .. pl:GetName() .. " @GF " .. rttr:GetGF() .. "] helpers: " ..
+                               pl:GetNumPeople(JOB_HELPER) .. ", wells: " .. pl:GetNumBuildings(BLD_WELL) ..
+                               ", water: " .. pl:GetNumWares(GD_WATER))
+            end
+        end
+    end
+
+    -- just output a message for now
+    function onOccupied(player, x, y)
+        rttr:Log("Point occupied: " .. player .. ": " .. x .. "," .. y)
+    end
+
+    -- just output a message for now
+    function onExplored(player, x, y)
+        rttr:Log("Point explored: " .. player .. ": " .. x .. "," .. y)
+    end
+```
+
+For a more complete example usage of all functions have a look at [tests/testData/maps/LuaFunctions.lua](../../tests/testData/maps/LuaFunctions.lua)
+
+[Back](#Content)

--- a/doc/lua/methods.md
+++ b/doc/lua/methods.md
@@ -1,0 +1,381 @@
+# Lua objects and their methods
+
+There are the following objects defined:
+
+- [`rttr`: Main object](#Main-object-rttr)
+- [`PlayerBase`: Player methods for settings and game mode](#PlayerBase)
+- [`SettingsPlayer`: Player methods for settings mode](#SettingsPlayer)
+- [`GamePlayer`: Player methods for game mode](#GamePlayer)
+- [`World`: Represents the game world](#World)
+- [`Serializer`: FIFO buffer for storing persistent data](#Serializer)
+
+## Main object `rttr`
+
+### Base functions (callable in settings and game mode)
+
+Reference: [libs/libGamedata/lua/LuaInterfaceBase.cpp](../../libs/libGamedata/lua/LuaInterfaceBase.cpp)
+
+**rttr:GetVersion()**  
+Get the current major and minor version as a pair.
+Changes to the major version reflect breaking changes that are expected to cause errors in existing scripts.
+Minor version changes only add new features.
+The current version is **1.0**.
+
+**rttr:Log(message)**  
+Log the message to console.
+
+**rttr:IsHost()**  
+Return true/false if the local player is the host.
+
+**rttr:GetNumPlayers()**  
+Return the number of players.
+
+**rttr:GetLocalPlayerIdx()**  
+Return 0-based index of the local player.
+
+**rttr:MsgBox(title, message, isError = false)**  
+Show a message box to the current user.
+`isError` is used to show a red or green icon.
+A scrollbar will be shown for long text.  
+Note: You can have multiple message boxes opened.
+First one will be on top until closed.
+
+**rttr:MsgBoxEx(title, message, iconFile, iconIdx[, iconX, iconY])**  
+Show a message box to the current user.
+`iconIdx` is the index into `iconFile` (name w/o extension) of the icon to use.
+The file must be loaded at this point!
+(Safe to use "io").
+The window is automatically adjusted to fit the image.
+The text is moved, if possible, otherwise it is drawn over the image.
+Place the image at the border if you don't want this.
+
+Notes:
+
+- You can have multiple message boxes opened.
+First one will be on top till closed  
+- You can not do any action until the window is closed  
+- You should use an offset (`iconX`/`iconY`) as 0:0 leads to a graphic that is drawn in the upper left over the border (16,24 recommended)  
+
+**rttr:RegisterTranslations(translations)**  
+Register translations for multilanguage scripts, by passing a table containing languages as keys.
+Example:
+
+```lua
+rttr:RegisterTranslations(
+{
+    en_GB =
+    {
+        World   = 'Hello World',
+        Message = 'Have a nice day'
+    },
+    de =
+    {
+        World   = 'Hallo Welt',
+        Message = 'Hab einen schönen Tag'
+    }
+}
+```
+
+In order to retrieve the Value, you simply use the following call:
+
+```lua
+_('World')
+```
+
+In this example,  
+
+- If the client language is English, `Hello World` is returned  
+- If the client language is German, `Hallo Welt` is returned  
+- If the client language is Czech (or any other than english or german), the key is returned, in this case `World`  
+
+[Back](#Lua-objects-and-their-methods)  
+
+### Settings functions (callable in settings mode only)
+
+Reference: [lua/LuaInterfaceSettings.h](../../libs/s25main/lua/LuaInterfaceSettings.h)  
+**Important: All functions can only be used by the host!**
+
+**rttr:GetPlayer(playerIdx)**  
+Get the player with the given index, returns a [`SettingsPlayer`](#SettingsPlayer)
+
+**rttr:SetAddon(addonId, value)**  
+Change setting of an addon.
+The addonId is the internal AddonID (see [const_addons.h](../../libs/s25main/addons/const_addons.h#L50)) with prefix ADDON_.
+
+```lua
+rttr:SetAddon(ADDON_FRONTIER_DISTANCE_REACHABLE, true)
+```
+
+For addons which can be enabled / disabled simply use true or false, for addons with different settings, add the number according to your setting.  
+
+**rttr:ResetAddons()**  
+Set all addons to S2 defaults
+
+**rttr:ResetGameSettings()**  
+Set all settings and addons to their defaults.
+Note: Exploration is currently FoW.
+Will be classic later.
+
+**rttr:SetGameSettings(settings)**  
+Set the settings with a table of keys:  
+
+- speed: GS_VERYSLOW, GS_SLOW, GS_NORMAL, GS_FAST, GS_VERYFAST
+- objective: GO_NONE, GO_CONQUER3_4, GO_TOTALDOMINATION
+- startWares: SWR_VLOW, SWR_LOW, SWR_NORMAL, SWR_ALOT
+- fow: EXP_DISABLED, EXP_CLASSIC, EXP_FOGOFWAR, EXP_FOGOFWARE_EXPLORED
+- lockedTeams, teamView, randomStartPosition: true/false
+
+[Back](#Lua-objects-and-their-methods)  
+
+### Gamefunctions (callable in game modeonly)
+
+Reference: [lua/LuaInterfaceGame.h](../../libs/s25main/lua/LuaInterfaceGame.h)  
+**Important: All state-changing functions should be executed by all players at the same time (GF), or there will be asyncs!**
+
+**rttr:ClearResources()**  
+Remove all workers and wares from all players warehouses.
+
+**rttr:GetGF()**  
+Return the current game frame number.
+
+**rttr:Chat(player, message)**  
+Send message to player (-1 for all players).
+
+**rttr:MissionStatement(player, title, message, imgIdx = IM_SWORDSMAN, pause = true)**  
+Send mission statement to player, pauses the game in single player if pause is set.  
+Possible images: `IM_NONE, IM_SWORDSMAN, IM_READER, IM_RIDER, IM_AVATAR1-IM_AVATAR12` (see [iwMissionStatement](../../libs/s25main/ingameWindows/iwMissionStatement.h#L28))
+
+```lua
+rttr:MissionStatement(0, "Diary", "Forth day\n\n\nThere are " .. rttr:GetNumPlayers() .. " players.")
+```
+
+Note: You can have multiple message boxes opened.
+First one will be on top till closed.
+_Not saved in savegame!_
+
+**rttr:PostMessage(player, message)**  
+Send post message to player.
+
+**rttr:PostMessageWithLocation(player, message, x, y)**  
+Send post message to player (with location x, y).
+
+**rttr:GetPlayer(playerIdx)**  
+Get the player with the given index, returns a [`GamePlayer`](#GamePlayer)
+
+**rttr:GetWorld()**  
+Get the world object, returns a [`World`](#World)
+
+[Back](#Lua-objects-and-their-methods)  
+
+## PlayerBase
+
+Reference: [lua/LuaPlayerBase.h](../../libs/s25main/lua/LuaPlayerBase.h)  
+This is the base object for [`GamePlayer`](#GamePlayer) and [`SettingsPlayer`](#SettingsPlayer).
+Hence these methods are available in settings and game stage.
+
+**GetName()**  
+Return the players name.
+
+**GetNation()**  
+Return the nation, one of `NAT_AFRICANS, NAT_JAPANESE, NAT_ROMANS, NAT_VIKINGS, NAT_BABYLONIANS`
+
+**GetTeam()**  
+Return the players team, one of `TM_NOTEAM, TM_RANDOMTEAM, TM_RANDOMTEAM2, TM_RANDOMTEAM3, TM_RANDOMTEAM4, TM_TEAM1, TM_TEAM2, TM_TEAM3, TM_TEAM4`  
+See [TeamTypes](../../libs/s25main/gameTypes/TeamTypes.h) for enums.
+
+**GetColor()**  
+Return color index if found or player color
+Color indices always have an alpha value.
+
+**IsHuman()**  
+Return true if the player is controlled by a human player.
+
+**IsAI()**  
+Return true if the player is controlled by an AI player.
+
+**IsClosed()**  
+Return true if the slot is closed.
+
+**IsFree()**  
+Return true if the slot is open and not controlled by a human or AI player.
+
+**GetAILevel()**  
+Return the AI difficulty level.
+
+- -1: Not an AI
+- 0: Dummy
+- 1-3: Easy-Hard
+
+[Back](#Lua-objects-and-their-methods)  
+
+## SettingsPlayer
+
+Reference: [lua/LuaServerPlayer.h](../../libs/s25main/lua/LuaServerPlayer.h)  
+Available in settings mode only.
+
+**SetNation(Nation)**  
+Change the players nation.
+
+**SetTeam(Team)**  
+Change the players team.
+
+**SetColor(color or colorIdx)**  
+Sets the players color by index or directly if its alpha value is not zero.
+Duplicate color values are possible, so you have to ensure unique colors if you want them!
+
+**Close()**  
+Closes a spot kicking any player or AI there.
+
+**SetAI(level)**  
+Add an AI or change its difficulty.
+
+**SetName(name)**  
+Change the players name.
+
+[Back](#Lua-objects-and-their-methods)  
+
+## GamePlayer
+
+Reference: [lua/LuaPlayer.h](../../libs/s25main/lua/LuaPlayer.h)  
+This is the game state player object.
+
+**player:EnableBuilding(type, notify)**  
+Enable the building specified for the player.
+If notify is true, the players gets a notification that the building is now available.  
+_Not saved in savegame!_
+
+**DisableBuilding(type)**  
+Disable the building for the player.
+_Not saved in savegame!_
+
+**EnableAllBuildings()**
+Enable all buildings for the player.
+_Not saved in savegame!_  
+
+**DisableAllBuildings()**  
+Disable all buildings for the player.
+_Not saved in savegame!_
+
+**SetRestrictedArea(x1,y1, ...)**  
+Restrict the area a player may have territory in.
+If called without any x/y-values (e.g. `rttr:GetPlayer(1):SetRestrictedArea()`), the restrictions are lifted.
+Otherwise, the coordinates specify one or multiple polygons the player may have territory in (replacing older restrictions).
+A polygon inside a polygon will create a hole in it.
+To specify multiple polygons, start with a 0,0-pair followed by the first polygon, another 0,0-pair, the second polygon etc. and a final 0,0-pair at the end.
+For multiple polygons, each polygons first point has to be repeated at the end of it.  
+
+Notes:
+
+1. It is unspecified whether a point on the boundary of a polygon is inside or outside of it.
+However if they are inside a polygon, then they are outside of a contained or containing polygon.
+This allows creation of mutual exclusive areas like allowing an area only for a player and disallowing this area for another player.
+2. RTTR/S2 uses a triangle-based grid.
+This may cause surprises when using this function as you cannot easily describe a "real" rectangle.
+Generally consider the border area as a "maybe" unless you tested it exactly.
+3. The current implementation uses the crossing-count method described [here](http://geomalgorithms.com/a03-_inclusion.html).
+But it assumes a rectangle grid, so every 2nd row is shifted by half a triangle for the means of the algorithm.  
+
+**IsInRestrictedArea(x, y)**  
+Return true if (x,y) is in the restricted area.
+Restricted means, building is allowed.
+The `SetRestrictedArea` function defines where you may build buildings and not where you are not allowed to.  
+
+**ClearResources()**  
+Remove all wares and workers from all warehouses
+
+**AddWares(wareMap)**  
+Add the specified goods to the players first warehouse.
+Keys must be `GoodType`s and values unsigned numbers
+
+**AddPeople(peopleMap)**  
+Add the specified people to the player's first warehouse.
+Keys must be `Job`s and values unsigned numbers
+
+**GetNumBuildings(building_type)**  
+Get number of buildings a player has of a given type.
+
+**GetNumBuildingSites(building_type)**
+Get number of building sites a player has of a given type.
+
+**GetNumWares(ware_type)**  
+Get number of wares a player has of a given type.
+
+**GetNumPeople(job_type)**  
+Get number of people a player has with a given job.
+
+**AIConstructionOrder(x,y,buildingtype)**  
+Order AI to build buildingtype at the given x,y location (AI will usually retry at a nearby location if the location is bad)
+Returns true, if the order was submitted, false otherwise.  
+Ignored, if player is not the host (returns always true)
+
+**ModifyHQ(isTent)**  
+Set whether the players HQ is shown as a tent (1) or not (0)
+
+**IsDefeated()**  
+Return true if the player is defeated
+
+**IsAlly(otherPlayerIdx)**  
+Return true if the player is an ally of this player
+
+**IsAttackable(otherPlayerIdx)**  
+Return true if the player can be attacked
+
+**SuggestPact(otherPlayerIdx, PactType, duration)**  
+Let the AI send a request to the other player for a new pact.
+Ignored if the current player is not controlled by AI.
+
+**CancelPact(PactType, otherPlayerIdx)**  
+Let the AI send a request to the other player to cancel a pact.
+Ignored if the current player is not controlled by AI.
+
+**GetHQPos()**  
+Return x,y of the players HQ
+
+**Surrender(destroyBuildings)**  
+Let the player give up either keeping its buildings or destroying them.
+Can be called multiple times e.g. to destroy buildings later.
+
+[Back](#Lua-objects-and-their-methods)  
+
+## World  
+
+Reference: [libs/s25main/lua/LuaWorld.h](../../libs/s25main/lua/LuaWorld.h)
+
+**AddEnvObject(x, y, id, file = 0xFFFF)**  
+Place a new environment object.
+Only environment/static objects and empty space can be overwritten.
+
+- `id`: id in file
+- `file`: `0xFFFF` = map_?_z.lst, `0-5` = mis?bobs.lst
+
+**AddStaticObject(x, y, id, file = 0xFFFF, size = 0)**  
+Place a new static object.
+Only environment/static objects and empty space can be overwritten.
+
+- `id`: id in file
+- `file`: `0xFFFF` = map_?_z.lst, `0-5` = mis?bobs.lst
+- `size`: 0: Block nothing (destructible), 1: Block single spot, 2: Block spots like castle-sized buildings
+
+**AddAnimal(x, y, species)**  
+Adds an animal.
+If the terrain is unsuitable the animal will die soon.
+`species` must be a [SPEC_*](constants.md#Animals) constant.
+
+```lua
+rttr:GetWorld():AddAnimal(41, 44, SPEC_DUCK)
+```
+
+[Back](#Lua-objects-and-their-methods)  
+
+## Serializer
+
+The following methods are available.
+Remember that this is a FIFO structure, hence what is `Push`ed first needs to be `Pop`ped first.
+
+**PushInt(value)**  
+**PushBool(value)**  
+**PushString(value)**  
+
+**number PopInt()**  
+**true/false PopBool()**  
+**string PopString()**

--- a/doc/lua/methods.md
+++ b/doc/lua/methods.md
@@ -138,6 +138,10 @@ Remove all workers and wares from all players warehouses.
 **rttr:GetGF()**  
 Return the current game frame number.
 
+**rttr:FormatNumGFs(numGFs)**  
+Return the real time duration for this number of game frames based on the current speed.
+Output will be in `HH:MM:SS` format with hours omitted if zero.
+
 **rttr:Chat(player, message)**  
 Send message to player (-1 for all players).
 

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -1620,7 +1620,7 @@ GamePlayer::PactState GamePlayer::GetPactState(const PactType pt, const unsigned
         if(!pacts[other_player][pt].accepted)
             return IN_PROGRESS;
 
-        if(pacts[other_player][pt].duration == 0xFFFFFFFF
+        if(pacts[other_player][pt].duration == DURATION_INFINITE
            || gwg.GetEvMgr().GetCurrentGF() < pacts[other_player][pt].start + pacts[other_player][pt].duration)
             return ACCEPTED;
     }
@@ -1639,15 +1639,15 @@ void GamePlayer::NotifyAlliesOfLocation(const MapPoint pt)
     }
 }
 
-/// Gibt die verbleibende Dauer zurück, die ein Bündnis noch laufen wird (0xFFFFFFFF = für immer)
+/// Gibt die verbleibende Dauer zurück, die ein Bündnis noch laufen wird (DURATION_INFINITE = für immer)
 unsigned GamePlayer::GetRemainingPactTime(const PactType pt, const unsigned char other_player) const
 {
     if(pacts[other_player][pt].duration)
     {
         if(pacts[other_player][pt].accepted)
         {
-            if(pacts[other_player][pt].duration == 0xFFFFFFFF)
-                return 0xFFFFFFFF;
+            if(pacts[other_player][pt].duration == DURATION_INFINITE)
+                return DURATION_INFINITE;
             else if(gwg.GetEvMgr().GetCurrentGF() <= pacts[other_player][pt].start + pacts[other_player][pt].duration)
                 return ((pacts[other_player][pt].start + pacts[other_player][pt].duration) - gwg.GetEvMgr().GetCurrentGF());
         }
@@ -1741,7 +1741,7 @@ void GamePlayer::MakeStartPacts()
             continue;
         for(unsigned z = 0; z < NUM_PACTS; ++z)
         {
-            pacts[i][z].duration = 0xFFFFFFFF;
+            pacts[i][z].duration = DURATION_INFINITE;
             pacts[i][z].start = 0;
             pacts[i][z].accepted = true;
             pacts[i][z].want_cancel = false;

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -275,7 +275,7 @@ public:
         ACCEPTED     /// Bündnis in Kraft
     };
     PactState GetPactState(PactType pt, unsigned char other_player) const;
-    /// Gibt die verbleibende Dauer zurück, die ein Bündnis noch laufen wird (0xFFFFFFFF = für immer)
+    /// Gibt die verbleibende Dauer zurück, die ein Bündnis noch laufen wird (DURATION_INFINITE = für immer)
     unsigned GetRemainingPactTime(PactType pt, unsigned char other_player) const;
     /// Setzt die initialen Bündnisse anhand der Teams
     void MakeStartPacts();
@@ -399,7 +399,7 @@ private:
     /// Bündnisse mit anderen Spielern
     struct Pact
     {
-        /// Dauer (in GF), 0 = kein Bündnise, 0xFFFFFFFF = Bündnis auf Ewigkeit
+        /// Dauer (in GF), 0 = kein Bündnise, DURATION_INFINITE = Bündnis auf Ewigkeit
         unsigned duration;
         /// Startzeitpunkt (in GF)
         unsigned start;

--- a/libs/s25main/ILocalGameState.h
+++ b/libs/s25main/ILocalGameState.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 - 2020 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef ILocalGameState_h__
+#define ILocalGameState_h__
+
+#include <string>
+
+class ILocalGameState
+{
+public:
+    /// Get the local player id
+    virtual unsigned GetPlayerId() const = 0;
+    /// Return true if the local player is the host
+    virtual bool IsHost() const = 0;
+    /// Convert a number of GameFrames into real time (HH:MM:SS or MM:SS if hours = 0)
+    virtual std::string FormatGFTime(unsigned numGFs) const = 0;
+    /// Send a chat message to the local player
+    virtual void SystemChat(const std::string& text) = 0;
+};
+
+#endif // ILocalGameState_h__

--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -596,7 +596,7 @@ void Loader::fillCaches()
         // Bobs from jobs.bob. Job = NUM_JOB_TYPES is used for fat carriers. See below.
         for(unsigned job = 0; job < NUM_JOB_TYPES + 1; ++job)
         {
-            for(Direction dir : Direction{})
+            for(Direction dir : helpers::EnumRange<Direction>{})
             {
                 for(unsigned ani_step = 0; ani_step < 8; ++ani_step)
                 {
@@ -787,7 +787,7 @@ void Loader::fillCaches()
     {
         for(bool fat : {true, false})
         {
-            for(Direction dir : Direction{})
+            for(Direction dir : helpers::EnumRange<Direction>{})
             {
                 for(unsigned ani_step = 0; ani_step < 8; ++ani_step)
                 {

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -252,7 +252,7 @@ void SerializedGameData::MakeSnapshot(const std::shared_ptr<Game>& game)
     writtenEventIds.clear();
 }
 
-void SerializedGameData::ReadSnapshot(const std::shared_ptr<Game>& game)
+void SerializedGameData::ReadSnapshot(const std::shared_ptr<Game>& game, ILocalGameState& localGameState)
 {
     Prepare(true);
 
@@ -261,7 +261,7 @@ void SerializedGameData::ReadSnapshot(const std::shared_ptr<Game>& game)
 
     expectedNumObjects = PopUnsignedInt();
 
-    gw.Deserialize(game, *this);
+    gw.Deserialize(game, localGameState, *this);
     em->Deserialize(*this);
     for(unsigned i = 0; i < gw.GetNumPlayers(); ++i)
         gw.GetPlayer(i).Deserialize(*this);

--- a/libs/s25main/SerializedGameData.h
+++ b/libs/s25main/SerializedGameData.h
@@ -37,6 +37,7 @@ class GameObject;
 class EventManager;
 class GameEvent;
 class Game;
+class ILocalGameState;
 
 /// Kümmert sich um das Serialisieren der GameDaten fürs Speichern und Resynchronisieren
 class SerializedGameData : public Serializer
@@ -55,7 +56,7 @@ public:
     void MakeSnapshot(const std::shared_ptr<Game>& game);
 
     /// Reads the snapshot from the internal buffer
-    void ReadSnapshot(const std::shared_ptr<Game>& game);
+    void ReadSnapshot(const std::shared_ptr<Game>& game, ILocalGameState& localGameState);
 
     /// Get the format version the data is saved in. Deserializing methods can use this to support
     /// loading data saved in an earlier format.

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -551,7 +551,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
             if(selObj.GetType() != NOP_FLAG && selObj.GetType() != NOP_BUILDING)
             {
                 // Check if there are roads
-                for(Direction dir : Direction())
+                for(Direction dir : helpers::EnumRange<Direction>{})
                 {
                     uint8_t curRoad = worldViewer.GetVisiblePointRoad(cSel, dir);
                     if(curRoad)

--- a/libs/s25main/desktops/dskHostGame.cpp
+++ b/libs/s25main/desktops/dskHostGame.cpp
@@ -84,7 +84,7 @@ dskHostGame::dskHostGame(ServerType serverType, const std::shared_ptr<GameLobby>
 
     if(!GAMECLIENT.GetLuaFilePath().empty() && gameLobby->isHost())
     {
-        lua = std::make_unique<LuaInterfaceSettings>(*lobbyHostController);
+        lua = std::make_unique<LuaInterfaceSettings>(*lobbyHostController, GAMECLIENT);
         if(!lua->loadScript(GAMECLIENT.GetLuaFilePath()))
         {
             WINDOWMANAGER.ShowAfterSwitch(

--- a/libs/s25main/figures/nofCarrier.cpp
+++ b/libs/s25main/figures/nofCarrier.cpp
@@ -36,7 +36,6 @@
 #include "s25util/Log.h"
 #include "s25util/MyTime.h"
 #include "s25util/colors.h"
-#include <boost/assign/std/vector.hpp>
 #include <array>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -55,56 +54,32 @@ const unsigned NEXT_ANIMATION_RANDOM = 200; // was noch dazu zufälliges addiert
 const unsigned FRAME_GF = 3;
 
 /// Animation indices, 1st Dim: small or big, 2nd Dim: Animation, 3rd Dim: Index in map.lst of the frame
-using AnimationsType = std::array<std::vector<std::vector<unsigned short>>, 2>;
-
-static AnimationsType fillAnimations()
-{
-    AnimationsType animations;
-    using namespace boost::assign; // Adds the vector += operator
-    std::vector<unsigned short> idxs;
-    // Small ones
-    // Hoola Hoop
-    idxs += 1745, 1746, 1747, 1748, 1749, 1750, 1751, 1748, 1748, 1747, 1746;
-    animations[0] += idxs;
-    // Wink
-    idxs.clear();
-    idxs += 1752, 1753, 1754, 1755, 1756, 1757, 1758, 1754, 1753, 1752;
-    animations[0] += idxs;
-    // Read newspaper
-    idxs.clear();
-    idxs += 1759, 1760, 1761, 1762, 1763, 1763, 1763, 1765, 1763, 1763, 1763, 1765, 1763, 1762, 1765, 1763, 1764, 1764, 1763, 1763, 1763,
-      1765, 1765, 1765, 1763, 1763, 1763, 1765, 1763, 1763, 1763, 1765, 1765, 1764, 1761;
-    animations[0] += idxs;
-    // Yawn
-    idxs.clear();
-    idxs += 1752, 1753, 1754, 1755, 1756, 1757, 1758, 1754, 1753, 1752;
-    animations[0] += idxs;
-    // Wink
-    idxs.clear();
-    idxs += 1752, 1770, 1771, 1772, 1773, 1772, 1773, 1772, 1773, 1772, 1773, 1771, 1771, 1773, 1771, 1771, 1771, 1771, 1770, 1752;
-    animations[0] += idxs;
-
-    // Fat ones
-    // Sneeze
-    idxs.clear();
-    idxs += 1726, 1727, 1728, 1729, 1730, 1730, 1729, 1728, 1727;
-    animations[1] += idxs;
-    // Chew bubblegum
-    idxs.clear();
-    idxs += 1731, 1732, 1733, 1734, 1734, 1735, 1736, 1737, 1737, 1736, 1736, 1737;
-    animations[1] += idxs;
-    // Blow bubblegum
-    idxs.clear();
-    idxs += 1738, 1739, 1740, 1739, 1738, 1739, 1740, 1739, 1741, 1742, 1743, 1744;
-    animations[1] += idxs;
-    // Touch pocket
-    idxs.clear();
-    idxs += 1726, 1766, 1767, 1768, 1769, 1768, 1769, 1768, 1769, 1766, 1767, 1766, 1726;
-    animations[1] += idxs;
-
-    return animations;
-}
-static const AnimationsType ANIMATIONS = fillAnimations();
+static const std::array<std::vector<std::vector<unsigned short>>, 2> ANIMATIONS = {
+  {// Small ones
+   {
+     // Hoola Hoop
+     {1745, 1746, 1747, 1748, 1749, 1750, 1751, 1748, 1748, 1747, 1746},
+     // Wink
+     {1752, 1753, 1754, 1755, 1756, 1757, 1758, 1754, 1753, 1752},
+     // Read newspaper
+     {1759, 1760, 1761, 1762, 1763, 1763, 1763, 1765, 1763, 1763, 1763, 1765, 1763, 1762, 1765, 1763, 1764, 1764,
+      1763, 1763, 1763, 1765, 1765, 1765, 1763, 1763, 1763, 1765, 1763, 1763, 1763, 1765, 1765, 1764, 1761},
+     // Yawn
+     {1752, 1753, 1754, 1755, 1756, 1757, 1758, 1754, 1753, 1752},
+     // Wink
+     {1752, 1770, 1771, 1772, 1773, 1772, 1773, 1772, 1773, 1772, 1773, 1771, 1771, 1773, 1771, 1771, 1771, 1771, 1770, 1752},
+   },
+   // Fat ones
+   {
+     // Sneeze
+     {1726, 1727, 1728, 1729, 1730, 1730, 1729, 1728, 1727},
+     // Chew bubblegum
+     {1731, 1732, 1733, 1734, 1734, 1735, 1736, 1737, 1737, 1736, 1736, 1737},
+     // Blow bubblegum
+     {1738, 1739, 1740, 1739, 1738, 1739, 1740, 1739, 1741, 1742, 1743, 1744},
+     // Touch pocket
+     {1726, 1766, 1767, 1768, 1769, 1768, 1769, 1768, 1769, 1766, 1767, 1766, 1726},
+   }}};
 
 const std::array<Job, 3> JOB_TYPES = {{JOB_HELPER, JOB_PACKDONKEY, JOB_BOATCARRIER}};
 

--- a/libs/s25main/gameTypes/Direction.h
+++ b/libs/s25main/gameTypes/Direction.h
@@ -57,11 +57,6 @@ struct Direction
     Direction& operator--();
     Direction operator--(int);
 
-    struct iterator;
-    using const_iterator = iterator;
-    const_iterator begin() const;
-    const_iterator end() const;
-
 private:
     // Disallow int operators
     Direction& operator+=(int i);
@@ -145,43 +140,6 @@ inline bool operator!=(const Direction::Type& lhs, const Direction& rhs)
 inline bool operator!=(const Direction& lhs, const Direction::Type& rhs)
 {
     return lhs.t_ != rhs;
-}
-
-struct Direction::iterator
-{
-    using iterator_category = std::forward_iterator_tag;
-    using value_type = Direction;
-    using reference = Direction;
-    using pointer = const Direction*;
-    using difference_type = std::ptrdiff_t;
-
-    explicit iterator(unsigned value) : value_(value) {}
-    iterator& operator++()
-    {
-        ++value_;
-        return *this;
-    }
-    iterator operator++(int)
-    {
-        iterator retval = *this;
-        ++(*this);
-        return retval;
-    }
-    bool operator==(iterator other) const { return value_ == other.value_; }
-    bool operator!=(iterator other) const { return !(*this == other); }
-    Direction operator*() const { return Direction::fromInt(value_ < COUNT ? value_ : value_ - COUNT); }
-
-private:
-    unsigned value_;
-};
-
-inline Direction::const_iterator Direction::begin() const
-{
-    return const_iterator(t_);
-}
-inline Direction::const_iterator Direction::end() const
-{
-    return const_iterator(t_ + COUNT);
 }
 
 namespace helpers {

--- a/libs/s25main/gameTypes/Direction.h
+++ b/libs/s25main/gameTypes/Direction.h
@@ -19,6 +19,7 @@
 #define Direction_h__
 
 #include "RTTR_Assert.h"
+#include "helpers/EnumRange.h"
 #include <iterator>
 
 /// "Enum" to represent one of the 6 directions from each node
@@ -182,5 +183,25 @@ inline Direction::const_iterator Direction::end() const
 {
     return const_iterator(t_ + COUNT);
 }
+
+namespace helpers {
+template<>
+struct EnumRange<Direction>
+{
+    class iterator
+    {
+        unsigned value;
+
+    public:
+        explicit BOOST_FORCEINLINE iterator(unsigned value) : value(value) {}
+        BOOST_FORCEINLINE Direction operator*() const { return Direction::fromInt(value); }
+        BOOST_FORCEINLINE void operator++() { ++value; }
+        BOOST_FORCEINLINE bool operator!=(iterator rhs) const { return value != rhs.value; }
+    };
+
+    BOOST_FORCEINLINE iterator begin() const { return iterator(0); }
+    BOOST_FORCEINLINE iterator end() const { return iterator(Direction::COUNT); }
+};
+} // namespace helpers
 
 #endif // Direction_h__

--- a/libs/s25main/gameTypes/PactTypes.h
+++ b/libs/s25main/gameTypes/PactTypes.h
@@ -32,6 +32,8 @@ DEFINE_MAX_ENUM_VALUE(PactType, NON_AGGRESSION_PACT)
 /// Number of the various pacts
 constexpr unsigned NUM_PACTS = helpers::NumEnumValues_v<PactType>;
 
+constexpr unsigned DURATION_INFINITE = 0xFFFFFFFF;
+
 /// Names of the possible pacts
 extern const std::array<const char*, NUM_PACTS> PACT_NAMES;
 

--- a/libs/s25main/ingameWindows/iwDiplomacy.cpp
+++ b/libs/s25main/ingameWindows/iwDiplomacy.cpp
@@ -147,7 +147,7 @@ void iwDiplomacy::Msg_PaintBefore()
             {
                 unsigned duration = gwv.GetPlayer().GetRemainingPactTime(PactType(z), i);
                 // Überhaupt ein Bündnis abgeschlossen und Bündnis nicht für die Ewigkeit?
-                if(duration > 0 && duration != 0xFFFFFFFF)
+                if(duration > 0 && duration != DURATION_INFINITE)
                     // Dann entsprechende Zeit setzen
                     GetCtrl<ctrlText>(500 + z * 100 + i)->SetText(GAMECLIENT.FormatGFTime(duration));
                 else
@@ -254,7 +254,7 @@ void iwSuggestPact::Msg_ButtonClick(const unsigned /*ctrl_id*/)
 {
     /// Dauer auswählen (wenn id == NUM_DURATIONS, dann "für alle Ewigkeit" ausgewählt)
     unsigned selected_id = GetCtrl<ctrlComboBox>(6)->GetSelection();
-    unsigned duration = (selected_id == NUM_DURATIONS) ? 0xFFFFFFFF : DURATIONS[selected_id];
+    unsigned duration = (selected_id == NUM_DURATIONS) ? DURATION_INFINITE : DURATIONS[selected_id];
     gcFactory.SuggestPact(player.GetPlayerId(), this->pt, duration);
     Close();
 }

--- a/libs/s25main/lua/LuaInterfaceGame.cpp
+++ b/libs/s25main/lua/LuaInterfaceGame.cpp
@@ -140,10 +140,10 @@ LuaInterfaceGame::LuaInterfaceGame(const std::weak_ptr<Game>& gameInstance) : gw
     lua["RES_GRANITE"] = Resource::Granite;
     lua["RES_WATER"] = Resource::Water;
 
-    lua["NON_AGGRESSION_PACT"] = NON_AGGRESSION_PACT;
-    lua["TREATY_OF_ALLIANCE"] = TREATY_OF_ALLIANCE;
+    ADD_LUA_CONST(NON_AGGRESSION_PACT);
+    ADD_LUA_CONST(TREATY_OF_ALLIANCE);
     // infinite pact duration, see GamePlayer::GetRemainingPactTime
-    lua["DURATION_INFINITE"] = 0xFFFFFFFF;
+    ADD_LUA_CONST(DURATION_INFINITE);
 
 #undef ADD_LUA_CONST
 #define ADD_LUA_CONST(name) lua[#name] = iwMissionStatement::name

--- a/libs/s25main/lua/LuaInterfaceGame.cpp
+++ b/libs/s25main/lua/LuaInterfaceGame.cpp
@@ -25,13 +25,13 @@
 #include "lua/LuaHelpers.h"
 #include "lua/LuaPlayer.h"
 #include "lua/LuaWorld.h"
-#include "network/GameClient.h"
 #include "postSystem/PostMsg.h"
 #include "world/GameWorldGame.h"
 #include "gameTypes/Resource.h"
 #include "s25util/Serializer.h"
 
-LuaInterfaceGame::LuaInterfaceGame(const std::weak_ptr<Game>& gameInstance) : gw(gameInstance.lock()->world_), game(gameInstance)
+LuaInterfaceGame::LuaInterfaceGame(const std::weak_ptr<Game>& gameInstance, ILocalGameState& localGameState)
+    : LuaInterfaceGameBase(localGameState), localGameState(localGameState), gw(gameInstance.lock()->world_), game(gameInstance)
 {
 #pragma region ConstDefs
 #define ADD_LUA_CONST(name) lua[#name] = name
@@ -250,10 +250,10 @@ unsigned LuaInterfaceGame::GetNumPlayers() const
 
 void LuaInterfaceGame::Chat(int playerIdx, const std::string& msg)
 {
-    if(playerIdx >= 0 && GAMECLIENT.GetPlayerId() != unsigned(playerIdx))
+    if(playerIdx >= 0 && localGameState.GetPlayerId() != unsigned(playerIdx))
         return;
 
-    GAMECLIENT.SystemChat(msg);
+    localGameState.SystemChat(msg);
 }
 
 void LuaInterfaceGame::MissionStatement(int playerIdx, const std::string& title, const std::string& msg)
@@ -268,7 +268,7 @@ void LuaInterfaceGame::MissionStatement2(int playerIdx, const std::string& title
 
 void LuaInterfaceGame::MissionStatement3(int playerIdx, const std::string& title, const std::string& msg, unsigned imgIdx, bool pause)
 {
-    if(playerIdx >= 0 && GAMECLIENT.GetPlayerId() != unsigned(playerIdx))
+    if(playerIdx >= 0 && localGameState.GetPlayerId() != unsigned(playerIdx))
         return;
 
     WINDOWMANAGER.Show(

--- a/libs/s25main/lua/LuaInterfaceGame.cpp
+++ b/libs/s25main/lua/LuaInterfaceGame.cpp
@@ -183,6 +183,7 @@ void LuaInterfaceGame::Register(kaguya::State& state)
     state["RTTRGame"].setClass(kaguya::UserdataMetatable<LuaInterfaceGame, LuaInterfaceGameBase>()
                                  .addFunction("ClearResources", &LuaInterfaceGame::ClearResources)
                                  .addFunction("GetGF", &LuaInterfaceGame::GetGF)
+                                 .addFunction("FormatNumGFs", &LuaInterfaceGame::FormatNumGFs)
                                  .addFunction("GetGameFrame", &LuaInterfaceGame::GetGF)
                                  .addFunction("GetNumPlayers", &LuaInterfaceGame::GetNumPlayers)
                                  .addFunction("Chat", &LuaInterfaceGame::Chat)
@@ -241,6 +242,11 @@ void LuaInterfaceGame::ClearResources()
 unsigned LuaInterfaceGame::GetGF() const
 {
     return gw.GetEvMgr().GetCurrentGF();
+}
+
+std::string LuaInterfaceGame::FormatNumGFs(unsigned numGFs) const
+{
+    return localGameState.FormatGFTime(numGFs);
 }
 
 unsigned LuaInterfaceGame::GetNumPlayers() const

--- a/libs/s25main/lua/LuaInterfaceGame.h
+++ b/libs/s25main/lua/LuaInterfaceGame.h
@@ -33,7 +33,7 @@ class Game;
 class LuaInterfaceGame : public LuaInterfaceGameBase
 {
 public:
-    LuaInterfaceGame(const std::weak_ptr<Game>& gameInstance);
+    LuaInterfaceGame(const std::weak_ptr<Game>& gameInstance, ILocalGameState& localGameState);
     virtual ~LuaInterfaceGame();
 
     static void Register(kaguya::State& state);
@@ -67,6 +67,7 @@ public:
     void PostMessageWithLocation(int playerIdx, const std::string& msg, int x, int y);
 
 private:
+    ILocalGameState& localGameState;
     GameWorldGame& gw;
     std::weak_ptr<Game> game;
     LuaPlayer GetPlayer(int playerIdx);

--- a/libs/s25main/lua/LuaInterfaceGame.h
+++ b/libs/s25main/lua/LuaInterfaceGame.h
@@ -57,6 +57,7 @@ public:
     // Callable from Lua
     void ClearResources();
     unsigned GetGF() const;
+    std::string FormatNumGFs(unsigned numGFs) const;
     unsigned GetNumPlayers() const;
     void Chat(int playerIdx, const std::string& msg);
     void MissionStatement(int playerIdx, const std::string& title, const std::string& msg);

--- a/libs/s25main/lua/LuaInterfaceGameBase.cpp
+++ b/libs/s25main/lua/LuaInterfaceGameBase.cpp
@@ -19,7 +19,6 @@
 #include "WindowManager.h"
 #include "ingameWindows/iwMsgbox.h"
 #include "mygettext/mygettext.h"
-#include "network/GameClient.h"
 #include "s25util/Log.h"
 
 unsigned LuaInterfaceGameBase::GetVersion()
@@ -32,7 +31,7 @@ unsigned LuaInterfaceGameBase::GetFeatureLevel()
     return 3;
 }
 
-LuaInterfaceGameBase::LuaInterfaceGameBase()
+LuaInterfaceGameBase::LuaInterfaceGameBase(const ILocalGameState& localGameState) : localGameState(localGameState)
 {
     Register(lua);
 }
@@ -70,12 +69,12 @@ bool LuaInterfaceGameBase::CheckScriptVersion()
 
 bool LuaInterfaceGameBase::IsHost() const
 {
-    return GAMECLIENT.IsHost();
+    return localGameState.IsHost();
 }
 
 unsigned LuaInterfaceGameBase::GetLocalPlayerIdx() const
 {
-    return GAMECLIENT.GetPlayerId();
+    return localGameState.GetPlayerId();
 }
 
 void LuaInterfaceGameBase::MsgBox(const std::string& title, const std::string& msg, bool isError)

--- a/libs/s25main/lua/LuaInterfaceGameBase.h
+++ b/libs/s25main/lua/LuaInterfaceGameBase.h
@@ -18,6 +18,7 @@
 #ifndef LuaInterfaceGameBase_h__
 #define LuaInterfaceGameBase_h__
 
+#include "ILocalGameState.h"
 #include "lua/LuaInterfaceBase.h"
 
 class LuaInterfaceGameBase : public LuaInterfaceBase
@@ -33,7 +34,7 @@ public:
     static unsigned GetFeatureLevel();
 
 protected:
-    LuaInterfaceGameBase();
+    explicit LuaInterfaceGameBase(const ILocalGameState& localGameState);
 
     /// Return true, if local player is the host
     bool IsHost() const;
@@ -46,6 +47,9 @@ protected:
     /// Shows a message with a custom icon. Image with iconIdx must exist in iconFile and iconFile must be loaded!
     void MsgBoxEx(const std::string& title, const std::string& msg, const std::string& iconFile, unsigned iconIdx);
     void MsgBoxEx2(const std::string& title, const std::string& msg, const std::string& iconFile, unsigned iconIdx, int iconX, int iconY);
+
+private:
+    const ILocalGameState& localGameState;
 };
 
 #endif // LuaInterfaceGameBase_h__

--- a/libs/s25main/lua/LuaInterfaceSettings.cpp
+++ b/libs/s25main/lua/LuaInterfaceSettings.cpp
@@ -31,7 +31,8 @@ struct AddonIdWrapper
     constexpr operator AddonId() const { return value; }
 };
 
-LuaInterfaceSettings::LuaInterfaceSettings(IGameLobbyController& lobbyServerController) : lobbyServerController_(lobbyServerController)
+LuaInterfaceSettings::LuaInterfaceSettings(IGameLobbyController& lobbyServerController, const ILocalGameState& localGameState)
+    : LuaInterfaceGameBase(localGameState), lobbyServerController_(lobbyServerController)
 {
     Register(lua);
     LuaServerPlayer::Register(lua);

--- a/libs/s25main/lua/LuaInterfaceSettings.h
+++ b/libs/s25main/lua/LuaInterfaceSettings.h
@@ -24,13 +24,14 @@
 
 class LuaServerPlayer;
 class IGameLobbyController;
+class ILocalGameState;
 enum class AddonId;
 struct AddonIdWrapper;
 
 class LuaInterfaceSettings : public LuaInterfaceGameBase
 {
 public:
-    LuaInterfaceSettings(IGameLobbyController& lobbyServerController);
+    LuaInterfaceSettings(IGameLobbyController& lobbyServerController, const ILocalGameState& localGameState);
     virtual ~LuaInterfaceSettings();
 
     static void Register(kaguya::State& state);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -292,7 +292,7 @@ void GameClient::StartGame(const unsigned random_init)
         ci->CI_GameLoading(game);
 
     // Get standard settings before they get overwritten
-    GetPlayer(mainPlayer.playerId).FillVisualSettings(default_settings);
+    GetPlayer(GetPlayerId()).FillVisualSettings(default_settings);
 
     GameWorld& gameWorld = game->world_;
     if(mapinfo.savegame)
@@ -777,12 +777,12 @@ bool GameClient::OnGameMessage(const GameMessage_Chat& msg)
         if(player.IsDefeated() && msg.destination != CD_ALL)
             return true;
         // Entscheiden, ob ich ein Gegner oder Vebündeter bin vom Absender
-        bool ally = player.IsAlly(mainPlayer.playerId);
+        bool ally = player.IsAlly(GetPlayerId());
 
         // Chatziel unerscheiden und ggf. nicht senden
         if(!ally && msg.destination == CD_ALLIES)
             return true;
-        if(ally && msg.destination == CD_ENEMIES && msg.player != mainPlayer.playerId)
+        if(ally && msg.destination == CD_ENEMIES && msg.player != GetPlayerId())
             return true;
     } else if(state == CS_CONFIG)
     {
@@ -823,8 +823,8 @@ bool GameClient::OnGameMessage(const GameMessage_Server_Async& msg)
         ci->CI_Async(checksum_list.str());
 
     std::string fileName = s25util::Time::FormatTime("async_%Y-%m-%d_%H-%i-%s");
-    fileName += "_" + s25util::toStringClassic(mainPlayer.playerId) + "_";
-    fileName += GetPlayer(mainPlayer.playerId).name;
+    fileName += "_" + s25util::toStringClassic(GetPlayerId()) + "_";
+    fileName += GetPlayer(GetPlayerId()).name;
 
     std::string filePathSave = RTTRCONFIG.ExpandPath(s25::folders::save) + "/" + makePortableFileName(fileName + ".sav");
     std::string filePathLog = RTTRCONFIG.ExpandPath(s25::folders::logs) + "/" + makePortableFileName(fileName + "Player.log");
@@ -1008,7 +1008,7 @@ bool GameClient::CreateLobby()
         default: return false;
     }
 
-    if(mainPlayer.playerId >= numPlayers)
+    if(GetPlayerId() >= numPlayers)
         return false;
 
     gameLobby = std::make_shared<GameLobby>(mapinfo.type == MAPTYPE_SAVEGAME, IsHost(), numPlayers);
@@ -1568,13 +1568,13 @@ void GameClient::SkipGF(unsigned gf, GameWorldView& gwv)
     unsigned ticks = VIDEODRIVER.GetTickCount() - start_ticks;
     boost::format text(_("Jump finished (%1$.3g seconds)."));
     text % (ticks / 1000.0);
-    ci->CI_Chat(mainPlayer.playerId, CD_SYSTEM, text.str());
+    SystemChat(text.str());
     SetPause(true);
 }
 
 void GameClient::SystemChat(const std::string& text)
 {
-    SystemChat(text, mainPlayer.playerId);
+    SystemChat(text, GetPlayerId());
 }
 
 void GameClient::SystemChat(const std::string& text, unsigned char fromPlayerIdx)
@@ -1620,7 +1620,7 @@ bool GameClient::SaveToFile(const std::string& filename)
 
 void GameClient::ResetVisualSettings()
 {
-    GetPlayer(mainPlayer.playerId).FillVisualSettings(visual_settings);
+    GetPlayer(GetPlayerId()).FillVisualSettings(visual_settings);
 }
 
 void GameClient::SetPause(bool pause)
@@ -1665,7 +1665,7 @@ unsigned GameClient::GetLastReplayGF() const
 bool GameClient::AddGC(gc::GameCommandPtr gc)
 {
     // Nicht in der Pause oder wenn er besiegt wurde
-    if(framesinfo.isPaused || GetPlayer(mainPlayer.playerId).IsDefeated() || IsReplayModeOn())
+    if(framesinfo.isPaused || GetPlayer(GetPlayerId()).IsDefeated() || IsReplayModeOn())
         return false;
 
     gameCommands_.push_back(gc);
@@ -1747,7 +1747,7 @@ void GameClient::ToggleHumanAIPlayer()
     if(it != game->aiPlayers_.end())
         game->aiPlayers_.erase(it);
     else
-        game->AddAIPlayer(CreateAIPlayer(mainPlayer.playerId, AI::Info(AI::DEFAULT, AI::EASY)));
+        game->AddAIPlayer(CreateAIPlayer(GetPlayerId(), AI::Info(AI::DEFAULT, AI::EASY)));
 }
 
 void GameClient::RequestSwapToPlayer(const unsigned char newId)

--- a/libs/s25main/network/GameClientCommands.cpp
+++ b/libs/s25main/network/GameClientCommands.cpp
@@ -81,7 +81,7 @@ void GameClient::ChangePlayerIngame(const unsigned char playerId1, const unsigne
 
     if(IsReplayModeOn())
     {
-        RTTR_Assert(playerId1 == mainPlayer.playerId);
+        RTTR_Assert(playerId1 == GetPlayerId());
         // There must be someone at this slot
         if(!GetPlayer(playerId2).isUsed())
             return;

--- a/libs/s25main/world/GameWorld.cpp
+++ b/libs/s25main/world/GameWorld.cpp
@@ -32,7 +32,8 @@ GameWorld::GameWorld(const std::vector<PlayerInfo>& playerInfos, const GlobalGam
 {}
 
 /// Lädt eine Karte
-bool GameWorld::LoadMap(const std::shared_ptr<Game>& game, const std::string& mapFilePath, const std::string& luaFilePath)
+bool GameWorld::LoadMap(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, const std::string& mapFilePath,
+                        const std::string& luaFilePath)
 {
     // Map laden
     libsiedler2::Archiv mapArchiv;
@@ -45,7 +46,7 @@ bool GameWorld::LoadMap(const std::shared_ptr<Game>& game, const std::string& ma
 
     if(bfs::exists(luaFilePath))
     {
-        SetLua(std::make_unique<LuaInterfaceGame>(game));
+        SetLua(std::make_unique<LuaInterfaceGame>(game, localgameState));
         if(!GetLua().loadScript(luaFilePath) || !GetLua().CheckScriptVersion())
         {
             SetLua(nullptr);
@@ -90,7 +91,7 @@ void GameWorld::Serialize(SerializedGameData& sgd) const
     }
 }
 
-void GameWorld::Deserialize(const std::shared_ptr<Game>& game, SerializedGameData& sgd)
+void GameWorld::Deserialize(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, SerializedGameData& sgd)
 {
     MapSerializer::Deserialize(*this, GetNumPlayers(), sgd);
 
@@ -110,7 +111,7 @@ void GameWorld::Deserialize(const std::shared_ptr<Game>& game, SerializedGameDat
             throw SerializedGameData::Error(_("Invalid end-id for lua data"));
 
         // Now init and load lua
-        SetLua(std::make_unique<LuaInterfaceGame>(game));
+        SetLua(std::make_unique<LuaInterfaceGame>(game, localgameState));
         if(!GetLua().loadScriptString(luaScript))
         {
             SetLua(nullptr);

--- a/libs/s25main/world/GameWorld.h
+++ b/libs/s25main/world/GameWorld.h
@@ -23,6 +23,7 @@
 #include <string>
 
 class SerializedGameData;
+class ILocalGameState;
 class Game;
 
 class GameWorld : public GameWorldGame
@@ -31,11 +32,12 @@ public:
     GameWorld(const std::vector<PlayerInfo>& playerInfos, const GlobalGameSettings& gameSettings, EventManager& em);
 
     /// Lädt eine Karte
-    bool LoadMap(const std::shared_ptr<Game>& game, const std::string& mapFilePath, const std::string& luaFilePath);
+    bool LoadMap(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, const std::string& mapFilePath,
+                 const std::string& luaFilePath);
 
     /// Serialisiert den gesamten GameWorld
     void Serialize(SerializedGameData& sgd) const;
-    void Deserialize(const std::shared_ptr<Game>& game, SerializedGameData& sgd);
+    void Deserialize(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, SerializedGameData& sgd);
 };
 
 #endif // GameWorld_h__

--- a/libs/s25main/world/GameWorldGame.cpp
+++ b/libs/s25main/world/GameWorldGame.cpp
@@ -423,7 +423,7 @@ void GameWorldGame::RecalcTerritory(const noBaseBuilding& building, TerritoryCha
         // Do not destroy the triggering building or its flag
         // TODO: What about this point?
         const uint8_t owner = GetNode(curMapPt).owner;
-        for(Direction dir : Direction())
+        for(Direction dir : helpers::EnumRange<Direction>{})
         {
             MapPoint neighbourPt = GetNeighbour(curMapPt, dir);
             if(ptsHandled.insert(neighbourPt).second)

--- a/tests/common/testMakeException.cpp
+++ b/tests/common/testMakeException.cpp
@@ -31,8 +31,8 @@ BOOST_AUTO_TEST_SUITE(Helpers)
 
 BOOST_AUTO_TEST_CASE(MakeExceptionDefault)
 {
-    RTTR_CHECK_THROW(throw makeException("Test"), std::runtime_error, "Test");
-    RTTR_CHECK_THROW(throw makeException("Test", 1, "bar", 42), std::runtime_error, "Test1bar42");
+    RTTR_CHECK_EXCEPTION_MSG(throw makeException("Test"), std::runtime_error, "Test");
+    RTTR_CHECK_EXCEPTION_MSG(throw makeException("Test", 1, "bar", 42), std::runtime_error, "Test1bar42");
 }
 
 struct CustomException : std::runtime_error
@@ -42,8 +42,8 @@ struct CustomException : std::runtime_error
 
 BOOST_AUTO_TEST_CASE(MakeExceptionCustom)
 {
-    RTTR_CHECK_THROW(throw makeException<CustomException>("Test"), CustomException, "Test");
-    RTTR_CHECK_THROW(throw makeException<CustomException>("Test", 1, "bar", 42), CustomException, "Test1bar42");
+    RTTR_CHECK_EXCEPTION_MSG(throw makeException<CustomException>("Test"), CustomException, "Test");
+    RTTR_CHECK_EXCEPTION_MSG(throw makeException<CustomException>("Test", 1, "bar", 42), CustomException, "Test1bar42");
 }
 
 BOOST_AUTO_TEST_CASE(MakeLastSystemError)

--- a/tests/s25Main/integration/testAttacking.cpp
+++ b/tests/s25Main/integration/testAttacking.cpp
@@ -804,7 +804,7 @@ BOOST_FIXTURE_TEST_CASE(DestroyRoadsOnConquer, DestroyRoadsOnConquerFixture)
     for(const MapPoint& bldPt : bldPts)
     {
         MapPoint flagPt = world.GetNeighbour(bldPt, Direction::SOUTHEAST);
-        for(Direction i : Direction())
+        for(Direction i : helpers::EnumRange<Direction>{})
         {
             // No routes except the main road
             if(i != Direction::NORTHWEST)

--- a/tests/s25Main/integration/testBuilding.cpp
+++ b/tests/s25Main/integration/testBuilding.cpp
@@ -28,7 +28,6 @@
 #include "world/GameWorldViewer.h"
 #include "nodeObjs/noEnvObject.h"
 #include "nodeObjs/noStaticObject.h"
-#include <boost/assign/std/vector.hpp>
 #include <boost/test/unit_test.hpp>
 
 // Test stuff related to building/building quality
@@ -443,11 +442,9 @@ BOOST_FIXTURE_TEST_CASE(RoadRemovesObjs, EmptyWorldFixture1P)
     const MapPoint hqPos = world.GetPlayer(0).GetHQPos();
     const MapPoint startPos = world.GetNeighbour(hqPos, Direction::SOUTHEAST);
     const MapPoint endPos = world.MakeMapPoint(startPos + Position(4, 0));
-    std::vector<unsigned> ids;
-    using namespace boost::assign;
     // Place these env objs
-    ids += 505, 506, 507, 508, 509, 510, 512, 513, 514, 515, 531, 536, 541, 542, 543, 544, 545, 546, 547, 548, 550, 551, 552, 553, 554, 555,
-      556, 557, 558, 559;
+    const std::vector<unsigned> ids{505, 506, 507, 508, 509, 510, 512, 513, 514, 515, 531, 536, 541, 542, 543,
+                                    544, 545, 546, 547, 548, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559};
     for(unsigned curId : ids)
     {
         MapPoint curPos = startPos;

--- a/tests/s25Main/integration/testGameEvents.cpp
+++ b/tests/s25Main/integration/testGameEvents.cpp
@@ -222,10 +222,10 @@ BOOST_AUTO_TEST_CASE(RemoveEvent)
     BOOST_CHECK(!evMgr.ObjectHasEvents(obj));
 }
 
+#if RTTR_ENABLE_ASSERTS
 BOOST_AUTO_TEST_CASE(InvalidEvent)
 {
     rttr::test::LogAccessor logAcc;
-#if RTTR_ENABLE_ASSERTS
     EventManager evMgr(100);
     TestEventHandler obj;
     // Need object
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(InvalidEvent)
     RTTR_REQUIRE_ASSERT(evMgr.AddEvent(nullptr, 50, 0, 50));
     // continued event cannot start before the game
     RTTR_REQUIRE_ASSERT(evMgr.AddEvent(nullptr, 200, 0, 150));
-#endif
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/integration/testPathfinding.cpp
+++ b/tests/s25Main/integration/testPathfinding.cpp
@@ -23,12 +23,9 @@
 #include "gameData/GameConsts.h"
 #include "gameData/TerrainDesc.h"
 #include <rttr/test/testHelpers.hpp>
-#include <boost/assign/std/vector.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/test/unit_test.hpp>
 #include <vector>
-
-using namespace boost::assign;
 
 // Tests are designed to check for every possible direction and terrain distribution
 // To understand what is tested check test/testPathfindingIllustration.png. It consists
@@ -88,9 +85,6 @@ void setupTestcase2to4(GameWorldGame& world, const MapPoint& startPt, DescIdx<Te
 
 BOOST_FIXTURE_TEST_CASE(WalkStraight, WorldFixtureEmpty0P)
 {
-    std::vector<Direction> testDirections;
-    testDirections += Direction::EAST, Direction::SOUTHEAST, Direction::NORTHEAST;
-    testDirections += Direction::WEST, Direction::SOUTHWEST, Direction::NORTHWEST;
     std::vector<DescIdx<TerrainDesc>> friendlyTerrains;
     for(DescIdx<TerrainDesc> t(0); t.value < world.GetDescription().terrain.size(); t.value++)
     {
@@ -103,7 +97,7 @@ BOOST_FIXTURE_TEST_CASE(WalkStraight, WorldFixtureEmpty0P)
     for(DescIdx<TerrainDesc> friendlyTerrain : friendlyTerrains)
     {
         clearWorld(world, friendlyTerrain);
-        for(Direction dir : testDirections)
+        for(Direction dir : helpers::EnumRange<Direction>())
         {
             // 3 steps in dir
             MapPoint endPt(startPt);
@@ -144,9 +138,8 @@ BOOST_FIXTURE_TEST_CASE(WalkAlongCoast, WorldFixtureEmpty0P)
     BOOST_REQUIRE_NE(world.FindHumanPath(startPt, endPt, 99, false, &length, &route), INVALID_DIR);
     BOOST_REQUIRE_EQUAL(length, 6u);
     BOOST_REQUIRE_EQUAL(route.size(), 6u);
-    std::vector<Direction> expectedRoute;
-    expectedRoute += Direction::NORTHEAST, Direction::SOUTHEAST, Direction::SOUTHEAST, Direction::NORTHEAST, Direction::EAST,
-      Direction::EAST;
+    const std::vector<Direction> expectedRoute{Direction::NORTHEAST, Direction::SOUTHEAST, Direction::SOUTHEAST,
+                                               Direction::NORTHEAST, Direction::EAST,      Direction::EAST};
     RTTR_REQUIRE_EQUAL_COLLECTIONS(route, expectedRoute);
     // Inverse route
     BOOST_REQUIRE_NE(world.FindHumanPath(endPt, startPt, 99, false, &length, &route), INVALID_DIR);
@@ -169,9 +162,9 @@ BOOST_FIXTURE_TEST_CASE(CrossTerrain, WorldFixtureEmpty1P)
     }
     // Start far enough away from the HQ in the middle
     const MapPoint startPt(1, 2);
-    std::vector<Direction> testDirections;
-    // Test cases 2         a)                 b)                     c)
-    testDirections += Direction::EAST, Direction::SOUTHEAST, Direction::NORTHEAST;
+    // Test cases 2                                    a)                 b)                     c)
+    const std::vector<Direction> testDirections{Direction::EAST, Direction::SOUTHEAST, Direction::NORTHEAST};
+
     std::vector<DescIdx<TerrainDesc>> deepWaterTerrains;
     for(DescIdx<TerrainDesc> t(0); t.value < world.GetDescription().terrain.size(); t.value++)
     {
@@ -229,11 +222,10 @@ BOOST_FIXTURE_TEST_CASE(DontPassTerrain, WorldFixtureEmpty1P)
     }
     // Start far enough away from the HQ in the middle
     const MapPoint startPt(1, 2);
-    std::vector<Direction> testDirections;
-    // Test cases 3         a)                 b)                     c)
-    testDirections += Direction::EAST, Direction::SOUTHEAST, Direction::NORTHEAST;
-    // Test cases 4         a)                 b)                     c)
-    testDirections += Direction::WEST, Direction::SOUTHWEST, Direction::NORTHWEST;
+    const std::vector<Direction> testDirections{// Test cases 3 a)        b)                    c)
+                                                Direction::EAST, Direction::SOUTHEAST, Direction::NORTHEAST,
+                                                // Test cases 4 a)        b)                    c)
+                                                Direction::WEST, Direction::SOUTHWEST, Direction::NORTHWEST};
     std::vector<DescIdx<TerrainDesc>> deadlyTerrains;
     const WorldDescription& worldDescription = world.GetDescription();
     for(DescIdx<TerrainDesc> t(0); t.value < worldDescription.terrain.size(); t.value++)

--- a/tests/s25Main/integration/testPathfinding.cpp
+++ b/tests/s25Main/integration/testPathfinding.cpp
@@ -140,7 +140,7 @@ BOOST_FIXTURE_TEST_CASE(WalkAlongCoast, WorldFixtureEmpty0P)
     BOOST_REQUIRE_EQUAL(route.size(), 6u);
     const std::vector<Direction> expectedRoute{Direction::NORTHEAST, Direction::SOUTHEAST, Direction::SOUTHEAST,
                                                Direction::NORTHEAST, Direction::EAST,      Direction::EAST};
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(route, expectedRoute);
+    BOOST_TEST_REQUIRE(route == expectedRoute, boost::test_tools::per_element());
     // Inverse route
     BOOST_REQUIRE_NE(world.FindHumanPath(endPt, startPt, 99, false, &length, &route), INVALID_DIR);
     BOOST_REQUIRE_EQUAL(length, 6u);
@@ -150,7 +150,7 @@ BOOST_FIXTURE_TEST_CASE(WalkAlongCoast, WorldFixtureEmpty0P)
     {
         expectedRevRoute.push_back(dir + 3u);
     }
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(route, expectedRevRoute);
+    BOOST_TEST(route == expectedRevRoute, boost::test_tools::per_element());
 }
 
 BOOST_FIXTURE_TEST_CASE(CrossTerrain, WorldFixtureEmpty1P)

--- a/tests/s25Main/integration/testSerialization.cpp
+++ b/tests/s25Main/integration/testSerialization.cpp
@@ -28,6 +28,7 @@
 #include "factories/GameCommandFactory.h"
 #include "network/PlayerGameCommands.h"
 #include "worldFixtures/CreateEmptyWorld.h"
+#include "worldFixtures/MockLocalGameState.h"
 #include "worldFixtures/WorldFixture.h"
 #include "nodeObjs/noFire.h"
 #include "gameTypes/MapInfo.h"
@@ -277,7 +278,8 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
                 players.push_back(PlayerInfo(loadSave.GetPlayer(j)));
             std::shared_ptr<Game> sharedGame(new Game(save.ggs, loadSave.start_gf, players));
             GameWorld& newWorld = sharedGame->world_;
-            save.sgd.ReadSnapshot(sharedGame);
+            MockLocalGameState localGameState;
+            save.sgd.ReadSnapshot(sharedGame, localGameState);
             auto& newEm = static_cast<TestEventManager&>(sharedGame->world_.GetEvMgr());
 
             BOOST_REQUIRE_EQUAL(newWorld.GetSize(), world.GetSize());

--- a/tests/s25Main/integration/testSerialization.cpp
+++ b/tests/s25Main/integration/testSerialization.cpp
@@ -300,7 +300,7 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
             {
                 const MapNode& worldNode = world.GetNode(pt);
                 const MapNode& loadNode = newWorld.GetNode(pt);
-                RTTR_REQUIRE_EQUAL_COLLECTIONS(loadNode.roads, worldNode.roads);
+                BOOST_TEST_REQUIRE(loadNode.roads == worldNode.roads, boost::test_tools::per_element());
                 BOOST_REQUIRE_EQUAL(loadNode.altitude, worldNode.altitude);
                 BOOST_REQUIRE_EQUAL(loadNode.shadow, worldNode.shadow);
                 BOOST_REQUIRE_EQUAL(loadNode.t1, worldNode.t1);
@@ -422,8 +422,8 @@ BOOST_AUTO_TEST_CASE(ReplayWithMap)
         BOOST_REQUIRE_EQUAL(newMap.type, map.type);
         BOOST_REQUIRE_EQUAL(newMap.title, map.title);
         BOOST_REQUIRE_EQUAL(newMap.filepath, map.filepath);
-        RTTR_REQUIRE_EQUAL_COLLECTIONS(newMap.mapData.data, map.mapData.data);
-        RTTR_REQUIRE_EQUAL_COLLECTIONS(newMap.luaData.data, map.luaData.data);
+        BOOST_TEST_REQUIRE(newMap.mapData.data == map.mapData.data, boost::test_tools::per_element());
+        BOOST_TEST_REQUIRE(newMap.luaData.data == map.luaData.data, boost::test_tools::per_element());
         BOOST_REQUIRE(loadReplay.IsReplaying());
 
         CheckReplayCmds(loadReplay, cmds);

--- a/tests/s25Main/integration/testTerritoryRegion.cpp
+++ b/tests/s25Main/integration/testTerritoryRegion.cpp
@@ -25,63 +25,51 @@
 #include "worldFixtures/WorldFixture.h"
 #include "world/GameWorld.h"
 #include "world/TerritoryRegion.h"
-#include <boost/assign/std/set.hpp>
-#include <boost/assign/std/vector.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/test/unit_test.hpp>
 #include <array>
 #include <iostream>
+#include <set>
 #include <vector>
-
-using namespace boost::assign;
 
 BOOST_AUTO_TEST_SUITE(TerritoryRegionTestSuite)
 
 BOOST_AUTO_TEST_CASE(IsPointValid)
 {
     // Max tested point is (20, 20) -> size > 20
-    MapExtent worldSize(24, 22);
-    std::vector<MapPoint> hole, hole_reversed;
-    std::vector<MapPoint> outer, outer_reversed;
+    const MapExtent worldSize(24, 22);
 
     // Hole
-    hole += MapPoint(14, 14), MapPoint(16, 14), MapPoint(16, 16), MapPoint(14, 16), MapPoint(14, 14);
+    const std::vector<MapPoint> hole{MapPoint(14, 14), MapPoint(16, 14), MapPoint(16, 16), MapPoint(14, 16), MapPoint(14, 14)};
 
     // Reverse it...
-    hole_reversed = hole;
+    std::vector<MapPoint> hole_reversed = hole;
     std::reverse(hole_reversed.begin(), hole_reversed.end());
 
     // Outer polygon
-    outer += MapPoint(10, 10), MapPoint(20, 10), MapPoint(20, 20), MapPoint(10, 20), MapPoint(10, 10);
+    const std::vector<MapPoint> outer{MapPoint(10, 10), MapPoint(20, 10), MapPoint(20, 20), MapPoint(10, 20), MapPoint(10, 10)};
 
     // Reverse it...
-    outer_reversed = outer;
+    std::vector<MapPoint> outer_reversed = outer;
     std::reverse(outer_reversed.begin(), outer_reversed.end());
 
     // Set of MapPoints that should return true
-    std::set<MapPoint, MapPointLess> results;
-
     // Auto-generated data (from different implementation with tests)
-    results += MapPoint(10, 10), MapPoint(10, 11), MapPoint(10, 12), MapPoint(10, 13), MapPoint(10, 14);
-    results += MapPoint(10, 15), MapPoint(10, 16), MapPoint(10, 17), MapPoint(10, 18), MapPoint(10, 19);
-    results += MapPoint(11, 10), MapPoint(11, 11), MapPoint(11, 12), MapPoint(11, 13), MapPoint(11, 14);
-    results += MapPoint(11, 15), MapPoint(11, 16), MapPoint(11, 17), MapPoint(11, 18), MapPoint(11, 19);
-    results += MapPoint(12, 10), MapPoint(12, 11), MapPoint(12, 12), MapPoint(12, 13), MapPoint(12, 14);
-    results += MapPoint(12, 15), MapPoint(12, 16), MapPoint(12, 17), MapPoint(12, 18), MapPoint(12, 19);
-    results += MapPoint(13, 10), MapPoint(13, 11), MapPoint(13, 12), MapPoint(13, 13), MapPoint(13, 14);
-    results += MapPoint(13, 15), MapPoint(13, 16), MapPoint(13, 17), MapPoint(13, 18), MapPoint(13, 19);
-    results += MapPoint(14, 10), MapPoint(14, 11), MapPoint(14, 12), MapPoint(14, 13), MapPoint(14, 16);
-    results += MapPoint(14, 17), MapPoint(14, 18), MapPoint(14, 19), MapPoint(15, 10), MapPoint(15, 11);
-    results += MapPoint(15, 12), MapPoint(15, 13), MapPoint(15, 16), MapPoint(15, 17), MapPoint(15, 18);
-    results += MapPoint(15, 19), MapPoint(16, 10), MapPoint(16, 11), MapPoint(16, 12), MapPoint(16, 13);
-    results += MapPoint(16, 14), MapPoint(16, 15), MapPoint(16, 16), MapPoint(16, 17), MapPoint(16, 18);
-    results += MapPoint(16, 19), MapPoint(17, 10), MapPoint(17, 11), MapPoint(17, 12), MapPoint(17, 13);
-    results += MapPoint(17, 14), MapPoint(17, 15), MapPoint(17, 16), MapPoint(17, 17), MapPoint(17, 18);
-    results += MapPoint(17, 19), MapPoint(18, 10), MapPoint(18, 11), MapPoint(18, 12), MapPoint(18, 13);
-    results += MapPoint(18, 14), MapPoint(18, 15), MapPoint(18, 16), MapPoint(18, 17), MapPoint(18, 18);
-    results += MapPoint(18, 19), MapPoint(19, 10), MapPoint(19, 11), MapPoint(19, 12), MapPoint(19, 13);
-    results += MapPoint(19, 14), MapPoint(19, 15), MapPoint(19, 16), MapPoint(19, 17), MapPoint(19, 18);
-    results += MapPoint(19, 19);
+    std::set<MapPoint, MapPointLess> results{
+      MapPoint(10, 10), MapPoint(10, 11), MapPoint(10, 12), MapPoint(10, 13), MapPoint(10, 14), MapPoint(10, 15), MapPoint(10, 16),
+      MapPoint(10, 17), MapPoint(10, 18), MapPoint(10, 19), MapPoint(11, 10), MapPoint(11, 11), MapPoint(11, 12), MapPoint(11, 13),
+      MapPoint(11, 14), MapPoint(11, 15), MapPoint(11, 16), MapPoint(11, 17), MapPoint(11, 18), MapPoint(11, 19), MapPoint(12, 10),
+      MapPoint(12, 11), MapPoint(12, 12), MapPoint(12, 13), MapPoint(12, 14), MapPoint(12, 15), MapPoint(12, 16), MapPoint(12, 17),
+      MapPoint(12, 18), MapPoint(12, 19), MapPoint(13, 10), MapPoint(13, 11), MapPoint(13, 12), MapPoint(13, 13), MapPoint(13, 14),
+      MapPoint(13, 15), MapPoint(13, 16), MapPoint(13, 17), MapPoint(13, 18), MapPoint(13, 19), MapPoint(14, 10), MapPoint(14, 11),
+      MapPoint(14, 12), MapPoint(14, 13), MapPoint(14, 16), MapPoint(14, 17), MapPoint(14, 18), MapPoint(14, 19), MapPoint(15, 10),
+      MapPoint(15, 11), MapPoint(15, 12), MapPoint(15, 13), MapPoint(15, 16), MapPoint(15, 17), MapPoint(15, 18), MapPoint(15, 19),
+      MapPoint(16, 10), MapPoint(16, 11), MapPoint(16, 12), MapPoint(16, 13), MapPoint(16, 14), MapPoint(16, 15), MapPoint(16, 16),
+      MapPoint(16, 17), MapPoint(16, 18), MapPoint(16, 19), MapPoint(17, 10), MapPoint(17, 11), MapPoint(17, 12), MapPoint(17, 13),
+      MapPoint(17, 14), MapPoint(17, 15), MapPoint(17, 16), MapPoint(17, 17), MapPoint(17, 18), MapPoint(17, 19), MapPoint(18, 10),
+      MapPoint(18, 11), MapPoint(18, 12), MapPoint(18, 13), MapPoint(18, 14), MapPoint(18, 15), MapPoint(18, 16), MapPoint(18, 17),
+      MapPoint(18, 18), MapPoint(18, 19), MapPoint(19, 10), MapPoint(19, 11), MapPoint(19, 12), MapPoint(19, 13), MapPoint(19, 14),
+      MapPoint(19, 15), MapPoint(19, 16), MapPoint(19, 17), MapPoint(19, 18), MapPoint(19, 19)};
 
     // check the whole area
     std::array<std::vector<MapPoint>, 8> polygon;
@@ -93,13 +81,11 @@ BOOST_AUTO_TEST_CASE(IsPointValid)
         // i = 2, 3, 6, 7 -> hole reversed
         // i = 4, 5, 6, 7 -> outer reversed
 
-        polygon[i] += MapPoint(0, 0);
-        polygon[i] = boost::push_back(polygon[i],
-                                      (i & (1 << 0)) ? ((i & (1 << 1)) ? hole : hole_reversed) : ((i & (1 << 2)) ? outer : outer_reversed));
-        polygon[i] += MapPoint(0, 0);
-        polygon[i] = boost::push_back(polygon[i],
-                                      (i & (1 << 0)) ? ((i & (1 << 2)) ? outer : outer_reversed) : ((i & (1 << 1)) ? hole : hole_reversed));
-        polygon[i] += MapPoint(0, 0);
+        polygon[i].emplace_back(0, 0);
+        boost::push_back(polygon[i], (i & (1 << 0)) ? ((i & (1 << 1)) ? hole : hole_reversed) : ((i & (1 << 2)) ? outer : outer_reversed));
+        polygon[i].emplace_back(0, 0);
+        boost::push_back(polygon[i], (i & (1 << 0)) ? ((i & (1 << 2)) ? outer : outer_reversed) : ((i & (1 << 1)) ? hole : hole_reversed));
+        polygon[i].emplace_back(0, 0);
     }
 
     for(const auto& i : polygon)
@@ -117,13 +103,10 @@ BOOST_AUTO_TEST_CASE(IsPointValid)
 
     // Make a rectangle (10,5)->(15,10) and 2 parallelograms below
     std::array<std::vector<MapPoint>, 4> rectAreas;
-    rectAreas[0] += MapPoint(10, 5), MapPoint(15, 5), MapPoint(15, 10);
-    rectAreas[0] += MapPoint(18, 13), MapPoint(15, 15);
-    rectAreas[0] += MapPoint(10, 15);
-    rectAreas[0] += MapPoint(13, 13), MapPoint(10, 10);
+    rectAreas[0] = {MapPoint(10, 5),  MapPoint(15, 5),  MapPoint(15, 10), MapPoint(18, 13),
+                    MapPoint(15, 15), MapPoint(10, 15), MapPoint(13, 13), MapPoint(10, 10)};
     // With duplicate start point
-    rectAreas[1].clear();
-    boost::push_back(rectAreas[1], rectAreas[0]) += rectAreas[0][0];
+    boost::push_back(rectAreas[1], rectAreas[0]).push_back(rectAreas[0][0]);
     rectAreas[2].resize(rectAreas[0].size());
     std::reverse_copy(rectAreas[0].begin(), rectAreas[0].end(), rectAreas[2].begin());
     rectAreas[3].resize(rectAreas[1].size());
@@ -150,24 +133,30 @@ BOOST_AUTO_TEST_CASE(IsPointValid)
     }
     // Get the points exactly at the border and just outside of it
     std::vector<MapPoint> borderPts;
-    std::vector<MapPoint> outsidePts;
-    outsidePts += MapPoint(9, 4), MapPoint(16, 4), MapPoint(16, 16), MapPoint(9, 16);
-    outsidePts += MapPoint(10, 12), MapPoint(10, 13), MapPoint(11, 13), MapPoint(10, 14);
+    std::vector<MapPoint> outsidePts{MapPoint(9, 4),   MapPoint(16, 4),  MapPoint(16, 16), MapPoint(9, 16),
+                                     MapPoint(10, 12), MapPoint(10, 13), MapPoint(11, 13), MapPoint(10, 14)};
     for(int x = 10; x <= 15; x++)
     {
-        borderPts += MapPoint(x, 5), MapPoint(x, 15);
-        outsidePts += MapPoint(x, 5 - 1), MapPoint(x, 15 + 1);
+        borderPts.emplace_back(x, 5);
+        borderPts.emplace_back(x, 15);
+        outsidePts.emplace_back(x, 5 - 1);
+        outsidePts.emplace_back(x, 15 + 1);
     }
     for(int y = 5; y <= 10; y++)
     {
-        borderPts += MapPoint(10, y), MapPoint(15, y);
-        outsidePts += MapPoint(10 - 1, y), MapPoint(15 + 1, y);
+        borderPts.emplace_back(10, y);
+        borderPts.emplace_back(15, y);
+        outsidePts.emplace_back(10 - 1, y);
+        outsidePts.emplace_back(15 + 1, y);
     }
     // Border at the parallelogram (not really all border, but hard to figure out which are outside
     for(int y = 11; y < 15; y++)
     {
         for(int x = 0; x <= 3; x++)
-            borderPts += MapPoint(x + 11, y), MapPoint(x + 16, y);
+        {
+            borderPts.emplace_back(x + 11, y);
+            borderPts.emplace_back(x + 16, y);
+        }
     }
     for(const auto& rectArea : rectAreas)
     {
@@ -187,26 +176,25 @@ BOOST_AUTO_TEST_CASE(IsPointValid)
             BOOST_REQUIRE_EQUAL(TerritoryRegion::IsPointValid(worldSize, rectAreas[i], pt), isValid);
     }
 
-    std::vector<MapPoint> fullMapArea;
     // Note the usage of width and height to include the border points
-    fullMapArea += MapPoint(0, 0), MapPoint(0, worldSize.y), MapPoint(worldSize), MapPoint(worldSize.x, 0), MapPoint(0, 0);
+    std::vector<MapPoint> fullMapArea{MapPoint(0, 0), MapPoint(0, worldSize.y), MapPoint(worldSize), MapPoint(worldSize.x, 0),
+                                      MapPoint(0, 0)};
     std::vector<MapPoint> fullMapAreaReversed(fullMapArea.size());
     std::reverse_copy(fullMapArea.begin(), fullMapArea.end(), fullMapAreaReversed.begin());
 
     for(unsigned i = 0; i < 4; i++)
     {
-        std::vector<MapPoint> fullArea;
-        fullArea += MapPoint(0, 0);
+        std::vector<MapPoint> fullArea{MapPoint(0, 0)};
         if(i < 2)
             boost::push_back(fullArea, fullMapArea);
         else
             boost::push_back(fullArea, fullMapAreaReversed);
-        fullArea += MapPoint(0, 0);
+        fullArea.emplace_back(0, 0);
         if(i % 2 == 0)
             boost::push_back(fullArea, rectAreas[1]);
         else
             boost::push_back(fullArea, rectAreas[3]);
-        fullArea += MapPoint(0, 0);
+        fullArea.emplace_back(0, 0);
 
         // check the whole area
         RTTR_FOREACH_PT(MapPoint, worldSize)

--- a/tests/s25Main/locale/testLocalization.cpp
+++ b/tests/s25Main/locale/testLocalization.cpp
@@ -23,7 +23,6 @@
 #include "s25util/StringConversion.h"
 #include <rttr/test/LocaleResetter.hpp>
 #include <rttr/test/LogAccessor.hpp>
-#include <boost/assign/std/vector.hpp>
 #include <boost/test/unit_test.hpp>
 #include <string>
 
@@ -68,18 +67,27 @@ BOOST_AUTO_TEST_CASE(ConvertToString)
 
 BOOST_AUTO_TEST_CASE(ConvertFromString)
 {
-    using namespace boost::assign;
-    std::vector<std::string> invalidInts;
-    invalidInts += "", "-", "+", "abc", ".1", ",1", "1.", "1,", "a1", "1a", "1-", "1 2", "--1", "++1";
-    invalidInts += s25util::toStringClassic(static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1);
-    invalidInts += s25util::toStringClassic(static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 1);
+    const std::vector<std::string> invalidInts{"",
+                                               "-",
+                                               "+",
+                                               "abc",
+                                               ".1",
+                                               ",1",
+                                               "1.",
+                                               "1,",
+                                               "a1",
+                                               "1a",
+                                               "1-",
+                                               "1 2",
+                                               "--1",
+                                               "++1",
+                                               s25util::toStringClassic(static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1),
+                                               s25util::toStringClassic(static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 1)};
 
-    std::vector<std::string> invalidUints;
-    invalidUints += "-", "+", "-1", "1-";
-    invalidUints += s25util::toStringClassic(static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1);
+    const std::vector<std::string> invalidUints{"-", "+", "-1", "1-",
+                                                s25util::toStringClassic(static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1)};
 
-    std::vector<std::string> invalidFloats;
-    invalidFloats += "", "-", "+", "abc", ",1", "1,", "a1", "1a", "1-", "1,1", "1 2", "--1", "++1";
+    const std::vector<std::string> invalidFloats{"", "-", "+", "abc", ",1", "1,", "a1", "1a", "1-", "1,1", "1 2", "--1", "++1"};
 
     // Partial values. At least all from above. All equal 1
     // Those would work, if eof of the stream is not checked. However clang on OSX fails this in C++98 and we don't need it.

--- a/tests/s25Main/lua/GameWithLuaAccess.h
+++ b/tests/s25Main/lua/GameWithLuaAccess.h
@@ -29,6 +29,7 @@
 #include "lua/GameDataLoader.h"
 #include "lua/LuaInterfaceGame.h"
 #include "worldFixtures/GCExecutor.h"
+#include "worldFixtures/MockLocalGameState.h"
 #include "worldFixtures/initGameRNG.hpp"
 #include "world/GameWorldGame.h"
 #include "world/MapLoader.h"
@@ -96,11 +97,12 @@ struct LuaTestsFixture : public rttr::test::LogAccessor, public LuaBaseFixture, 
 public:
     std::shared_ptr<GameWithLuaAccess> game;
     GameWorld& world;
+    MockLocalGameState localGameState;
     std::vector<MapPoint> hqPositions;
 
     LuaTestsFixture() : game(std::make_shared<GameWithLuaAccess>()), world(game->world_)
     {
-        game->world_.SetLua(std::make_unique<LuaInterfaceGame>(game));
+        game->world_.SetLua(std::make_unique<LuaInterfaceGame>(game, localGameState));
         setLua(&game->world_.GetLua());
     }
 

--- a/tests/s25Main/lua/LuaBaseFixture.h
+++ b/tests/s25Main/lua/LuaBaseFixture.h
@@ -22,6 +22,7 @@
 #include "lua/LuaInterfaceGameBase.h"
 #include <boost/format.hpp>
 #include <boost/test/unit_test.hpp>
+#include <sstream>
 
 /// Provide lua execution methods and check if lua values equal given value
 class LuaBaseFixture
@@ -43,7 +44,12 @@ public:
     {
         try
         {
-            executeLua(std::string("assert(") + luaVal + "==" + expectedValue + ", 'xxx=' .. tostring(" + luaVal + "))");
+            std::ostringstream ss;
+            // Save to temporaries to run code only once
+            ss << "_isVal = " << luaVal << "\n";
+            ss << "_expectedVal = " << expectedValue << "\n";
+            ss << "assert(_isVal == _expectedVal, 'xxx=' .. tostring(_isVal))";
+            executeLua(ss.str());
         } catch(std::runtime_error& e)
         {
             boost::test_tools::predicate_result result(false);

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE(RestrictedArea)
     executeLua("player:SetRestrictedArea(5,7, 5,12, 15,12)");
     std::vector<MapPoint> expectedRestrictedArea;
     expectedRestrictedArea = {MapPoint(5, 7), MapPoint(5, 12), MapPoint(15, 12)};
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea); //-V807
+    BOOST_TEST_REQUIRE(player.GetRestrictedArea() == expectedRestrictedArea, boost::test_tools::per_element()); //-V807
     executeLua("assert(not player:IsInRestrictedArea(1, 2))");
     executeLua("assert(not player:IsInRestrictedArea(0, 0))");
     executeLua("assert(player:IsInRestrictedArea(6, 8))");
@@ -513,28 +513,28 @@ BOOST_AUTO_TEST_CASE(RestrictedArea)
     executeLua("player:SetRestrictedArea(0,0, 1,1, 10,1, 10,10, 1,10, 1,1, 0,0, 5,5, 7,5, 7,7, 5,5, 0,0)");
     expectedRestrictedArea = {MapPoint(0, 0), MapPoint(1, 1), MapPoint(10, 1), MapPoint(10, 10), MapPoint(1, 10), MapPoint(1, 1),
                               MapPoint(0, 0), MapPoint(5, 5), MapPoint(7, 5),  MapPoint(7, 7),   MapPoint(5, 5),  MapPoint(0, 0)};
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
+    BOOST_TEST_REQUIRE(player.GetRestrictedArea() == expectedRestrictedArea, boost::test_tools::per_element());
     BOOST_REQUIRE_EQUAL(getLog(), "");
     // Some prefer using nils
     executeLua("player:SetRestrictedArea(nil,nil, 1,1, 10,1, 10,10, 1,10, 1,1, nil,nil, 5,5, 7,5, 7,7, 5,5, nil,nil)");
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
+    BOOST_TEST_REQUIRE(player.GetRestrictedArea() == expectedRestrictedArea, boost::test_tools::per_element());
     RTTR_REQUIRE_LOG_CONTAINS("don't need leading nils", false);
 
     // New API: Single nil and no double point
     executeLua("player:SetRestrictedArea(1,1, 10,1, 10,10, 1,10, nil, 5,5, 7,5, 7,7)");
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
+    BOOST_TEST_REQUIRE(player.GetRestrictedArea() == expectedRestrictedArea, boost::test_tools::per_element());
     // Although you could use nil at the end...
     executeLua("player:SetRestrictedArea(1,1, 10,1, 10,10, 1,10, nil, 5,5, 7,5, 7,7, nil)");
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
+    BOOST_TEST_REQUIRE(player.GetRestrictedArea() == expectedRestrictedArea, boost::test_tools::per_element());
     // ...or beginning
     executeLua("player:SetRestrictedArea(nil,1,1, 10,1, 10,10, 1,10, nil, 5,5, 7,5, 7,7)");
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
+    BOOST_TEST_REQUIRE(player.GetRestrictedArea() == expectedRestrictedArea, boost::test_tools::per_element());
     RTTR_REQUIRE_LOG_CONTAINS("don't need leading nils", false);
 
     // Also for single polygon
     executeLua("player:SetRestrictedArea(5,7, 5,12, 15,12, nil)");
     expectedRestrictedArea = {MapPoint(5, 7), MapPoint(5, 12), MapPoint(15, 12)};
-    RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
+    BOOST_TEST_REQUIRE(player.GetRestrictedArea() == expectedRestrictedArea, boost::test_tools::per_element());
 
     executeLua("player:SetRestrictedArea()");
     BOOST_REQUIRE_EQUAL(player.GetRestrictedArea().size(), 0u);
@@ -760,7 +760,7 @@ BOOST_AUTO_TEST_CASE(onOccupied)
         Points& luaPts = luaPtsPerPlayer[i];
         std::sort(gamePts.begin(), gamePts.end());
         std::sort(luaPts.begin(), luaPts.end());
-        RTTR_REQUIRE_EQUAL_COLLECTIONS(luaPts, gamePts);
+        BOOST_TEST_REQUIRE(luaPts == gamePts, boost::test_tools::per_element());
     }
 }
 
@@ -792,7 +792,7 @@ BOOST_AUTO_TEST_CASE(onExplored)
         Points& luaPts = luaPtsPerPlayer[i];
         std::sort(gamePts.begin(), gamePts.end());
         std::sort(luaPts.begin(), luaPts.end());
-        RTTR_REQUIRE_EQUAL_COLLECTIONS(luaPts, gamePts);
+        BOOST_TEST_REQUIRE(luaPts == gamePts, boost::test_tools::per_element());
     }
 }
 

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(LuaPacts)
     executeLua("function onPactCanceled(pt, canceledByPlayerId, targetPlayerId) rttr:Log('Pact canceled') end");
 
     // create alliance and check players state
-    player.SuggestPact(1, TREATY_OF_ALLIANCE, 0xFFFFFFFF);
+    player.SuggestPact(1, TREATY_OF_ALLIANCE, DURATION_INFINITE);
     game->executeAICommands();
     BOOST_REQUIRE(player.IsAlly(1));
     executeLua("assert(player:IsAlly(0))");
@@ -870,7 +870,7 @@ BOOST_AUTO_TEST_CASE(LuaPacts)
 
     // accept cancel-request via lua callback
     executeLua("function onCancelPactRequest(pt, player, ai) return true end");
-    player.SuggestPact(1, NON_AGGRESSION_PACT, 0xFFFFFFFF);
+    player.SuggestPact(1, NON_AGGRESSION_PACT, DURATION_INFINITE);
     game->executeAICommands();
     // non aggression was created
     BOOST_REQUIRE(!player.IsAttackable(1));

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -42,8 +42,6 @@
 #include <utility>
 #include <vector>
 
-using namespace boost::assign;
-
 BOOST_FIXTURE_TEST_SUITE(LuaTestSuite, LuaTestsFixture)
 
 BOOST_AUTO_TEST_CASE(LuaEqual_IsCorrect)
@@ -501,7 +499,7 @@ BOOST_AUTO_TEST_CASE(RestrictedArea)
     // Just a single polygon
     executeLua("player:SetRestrictedArea(5,7, 5,12, 15,12)");
     std::vector<MapPoint> expectedRestrictedArea;
-    expectedRestrictedArea += MapPoint(5, 7), MapPoint(5, 12), MapPoint(15, 12);
+    expectedRestrictedArea = {MapPoint(5, 7), MapPoint(5, 12), MapPoint(15, 12)};
     RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea); //-V807
     executeLua("assert(not player:IsInRestrictedArea(1, 2))");
     executeLua("assert(not player:IsInRestrictedArea(0, 0))");
@@ -510,9 +508,8 @@ BOOST_AUTO_TEST_CASE(RestrictedArea)
 
     // Polygon with hole
     executeLua("player:SetRestrictedArea(0,0, 1,1, 10,1, 10,10, 1,10, 1,1, 0,0, 5,5, 7,5, 7,7, 5,5, 0,0)");
-    expectedRestrictedArea.clear();
-    expectedRestrictedArea += MapPoint(0, 0), MapPoint(1, 1), MapPoint(10, 1), MapPoint(10, 10), MapPoint(1, 10), MapPoint(1, 1);
-    expectedRestrictedArea += MapPoint(0, 0), MapPoint(5, 5), MapPoint(7, 5), MapPoint(7, 7), MapPoint(5, 5), MapPoint(0, 0);
+    expectedRestrictedArea = {MapPoint(0, 0), MapPoint(1, 1), MapPoint(10, 1), MapPoint(10, 10), MapPoint(1, 10), MapPoint(1, 1),
+                              MapPoint(0, 0), MapPoint(5, 5), MapPoint(7, 5),  MapPoint(7, 7),   MapPoint(5, 5),  MapPoint(0, 0)};
     RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
     BOOST_REQUIRE_EQUAL(getLog(), "");
     // Some prefer using nils
@@ -533,8 +530,7 @@ BOOST_AUTO_TEST_CASE(RestrictedArea)
 
     // Also for single polygon
     executeLua("player:SetRestrictedArea(5,7, 5,12, 15,12, nil)");
-    expectedRestrictedArea.clear();
-    expectedRestrictedArea += MapPoint(5, 7), MapPoint(5, 12), MapPoint(15, 12);
+    expectedRestrictedArea = {MapPoint(5, 7), MapPoint(5, 12), MapPoint(15, 12)};
     RTTR_REQUIRE_EQUAL_COLLECTIONS(player.GetRestrictedArea(), expectedRestrictedArea);
 
     executeLua("player:SetRestrictedArea()");

--- a/tests/s25Main/lua/testLua.cpp
+++ b/tests/s25Main/lua/testLua.cpp
@@ -239,6 +239,9 @@ BOOST_AUTO_TEST_CASE(GameFunctions)
     BOOST_REQUIRE_NE(getLog(), "");
 
     executeLua("assert(rttr:GetWorld())");
+
+    MOCK_EXPECT(localGameState.FormatGFTime).once().with(1023u).returns("01:13:17");
+    BOOST_TEST(isLuaEqual("rttr:FormatNumGFs(1023)", "'01:13:17'"));
 }
 
 BOOST_AUTO_TEST_CASE(MissionGoal)

--- a/tests/s25Main/lua/testLuaGUI.cpp
+++ b/tests/s25Main/lua/testLuaGUI.cpp
@@ -24,7 +24,6 @@
 #include "controls/ctrlMultiline.h"
 #include "ingameWindows/iwMissionStatement.h"
 #include "ingameWindows/iwMsgbox.h"
-#include "network/GameClient.h"
 #include "ogl/glFont.h"
 #include "uiHelper/uiHelpers.hpp"
 #include <boost/assign/std/vector.hpp>
@@ -36,7 +35,7 @@ BOOST_AUTO_TEST_CASE(MissionStatement)
     uiHelper::initGUITests();
 
     // Set player
-    GAMECLIENT.SetTestPlayerId(1);
+    MOCK_EXPECT(localGameState.GetPlayerId).returns(1);
 
     BOOST_REQUIRE(!WINDOWMANAGER.GetTopMostWindow());
 

--- a/tests/s25Main/lua/testLuaGUI.cpp
+++ b/tests/s25Main/lua/testLuaGUI.cpp
@@ -26,7 +26,6 @@
 #include "ingameWindows/iwMsgbox.h"
 #include "ogl/glFont.h"
 #include "uiHelper/uiHelpers.hpp"
-#include <boost/assign/std/vector.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(LuaGUITestSuite, LuaTestsFixture)
 
@@ -156,10 +155,8 @@ BOOST_AUTO_TEST_CASE(MessageBoxTest)
     BOOST_REQUIRE_LE(bt->GetPos().x, static_cast<int>(wnd->GetSize().x / 2));
     BOOST_REQUIRE_GT(bt->GetPos().x, static_cast<int>(wnd->GetSize().x / 2 - bt->GetSize().x));
 
-    using namespace boost::assign;
-    std::vector<DrawPoint> imgPts;
     // Left, right, top, bottom
-    imgPts += DrawPoint(30, 30), DrawPoint(300, 30), DrawPoint(150, 30), DrawPoint(150, 300);
+    const std::vector<DrawPoint> imgPts{DrawPoint(30, 30), DrawPoint(300, 30), DrawPoint(150, 30), DrawPoint(150, 300)};
     for(const auto& imgPt : imgPts)
     {
         const_cast<iwMsgbox*>(wnd)->MoveIcon(imgPt);

--- a/tests/s25Main/lua/testLuaSettings.cpp
+++ b/tests/s25Main/lua/testLuaSettings.cpp
@@ -21,6 +21,7 @@
 #include "addons/Addon.h"
 #include "lua/LuaInterfaceSettings.h"
 #include "network/IGameLobbyController.h"
+#include "worldFixtures/MockLocalGameState.h"
 #include "s25util/colors.h"
 #include <rttr/test/LogAccessor.hpp>
 #include <boost/test/unit_test.hpp>
@@ -40,6 +41,7 @@ struct LuaSettingsTestsFixture : public LuaBaseFixture, public IGameLobbyControl
 {
     std::vector<JoinPlayerInfo> players;
     GlobalGameSettings ggs;
+    MockLocalGameState localGameState;
     LuaInterfaceSettings lua;
 
     unsigned GetMaxNumPlayers() const override { return players.size(); }
@@ -57,7 +59,7 @@ struct LuaSettingsTestsFixture : public LuaBaseFixture, public IGameLobbyControl
     void SetTeam(unsigned playerIdx, Team newTeam) override { GetJoinPlayer(playerIdx).team = newTeam; }
     void SetNation(unsigned playerIdx, Nation newNation) override { GetJoinPlayer(playerIdx).nation = newNation; }
 
-    LuaSettingsTestsFixture() : lua(*this)
+    LuaSettingsTestsFixture() : lua(*this, localGameState)
     {
         setLua(&lua);
 

--- a/tests/s25Main/simple/testDirection.cpp
+++ b/tests/s25Main/simple/testDirection.cpp
@@ -76,7 +76,8 @@ BOOST_AUTO_TEST_CASE(DirectionIncDec)
     }
 }
 
-BOOST_AUTO_TEST_CASE(DirectionIterator)
+/*
+BOOST_AUTO_TEST_CASE(DirectionIteratorWithOffset)
 {
     for(unsigned i = 0; i < Direction::COUNT; i++)
     {
@@ -92,11 +93,11 @@ BOOST_AUTO_TEST_CASE(DirectionIterator)
         unsigned expectedCt = Direction::COUNT;
         BOOST_REQUIRE_EQUAL(ct, expectedCt);
     }
-}
+}*/
 
 BOOST_AUTO_TEST_CASE(DirectionToImgDir)
 {
-    for(Direction curDir : Direction())
+    for(Direction curDir : helpers::EnumRange<Direction>{})
     {
         // S2 Img dir is offset by 3
         BOOST_TEST(static_cast<unsigned>(toImgDir(curDir)) == (static_cast<unsigned>(curDir) + 3) % 6);

--- a/tests/s25Main/simple/testMapBase.cpp
+++ b/tests/s25Main/simple/testMapBase.cpp
@@ -19,14 +19,13 @@
 #include "world/MapBase.h"
 #include "world/MapGeometry.h"
 #include "gameData/MapConsts.h"
-#include <boost/assign/std/vector.hpp>
 #include <boost/test/unit_test.hpp>
+#include <array>
 
 BOOST_AUTO_TEST_SUITE(WorldCreationSuite)
 
 BOOST_AUTO_TEST_CASE(NeighbourPts)
 {
-    using namespace boost::assign;
     MapBase world;
     world.Resize(MapExtent(20, 30));
 
@@ -49,15 +48,14 @@ BOOST_AUTO_TEST_CASE(NeighbourPts)
     oddPtMod[Direction::SOUTHWEST] = Position(0, 1);
     evenPtMod[Direction::SOUTHEAST] = Position(0, 1);
     oddPtMod[Direction::SOUTHEAST] = Position(1, 1);
-    std::vector<Position> testPoints;
-    // Test a simple even and odd point
-    testPoints += Position(10, 10), Position(10, 9);
-    // Test border points
-    testPoints += Position(0, 0), Position(0, world.GetHeight() - 1), Position(world.GetWidth() - 1, 0),
-      Position(world.GetWidth() - 1, world.GetHeight() - 1);
-    // Test border points with 1 offset in Y
-    testPoints += Position(0, 1), Position(0, world.GetHeight() - 2), Position(world.GetWidth() - 1, 1),
-      Position(world.GetWidth() - 1, world.GetHeight() - 2);
+    std::vector<Position> testPoints{// Test a simple even and odd point
+                                     Position(10, 10), Position(10, 9),
+                                     // Test border points
+                                     Position(0, 0), Position(0, world.GetHeight() - 1), Position(world.GetWidth() - 1, 0),
+                                     Position(world.GetWidth() - 1, world.GetHeight() - 1),
+                                     // Test border points with 1 offset in Y
+                                     Position(0, 1), Position(0, world.GetHeight() - 2), Position(world.GetWidth() - 1, 1),
+                                     Position(world.GetWidth() - 1, world.GetHeight() - 2)};
     for(const Position& pt : testPoints)
     {
         for(unsigned dir = 0; dir < Direction::COUNT; dir++)
@@ -82,10 +80,10 @@ BOOST_AUTO_TEST_CASE(NeighbourPts)
         BOOST_REQUIRE_EQUAL(world.CalcDistance(curPt, curTargetPoint), 2u);
         BOOST_REQUIRE_EQUAL(world.GetNeighbour2(curPt, 0), curTargetPoint);
         // We now go 2 steps in each direction to describe the circle
-        // (Note: Could iterator over directions, but to easily indentifiy errors and make intentions clear we do it explicitely)
-        std::vector<Direction> steps;
-        steps += Direction::NORTHEAST, Direction::NORTHEAST, Direction::EAST, Direction::EAST, Direction::SOUTHEAST, Direction::SOUTHEAST;
-        steps += Direction::SOUTHWEST, Direction::SOUTHWEST, Direction::WEST, Direction::WEST, Direction::NORTHWEST;
+        // (Note: Could iterator over directions, but to easily identify errors and make intentions clear we do it explicitely)
+        const std::array<Direction, 11> steps{Direction::NORTHEAST, Direction::NORTHEAST, Direction::EAST,      Direction::EAST,
+                                              Direction::SOUTHEAST, Direction::SOUTHEAST, Direction::SOUTHWEST, Direction::SOUTHWEST,
+                                              Direction::WEST,      Direction::WEST,      Direction::NORTHWEST};
         // Note: 0==12 already handled
         for(unsigned j = 1; j < 12; j++)
         {

--- a/tests/s25Main/worldFixtures/MockLocalGameState.h
+++ b/tests/s25Main/worldFixtures/MockLocalGameState.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 - 2020 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef MockLocalGameState_h__
+#define MockLocalGameState_h__
+
+#include "ILocalGameState.h"
+#include <turtle/mock.hpp>
+
+// Fix those macros to auto-detect signature: https://github.com/mat007/turtle/issues/93
+#undef MOCK_CONST_METHOD
+#undef MOCK_NON_CONST_METHOD
+#define MOCK_CONST_METHOD(M, ...)                                                                                         \
+    MOCK_CONST_METHOD_EXT(M, MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), MOCK_VARIADIC_ELEM_1(__VA_ARGS__, MOCK_SIGNATURE(M), ), \
+                          MOCK_VARIADIC_ELEM_2(__VA_ARGS__, M, M, ))
+#define MOCK_NON_CONST_METHOD(M, ...)                                                                                         \
+    MOCK_NON_CONST_METHOD_EXT(M, MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), MOCK_VARIADIC_ELEM_1(__VA_ARGS__, MOCK_SIGNATURE(M), ), \
+                              MOCK_VARIADIC_ELEM_2(__VA_ARGS__, M, M, ))
+
+MOCK_BASE_CLASS(MockLocalGameState, ILocalGameState)
+{
+    MOCK_CONST_METHOD(GetPlayerId, 0);
+    MOCK_CONST_METHOD(IsHost, 0);
+    MOCK_CONST_METHOD(FormatGFTime, 1);
+    MOCK_NON_CONST_METHOD(SystemChat, 1);
+};
+
+#endif // MockLocalGameState_h__

--- a/tests/testHelpers/rttr/test/testHelpers.hpp
+++ b/tests/testHelpers/rttr/test/testHelpers.hpp
@@ -63,7 +63,4 @@ do                                                                           \
 } while(false)
 /* clang-format on */
 
-#define RTTR_REQUIRE_EQUAL_COLLECTIONS(Col1, Col2) \
-    BOOST_REQUIRE_EQUAL_COLLECTIONS((Col1).begin(), (Col1).end(), (Col2).begin(), (Col2).end())
-
 #endif // testHelpers_h__

--- a/tests/testHelpers/rttr/test/testHelpers.hpp
+++ b/tests/testHelpers/rttr/test/testHelpers.hpp
@@ -31,36 +31,11 @@ namespace boost { namespace test_tools { namespace tt_detail {
     };
 }}} // namespace boost::test_tools::tt_detail
 
-template<typename T1, typename T2>
-inline boost::test_tools::predicate_result testCmp(const char* cmp, const T1& l, const T2& r, bool equal)
-{
-    if((l == r) != equal)
-    {
-        boost::test_tools::predicate_result res(false);
-        res.message() << cmp << " [" << l << (equal ? "!=" : "==") << r << "]";
-        return res;
-    }
-
-    return true;
-}
-
 /// Check that an exception of the given type is thrown and it contains the message
-/* clang-format off */
-#define RTTR_CHECK_THROW(S, E, MSG)                                          \
-do                                                                           \
-{                                                                            \
-    try                                                                      \
-    {                                                                        \
-        BOOST_TEST_PASSPOINT();                                              \
-        S;                                                                   \
-        RTTR_IGNORE_UNREACHABLE_CODE                                         \
-        BOOST_TEST_ERROR("Exception " << #E << " expected but not thrown");  \
-        RTTR_POP_DIAGNOSTIC                                                  \
-    } catch(const E& e)                                                      \
-    {                                                                        \
-        BOOST_TEST(e.what() == (MSG));                                       \
-    }                                                                        \
-} while(false)
-/* clang-format on */
+#define RTTR_CHECK_EXCEPTION_MSG(S, E, MSG)         \
+    BOOST_CHECK_EXCEPTION(S, E, [](const E& e) {    \
+        BOOST_TEST(std::string(e.what()) == (MSG)); \
+        return std::string(e.what()) == (MSG);      \
+    })
 
 #endif // testHelpers_h__


### PR DESCRIPTION
This bundles some improvements to the documentation, tests and adds the requested rttr:FormatNumGFs from #1185 

- Add a `doc` folder for documentation
- Convert the Lua doc from the wiki to files and fix references
- Ensure consistent Markdown via linter
- Fix a minor issue where lua code is ran twice for the equality check which can make mocks fail
- Refactor Lua interfaces to work with a new ILocalGameState which avoids some hacks required for testing and is the base for the  new feature which would otherwise be untestable
- Replace usage of Boost features with std features and Rttr features with Boost features where they exist