### PR TITLE
Allow dot in showVersion test

### DIFF
--- a/tests/s25client/CMakeLists.txt
+++ b/tests/s25client/CMakeLists.txt
@@ -7,7 +7,7 @@ set_tests_properties(s25client_showHelp PROPERTIES
 add_test(NAME s25client_showVersion COMMAND s25client --version
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(s25client_showVersion PROPERTIES
-  PASS_REGULAR_EXPRESSION "^Return To The Roots v[0-9]+-[0-9a-f]+\n"
+  PASS_REGULAR_EXPRESSION "^Return To The Roots v[0-9.]+-[0-9a-f]+\n"
 )
 
 add_test(NAME s25client_invalidOption COMMAND s25client --nonExistantOption


### PR DESCRIPTION
The existing regular expression seems to expect that the test will
only ever be run from a git checkout. Gentoo would like to eventually
run it from a release source tarball.