### PR TITLE
Fix musicplayer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >-
   -readability-named-parameter,
   -readability-static-accessed-through-instance,
   -readability-uppercase-literal-suffix,
+  -readability-identifier-naming,
   -clang-diagnostic-inconsistent-missing-override
 CheckOptions:
   - key: performance-for-range-copy.AllowedTypes

--- a/libs/common/include/helpers/GetInsertIterator.hpp
+++ b/libs/common/include/helpers/GetInsertIterator.hpp
@@ -19,6 +19,7 @@
 #define GetInsertIterator_h__
 
 #include <boost/type_traits/make_void.hpp>
+#include <iterator>
 #include <utility>
 
 namespace helpers {
@@ -27,13 +28,13 @@ namespace helpers {
 template<class T, typename = void>
 struct GetInsertIterator
 {
-    static auto get(T& collection) { return std::insert_iterator<T>(collection, collection.end()); }
+    static auto get(T& collection) { return std::inserter(collection, collection.end()); }
 };
 
 template<class T>
 struct GetInsertIterator<T, boost::void_t<decltype(std::declval<T>().push_back(std::declval<typename T::value_type>()))>>
 {
-    static auto get(T& collection) { return std::back_insert_iterator<T>(collection); }
+    static auto get(T& collection) { return std::back_inserter(collection); }
 };
 
 } // namespace helpers

--- a/libs/rttrConfig/src/files.h
+++ b/libs/rttrConfig/src/files.h
@@ -51,6 +51,7 @@ namespace folders {
     constexpr auto mapsSea = "<RTTR_RTTR>/MAPS/SEA";    // seafaring maps
     constexpr auto mbob = "<RTTR_GAME>/DATA/MBOB";      // nation graphics
     constexpr auto music = "<RTTR_RTTR>/MUSIC";
+    constexpr auto playlists = "<RTTR_USERDATA>/playlists";
     constexpr auto replays = "<RTTR_USERDATA>/REPLAYS";
     constexpr auto save = "<RTTR_USERDATA>/SAVE";
     constexpr auto screenshots = "<RTTR_USERDATA>/screenshots";
@@ -62,6 +63,7 @@ namespace files {
     constexpr auto splash = "<RTTR_RTTR>/splash.bmp";
     constexpr auto soundOrig = "<RTTR_GAME>/DATA/SOUNDDAT/SOUND.LST"; // original sound.lst
     constexpr auto soundScript = "<RTTR_RTTR>/sound.scs";             // converter script
+    constexpr auto defaultPlaylist = "<RTTR_RTTR>/MUSIC/S2_Standard.pll";
 } // namespace files
 namespace resources {
     constexpr auto boat = "<RTTR_GAME>/DATA/BOBS/BOAT.LST";

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -362,9 +362,9 @@ bool InitDirectories()
     LOG.write("Starting in %s\n", LogTarget::Stdout) % curPath;
 
     // diverse dirs anlegen
-    const std::array<std::string, 9> dirs = {{s25::folders::config, s25::folders::mapsOwn, s25::folders::logs, s25::folders::mapsPlayed,
-                                              s25::folders::replays, s25::folders::save, s25::folders::lstsUser, s25::folders::gameLstsUser,
-                                              s25::folders::screenshots}}; // settingsdir muss zuerst angelegt werden (94)
+    const std::array<std::string, 10> dirs = {{s25::folders::config, s25::folders::mapsOwn, s25::folders::logs, s25::folders::mapsPlayed,
+                                               s25::folders::replays, s25::folders::save, s25::folders::lstsUser,
+                                               s25::folders::gameLstsUser, s25::folders::screenshots, s25::folders::playlists}};
 
     if(!MigrateFilesAndDirectories())
         return false;

--- a/libs/s25main/MusicPlayer.cpp
+++ b/libs/s25main/MusicPlayer.cpp
@@ -28,11 +28,6 @@
 
 MusicPlayer::MusicPlayer() : playing(false) {}
 
-bool MusicPlayer::Load(const std::string& filename)
-{
-    return list.Load(LOG, filename);
-}
-
 /**
  *  Startet Abspielvorgang
  */

--- a/libs/s25main/MusicPlayer.h
+++ b/libs/s25main/MusicPlayer.h
@@ -36,12 +36,11 @@ public:
     /// Stoppt Abspielvorgang
     void Stop();
 
-    /// Playlist laden
-    bool Load(const std::string& filename);
     /// Musik wurde fertiggespielt (Callback)
     void MusicFinished() { PlayNext(); }
     /// liefert die Playlist.
-    Playlist& GetPlaylist() { return list; }
+    const Playlist& GetPlaylist() const { return list; }
+    void SetPlaylist(Playlist pl) { list = std::move(pl); }
 
 protected:
     /// Spielt nächstes Stück ab

--- a/libs/s25main/Playlist.cpp
+++ b/libs/s25main/Playlist.cpp
@@ -57,11 +57,11 @@ std::string Playlist::getCurrentSong() const
 /**
  *  Playlist in Datei speichern
  */
-bool Playlist::SaveAs(const std::string& filename, const bool overwrite)
+bool Playlist::SaveAs(const boost::filesystem::path& filepath, const bool overwrite)
 {
     if(!overwrite)
     {
-        bnw::ifstream in(filename.c_str());
+        bnw::ifstream in(filepath);
         if(in.good())
         {
             // Datei existiert und wir sollen sie nicht überschreiben
@@ -70,7 +70,7 @@ bool Playlist::SaveAs(const std::string& filename, const bool overwrite)
         }
     }
 
-    s25util::ClassicImbuedStream<bnw::ofstream> out(filename.c_str());
+    s25util::ClassicImbuedStream<bnw::ofstream> out(filepath);
     if(!out.good())
         return false;
 
@@ -89,17 +89,14 @@ bool Playlist::SaveAs(const std::string& filename, const bool overwrite)
 /**
  *  Playlist laden
  */
-bool Playlist::Load(Log& logger, const std::string& filename)
+bool Playlist::Load(Log& logger, const boost::filesystem::path& filepath)
 {
     songs.clear();
-    if(filename.empty())
+    if(filepath.empty())
         return false;
 
-    logger.write(_("Loading \"%s\"\n")) % filename;
+    logger.write(_("Loading \"%s\"\n")) % filepath;
 
-    boost::filesystem::path filepath(filename);
-    if(filepath.extension() != ".pll")
-        filepath.replace_extension("pll");
     bnw::ifstream in(filepath);
 
     if(in.fail())

--- a/libs/s25main/Playlist.cpp
+++ b/libs/s25main/Playlist.cpp
@@ -59,19 +59,8 @@ std::string Playlist::getCurrentSong() const
 /**
  *  Playlist in Datei speichern
  */
-bool Playlist::SaveAs(const boost::filesystem::path& filepath, const bool overwrite) const
+bool Playlist::SaveAs(const boost::filesystem::path& filepath) const
 {
-    if(!overwrite)
-    {
-        bnw::ifstream in(filepath);
-        if(in.good())
-        {
-            // Datei existiert und wir sollen sie nicht überschreiben
-            in.close();
-            return false;
-        }
-    }
-
     s25util::ClassicImbuedStream<bnw::ofstream> out(filepath);
     if(!out.good())
         return false;

--- a/libs/s25main/Playlist.h
+++ b/libs/s25main/Playlist.h
@@ -39,7 +39,7 @@ public:
     std::string getNextSong();
 
     /// Playlist in Datei speichern
-    bool SaveAs(const boost::filesystem::path& filepath, bool overwrite) const;
+    bool SaveAs(const boost::filesystem::path& filepath) const;
     /// Playlist laden
     bool Load(Log& logger, const boost::filesystem::path& filepath);
 

--- a/libs/s25main/Playlist.h
+++ b/libs/s25main/Playlist.h
@@ -17,6 +17,7 @@
 #ifndef PLAYLIST_H_INCLUDED
 #define PLAYLIST_H_INCLUDED
 
+#include <boost/filesystem/path.hpp>
 #include <string>
 #include <vector>
 
@@ -41,9 +42,9 @@ public:
     std::string getNextSong();
 
     /// Playlist in Datei speichern
-    bool SaveAs(const std::string& filename, bool overwrite);
+    bool SaveAs(const boost::filesystem::path& filepath, bool overwrite);
     /// Playlist laden
-    bool Load(Log& logger, const std::string& filename);
+    bool Load(Log& logger, const boost::filesystem::path& filepath);
 
     /// Füllt das iwMusicPlayer-Fenster mit den entsprechenden Werten
     void FillMusicPlayer(iwMusicPlayer* window) const;

--- a/libs/s25main/Playlist.h
+++ b/libs/s25main/Playlist.h
@@ -23,17 +23,14 @@
 
 #pragma once
 
-class iwMusicPlayer;
 class Log;
 
 /// Speichert die Daten über eine Playlist und verwaltet diese
 class Playlist
 {
 public:
-    Playlist();
-
-    /// bereitet die Playlist aufs abspielen vor.
-    void Prepare();
+    Playlist() = default;
+    Playlist(std::vector<std::string> songs, unsigned numRepeats, bool random);
 
     /// liefert den Dateinamen des aktuellen Songs
     std::string getCurrentSong() const;
@@ -42,24 +39,26 @@ public:
     std::string getNextSong();
 
     /// Playlist in Datei speichern
-    bool SaveAs(const boost::filesystem::path& filepath, bool overwrite);
+    bool SaveAs(const boost::filesystem::path& filepath, bool overwrite) const;
     /// Playlist laden
     bool Load(Log& logger, const boost::filesystem::path& filepath);
 
-    /// Füllt das iwMusicPlayer-Fenster mit den entsprechenden Werten
-    void FillMusicPlayer(iwMusicPlayer* window) const;
-    /// Liest die Werte aus dem iwMusicPlayer-Fenster
-    void ReadMusicPlayer(const iwMusicPlayer* window);
+    const auto& getSongs() const { return songs_; }
+    unsigned getNumRepeats() const { return numRepeats_; }
+    bool isRandomized() const { return random_; }
 
     /// Wählt den Start-Song aus
     void SetStartSong(unsigned id);
 
-protected:
-    int current;
-    unsigned repeats;               /// Anzahl der Wiederholungen
-    bool random;                    /// Zufallswiedergabe?
-    std::vector<std::string> songs; /// Dateinamen der abzuspielenden Titel
-    std::vector<unsigned> order;    /// Reihenfolge der Titel
+private:
+    /// Get the playlist ready for playing
+    void Prepare();
+
+    std::vector<std::string> songs_; /// Filenames of titles to play
+    unsigned numRepeats_ = 1;        /// How often to repeat all songs
+    bool random_ = false;            /// True for random order, else in-order
+    std::vector<unsigned> order_;    /// Actual order of the songs, indices into songs
+    std::string currentSong_;
 };
 
 #endif // !PLAYLIST_H_INCLUDED

--- a/libs/s25main/QuickStartGame.cpp
+++ b/libs/s25main/QuickStartGame.cpp
@@ -55,7 +55,7 @@ bool QuickStartGame(const std::string& filePath, bool singlePlayer)
     if(!loader.load())
         return false;
     if(loader.getPlaylist())
-        MUSICPLAYER.GetPlaylist() = std::move(*loader.getPlaylist());
+        MUSICPLAYER.SetPlaylist(std::move(*loader.getPlaylist()));
     if(SETTINGS.sound.musik)
         MUSICPLAYER.Play();
 

--- a/libs/s25main/QuickStartGame.cpp
+++ b/libs/s25main/QuickStartGame.cpp
@@ -18,6 +18,7 @@
 #include "QuickStartGame.h"
 #include "Loader.h"
 #include "MusicPlayer.h"
+#include "RttrConfig.h"
 #include "Settings.h"
 #include "WindowManager.h"
 #include "desktops/dskGameLoader.h"
@@ -50,7 +51,7 @@ bool QuickStartGame(const std::string& filePath, bool singlePlayer)
         return false;
     }
 
-    ApplicationLoader loader(LOADER, LOG, iwMusicPlayer::GetFullPlaylistPath(SETTINGS.sound.playlist));
+    ApplicationLoader loader(RTTRCONFIG, LOADER, LOG, SETTINGS.sound.playlist);
     if(!loader.load())
         return false;
     if(loader.getPlaylist())

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -105,7 +105,7 @@ void Settings::LoadDefaults()
     sound.musik_volume = 30;
     sound.effekte = true;
     sound.effekte_volume = 75;
-    sound.playlist = "S2_Standard";
+    sound.playlist = s25::files::defaultPlaylist;
     // }
 
     // lobby

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -243,7 +243,7 @@ void Settings::Load()
         // {
         server.last_ip = iniServer->getValue("last_ip");
         boost::optional<uint16_t> port = validate::checkPort(iniServer->getValue("local_port"));
-        server.localPort = port.get_value_or(3665);
+        server.localPort = port.value_or(3665);
         server.ipv6 = (iniServer->getValueI("ipv6") != 0);
         // }
 
@@ -251,7 +251,7 @@ void Settings::Load()
         // {
         proxy.hostname = iniProxy->getValue("proxy");
         port = validate::checkPort(iniProxy->getValue("port"));
-        proxy.port = port.get_value_or(1080);
+        proxy.port = port.value_or(1080);
         proxy.type = ProxyType(iniProxy->getValueI("typ"));
         // }
 

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -29,6 +29,7 @@
 #include "gameTypes/Nation.h"
 #include "gameTypes/TextureColor.h"
 #include "s25util/colors.h"
+#include <boost/optional/optional_fwd.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <map>
 #include <vector>
@@ -235,10 +236,10 @@ public:
     virtual void Msg_ScrollShow(unsigned /*ctrl_id*/, bool /*visible*/) {}
     virtual void Msg_OptionGroupChange(unsigned /*ctrl_id*/, unsigned /*selection*/) {}
     virtual void Msg_Timer(unsigned /*ctrl_id*/) {}
-    virtual void Msg_TableSelectItem(unsigned /*ctrl_id*/, int /*selection*/) {}
+    virtual void Msg_TableSelectItem(unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
     virtual void Msg_TableChooseItem(unsigned /*ctrl_id*/, unsigned /*selection*/) {}
-    virtual void Msg_TableRightButton(unsigned /*ctrl_id*/, int /*selection*/) {}
-    virtual void Msg_TableLeftButton(unsigned /*ctrl_id*/, int /*selection*/) {}
+    virtual void Msg_TableRightButton(unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
+    virtual void Msg_TableLeftButton(unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
 
     // Sonstiges
     virtual void Msg_MsgBoxResult(unsigned /*msgbox_id*/, MsgboxResult /*mbr*/) {}
@@ -255,9 +256,9 @@ public:
     virtual void Msg_Group_ScrollShow(unsigned /*group_id*/, unsigned /*ctrl_id*/, bool /*visible*/) {}
     virtual void Msg_Group_OptionGroupChange(unsigned /*group_id*/, unsigned /*ctrl_id*/, unsigned /*selection*/) {}
     virtual void Msg_Group_Timer(unsigned /*group_id*/, unsigned /*ctrl_id*/) {}
-    virtual void Msg_Group_TableSelectItem(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}
-    virtual void Msg_Group_TableRightButton(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}
-    virtual void Msg_Group_TableLeftButton(unsigned /*group_id*/, unsigned /*ctrl_id*/, int /*selection*/) {}
+    virtual void Msg_Group_TableSelectItem(unsigned /*group_id*/, unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
+    virtual void Msg_Group_TableRightButton(unsigned /*group_id*/, unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
+    virtual void Msg_Group_TableLeftButton(unsigned /*group_id*/, unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
 
 protected:
     enum ButtonState

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -694,7 +694,7 @@ void WindowManager::Close(const IngameWindow* window)
         else
             SetActiveWindow(*windows.back());
     }
-    curDesktop->Msg_WindowClosed(const_cast<IngameWindow&>(*window));
+    curDesktop->Msg_WindowClosed(*tmpHolder);
 }
 
 /**

--- a/libs/s25main/addons/AddonList.cpp
+++ b/libs/s25main/addons/AddonList.cpp
@@ -59,5 +59,5 @@ unsigned AddonList::Gui::getStatus(const Window& window)
 {
     const auto* cb = window.GetCtrl<ctrlComboBox>(2);
     RTTR_Assert(cb);
-    return cb->GetSelection();
+    return cb->GetSelection().get();
 }

--- a/libs/s25main/controls/ctrlComboBox.cpp
+++ b/libs/s25main/controls/ctrlComboBox.cpp
@@ -152,8 +152,8 @@ bool ctrlComboBox::Msg_WheelUp(const MouseCoords& mc)
     if(IsPointInRect(mc.GetPos(), GetDrawRect()))
     {
         // Don't scroll too far down
-        if(list->GetSelection() > 0)
-            list->SetSelection(list->GetSelection() - 1);
+        if(list->GetSelection().value_or(0u) > 0u)
+            list->SetSelection(*list->GetSelection() - 1u);
         return true;
     }
 
@@ -176,7 +176,7 @@ bool ctrlComboBox::Msg_WheelDown(const MouseCoords& mc)
     if(IsPointInRect(mc.GetPos(), GetDrawRect()))
     {
         // Will be ignored by the list if to high
-        list->SetSelection(list->GetSelection() + 1);
+        list->SetSelection(list->GetSelection() ? *list->GetSelection() + 1u : 0u);
         return true;
     }
 

--- a/libs/s25main/controls/ctrlComboBox.h
+++ b/libs/s25main/controls/ctrlComboBox.h
@@ -36,7 +36,7 @@ public:
     void DeleteAllItems();
 
     void SetSelection(unsigned short selection);
-    int GetSelection() const { return GetCtrl<ctrlList>(0)->GetSelection(); };
+    const boost::optional<unsigned>& GetSelection() const { return GetCtrl<ctrlList>(0)->GetSelection(); };
     unsigned short GetNumItems() const { return GetCtrl<ctrlList>(0)->GetNumLines(); }
     const std::string& GetText(unsigned short item) const { return GetCtrl<ctrlList>(0)->GetItemText(item); }
 

--- a/libs/s25main/controls/ctrlGroup.cpp
+++ b/libs/s25main/controls/ctrlGroup.cpp
@@ -77,17 +77,17 @@ void ctrlGroup::Msg_Timer(const unsigned ctrl_id)
     GetParent()->Msg_Group_Timer(this->GetID(), ctrl_id);
 }
 
-void ctrlGroup::Msg_TableSelectItem(const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_TableSelectItem(const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableSelectItem(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlGroup::Msg_TableRightButton(const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_TableRightButton(const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableRightButton(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlGroup::Msg_TableLeftButton(const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_TableLeftButton(const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableLeftButton(this->GetID(), ctrl_id, selection);
 }
@@ -187,17 +187,17 @@ void ctrlGroup::Msg_Group_Timer(const unsigned /*group_id*/, const unsigned ctrl
     GetParent()->Msg_Group_Timer(this->GetID(), ctrl_id);
 }
 
-void ctrlGroup::Msg_Group_TableSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_Group_TableSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableSelectItem(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlGroup::Msg_Group_TableRightButton(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_Group_TableRightButton(const unsigned /*group_id*/, const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableRightButton(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlGroup::Msg_Group_TableLeftButton(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlGroup::Msg_Group_TableLeftButton(const unsigned /*group_id*/, const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableLeftButton(this->GetID(), ctrl_id, selection);
 }

--- a/libs/s25main/controls/ctrlGroup.h
+++ b/libs/s25main/controls/ctrlGroup.h
@@ -39,9 +39,9 @@ public:
     void Msg_ScrollShow(unsigned ctrl_id, bool visible) override;
     void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_Timer(unsigned ctrl_id) override;
-    void Msg_TableSelectItem(unsigned ctrl_id, int selection) override;
-    void Msg_TableRightButton(unsigned ctrl_id, int selection) override;
-    void Msg_TableLeftButton(unsigned ctrl_id, int selection) override;
+    void Msg_TableSelectItem(unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
+    void Msg_TableRightButton(unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
+    void Msg_TableLeftButton(unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
 
     void Msg_Group_ButtonClick(unsigned group_id, unsigned ctrl_id) override;
     void Msg_Group_EditEnter(unsigned group_id, unsigned ctrl_id) override;
@@ -54,9 +54,9 @@ public:
     void Msg_Group_ScrollShow(unsigned group_id, unsigned ctrl_id, bool visible) override;
     void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_Group_Timer(unsigned group_id, unsigned ctrl_id) override;
-    void Msg_Group_TableSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
-    void Msg_Group_TableRightButton(unsigned group_id, unsigned ctrl_id, int selection) override;
-    void Msg_Group_TableLeftButton(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_TableSelectItem(unsigned group_id, unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
+    void Msg_Group_TableRightButton(unsigned group_id, unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
+    void Msg_Group_TableLeftButton(unsigned group_id, unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
 
     bool Msg_LeftDown(const MouseCoords& mc) override;
     bool Msg_RightDown(const MouseCoords& mc) override;

--- a/libs/s25main/controls/ctrlList.h
+++ b/libs/s25main/controls/ctrlList.h
@@ -21,8 +21,10 @@
 
 #include "Window.h"
 #include "controls/ctrlBaseTooltip.h"
+#include <boost/optional.hpp>
 #include <string>
 #include <vector>
+
 class MouseCoords;
 class glFont;
 
@@ -44,15 +46,15 @@ public:
     /// liefert den Wert einer Zeile.
     const std::string& GetItemText(unsigned short line) const;
     /// liefert den Wert der aktuell gewählten Zeile.
-    const std::string& GetSelItemText() const { return GetItemText(selection_); };
+    const std::string& GetSelItemText() const;
     /// Vertauscht zwei Zeilen.
-    void Swap(unsigned short first, unsigned short second);
+    void Swap(unsigned first, unsigned second);
     /// Löscht ein Element
     void Remove(unsigned short index);
 
     unsigned short GetNumLines() const { return static_cast<unsigned short>(lines.size()); }
-    int GetSelection() const { return selection_; };
-    void SetSelection(int selection);
+    const boost::optional<unsigned>& GetSelection() const { return selection_; };
+    void SetSelection(const boost::optional<unsigned>& selection);
 
     bool Msg_MouseMove(const MouseCoords& mc) override;
     bool Msg_LeftDown(const MouseCoords& mc) override;
@@ -66,7 +68,7 @@ protected:
     void Draw_() override;
 
 private:
-    int GetItemFromPos(const Position& pos) const;
+    boost::optional<unsigned> GetItemFromPos(const Position& pos) const;
     Rect GetFullDrawArea() const;
     Rect GetListDrawArea() const;
 
@@ -76,8 +78,8 @@ private:
 
     std::vector<std::string> lines;
 
-    int selection_;
-    int mouseover;
+    boost::optional<unsigned> selection_;
+    boost::optional<unsigned> mouseover_;
     unsigned pagesize;
 };
 

--- a/libs/s25main/controls/ctrlTab.cpp
+++ b/libs/s25main/controls/ctrlTab.cpp
@@ -204,17 +204,17 @@ void ctrlTab::Msg_Group_Timer(const unsigned /*group_id*/, const unsigned ctrl_i
     GetParent()->Msg_Group_Timer(this->GetID(), ctrl_id);
 }
 
-void ctrlTab::Msg_Group_TableSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlTab::Msg_Group_TableSelectItem(const unsigned /*group_id*/, const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableSelectItem(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlTab::Msg_Group_TableRightButton(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlTab::Msg_Group_TableRightButton(const unsigned /*group_id*/, const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableRightButton(this->GetID(), ctrl_id, selection);
 }
 
-void ctrlTab::Msg_Group_TableLeftButton(const unsigned /*group_id*/, const unsigned ctrl_id, const int selection)
+void ctrlTab::Msg_Group_TableLeftButton(const unsigned /*group_id*/, const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     GetParent()->Msg_Group_TableLeftButton(this->GetID(), ctrl_id, selection);
 }

--- a/libs/s25main/controls/ctrlTab.h
+++ b/libs/s25main/controls/ctrlTab.h
@@ -55,9 +55,9 @@ public:
     void Msg_Group_ScrollShow(unsigned group_id, unsigned ctrl_id, bool visible) override;
     void Msg_Group_OptionGroupChange(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
     void Msg_Group_Timer(unsigned group_id, unsigned ctrl_id) override;
-    void Msg_Group_TableSelectItem(unsigned group_id, unsigned ctrl_id, int selection) override;
-    void Msg_Group_TableRightButton(unsigned group_id, unsigned ctrl_id, int selection) override;
-    void Msg_Group_TableLeftButton(unsigned group_id, unsigned ctrl_id, int selection) override;
+    void Msg_Group_TableSelectItem(unsigned group_id, unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
+    void Msg_Group_TableRightButton(unsigned group_id, unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
+    void Msg_Group_TableLeftButton(unsigned group_id, unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     bool Msg_LeftDown(const MouseCoords& mc) override;
     bool Msg_LeftUp(const MouseCoords& mc) override;

--- a/libs/s25main/controls/ctrlTable.h
+++ b/libs/s25main/controls/ctrlTable.h
@@ -21,6 +21,7 @@
 
 #include "Window.h"
 #include "gameTypes/TextureColor.h"
+#include <boost/optional.hpp>
 #include <string>
 #include <vector>
 
@@ -72,8 +73,8 @@ public:
     TableSortDir GetSortDirection() const { return sortDir_; }
     unsigned short GetNumRows() const { return static_cast<unsigned short>(rows_.size()); }
     unsigned short GetNumColumns() const { return static_cast<unsigned short>(columns_.size()); }
-    int GetSelection() const { return selection_; }
-    void SetSelection(int selection);
+    const boost::optional<unsigned>& GetSelection() const { return selection_; }
+    void SetSelection(const boost::optional<unsigned>& selection);
 
     bool Msg_LeftDown(const MouseCoords& mc) override;
     bool Msg_RightDown(const MouseCoords& mc) override;
@@ -90,7 +91,7 @@ protected:
 
     /// Setzt die Breite und Position der Buttons ohne Scrolleiste
     void ResetButtonWidths();
-    int GetSelectionFromMouse(const MouseCoords& mc);
+    boost::optional<unsigned> GetSelectionFromMouse(const MouseCoords& mc) const;
     /// Get the area of the content (table itself w/o header)
     Rect GetContentDrawArea() const;
     /// Get the full area (element less spacing)
@@ -104,8 +105,8 @@ private:
     unsigned short line_count;
     Columns columns_;
 
-    /// Selected row. -1 for none
-    int selection_;
+    /// Selected row.
+    boost::optional<unsigned> selection_;
     /// Column to sort by. -1 for none
     int sortColumn_;
     TableSortDir sortDir_;

--- a/libs/s25main/desktops/dskHostGame.cpp
+++ b/libs/s25main/desktops/dskHostGame.cpp
@@ -424,7 +424,7 @@ void dskHostGame::UpdatePlayerRow(const unsigned row)
                 {
                     combo->AddString(gameLobby->getPlayer(i).originName);
                     if(i == row)
-                        combo->SetSelection(combo->GetNumItems() - 1);
+                        combo->SetSelection(combo->GetNumItems() - 1u);
                 }
             }
         }
@@ -809,13 +809,13 @@ void dskHostGame::UpdateGGS()
     GlobalGameSettings& ggs = gameLobby->getSettings();
 
     // Geschwindigkeit
-    ggs.speed = static_cast<GameSpeed>(GetCtrl<ctrlComboBox>(43)->GetSelection());
+    ggs.speed = static_cast<GameSpeed>(GetCtrl<ctrlComboBox>(43)->GetSelection().get());
     // Spielziel
-    ggs.objective = static_cast<GameObjective>(GetCtrl<ctrlComboBox>(42)->GetSelection());
+    ggs.objective = static_cast<GameObjective>(GetCtrl<ctrlComboBox>(42)->GetSelection().get());
     // Waren zu Beginn
-    ggs.startWares = static_cast<StartWares>(GetCtrl<ctrlComboBox>(41)->GetSelection());
+    ggs.startWares = static_cast<StartWares>(GetCtrl<ctrlComboBox>(41)->GetSelection().get());
     // Aufklärung
-    ggs.exploration = static_cast<Exploration>(GetCtrl<ctrlComboBox>(40)->GetSelection());
+    ggs.exploration = static_cast<Exploration>(GetCtrl<ctrlComboBox>(40)->GetSelection().get());
     // Teams gesperrt
     ggs.lockedTeams = GetCtrl<ctrlCheck>(20)->GetCheck();
     // Team sicht

--- a/libs/s25main/desktops/dskLAN.cpp
+++ b/libs/s25main/desktops/dskLAN.cpp
@@ -126,9 +126,7 @@ void dskLAN::UpdateServerList()
 
     auto* servertable = GetCtrl<ctrlTable>(ID_tblServer);
 
-    int selection = servertable->GetSelection();
-    if(selection == -1)
-        selection = 0;
+    const unsigned selection = servertable->GetSelection().value_or(0u);
     int sortColumn = servertable->GetSortColumn();
     if(sortColumn == -1)
         sortColumn = 0;
@@ -155,10 +153,10 @@ bool dskLAN::ConnectToSelectedGame()
         return false;
 
     const auto* table = GetCtrl<ctrlTable>(ID_tblServer);
-    const int selectedRow = table->GetSelection();
-    if(selectedRow < 0)
+    const auto& selectedRow = table->GetSelection();
+    if(!selectedRow)
         return false;
-    const auto selectedId = boost::lexical_cast<unsigned>(table->GetItemText(selectedRow, 0));
+    const auto selectedId = boost::lexical_cast<unsigned>(table->GetItemText(*selectedRow, 0));
 
     if(selectedId >= openGames.size())
         return false;

--- a/libs/s25main/desktops/dskLobby.h
+++ b/libs/s25main/desktops/dskLobby.h
@@ -62,7 +62,7 @@ protected:
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_EditEnter(unsigned ctrl_id) override;
-    void Msg_TableRightButton(unsigned ctrl_id, int selection) override;
+    void Msg_TableRightButton(unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
     void Msg_TableChooseItem(unsigned ctrl_id, unsigned selection) override;
 
     /**

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -304,7 +304,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
         if(SETTINGS.video.vsync == framerate)
             cbFrameRate->SetSelection(cbFrameRate->GetNumItems() - 1);
     }
-    if(cbFrameRate->GetSelection() < 0)
+    if(!cbFrameRate->GetSelection())
         cbFrameRate->SetSelection(0);
 
     // "VBO" setzen

--- a/libs/s25main/desktops/dskSelectMap.cpp
+++ b/libs/s25main/desktops/dskSelectMap.cpp
@@ -189,7 +189,7 @@ void dskSelectMap::Msg_OptionGroupChange(const unsigned /*ctrl_id*/, unsigned se
     table->SortRows(0, TableSortDir::Ascending);
 
     // und Auswahl zurücksetzen
-    table->SetSelection(-1);
+    table->SetSelection(boost::none);
 }
 
 /// Load a map, throw on error
@@ -211,7 +211,7 @@ static std::unique_ptr<glArchivItem_Map> loadAndVerifyMap(const std::string& pat
 /**
  *  Occurs when user changes the selection in the table of maps.
  */
-void dskSelectMap::Msg_TableSelectItem(const unsigned ctrl_id, const int selection)
+void dskSelectMap::Msg_TableSelectItem(const unsigned ctrl_id, const boost::optional<unsigned>& selection)
 {
     if(ctrl_id != 1)
         return;
@@ -226,10 +226,10 @@ void dskSelectMap::Msg_TableSelectItem(const unsigned ctrl_id, const int selecti
     btContinue.SetEnabled(false);
 
     // is the selection valid?
-    if(selection >= 0)
+    if(selection)
     {
         ctrlTable& table = *GetCtrl<ctrlTable>(1);
-        const std::string& path = table.GetItemText(selection, 5);
+        const std::string& path = table.GetItemText(*selection, 5);
         if(!path.empty())
         {
             try
@@ -246,7 +246,7 @@ void dskSelectMap::Msg_TableSelectItem(const unsigned ctrl_id, const int selecti
                 LOG.write("%1%\n") % errorTxt;
                 WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Error"), errorTxt, this, MSB_OK, MSB_EXCLAMATIONRED, 1));
                 brokenMapPaths.insert(path);
-                table.RemoveRow(selection);
+                table.RemoveRow(*selection);
             }
         }
     }
@@ -357,13 +357,13 @@ void dskSelectMap::OnMapCreated(const std::string& mapPath)
 void dskSelectMap::StartServer()
 {
     auto* table = GetCtrl<ctrlTable>(1);
-    unsigned short selection = table->GetSelection();
+    const auto& selection = table->GetSelection();
 
     // Ist die Auswahl gültig?
-    if(selection < table->GetNumRows())
+    if(selection)
     {
         // Kartenpfad aus Tabelle holen
-        const std::string& mapPath = table->GetItemText(selection, 5);
+        const std::string& mapPath = table->GetItemText(*selection, 5);
 
         // Server starten
         if(!GAMECLIENT.HostGame(csi, mapPath, MAPTYPE_OLDMAP))

--- a/libs/s25main/desktops/dskSelectMap.h
+++ b/libs/s25main/desktops/dskSelectMap.h
@@ -47,7 +47,7 @@ private:
     void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
-    void Msg_TableSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_TableSelectItem(unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
     void Msg_TableChooseItem(unsigned ctrl_id, unsigned selection) override;
 
     void CI_NextConnectState(ConnectState cs) override;

--- a/libs/s25main/desktops/dskSplash.cpp
+++ b/libs/s25main/desktops/dskSplash.cpp
@@ -20,6 +20,7 @@
 #include "Loader.h"
 #include "MusicPlayer.h"
 #include "Playlist.h"
+#include "RttrConfig.h"
 #include "Settings.h"
 #include "WindowManager.h"
 #include "controls/ctrlTimer.h"
@@ -74,7 +75,7 @@ bool dskSplash::Msg_LeftDown(const MouseCoords& /*mc*/)
 
 void dskSplash::LoadFiles()
 {
-    ApplicationLoader loader(LOADER, LOG, iwMusicPlayer::GetFullPlaylistPath(SETTINGS.sound.playlist));
+    ApplicationLoader loader(RTTRCONFIG, LOADER, LOG, SETTINGS.sound.playlist);
     if(loader.load())
     {
         isLoaded = true;

--- a/libs/s25main/desktops/dskSplash.cpp
+++ b/libs/s25main/desktops/dskSplash.cpp
@@ -82,7 +82,7 @@ void dskSplash::LoadFiles()
         AddTimer(2, 5000);
         SetFpsDisplay(true);
         if(loader.getPlaylist())
-            MUSICPLAYER.GetPlaylist() = std::move(*loader.getPlaylist());
+            MUSICPLAYER.SetPlaylist(std::move(*loader.getPlaylist()));
         if(SETTINGS.sound.musik)
             MUSICPLAYER.Play();
 

--- a/libs/s25main/desktops/dskTextureTest.cpp
+++ b/libs/s25main/desktops/dskTextureTest.cpp
@@ -64,9 +64,7 @@ void dskTextureTest::Load()
     desc = newDesc;
 
     auto* cb = GetCtrl<ctrlComboBox>(ID_cbTexture);
-    int selection = cb->GetSelection();
-    if(selection < 0)
-        selection = 0;
+    const unsigned selection = cb->GetSelection().value_or(0);
     cb->DeleteAllItems();
     LOADER.ClearOverrideFolders();
     LOADER.AddOverrideFolder(s25::folders::gameLstsGlobal);

--- a/libs/s25main/gameData/ApplicationLoader.cpp
+++ b/libs/s25main/gameData/ApplicationLoader.cpp
@@ -18,10 +18,11 @@
 #include "ApplicationLoader.h"
 #include "Loader.h"
 #include "Playlist.h"
+#include "RttrConfig.h"
 #include "files.h"
 
-ApplicationLoader::ApplicationLoader(Loader& loader, Log& log, std::string playlistPath)
-    : loader_(loader), logger_(log), playlistPath_(std::move(playlistPath))
+ApplicationLoader::ApplicationLoader(const RttrConfig& rttrConfig, Loader& loader, Log& log, std::string playlistPath)
+    : rttrConfig_(rttrConfig), loader_(loader), logger_(log), playlistPath_(std::move(playlistPath))
 {}
 
 ApplicationLoader::~ApplicationLoader() = default;
@@ -36,7 +37,7 @@ bool ApplicationLoader::load()
     if(!playlistPath_.empty())
     {
         playlist_ = std::make_unique<Playlist>();
-        if(!playlist_->Load(logger_, playlistPath_))
+        if(!playlist_->Load(logger_, playlistPath_) && !playlist_->Load(logger_, rttrConfig_.ExpandPath(s25::files::defaultPlaylist)))
             return false;
     }
     return true;

--- a/libs/s25main/gameData/ApplicationLoader.h
+++ b/libs/s25main/gameData/ApplicationLoader.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 
+class RttrConfig;
 class Loader;
 class Log;
 class Playlist;
@@ -28,13 +29,14 @@ class Playlist;
 class ApplicationLoader
 {
 public:
-    ApplicationLoader(Loader&, Log&, std::string playlistPath);
+    ApplicationLoader(const RttrConfig&, Loader&, Log&, std::string playlistPath);
     ~ApplicationLoader();
 
     bool load();
     Playlist* getPlaylist() const { return playlist_.get(); }
 
 private:
+    const RttrConfig& rttrConfig_;
     Loader& loader_;
     Log& logger_;
     std::string playlistPath_;

--- a/libs/s25main/ingameWindows/iwBuildOrder.cpp
+++ b/libs/s25main/ingameWindows/iwBuildOrder.cpp
@@ -69,7 +69,7 @@ iwBuildOrder::~iwBuildOrder()
 {
     try
     {
-        GAMECLIENT.visual_settings.useCustomBuildOrder = GetCtrl<ctrlComboBox>(6)->GetSelection() == 1;
+        GAMECLIENT.visual_settings.useCustomBuildOrder = GetCtrl<ctrlComboBox>(6)->GetSelection() == 1u;
 
         TransmitSettings();
     } catch(...)
@@ -86,7 +86,7 @@ void iwBuildOrder::TransmitSettings()
     if(settings_changed)
     {
         // Einstellungen speichern
-        GAMECLIENT.ChangeBuildOrder(GetCtrl<ctrlComboBox>(6)->GetSelection() != 0, GAMECLIENT.visual_settings.build_order);
+        GAMECLIENT.ChangeBuildOrder(GetCtrl<ctrlComboBox>(6)->GetSelection() != 0u, GAMECLIENT.visual_settings.build_order);
         settings_changed = false;
     }
 }
@@ -123,12 +123,14 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
     if(GAMECLIENT.IsReplayModeOn())
         return;
     auto* list = GetCtrl<ctrlList>(0);
-    unsigned short auswahl = list->GetSelection();
-    unsigned short anzahl = list->GetNumLines();
+
+    if(!list->GetSelection())
+        return;
+
+    unsigned selection = *list->GetSelection();
+    unsigned numOptions = list->GetNumLines();
 
     // Auswahl gültig?
-    if(auswahl >= anzahl)
-        return;
 
     switch(ctrl_id)
     {
@@ -136,42 +138,42 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
 
         case 1: // Nach ganz oben
         {
-            while(auswahl > 0)
+            while(selection > 0)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[auswahl - 1], GAMECLIENT.visual_settings.build_order[auswahl]);
-                list->Swap(auswahl - 1, auswahl);
-                --auswahl;
+                std::swap(GAMECLIENT.visual_settings.build_order[selection - 1], GAMECLIENT.visual_settings.build_order[selection]);
+                list->Swap(selection - 1, selection);
+                --selection;
             }
             settings_changed = true;
         }
         break;
         case 2: // Hoch
         {
-            if(auswahl > 0)
+            if(selection > 0)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[auswahl - 1], GAMECLIENT.visual_settings.build_order[auswahl]);
-                list->Swap(auswahl - 1, auswahl);
+                std::swap(GAMECLIENT.visual_settings.build_order[selection - 1], GAMECLIENT.visual_settings.build_order[selection]);
+                list->Swap(selection - 1, selection);
             }
             settings_changed = true;
         }
         break;
         case 3: // Runter
         {
-            if(auswahl < anzahl - 1)
+            if(selection < numOptions - 1u)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[auswahl + 1], GAMECLIENT.visual_settings.build_order[auswahl]);
-                list->Swap(auswahl + 1, auswahl);
+                std::swap(GAMECLIENT.visual_settings.build_order[selection + 1], GAMECLIENT.visual_settings.build_order[selection]);
+                list->Swap(selection + 1, selection);
             }
             settings_changed = true;
         }
         break;
         case 4: // Nach ganz unten
         {
-            while(auswahl < anzahl - 1)
+            while(selection < numOptions - 1u)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[auswahl + 1], GAMECLIENT.visual_settings.build_order[auswahl]);
-                list->Swap(auswahl + 1, auswahl);
-                ++auswahl;
+                std::swap(GAMECLIENT.visual_settings.build_order[selection + 1], GAMECLIENT.visual_settings.build_order[selection]);
+                list->Swap(selection + 1, selection);
+                ++selection;
             }
             settings_changed = true;
         }

--- a/libs/s25main/ingameWindows/iwDiplomacy.cpp
+++ b/libs/s25main/ingameWindows/iwDiplomacy.cpp
@@ -253,7 +253,7 @@ iwSuggestPact::iwSuggestPact(const PactType pt, const GamePlayer& player, GameCo
 void iwSuggestPact::Msg_ButtonClick(const unsigned /*ctrl_id*/)
 {
     /// Dauer auswählen (wenn id == NUM_DURATIONS, dann "für alle Ewigkeit" ausgewählt)
-    unsigned selected_id = GetCtrl<ctrlComboBox>(6)->GetSelection();
+    unsigned selected_id = GetCtrl<ctrlComboBox>(6)->GetSelection().get();
     unsigned duration = (selected_id == NUM_DURATIONS) ? DURATION_INFINITE : DURATIONS[selected_id];
     gcFactory.SuggestPact(player.GetPlayerId(), this->pt, duration);
     Close();

--- a/libs/s25main/ingameWindows/iwMapDebug.cpp
+++ b/libs/s25main/ingameWindows/iwMapDebug.cpp
@@ -190,8 +190,8 @@ iwMapDebug::iwMapDebug(GameWorldView& gwv, bool allowCheating)
                 players->AddString(p.name);
         }
         players->SetSelection(0);
-        printer->showDataIdx = data->GetSelection();
-        printer->playerIdx = players->GetSelection();
+        printer->showDataIdx = data->GetSelection().get();
+        printer->playerIdx = players->GetSelection().get();
     } else
     {
         printer->showDataIdx = 0;

--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -124,13 +124,13 @@ void iwMapGenerator::Msg_ButtonClick(const unsigned ctrl_id)
 
 void iwMapGenerator::Apply()
 {
-    mapSettings.numPlayers = GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->GetSelection() + 2;
+    mapSettings.numPlayers = GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->GetSelection().get() + 2;
     mapSettings.ratioGold = GetCtrl<ctrlProgress>(CTRL_RATIO_GOLD)->GetPosition();
     mapSettings.ratioIron = GetCtrl<ctrlProgress>(CTRL_RATIO_IRON)->GetPosition();
     mapSettings.ratioCoal = GetCtrl<ctrlProgress>(CTRL_RATIO_COAL)->GetPosition();
     mapSettings.ratioGranite = GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->GetPosition();
 
-    switch(GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->GetSelection())
+    switch(GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->GetSelection().get())
     {
         case 0: mapSettings.style = MapStyle::Islands; break;
         case 1: mapSettings.style = MapStyle::Continent; break;
@@ -141,7 +141,7 @@ void iwMapGenerator::Apply()
         case 6: mapSettings.style = MapStyle::Random; break;
         default: break;
     }
-    switch(GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->GetSelection())
+    switch(GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->GetSelection().get())
     {
         case 0: mapSettings.size = MapExtent::all(64); break;
         case 1: mapSettings.size = MapExtent::all(128); break;
@@ -150,7 +150,7 @@ void iwMapGenerator::Apply()
         case 4: mapSettings.size = MapExtent::all(1024); break;
         default: break;
     }
-    switch(GetCtrl<ctrlComboBox>(CTRL_PLAYER_RADIUS)->GetSelection())
+    switch(GetCtrl<ctrlComboBox>(CTRL_PLAYER_RADIUS)->GetSelection().get())
     {
         case 0:
             mapSettings.minPlayerRadius = 0.19;
@@ -178,9 +178,9 @@ void iwMapGenerator::Apply()
             break;
         default: break;
     }
-    int mapType = GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->GetSelection();
-    if(mapType >= 0)
-        mapSettings.type = DescIdx<LandscapeDesc>(mapType);
+    const auto& mapType = GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->GetSelection();
+    if(mapType)
+        mapSettings.type = DescIdx<LandscapeDesc>(*mapType);
 }
 
 void iwMapGenerator::Reset()

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -37,54 +37,83 @@
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 
+namespace {
+enum
+{
+    ID_lstSongs,
+    ID_txtPlaylist,
+    ID_cbPlaylist,
+    ID_btAddPlaylist,
+    ID_btRemovePlaylist,
+    ID_btAddTrack,
+    ID_btAddTrackDir,
+    ID_btRemoveTrack,
+    ID_btUp,
+    ID_btDown,
+    ID_txtRepeat,
+    ID_btIncRepeat,
+    ID_btDecRepeat,
+    ID_btRandom,
+
+    ID_edtName,
+    ID_btOk,
+    ID_btAbort,
+
+    ID_wndAddTrack,
+    ID_wndAddPlaylist,
+    ID_wndAddTrackDir
+};
+}
+
 iwMusicPlayer::InputWindow::InputWindow(iwMusicPlayer& playerWnd, const unsigned win_id, const std::string& title)
     : IngameWindow(CGI_INPUTWINDOW, IngameWindow::posAtMouse, Extent(300, 100), title, LOADER.GetImageN("resource", 41), true),
       win_id(win_id), playerWnd_(playerWnd)
 {
-    AddEdit(0, DrawPoint(20, 30), Extent(GetSize().x - 40, 22), TC_GREEN2, NormalFont);
-    AddTextButton(1, DrawPoint(20, 60), Extent(100, 22), TC_GREEN1, _("OK"), NormalFont);
-    AddTextButton(2, DrawPoint(130, 60), Extent(100, 22), TC_RED1, _("Abort"), NormalFont);
+    AddEdit(ID_edtName, DrawPoint(20, 30), Extent(GetSize().x - 40, 22), TC_GREEN2, NormalFont);
+    AddTextButton(ID_btOk, DrawPoint(20, 60), Extent(100, 22), TC_GREEN1, _("OK"), NormalFont);
+    AddTextButton(ID_btAbort, DrawPoint(130, 60), Extent(100, 22), TC_RED1, _("Abort"), NormalFont);
 }
 
 void iwMusicPlayer::InputWindow::Msg_ButtonClick(const unsigned ctrl_id)
 {
-    if(ctrl_id == 1)
-        playerWnd_.Msg_Input(win_id, GetCtrl<ctrlEdit>(0)->GetText());
+    if(ctrl_id == ID_btOk)
+        playerWnd_.Msg_Input(win_id, GetCtrl<ctrlEdit>(ID_edtName)->GetText());
 
     Close();
 }
 
 void iwMusicPlayer::InputWindow::Msg_EditEnter(const unsigned /*ctrl_id*/)
 {
-    Msg_ButtonClick(1);
+    Msg_ButtonClick(ID_btOk);
 }
 
 iwMusicPlayer::iwMusicPlayer()
     : IngameWindow(CGI_MUSICPLAYER, IngameWindow::posLastOrCenter, Extent(430, 330), _("Music player"), LOADER.GetImageN("resource", 41)),
       changed(false)
 {
-    AddList(0, DrawPoint(20, 30), Extent(330, 200), TC_GREEN1, NormalFont);
-    AddText(1, DrawPoint(20, 240), _("Playlist:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddComboBox(2, DrawPoint(20, 260), Extent(330, 22), TC_GREEN1, NormalFont, 200);
+    AddList(ID_lstSongs, DrawPoint(20, 30), Extent(330, 200), TC_GREEN1, NormalFont);
+    AddText(ID_txtPlaylist, DrawPoint(20, 240), _("Playlist:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddComboBox(ID_cbPlaylist, DrawPoint(20, 260), Extent(330, 22), TC_GREEN1, NormalFont, 200);
 
     // Playlistbuttons
     const unsigned short button_distance = 10;
     const Extent buttonSize((330 - button_distance) / 2, 22);
-    ctrlButton* b1 = AddTextButton(3, DrawPoint(20, 290), buttonSize, TC_GREEN2, _("Add"), NormalFont);
-    AddTextButton(4, b1->GetPos() + DrawPoint(buttonSize.x + button_distance, 0), buttonSize, TC_GREEN2, _("Remove"), NormalFont);
-    // AddTextButton(5,b1->GetPos().x,320,button_width,22,TC_GREEN2,_("Save"),NormalFont);
-    // AddTextButton(6,b2->GetPos().x,320,button_width,22,TC_GREEN2,_("Load"),NormalFont);
+    ctrlButton* b1 = AddTextButton(ID_btAddPlaylist, DrawPoint(20, 290), buttonSize, TC_GREEN2, _("Add"), NormalFont);
+    AddTextButton(ID_btRemovePlaylist, b1->GetPos() + DrawPoint(buttonSize.x + button_distance, 0), buttonSize, TC_GREEN2, _("Remove"),
+                  NormalFont);
 
     // Buttons für die Musikstücke
-    AddImageButton(7, DrawPoint(370, 30), Extent(40, 40), TC_GREY, LOADER.GetImageN("io", 138), _("Add track"));
-    AddImageButton(8, DrawPoint(370, 80), Extent(40, 40), TC_GREY, LOADER.GetImageN("io_new", 2), _("Add directory of tracks"));
-    AddImageButton(9, DrawPoint(370, 130), Extent(40, 40), TC_RED1, LOADER.GetImageN("io", 220), _("Remove track"));
-    AddImageButton(10, DrawPoint(370, 180), Extent(40, 15), TC_GREY, LOADER.GetImageN("io", 33), _("Upwards"));
-    AddImageButton(11, DrawPoint(370, 195), Extent(40, 15), TC_GREY, LOADER.GetImageN("io", 34), _("Downwards"));
-    AddTextDeepening(12, DrawPoint(370, 220), Extent(40, 20), TC_GREY, "1", NormalFont, COLOR_YELLOW);
-    AddImageButton(13, DrawPoint(370, 240), Extent(20, 20), TC_RED1, LOADER.GetImageN("io", 139), _("Less repeats"));
-    AddImageButton(14, DrawPoint(390, 240), Extent(20, 20), TC_GREY, LOADER.GetImageN("io", 138), _("More repeats"));
-    AddImageButton(15, DrawPoint(370, 270), Extent(40, 40), TC_GREY, LOADER.GetImageN("io", 107), _("Playback in this order")); // 225
+    AddImageButton(ID_btAddTrack, DrawPoint(370, 30), Extent(40, 40), TC_GREY, LOADER.GetImageN("io", 138), _("Add track"));
+    AddImageButton(ID_btAddTrackDir, DrawPoint(370, 80), Extent(40, 40), TC_GREY, LOADER.GetImageN("io_new", 2),
+                   _("Add directory of tracks"));
+    AddImageButton(ID_btRemoveTrack, DrawPoint(370, 130), Extent(40, 40), TC_RED1, LOADER.GetImageN("io", 220), _("Remove track"));
+    AddImageButton(ID_btUp, DrawPoint(370, 180), Extent(40, 15), TC_GREY, LOADER.GetImageN("io", 33), _("Upwards"));
+    AddImageButton(ID_btDown, DrawPoint(370, 195), Extent(40, 15), TC_GREY, LOADER.GetImageN("io", 34), _("Downwards"));
+    AddTextDeepening(ID_txtRepeat, DrawPoint(370, 220), Extent(40, 20), TC_GREY, "1", NormalFont, COLOR_YELLOW);
+    AddImageButton(ID_btDecRepeat, DrawPoint(370, 240), Extent(20, 20), TC_RED1, LOADER.GetImageN("io", 139), _("Less repeats"));
+    AddImageButton(ID_btIncRepeat, DrawPoint(390, 240), Extent(20, 20), TC_GREY, LOADER.GetImageN("io", 138), _("More repeats"));
+    AddImageButton(ID_btRandom, DrawPoint(370, 270), Extent(40, 40), TC_GREY, LOADER.GetImageN("io", 107),
+                   _("Playback in this order")); // 225
 
     // Mit Werten füllen
     MUSICPLAYER.GetPlaylist().FillMusicPlayer(this);
@@ -94,31 +123,33 @@ iwMusicPlayer::iwMusicPlayer()
 iwMusicPlayer::~iwMusicPlayer()
 {
     // Playlist ggf. speichern, die ausgewählt ist, falls eine ausgewählt ist
-    unsigned short selection = GetCtrl<ctrlComboBox>(2)->GetSelection();
+    const auto& selection = GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetSelection();
 
     // Entsprechende Datei speichern
-    if(selection != 0xFFFF)
+    if(selection)
     {
         Playlist pl;
         pl.ReadMusicPlayer(this);
 
-        std::string str(GetCtrl<ctrlComboBox>(2)->GetText(selection));
+        const std::string playlistName(GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetText(*selection));
 
         // RTTR-Playlisten dürfen nicht gelöscht werden
-        if(str == "S2_Standard")
+        if(playlistName == "S2_Standard")
             return;
 
         try
         {
-            if(!pl.SaveAs(GetFullPlaylistPath(str), true))
+            if(!pl.SaveAs(GetFullPlaylistPath(playlistName), true))
+            {
                 // Fehler, konnte nicht gespeichert werden
                 WINDOWMANAGER.Show(
                   std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be saved!"), nullptr, MSB_OK, MSB_EXCLAMATIONRED));
+            }
         } catch(std::exception&)
         {}
 
         // Entsprechenden Dateipfad speichern
-        SETTINGS.sound.playlist = GetCtrl<ctrlComboBox>(2)->GetText(selection);
+        SETTINGS.sound.playlist = playlistName;
     }
 
     // Werte in Musikplayer bringen
@@ -133,15 +164,16 @@ void iwMusicPlayer::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsign
 {
     // Entsprechende Datei geladen
     Playlist pl;
-    if(pl.Load(LOG, GetFullPlaylistPath(GetCtrl<ctrlComboBox>(2)->GetText(selection))))
+    if(pl.Load(LOG, GetFullPlaylistPath(GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetText(selection))))
     {
         // Das Fenster entsprechend mit den geladenen Werten füllen
         pl.FillMusicPlayer(this);
         changed = true;
     } else
-        // Fehler, konnte nicht geladen werden
+    {
         WINDOWMANAGER.Show(
           std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be loaded!"), this, MSB_OK, MSB_EXCLAMATIONRED));
+    }
 }
 
 void iwMusicPlayer::Msg_ListChooseItem(const unsigned /*ctrl_id*/, const unsigned selection)
@@ -164,24 +196,18 @@ void iwMusicPlayer::Msg_ButtonClick(const unsigned ctrl_id)
 {
     switch(ctrl_id)
     {
-        // Add Playlist
-        case 3:
+        case ID_btAddPlaylist:
+            WINDOWMANAGER.Show(std::make_unique<InputWindow>(*this, ID_wndAddPlaylist, _("Specify the playlist name")));
+            break;
+        case ID_btRemovePlaylist:
         {
-            WINDOWMANAGER.Show(std::make_unique<InputWindow>(*this, 1, _("Specify the playlist name")));
-        }
-        break;
-        // Remove Playlist
-        case 4:
-        {
-            unsigned short selection = GetCtrl<ctrlComboBox>(2)->GetSelection();
-
-            // Entsprechende Datei löschen
-            if(selection != 0xFFFF)
+            const auto& selection = GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetSelection();
+            if(selection)
             {
-                std::string str(GetCtrl<ctrlComboBox>(2)->GetText(selection));
+                const std::string playlistName(GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetText(*selection));
 
                 // RTTR-Playlisten dürfen nicht gelöscht werden
-                if(str == "S2_Standard")
+                if(playlistName == "S2_Standard")
                 {
                     WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Error"), _("You are not allowed to delete the standard playlist!"),
                                                                   this, MSB_OK, MSB_EXCLAMATIONRED));
@@ -189,57 +215,47 @@ void iwMusicPlayer::Msg_ButtonClick(const unsigned ctrl_id)
                 }
 
                 boost::system::error_code ec;
-                boost::filesystem::remove(GetFullPlaylistPath(str), ec);
+                boost::filesystem::remove(GetFullPlaylistPath(playlistName), ec);
                 this->UpdatePlaylistCombo(SETTINGS.sound.playlist);
             }
         }
         break;
-        // Add Track
-        case 7:
-        {
-            WINDOWMANAGER.ToggleWindow(std::make_unique<InputWindow>(*this, 0, _("Add track")));
+        case ID_btAddTrack:
+            WINDOWMANAGER.ToggleWindow(std::make_unique<InputWindow>(*this, ID_wndAddTrack, _("Add track")));
             changed = true;
-        }
-        break;
-        // Add Directory of tracks
-        case 8:
-        {
-            WINDOWMANAGER.ToggleWindow(std::make_unique<InputWindow>(*this, 2, _("Add directory of tracks")));
+            break;
+        case ID_btAddTrackDir:
+            WINDOWMANAGER.ToggleWindow(std::make_unique<InputWindow>(*this, ID_wndAddTrackDir, _("Add directory of tracks")));
             changed = true;
-        }
-        break;
-        // Remove Track
-        case 9:
+            break;
+        case ID_btRemoveTrack:
         {
-            unsigned short selection = GetCtrl<ctrlList>(0)->GetSelection();
+            const auto& selection = GetCtrl<ctrlList>(ID_lstSongs)->GetSelection();
 
-            if(selection != 0xFFFF)
+            if(selection)
             {
-                GetCtrl<ctrlList>(0)->Remove(selection);
+                GetCtrl<ctrlList>(ID_lstSongs)->Remove(*selection);
                 changed = true;
             }
         }
         break;
-        // Upwards
-        case 10:
+        case ID_btUp:
         {
-            unsigned short selection = GetCtrl<ctrlList>(0)->GetSelection();
+            const auto& selection = GetCtrl<ctrlList>(ID_lstSongs)->GetSelection();
 
-            if(selection > 0 && selection != 0xFFFF)
-                GetCtrl<ctrlList>(0)->Swap(selection - 1, selection);
+            if(selection && *selection > 0u)
+                GetCtrl<ctrlList>(ID_lstSongs)->Swap(*selection - 1u, *selection);
         }
         break;
-        // Downwards
-        case 11:
+        case ID_btDown:
         {
-            unsigned short selection = GetCtrl<ctrlList>(0)->GetSelection();
+            const auto& selection = GetCtrl<ctrlList>(ID_lstSongs)->GetSelection();
 
-            if(selection < GetCtrl<ctrlList>(0)->GetNumLines() - 1 && selection != 0xFFFF)
-                GetCtrl<ctrlList>(0)->Swap(selection + 1, selection);
+            if(selection && *selection < GetCtrl<ctrlList>(ID_lstSongs)->GetNumLines() - 1u)
+                GetCtrl<ctrlList>(ID_lstSongs)->Swap(*selection + 1u, *selection);
         }
         break;
-        // Less Repeats
-        case 13:
+        case ID_btDecRepeat:
         {
             unsigned repeats = GetRepeats();
 
@@ -251,8 +267,7 @@ void iwMusicPlayer::Msg_ButtonClick(const unsigned ctrl_id)
             }
         }
         break;
-        // More Repeats
-        case 14:
+        case ID_btIncRepeat:
         {
             unsigned repeats = GetRepeats();
             ++repeats;
@@ -260,15 +275,9 @@ void iwMusicPlayer::Msg_ButtonClick(const unsigned ctrl_id)
             changed = true;
         }
         break;
-        // Play Order
-        case 15:
+        case ID_btRandom:
         {
-            GetCtrl<ctrlImageButton>(15)->SetImage(GetCtrl<ctrlImageButton>(15)->GetImage() == LOADER.GetTextureN("io", 107) ?
-                                                     LOADER.GetTextureN("io", 225) :
-                                                     LOADER.GetTextureN("io", 107));
-            GetCtrl<ctrlImageButton>(15)->SetTooltip(GetCtrl<ctrlImageButton>(15)->GetImage() == LOADER.GetTextureN("io", 107) ?
-                                                       _("Playback in this order") :
-                                                       _("Random playback"));
+            SetRandomPlayback(!GetRandomPlayback());
             changed = true;
         }
         break;
@@ -279,8 +288,7 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
 {
     switch(win_id)
     {
-        // Add Track - Window
-        case 0:
+        case ID_wndAddTrack:
         {
             bool valid = false;
             if(boost::filesystem::exists(msg))
@@ -299,15 +307,14 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
             if(valid)
             {
                 // Hinzufügen
-                GetCtrl<ctrlList>(0)->AddString(msg);
+                GetCtrl<ctrlList>(ID_lstSongs)->AddString(msg);
                 changed = true;
             } else
                 WINDOWMANAGER.Show(
                   std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be opened!"), this, MSB_OK, MSB_EXCLAMATIONRED));
         }
         break;
-        // Add Playlist
-        case 1:
+        case ID_wndAddPlaylist:
         {
             // Ungültige Namen ausschließen
             const auto isLetter = [](const char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); };
@@ -324,13 +331,12 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
             }
         }
         break;
-        // Add Track directory of tracks - Window
-        case 2:
+        case ID_wndAddTrackDir:
         {
             std::vector<boost::filesystem::path> oggFiles = ListDir(msg, "ogg");
 
             for(const auto& oggFile : oggFiles)
-                GetCtrl<ctrlList>(0)->AddString(oggFile.string());
+                GetCtrl<ctrlList>(ID_lstSongs)->AddString(oggFile.string());
 
             changed = true;
         }
@@ -340,48 +346,50 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
 
 void iwMusicPlayer::SetSegments(const std::vector<std::string>& segments)
 {
-    GetCtrl<ctrlList>(0)->DeleteAllItems();
+    GetCtrl<ctrlList>(ID_lstSongs)->DeleteAllItems();
 
     for(const auto& segment : segments)
-        GetCtrl<ctrlList>(0)->AddString(segment);
+        GetCtrl<ctrlList>(ID_lstSongs)->AddString(segment);
 }
 void iwMusicPlayer::SetRepeats(unsigned repeats)
 {
-    GetCtrl<ctrlTextDeepening>(12)->SetText(helpers::toString(repeats));
+    GetCtrl<ctrlTextDeepening>(ID_txtRepeat)->SetText(helpers::toString(repeats));
 }
 
 void iwMusicPlayer::SetRandomPlayback(const bool random_playback)
 {
-    GetCtrl<ctrlImageButton>(15)->SetImage(random_playback ? LOADER.GetTextureN("io", 225) : LOADER.GetTextureN("io", 107));
+    GetCtrl<ctrlImageButton>(ID_btRandom)->SetImage(random_playback ? LOADER.GetTextureN("io", 225) : LOADER.GetTextureN("io", 107));
+    GetCtrl<ctrlImageButton>(ID_btRandom)->SetTooltip(random_playback ? _("Playback in this order") : _("Random playback"));
 }
 
 void iwMusicPlayer::SetCurrentSong(const unsigned selection)
 {
-    GetCtrl<ctrlList>(0)->SetSelection(selection);
+    GetCtrl<ctrlList>(ID_lstSongs)->SetSelection(selection);
 }
 
 std::vector<std::string> iwMusicPlayer::GetSegments() const
 {
     std::vector<std::string> segments;
-    for(unsigned i = 0; i < GetCtrl<ctrlList>(0)->GetNumLines(); ++i)
-        segments.push_back(GetCtrl<ctrlList>(0)->GetItemText(i));
+    for(unsigned i = 0; i < GetCtrl<ctrlList>(ID_lstSongs)->GetNumLines(); ++i)
+        segments.push_back(GetCtrl<ctrlList>(ID_lstSongs)->GetItemText(i));
     return segments;
 }
 
 unsigned iwMusicPlayer::GetRepeats() const
 {
-    return boost::lexical_cast<unsigned>(GetCtrl<ctrlTextDeepening>(12)->GetText());
+    return boost::lexical_cast<unsigned>(GetCtrl<ctrlTextDeepening>(ID_txtRepeat)->GetText());
 }
 
 bool iwMusicPlayer::GetRandomPlayback() const
 {
-    return !(GetCtrl<ctrlImageButton>(15)->GetImage() == LOADER.GetTextureN("io", 107));
+    return GetCtrl<ctrlImageButton>(ID_btRandom)->GetImage() != LOADER.GetTextureN("io", 107);
 }
 
 /// Updatet die Playlist - Combo
 void iwMusicPlayer::UpdatePlaylistCombo(const std::string& highlight_entry)
 {
-    GetCtrl<ctrlComboBox>(2)->DeleteAllItems();
+    auto* cbPlaylist = GetCtrl<ctrlComboBox>(ID_cbPlaylist);
+    cbPlaylist->DeleteAllItems();
 
     std::vector<boost::filesystem::path> playlists = ListDir(RTTRCONFIG.ExpandPath(s25::folders::music), "pll");
 
@@ -390,9 +398,9 @@ void iwMusicPlayer::UpdatePlaylistCombo(const std::string& highlight_entry)
     {
         // Reduce to pure filename
         const auto name = playlistPath.stem().string();
-        GetCtrl<ctrlComboBox>(2)->AddString(name);
+        cbPlaylist->AddString(name);
         if(name == highlight_entry)
-            GetCtrl<ctrlComboBox>(2)->SetSelection(i);
+            cbPlaylist->SetSelection(i);
         ++i;
     }
 }

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -153,7 +153,8 @@ iwMusicPlayer::~iwMusicPlayer()
 void iwMusicPlayer::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsigned selection)
 {
     Playlist pl;
-    if(pl.Load(LOG, GetFullPlaylistPath(GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetText(selection))))
+    const std::string playlistName = GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetText(selection);
+    if(pl.Load(LOG, GetFullPlaylistPath(playlistName)))
     {
         // Das Fenster entsprechend mit den geladenen Werten füllen
         pl.FillMusicPlayer(this);
@@ -163,6 +164,9 @@ void iwMusicPlayer::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsign
         WINDOWMANAGER.Show(
           std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be loaded!"), this, MSB_OK, MSB_EXCLAMATIONRED));
     }
+    const bool isReadOnly = isReadonlyPlaylist(playlistName);
+    for(const auto id : {ID_btRemovePlaylist, ID_btSave})
+        GetCtrl<ctrlButton>(id)->SetEnabled(!isReadOnly);
 }
 
 void iwMusicPlayer::Msg_ListChooseItem(const unsigned /*ctrl_id*/, const unsigned selection)

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -66,10 +66,10 @@ enum
 }
 
 iwMusicPlayer::InputWindow::InputWindow(iwMusicPlayer& playerWnd, const unsigned win_id, const std::string& title)
-    : IngameWindow(CGI_INPUTWINDOW, IngameWindow::posAtMouse, Extent(300, 100), title, LOADER.GetImageN("resource", 41), true),
+    : IngameWindow(CGI_INPUTWINDOW, IngameWindow::posCenter, Extent(300, 100), title, LOADER.GetImageN("resource", 41), true),
       win_id(win_id), playerWnd_(playerWnd)
 {
-    AddEdit(ID_edtName, DrawPoint(20, 30), Extent(GetSize().x - 40, 22), TC_GREEN2, NormalFont);
+    AddEdit(ID_edtName, DrawPoint(20, 30), Extent(GetSize().x - 40, 22), TC_GREEN2, NormalFont)->SetFocus();
     AddTextButton(ID_btOk, DrawPoint(20, 60), Extent(100, 22), TC_GREEN1, _("OK"), NormalFont);
     AddTextButton(ID_btAbort, DrawPoint(130, 60), Extent(100, 22), TC_RED1, _("Abort"), NormalFont);
 }
@@ -318,7 +318,7 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
         {
             // Ungültige Namen ausschließen
             const auto isLetter = [](const char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); };
-            if(!msg.empty() && isLetter(msg.front()) && Playlist().SaveAs(msg, true))
+            if(!msg.empty() && isLetter(msg.front()) && Playlist().SaveAs(GetFullPlaylistPath(msg), true))
             {
                 // Combobox updaten
                 UpdatePlaylistCombo(msg);
@@ -391,7 +391,7 @@ void iwMusicPlayer::UpdatePlaylistCombo(const std::string& highlight_entry)
     auto* cbPlaylist = GetCtrl<ctrlComboBox>(ID_cbPlaylist);
     cbPlaylist->DeleteAllItems();
 
-    std::vector<boost::filesystem::path> playlists = ListDir(RTTRCONFIG.ExpandPath(s25::folders::music), "pll");
+    const std::vector<boost::filesystem::path> playlists = ListDir(RTTRCONFIG.ExpandPath(s25::folders::music), "pll");
 
     unsigned i = 0;
     for(const auto& playlistPath : playlists)

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -201,7 +201,7 @@ bool iwMusicPlayer::SaveCurrentPlaylist()
     if(isReadonlyPlaylist(playlistName))
         return false;
 
-    return pl.SaveAs(fullPlaylistPath, true);
+    return pl.SaveAs(fullPlaylistPath);
 }
 
 void iwMusicPlayer::UpdateFromPlaylist(const Playlist& playlist)
@@ -378,7 +378,7 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
             // Ungültige Namen ausschließen
             const auto isLetter = [](const char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); };
             const boost::filesystem::path fullPlaylistPath = GetFullPlaylistPath(msg);
-            if(!msg.empty() && isLetter(msg.front()) && Playlist().SaveAs(fullPlaylistPath, true))
+            if(!msg.empty() && isLetter(msg.front()) && Playlist().SaveAs(fullPlaylistPath))
             {
                 // Combobox updaten
                 UpdatePlaylistCombo(fullPlaylistPath.string());

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -136,7 +136,11 @@ static bool isReadonlyPlaylist(const std::string& name)
 
 iwMusicPlayer::~iwMusicPlayer()
 {
-    SaveCurrentPlaylist();
+    try
+    {
+        SaveCurrentPlaylist();
+    } catch(...)
+    {}
 
     const auto& selection = GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetSelection();
 
@@ -236,7 +240,7 @@ Playlist iwMusicPlayer::MakePlaylist()
     for(const auto i : helpers::Range<unsigned>{lstSongs->GetNumLines()})
         songs.push_back(lstSongs->GetItemText(i));
 
-    return Playlist(songs, GetRepeats(), GetRandomPlayback());
+    return Playlist(std::move(songs), GetRepeats(), GetRandomPlayback());
 }
 
 void iwMusicPlayer::Msg_ButtonClick(const unsigned ctrl_id)

--- a/libs/s25main/ingameWindows/iwMusicPlayer.h
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.h
@@ -20,6 +20,8 @@
 #include "IngameWindow.h"
 #include <boost/filesystem/path.hpp>
 
+class Playlist;
+
 /// Fenster zum Einstellen des Musik-Players
 class iwMusicPlayer final : public IngameWindow
 {
@@ -44,25 +46,21 @@ public:
     iwMusicPlayer();
     ~iwMusicPlayer() override;
 
-    /// Setzt Werte
-    void SetSegments(const std::vector<std::string>& segments);
-    void SetRepeats(unsigned repeats);
-    void SetRandomPlayback(bool random_playback);
-    void SetCurrentSong(unsigned selection);
-
-    /// Gibt Werte zurück
-    std::vector<std::string> GetSegments() const;
-    unsigned GetRepeats() const;
-    bool GetRandomPlayback() const;
-
-    /// Updatet die Playlist- Combo, selektiert entsprechenden Eintrag, falls vorhanden
-    void UpdatePlaylistCombo(const std::string& highlight_entry);
-
 private:
     /// Get the full path to a playlist by its name
     static boost::filesystem::path GetFullPlaylistPath(const std::string& name);
 
+    unsigned GetRepeats() const;
+    void SetRepeats(unsigned repeats);
+    bool GetRandomPlayback() const;
+    void SetRandomPlayback(bool random_playback);
+
+    /// Updatet die Playlist- Combo, selektiert entsprechenden Eintrag, falls vorhanden
+    void UpdatePlaylistCombo(const std::string& highlight_entry);
+
     bool SaveCurrentPlaylist();
+    void UpdateFromPlaylist(const Playlist&);
+    Playlist MakePlaylist();
 
     void Msg_ListChooseItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;

--- a/libs/s25main/ingameWindows/iwMusicPlayer.h
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.h
@@ -18,6 +18,7 @@
 #define MUSICPLAYER_H_
 
 #include "IngameWindow.h"
+#include <boost/filesystem/path.hpp>
 
 /// Fenster zum Einstellen des Musik-Players
 class iwMusicPlayer : public IngameWindow
@@ -57,10 +58,10 @@ public:
     /// Updatet die Playlist- Combo, selektiert entsprechenden Eintrag, falls vorhanden
     void UpdatePlaylistCombo(const std::string& highlight_entry);
 
-    /// Get the full path to a playlist by its name
-    static std::string GetFullPlaylistPath(const std::string& name);
-
 private:
+    /// Get the full path to a playlist by its name
+    static boost::filesystem::path GetFullPlaylistPath(const std::string& name);
+
     void Msg_ListChooseItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;

--- a/libs/s25main/ingameWindows/iwMusicPlayer.h
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.h
@@ -21,10 +21,10 @@
 #include <boost/filesystem/path.hpp>
 
 /// Fenster zum Einstellen des Musik-Players
-class iwMusicPlayer : public IngameWindow
+class iwMusicPlayer final : public IngameWindow
 {
     /// Kleines Fenster zur Eingabe von Text
-    class InputWindow : public IngameWindow
+    class InputWindow final : public IngameWindow
     {
         const unsigned win_id;
         iwMusicPlayer& playerWnd_;
@@ -61,6 +61,8 @@ public:
 private:
     /// Get the full path to a playlist by its name
     static boost::filesystem::path GetFullPlaylistPath(const std::string& name);
+
+    bool SaveCurrentPlaylist();
 
     void Msg_ListChooseItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;

--- a/libs/s25main/ingameWindows/iwPlayReplay.cpp
+++ b/libs/s25main/ingameWindows/iwPlayReplay.cpp
@@ -157,7 +157,7 @@ void iwPlayReplay::Msg_ButtonClick(const unsigned ctrl_id)
         case 3:
         {
             auto* table = GetCtrl<ctrlTable>(0);
-            if(table->GetSelection() < table->GetNumRows())
+            if(table->GetSelection())
                 WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
                   _("Delete selected"), _("Are you sure you want to remove the selected replay?"), this, MSB_YESNO, MSB_QUESTIONRED, 2));
             break;
@@ -183,10 +183,10 @@ void iwPlayReplay::StartReplay()
     VIDEODRIVER.SwapBuffers();
 
     auto* table = GetCtrl<ctrlTable>(0);
-    if(table->GetSelection() < table->GetNumRows())
+    if(table->GetSelection())
     {
         SwitchOnStart switchOnStart;
-        if(!GAMECLIENT.StartReplay(table->GetItemText(table->GetSelection(), 4)))
+        if(!GAMECLIENT.StartReplay(table->GetItemText(*table->GetSelection(), 4)))
             WINDOWMANAGER.Show(
               std::make_unique<iwMsgbox>(_("Error while playing replay!"), _("Invalid Replay!"), this, MSB_OK, MSB_EXCLAMATIONRED));
     }
@@ -224,10 +224,10 @@ void iwPlayReplay::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult
     } else if(msgbox_id == 2 && mbr == MSR_YES)
     {
         auto* table = GetCtrl<ctrlTable>(0);
-        if(table->GetSelection() < table->GetNumRows())
+        if(table->GetSelection())
         {
             boost::system::error_code ec;
-            bfs::remove(table->GetItemText(table->GetSelection(), 4), ec);
+            bfs::remove(table->GetItemText(*table->GetSelection(), 4), ec);
             PopulateTable();
         }
     }

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -61,10 +61,10 @@ void iwSaveLoad::Msg_ButtonClick(const unsigned /*ctrl_id*/)
     SaveLoad();
 }
 
-void iwSaveLoad::Msg_TableSelectItem(const unsigned /*ctrl_id*/, const int selection)
+void iwSaveLoad::Msg_TableSelectItem(const unsigned /*ctrl_id*/, const boost::optional<unsigned>& selection)
 {
     // Dateiname ins Edit schreiben, wenn wir entsprechende Einträge auswählen
-    GetCtrl<ctrlEdit>(1)->SetText(GetCtrl<ctrlTable>(0)->GetItemText(selection, 0));
+    GetCtrl<ctrlEdit>(1)->SetText(selection ? GetCtrl<ctrlTable>(0)->GetItemText(*selection, 0) : "");
 }
 
 void iwSaveLoad::RefreshTable()
@@ -191,8 +191,10 @@ void iwLoad::SaveLoad()
 {
     // Server starten
     auto* table = GetCtrl<ctrlTable>(0);
+    if(!table->GetSelection())
+        return;
 
-    if(!GAMECLIENT.HostGame(csi, table->GetItemText(table->GetSelection(), 4), MAPTYPE_SAVEGAME))
+    if(!GAMECLIENT.HostGame(csi, table->GetItemText(*table->GetSelection(), 4), MAPTYPE_SAVEGAME))
     {
         // Server starten
         if(LOBBYCLIENT.IsLoggedIn())

--- a/libs/s25main/ingameWindows/iwSave.h
+++ b/libs/s25main/ingameWindows/iwSave.h
@@ -38,7 +38,7 @@ private:
 
     void Msg_EditEnter(unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_TableSelectItem(unsigned ctrl_id, int selection) override;
+    void Msg_TableSelectItem(unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
 
     /// Callbackfunktion zum Eintragen eines Spielstandes in die Tabelle
     static void FillSaveTable(const std::string& filePath, void* param);

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -73,7 +73,7 @@ iwSettings::~iwSettings()
     try
     {
         auto* SizeCombo = GetCtrl<ctrlComboBox>(0);
-        SETTINGS.video.fullscreenSize = video_modes[SizeCombo->GetSelection()];
+        SETTINGS.video.fullscreenSize = video_modes[SizeCombo->GetSelection().get()];
 
         if((SETTINGS.video.fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize())
            || SETTINGS.video.fullscreen != VIDEODRIVER.IsFullscreen())

--- a/libs/s25main/ingameWindows/iwTrade.cpp
+++ b/libs/s25main/ingameWindows/iwTrade.cpp
@@ -101,8 +101,8 @@ void iwTrade::Msg_PaintBefore()
 void iwTrade::Msg_ButtonClick(const unsigned /*ctrl_id*/)
 {
     // pressed the send button
-    const unsigned short ware_figure_selection = GetCtrl<ctrlComboBox>(4)->GetSelection();
-    const bool isJob = this->GetCtrl<ctrlComboBox>(2)->GetSelection() == 1;
+    const unsigned short ware_figure_selection = GetCtrl<ctrlComboBox>(4)->GetSelection().get();
+    const bool isJob = this->GetCtrl<ctrlComboBox>(2)->GetSelection() == 1u;
     boost::variant<Job, GoodType> what;
     if(isJob)
         what = jobs[ware_figure_selection];
@@ -147,7 +147,7 @@ void iwTrade::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selecti
         case 4:
         {
             unsigned number;
-            if(this->GetCtrl<ctrlComboBox>(2)->GetSelection() == 0)
+            if(this->GetCtrl<ctrlComboBox>(2)->GetSelection() == 0u)
             {
                 // Wares
 

--- a/libs/s25main/ingameWindows/iwTransport.cpp
+++ b/libs/s25main/ingameWindows/iwTransport.cpp
@@ -148,7 +148,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             auto* group = GetCtrl<ctrlOptionGroup>(6);
 
             // Wenn wir schon ganz oben sind, gehts nicht weiter höher
-            while(group->GetSelection() > 0 && group->GetSelection() != 0xFFFF)
+            while(group->GetSelection() > 0)
             {
                 std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
                           GAMECLIENT.visual_settings.transport_order[group->GetSelection() - 1]);
@@ -167,7 +167,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             auto* group = GetCtrl<ctrlOptionGroup>(6);
 
             // Wenn wir schon ganz oben sind, gehts nicht weiter höher
-            if(group->GetSelection() > 0 && group->GetSelection() != 0xFFFF)
+            if(group->GetSelection() > 0)
             {
                 std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
                           GAMECLIENT.visual_settings.transport_order[group->GetSelection() - 1]);
@@ -186,7 +186,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             auto* group = GetCtrl<ctrlOptionGroup>(6);
 
             // Wenn wir schon ganz unten sind, gehts nicht weiter runter
-            if(group->GetSelection() < 13 && group->GetSelection() != 0xFFFF)
+            if(group->GetSelection() < 13)
             {
                 std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
                           GAMECLIENT.visual_settings.transport_order[group->GetSelection() + 1]);
@@ -205,7 +205,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             auto* group = GetCtrl<ctrlOptionGroup>(6);
 
             // Wenn wir schon ganz unten sind, gehts nicht weiter runter
-            while(group->GetSelection() < 13 && group->GetSelection() != 0xFFFF)
+            while(group->GetSelection() < 13)
             {
                 std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
                           GAMECLIENT.visual_settings.transport_order[group->GetSelection() + 1]);

--- a/tests/s25Main/audio/testPlaylist.cpp
+++ b/tests/s25Main/audio/testPlaylist.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2016 - 2020 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "Playlist.h"
+#include "helpers/containerUtils.h"
+#include "rttr/test/TmpFolder.hpp"
+#include "rttr/test/random.hpp"
+#include "s25util/Log.h"
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+
+BOOST_AUTO_TEST_SUITE(PlaylistTests)
+
+BOOST_AUTO_TEST_CASE(DefaultConstructedPlaylistIsEmpty)
+{
+    Playlist pl;
+    BOOST_TEST(pl.getSongs().empty());
+    BOOST_TEST(pl.getCurrentSong().empty());
+    BOOST_TEST(pl.getNextSong().empty());
+    pl.SetStartSong(0); // No error
+    BOOST_TEST(pl.getNextSong().empty());
+}
+
+BOOST_AUTO_TEST_CASE(PlaylistPlaysInOrder)
+{
+    const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
+    Playlist pl(songs, 1, false);
+    BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
+    for(const auto& song : songs)
+    {
+        BOOST_TEST(pl.getNextSong() == song);
+        BOOST_TEST(pl.getCurrentSong() == song);
+    }
+    // End of playlist
+    BOOST_TEST(pl.getNextSong().empty());
+    BOOST_TEST(pl.getCurrentSong().empty());
+}
+
+BOOST_AUTO_TEST_CASE(RepeatedPlaylistPlaysInOrder)
+{
+    const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
+    const auto numRepeats = rttr::test::randomValue(2u, 5u);
+    Playlist pl(songs, numRepeats, false);
+    BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
+    for(unsigned i = 0; i < numRepeats; i++)
+    {
+        for(const auto& song : songs)
+        {
+            BOOST_TEST(pl.getNextSong() == song);
+            BOOST_TEST(pl.getCurrentSong() == song);
+        }
+    }
+    // End of playlist
+    BOOST_TEST(pl.getNextSong().empty());
+    BOOST_TEST(pl.getCurrentSong().empty());
+}
+
+BOOST_AUTO_TEST_CASE(RandomPlaylistPlaysEachSongOnce)
+{
+    const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
+    Playlist pl(songs, 1, true);
+    BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
+    std::vector<std::string> playedSongs;
+    for(unsigned i = 0; i < songs.size(); i++)
+    {
+        const auto song = pl.getNextSong();
+        BOOST_TEST(!song.empty());
+        BOOST_TEST(pl.getCurrentSong() == song);
+        playedSongs.push_back(song);
+    }
+    // End of playlist
+    BOOST_TEST(pl.getNextSong().empty());
+    BOOST_TEST(pl.getCurrentSong().empty());
+    for(const auto& song : songs)
+    {
+        BOOST_TEST(helpers::contains(playedSongs, song));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(RandomPlaylistPlaysEachSongNumRepeatsTimes)
+{
+    const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
+    const auto numRepeats = rttr::test::randomValue(2u, 5u);
+    Playlist pl(songs, numRepeats, true);
+    BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
+    std::vector<std::string> playedSongs;
+    for(unsigned i = 0; i < songs.size() * numRepeats; i++)
+    {
+        const auto song = pl.getNextSong();
+        BOOST_TEST(!song.empty());
+        BOOST_TEST(pl.getCurrentSong() == song);
+        playedSongs.push_back(song);
+    }
+    // End of playlist
+    BOOST_TEST(pl.getNextSong().empty());
+    BOOST_TEST(pl.getCurrentSong().empty());
+    for(const auto& song : songs)
+    {
+        const auto numPlayed = static_cast<unsigned>(std::count(playedSongs.cbegin(), playedSongs.cend(), song));
+        BOOST_TEST(numPlayed == numRepeats);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(SaveLoadResultsInSamePlaylist)
+{
+    const auto songs = std::vector<std::string>{"folder/s01.ogg", "s02 with space", "winfolder\\s03.mp3"};
+    const auto numRepeats = rttr::test::randomValue(2u, 5u);
+    const bool isRandom = rttr::test::randomValue(0u, 1u) == 1u;
+    Playlist pl(songs, numRepeats, isRandom);
+    rttr::test::TmpFolder tmpFolder;
+    const auto filepath = tmpFolder.get() / "playlist.pll";
+    BOOST_TEST_REQUIRE(pl.SaveAs(filepath));
+    Playlist pl2;
+    BOOST_TEST_REQUIRE(pl2.Load(LOG, filepath));
+    BOOST_TEST(pl.getSongs() == pl2.getSongs(), boost::test_tools::per_element());
+    BOOST_TEST(pl.getNumRepeats() == pl2.getNumRepeats());
+    BOOST_TEST(pl.isRandomized() == pl2.isRandomized());
+    // Playlist is prepared
+    BOOST_TEST(!pl.getNextSong().empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tools/runClangTidy.sh
+++ b/tools/runClangTidy.sh
@@ -27,7 +27,7 @@ fi
 FILTER="$(pwd)/(extras|libs|tests|\
 external/(libendian|liblobby|libsiedler2|\
 libutil/(tests|lib)|\
-mygettext|s-c/src|s25edit|s25update))"
+mygettext|s25edit|s25update))"
 
 ${CLANG_TIDY_CMD} -p build \
     -j $(nproc) \


### PR DESCRIPTION
This combines some refactoring in order to fix some issues:

- Use optional to be able to distinguish between selected item and "nothing selected". This forces to check for that and makes the semantic clear. This was likely the cause for and fixes #1278 : Integer promotion led to not detecting the invalid value
- Fix #1281 : The playlist was saved in the current folder, not where it should be
- Add a button to manually save the playlist as all progress will be lost when switching between playlists. It is still saved when closing the window
- As the default playlist cannot be saved disable the buttons to do so
- We were saving the playlists into the program folder which is wrong and potentially read-only. Create new folder in user data for that.
- Refactor the playlist class to remove the circular reference to the iwMusicPlayer. This allows to add tests for it