### PR TITLE
Make more use of bfs::path

### DIFF
--- a/libs/libGamedata/lua/GameDataLoader.h
+++ b/libs/libGamedata/lua/GameDataLoader.h
@@ -19,6 +19,7 @@
 #define GameDataLoader_h__
 
 #include "LuaInterfaceBase.h"
+#include <boost/filesystem/path.hpp>
 
 namespace kaguya {
 class State;
@@ -29,7 +30,7 @@ struct WorldDescription;
 class GameDataLoader : public LuaInterfaceBase
 {
 public:
-    GameDataLoader(WorldDescription& worldDesc, const std::string& basePath);
+    GameDataLoader(WorldDescription& worldDesc, const boost::filesystem::path& basePath);
     GameDataLoader(WorldDescription& worldDesc);
     ~GameDataLoader() override;
 
@@ -44,7 +45,7 @@ private:
     void AddTerrain(const kaguya::LuaTable& data);
 
     WorldDescription& worldDesc_;
-    std::string basePath_, curFile_;
+    boost::filesystem::path basePath_, curFile_;
     int curIncludeDepth_;
     bool errorInIncludeFile_;
 };

--- a/libs/libGamedata/lua/LuaInterfaceBase.cpp
+++ b/libs/libGamedata/lua/LuaInterfaceBase.cpp
@@ -64,9 +64,9 @@ void LuaInterfaceBase::errorHandler(int status, const char* message)
     throw LuaExecutionError(message ? message : _("Unknown error"));
 }
 
-bool LuaInterfaceBase::loadScript(const std::string& scriptPath)
+bool LuaInterfaceBase::loadScript(const boost::filesystem::path& scriptPath)
 {
-    boost::nowide::ifstream scriptFile(scriptPath.c_str());
+    boost::nowide::ifstream scriptFile(scriptPath);
     std::string tmpScript;
     tmpScript.assign(std::istreambuf_iterator<char>(scriptFile), std::istreambuf_iterator<char>());
     if(!scriptFile)

--- a/libs/libGamedata/lua/LuaInterfaceBase.h
+++ b/libs/libGamedata/lua/LuaInterfaceBase.h
@@ -19,6 +19,7 @@
 #define LuaInterfaceBase_h__
 
 #include <kaguya/kaguya.hpp>
+#include <boost/filesystem/path.hpp>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -40,7 +41,7 @@ class LuaInterfaceBase
 public:
     static void Register(kaguya::State& state);
 
-    bool loadScript(const std::string& scriptPath);
+    bool loadScript(const boost::filesystem::path& scriptPath);
     bool loadScriptString(const std::string& script, bool rethrowError = false);
     const std::string& getScript() const { return script_; }
     /// Disable or re-enable throwing an exception on error.

--- a/libs/rttrConfig/src/RttrConfig.cpp
+++ b/libs/rttrConfig/src/RttrConfig.cpp
@@ -94,10 +94,10 @@ boost::filesystem::path RttrConfig::GetSourceDir()
     return RTTR_SRCDIR;
 }
 
-std::string RttrConfig::ExpandPath(const std::string& path) const
+boost::filesystem::path RttrConfig::ExpandPath(const std::string& path) const
 {
     if(path.empty())
-        return prefixPath_.string();
+        return prefixPath_;
     bfs::path outPath;
     if(path[0] == '<')
     {
@@ -119,7 +119,7 @@ std::string RttrConfig::ExpandPath(const std::string& path) const
         outPath = homePath / outPath.string().substr(2);
 
     outPath = bfs::absolute(outPath, prefixPath_).lexically_normal();
-    return outPath.make_preferred().string();
+    return outPath.make_preferred();
 }
 
 bool RttrConfig::Init()

--- a/libs/rttrConfig/src/RttrConfig.h
+++ b/libs/rttrConfig/src/RttrConfig.h
@@ -37,7 +37,7 @@ public:
     /// Return the path from which RTTR was compiled
     static boost::filesystem::path GetSourceDir();
     /// Expand the given path to a valid, absolute path replacing placeholders like <RTTR_BINDIR>/foo.bar
-    std::string ExpandPath(const std::string& path) const;
+    boost::filesystem::path ExpandPath(const std::string& path) const;
 };
 
 #define RTTRCONFIG RttrConfig::inst()

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -358,7 +358,7 @@ bool MigrateFilesAndDirectories()
 bool InitDirectories()
 {
     // Note: Do not use logger yet. Filepath may not exist
-    const std::string curPath = bfs::current_path().string();
+    const auto curPath = bfs::current_path();
     LOG.write("Starting in %s\n", LogTarget::Stdout) % curPath;
 
     // diverse dirs anlegen
@@ -371,7 +371,7 @@ bool InitDirectories()
 
     for(const std::string& rawDir : dirs)
     {
-        std::string dir = RTTRCONFIG.ExpandPath(rawDir);
+        const bfs::path dir = RTTRCONFIG.ExpandPath(rawDir);
         boost::system::error_code ec;
         bfs::create_directories(dir, ec);
         if(ec != boost::system::errc::success)
@@ -380,7 +380,7 @@ bool InitDirectories()
             // Make sure we catch that
             try
             {
-                s25util::error(std::string("Directory ") + dir + " could not be created.");
+                s25util::error(std::string("Directory ") + dir.string() + " could not be created.");
                 s25util::error("Failed to start the game");
             } catch(const std::runtime_error& error)
             {

--- a/libs/s25main/Debug.cpp
+++ b/libs/s25main/Debug.cpp
@@ -308,7 +308,7 @@ bool DebugInfo::SendReplay()
     return true;
 }
 
-bool DebugInfo::SendAsyncLog(const std::string& asyncLogFilepath)
+bool DebugInfo::SendAsyncLog(const boost::filesystem::path& asyncLogFilepath)
 {
     BinaryFile file;
     if(!file.Open(asyncLogFilepath, OFM_READ))

--- a/libs/s25main/Debug.h
+++ b/libs/s25main/Debug.h
@@ -18,6 +18,7 @@
 #define DEBUG_H_
 
 #include "s25util/Socket.h"
+#include <boost/filesystem/path.hpp>
 #include <vector>
 
 class BinaryFile;
@@ -41,7 +42,7 @@ public:
 
     bool SendStackTrace(const std::vector<void*>& stacktrace);
     bool SendReplay();
-    bool SendAsyncLog(const std::string& asyncLogFilepath);
+    bool SendAsyncLog(const boost::filesystem::path& asyncLogFilepath);
     bool SendFile(BinaryFile& file);
 };
 

--- a/libs/s25main/FileChecksum.cpp
+++ b/libs/s25main/FileChecksum.cpp
@@ -18,7 +18,7 @@
 #include "FileChecksum.h"
 #include <boost/nowide/fstream.hpp>
 
-uint32_t CalcChecksumOfFile(const std::string& path)
+uint32_t CalcChecksumOfFile(const boost::filesystem::path& path)
 {
     boost::nowide::ifstream file(path);
     if(!file)

--- a/libs/s25main/FileChecksum.h
+++ b/libs/s25main/FileChecksum.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
+#include <boost/filesystem/path.hpp>
 #include <string>
 
-uint32_t CalcChecksumOfFile(const std::string& path);
+uint32_t CalcChecksumOfFile(const boost::filesystem::path& path);
 uint32_t CalcChecksumOfBuffer(const uint8_t* buffer, size_t size);
 
 inline uint32_t CalcChecksumOfBuffer(const int8_t* buffer, size_t size)

--- a/libs/s25main/ListDir.cpp
+++ b/libs/s25main/ListDir.cpp
@@ -34,8 +34,8 @@ std::vector<bfs::path> ListDir(const bfs::path& path, std::string extension, boo
     {
         extension = s25util::toLower(extension);
         // Add dot if missing
-        if(extension[0] != '.')
-            extension = "." + extension;
+        if(extension.front() != '.')
+            extension.insert(extension.begin(), '.');
     }
 
     for(const auto& it : bfs::directory_iterator(path))

--- a/libs/s25main/QuickStartGame.cpp
+++ b/libs/s25main/QuickStartGame.cpp
@@ -42,9 +42,8 @@ public:
     void CI_GameLoading(const std::shared_ptr<Game>& game) override { WINDOWMANAGER.Switch(std::make_unique<dskGameLoader>(game)); }
 };
 
-bool QuickStartGame(const std::string& filePath, bool singlePlayer)
+bool QuickStartGame(const boost::filesystem::path& mapOrReplayPath, bool singlePlayer)
 {
-    const boost::filesystem::path mapOrReplayPath(filePath);
     if(!exists(mapOrReplayPath))
     {
         LOG.write(_("Given map or replay (%1%) does not exist!")) % mapOrReplayPath;
@@ -66,14 +65,14 @@ bool QuickStartGame(const std::string& filePath, bool singlePlayer)
 
     WINDOWMANAGER.Switch(std::make_unique<dskSelectMap>(csi));
 
-    if((extension == ".sav" && GAMECLIENT.HostGame(csi, filePath, MAPTYPE_SAVEGAME))
-       || ((extension == ".swd" || extension == ".wld") && GAMECLIENT.HostGame(csi, filePath, MAPTYPE_OLDMAP)))
+    if((extension == ".sav" && GAMECLIENT.HostGame(csi, mapOrReplayPath, MAPTYPE_SAVEGAME))
+       || ((extension == ".swd" || extension == ".wld") && GAMECLIENT.HostGame(csi, mapOrReplayPath, MAPTYPE_OLDMAP)))
     {
         WINDOWMANAGER.ShowAfterSwitch(std::make_unique<iwPleaseWait>());
         return true;
     } else
     {
         SwitchOnStart switchOnStart;
-        return GAMECLIENT.StartReplay(filePath);
+        return GAMECLIENT.StartReplay(mapOrReplayPath);
     }
 }

--- a/libs/s25main/QuickStartGame.h
+++ b/libs/s25main/QuickStartGame.h
@@ -18,9 +18,10 @@
 #ifndef QuickStartGame_h__
 #define QuickStartGame_h__
 
+#include <boost/filesystem/path.hpp>
 #include <string>
 
 /// Tries to start a game (map, savegame or replay) and returns whether this was successfull
-bool QuickStartGame(const std::string& filePath, bool singlePlayer = false);
+bool QuickStartGame(const boost::filesystem::path& mapOrReplayPath, bool singlePlayer = false);
 
 #endif // QuickStartGame_h__

--- a/libs/s25main/Replay.cpp
+++ b/libs/s25main/Replay.cpp
@@ -55,13 +55,13 @@ void Replay::StopRecording()
     isRecording = false;
 }
 
-bool Replay::StartRecording(const std::string& filename, const MapInfo& mapInfo)
+bool Replay::StartRecording(const boost::filesystem::path& filepath, const MapInfo& mapInfo)
 {
     // Deny overwrite, also avoids double-opening by different processes
-    if(boost::filesystem::exists(filename))
+    if(boost::filesystem::exists(filepath))
         return false;
     // Datei öffnen
-    if(!file.Open(filename, OFM_WRITE))
+    if(!file.Open(filepath, OFM_WRITE))
         return false;
 
     isRecording = true;
@@ -86,7 +86,7 @@ bool Replay::StartRecording(const std::string& filename, const MapInfo& mapInfo)
 
     // Game data
     file.WriteUnsignedInt(random_init);
-    file.WriteLongString(mapInfo.filepath);
+    file.WriteLongString(mapInfo.filepath.string());
 
     switch(mapType_)
     {
@@ -110,10 +110,10 @@ bool Replay::StartRecording(const std::string& filename, const MapInfo& mapInfo)
     return true;
 }
 
-bool Replay::LoadHeader(const std::string& filename, bool loadSettings)
+bool Replay::LoadHeader(const boost::filesystem::path& filepath, bool loadSettings)
 {
     // Datei öffnen
-    if(!file.Open(filename, OFM_READ))
+    if(!file.Open(filepath, OFM_READ))
     {
         lastErrorMsg = _("File could not be opened.");
         return false;

--- a/libs/s25main/Replay.h
+++ b/libs/s25main/Replay.h
@@ -51,7 +51,7 @@ public:
     uint16_t GetVersion() const override;
 
     /// Beginnt die Save-Datei und schreibt den Header
-    bool StartRecording(const std::string& filename, const MapInfo& mapInfo);
+    bool StartRecording(const boost::filesystem::path& filepath, const MapInfo& mapInfo);
     /// Räumt auf, schließt datei
     void StopRecording();
 
@@ -61,7 +61,7 @@ public:
     bool IsReplaying() const { return !isRecording && file.IsValid(); }
 
     /// Loads the header and optionally the mapInfo (former "extended header")
-    bool LoadHeader(const std::string& filename, bool loadSettings);
+    bool LoadHeader(const boost::filesystem::path& filepath, bool loadSettings);
     bool LoadGameData(MapInfo& mapInfo);
 
     /// Fügt ein Chat-Kommando hinzu (schreibt)

--- a/libs/s25main/ReplayInfo.h
+++ b/libs/s25main/ReplayInfo.h
@@ -21,6 +21,7 @@
 #define ReplayInfo_h__
 
 #include "Replay.h"
+#include <boost/filesystem/path.hpp>
 #include <string>
 
 struct ReplayInfo
@@ -29,7 +30,7 @@ struct ReplayInfo
 
     /// Replaydatei
     Replay replay;
-    std::string fileName;
+    boost::filesystem::path filename;
     /// Replay asynchron (Meldung nur einmal ausgeben!)
     int async;
     bool end;

--- a/libs/s25main/Savegame.cpp
+++ b/libs/s25main/Savegame.cpp
@@ -35,11 +35,11 @@ Savegame::Savegame() : start_gf(0) {}
 
 Savegame::~Savegame() = default;
 
-bool Savegame::Save(const std::string& filename, const std::string& mapName)
+bool Savegame::Save(const boost::filesystem::path& filepath, const std::string& mapName)
 {
     BinaryFile file;
 
-    return file.Open(filename, OFM_WRITE) && Save(file, mapName);
+    return file.Open(filepath, OFM_WRITE) && Save(file, mapName);
 }
 
 bool Savegame::Save(BinaryFile& file, const std::string& mapName)
@@ -52,7 +52,7 @@ bool Savegame::Save(BinaryFile& file, const std::string& mapName)
     return true;
 }
 
-bool Savegame::Load(const std::string& filePath, const SaveGameDataToLoad what)
+bool Savegame::Load(const boost::filesystem::path& filePath, const SaveGameDataToLoad what)
 {
     BinaryFile file;
 

--- a/libs/s25main/Savegame.h
+++ b/libs/s25main/Savegame.h
@@ -21,6 +21,8 @@
 
 #include "SavedFile.h"
 #include "SerializedGameData.h"
+#include <boost/filesystem/path.hpp>
+
 class BinaryFile;
 
 enum class SaveGameDataToLoad
@@ -40,11 +42,11 @@ public:
     uint16_t GetVersion() const override;
 
     /// Schreibst Savegame oder Teile davon
-    bool Save(const std::string& filename, const std::string& mapName);
+    bool Save(const boost::filesystem::path& filepath, const std::string& mapName);
     bool Save(BinaryFile& file, const std::string& mapName);
 
     /// Lädt Savegame oder Teile davon
-    bool Load(const std::string& filePath, SaveGameDataToLoad what);
+    bool Load(const boost::filesystem::path& filePath, SaveGameDataToLoad what);
     bool Load(BinaryFile& file, SaveGameDataToLoad what);
 
     void WriteExtHeader(BinaryFile& file, const std::string& mapName) override;

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -148,7 +148,7 @@ void Settings::LoadDefaults()
 void Settings::Load()
 {
     libsiedler2::Archiv settings;
-    std::string settingsPath = RTTRCONFIG.ExpandPath(s25::resources::config);
+    const auto settingsPath = RTTRCONFIG.ExpandPath(s25::resources::config);
     try
     {
         if(libsiedler2::Load(settingsPath, settings) != 0 || settings.size() != SECTION_NAMES.size())
@@ -291,7 +291,8 @@ void Settings::Load()
 
     } catch(std::runtime_error& e)
     {
-        s25util::warning(std::string("Could not use settings from \"") + settingsPath + "\", using default values. Reason: " + e.what());
+        s25util::warning(std::string("Could not use settings from \"") + settingsPath.string()
+                         + "\", using default values. Reason: " + e.what());
         LoadDefaults();
         Save();
     }
@@ -404,6 +405,6 @@ void Settings::Save()
     // }
 
     bfs::path settingsPath = RTTRCONFIG.ExpandPath(s25::resources::config);
-    if(libsiedler2::Write(settingsPath.string(), settings) == 0)
+    if(libsiedler2::Write(settingsPath, settings) == 0)
         bfs::permissions(settingsPath, bfs::owner_read | bfs::owner_write);
 }

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -791,8 +791,8 @@ void WindowManager::TakeScreenshot()
     libsiedler2::PixelBufferBGRA buffer(curRenderSize.x, curRenderSize.y);
     glReadPixels(0, 0, curRenderSize.x, curRenderSize.y, GL_BGRA, GL_UNSIGNED_BYTE, buffer.getPixelPtr());
     flipVertical(buffer);
-    bfs::path outFilepath =
-      bfs::path(RTTRCONFIG.ExpandPath(s25::folders::screenshots)) / (s25util::Time::FormatTime("%Y-%m-%d_%H-%i-%s") + ".bmp");
+    const bfs::path outFilepath =
+      RTTRCONFIG.ExpandPath(s25::folders::screenshots) / (s25util::Time::FormatTime("%Y-%m-%d_%H-%i-%s") + ".bmp");
     try
     {
         saveBitmap(buffer, outFilepath);

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -330,7 +330,8 @@ void dskGameInterface::Msg_PaintAfter()
 
     // Replaydateianzeige in der linken unteren Ecke
     if(GAMECLIENT.IsReplayModeOn())
-        NormalFont->Draw(DrawPoint(0, VIDEODRIVER.GetRenderSize().y), GAMECLIENT.GetReplayFileName(), FontStyle::BOTTOM, COLOR_YELLOW);
+        NormalFont->Draw(DrawPoint(0, VIDEODRIVER.GetRenderSize().y), GAMECLIENT.GetReplayFilename().string(), FontStyle::BOTTOM,
+                         COLOR_YELLOW);
     else
     {
         // Laggende Spieler anzeigen in Form von Schnecken

--- a/libs/s25main/desktops/dskSelectMap.h
+++ b/libs/s25main/desktops/dskSelectMap.h
@@ -70,12 +70,13 @@ private:
      */
     void CreateRandomMap();
 
-    void OnMapCreated(const std::string& mapPath);
+    void OnMapCreated(const boost::filesystem::path& mapPath);
 
     CreateServerInfo csi;
     MapSettings rndMapSettings;
     boost::thread* mapGenThread;
-    std::string newRandMapPath;
+    boost::filesystem::path newRandMapPath;
+    std::string randMapGenError;
     IngameWindow* waitWnd;
     /// Mapping of s2 ids to landscape names
     std::map<uint8_t, std::string> landscapeNames;

--- a/libs/s25main/desktops/dskSinglePlayer.cpp
+++ b/libs/s25main/desktops/dskSinglePlayer.cpp
@@ -79,7 +79,7 @@ void dskSinglePlayer::Msg_ButtonClick(const unsigned ctrl_id)
                 Savegame save;
 
                 // Datei öffnen
-                if(!save.Load(savFile.string(), SaveGameDataToLoad::Header))
+                if(!save.Load(savFile, SaveGameDataToLoad::Header))
                     continue;
 
                 if(save.GetSaveTime() > recent)
@@ -94,14 +94,14 @@ void dskSinglePlayer::Msg_ButtonClick(const unsigned ctrl_id)
                 // Dateiname noch rausextrahieren aus dem Pfad
                 if(!mostRecentFilepath.has_filename())
                     return;
-                const bfs::path name = mostRecentFilepath.stem();
+                const auto name = mostRecentFilepath.stem().string();
 
                 // Server info
-                CreateServerInfo csi = createLocalGameInfo(name.string());
+                CreateServerInfo csi = createLocalGameInfo(name);
 
                 WINDOWMANAGER.Switch(std::make_unique<dskSelectMap>(csi));
 
-                if(GAMECLIENT.HostGame(csi, mostRecentFilepath.string(), MAPTYPE_SAVEGAME))
+                if(GAMECLIENT.HostGame(csi, mostRecentFilepath, MAPTYPE_SAVEGAME))
                     WINDOWMANAGER.ShowAfterSwitch(std::make_unique<iwPleaseWait>());
                 else
                 {

--- a/libs/s25main/drivers/DriverWrapper.cpp
+++ b/libs/s25main/drivers/DriverWrapper.cpp
@@ -146,7 +146,7 @@ std::vector<DriverWrapper::DriverItem> DriverWrapper::LoadDriverList(const Drive
 {
     std::vector<DriverItem> driver_list;
 
-    std::string path = RTTRCONFIG.ExpandPath(s25::folders::driver) + "/" + getName(dt);
+    const auto driverDir = RTTRCONFIG.ExpandPath(s25::folders::driver) / getName(dt);
     std::string extension =
 #ifdef _WIN32
       "dll";
@@ -158,8 +158,8 @@ std::vector<DriverWrapper::DriverItem> DriverWrapper::LoadDriverList(const Drive
 #endif // !__APPLE__
 #endif // !_WIN32
 
-    LOG.write(_("Searching for drivers in %s\n")) % path;
-    const std::vector<boost::filesystem::path> driver_files = ListDir(path, extension, false);
+    LOG.write(_("Searching for drivers in %s\n")) % driverDir;
+    const std::vector<boost::filesystem::path> driver_files = ListDir(driverDir, extension, false);
 
     for(const auto& path : driver_files)
     {

--- a/libs/s25main/gameTypes/CompressedData.cpp
+++ b/libs/s25main/gameTypes/CompressedData.cpp
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <memory>
 
-bool CompressedData::DecompressToFile(const std::string& filePath, unsigned* checksum)
+bool CompressedData::DecompressToFile(const boost::filesystem::path& filePath, unsigned* checksum)
 {
     boost::nowide::ofstream file(filePath, std::ios::binary);
 
@@ -62,7 +62,7 @@ bool CompressedData::DecompressToFile(const std::string& filePath, unsigned* che
     return true;
 }
 
-bool CompressedData::CompressFromFile(const std::string& filePath, unsigned* checksum /* = nullptr */)
+bool CompressedData::CompressFromFile(const boost::filesystem::path& filePath, unsigned* checksum /* = nullptr */)
 {
     boost::nowide::ifstream file(filePath, std::ios::binary | std::ios::ate);
     length = static_cast<unsigned>(file.tellg());

--- a/libs/s25main/gameTypes/CompressedData.h
+++ b/libs/s25main/gameTypes/CompressedData.h
@@ -18,6 +18,7 @@
 #ifndef CompressedData_h__
 #define CompressedData_h__
 
+#include <boost/filesystem/path.hpp>
 #include <string>
 #include <vector>
 
@@ -30,8 +31,8 @@ struct CompressedData
         length = 0;
         data.clear();
     }
-    bool DecompressToFile(const std::string& filePath, unsigned* checksum = nullptr);
-    bool CompressFromFile(const std::string& filePath, unsigned* checksum = nullptr);
+    bool DecompressToFile(const boost::filesystem::path& filePath, unsigned* checksum = nullptr);
+    bool CompressFromFile(const boost::filesystem::path& filePath, unsigned* checksum = nullptr);
 
     /// Uncompressed length
     unsigned length;

--- a/libs/s25main/gameTypes/MapInfo.h
+++ b/libs/s25main/gameTypes/MapInfo.h
@@ -20,6 +20,7 @@
 
 #include "gameTypes/CompressedData.h"
 #include "gameTypes/MapType.h"
+#include <boost/filesystem/path.hpp>
 #include <memory>
 #include <string>
 
@@ -37,9 +38,9 @@ public:
     /// Name of the map
     std::string title;
     /// Path where map is/will be stored
-    std::string filepath;
+    boost::filesystem::path filepath;
     /// Path to lua file (if any)
-    std::string luaFilepath;
+    boost::filesystem::path luaFilepath;
     /// map data as received from server
     CompressedData mapData;
     /// lua script as received from server

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -267,7 +267,7 @@ void iwMusicPlayer::Msg_ButtonClick(const unsigned ctrl_id)
 
                 boost::system::error_code ec;
                 boost::filesystem::remove(GetFullPlaylistPath(playlistName), ec);
-                SETTINGS.sound.playlist = RTTRCONFIG.ExpandPath(s25::files::defaultPlaylist);
+                SETTINGS.sound.playlist = RTTRCONFIG.ExpandPath(s25::files::defaultPlaylist).string();
                 UpdatePlaylistCombo(SETTINGS.sound.playlist);
             }
         }

--- a/libs/s25main/ingameWindows/iwPlayReplay.cpp
+++ b/libs/s25main/ingameWindows/iwPlayReplay.cpp
@@ -95,7 +95,7 @@ void iwPlayReplay::PopulateTable()
         Replay replay;
 
         // Datei laden
-        if(!replay.LoadHeader(path.string(), false))
+        if(!replay.LoadHeader(path, false))
         {
             // Show errors only first time this is loaded
             if(!loadedOnce)
@@ -212,7 +212,7 @@ void iwPlayReplay::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult
         for(const auto& it : replays)
         {
             Replay replay;
-            if(!replay.LoadHeader(it.string(), false))
+            if(!replay.LoadHeader(it, false))
             {
                 replay.Close();
                 boost::system::error_code ec;

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -79,7 +79,7 @@ void iwSaveLoad::RefreshTable()
         Savegame save;
 
         // Datei öffnen
-        if(!save.Load(saveFile.string(), SaveGameDataToLoad::Header))
+        if(!save.Load(saveFile, SaveGameDataToLoad::Header))
         {
             // Show errors only first time this is loaded
             if(!loadedOnce)
@@ -110,12 +110,12 @@ void iwSaveLoad::RefreshTable()
     loadedOnce = true;
 }
 
-void iwSaveLoad::FillSaveTable(const std::string&, void*) {}
+void iwSaveLoad::FillSaveTable(const boost::filesystem::path&, void*) {}
 
 void iwSave::SaveLoad()
 {
     // Speichern
-    std::string savePath = RTTRCONFIG.ExpandPath(s25::folders::save) + "/" + GetCtrl<ctrlEdit>(1)->GetText() + ".sav";
+    const boost::filesystem::path savePath = RTTRCONFIG.ExpandPath(s25::folders::save) / (GetCtrl<ctrlEdit>(1)->GetText() + ".sav");
 
     // Speichern
     GAMECLIENT.SaveToFile(savePath);

--- a/libs/s25main/ingameWindows/iwSave.h
+++ b/libs/s25main/ingameWindows/iwSave.h
@@ -21,6 +21,7 @@
 
 #include "IngameWindow.h"
 #include "network/CreateServerInfo.h"
+#include <boost/filesystem/path.hpp>
 
 /// Fenster fürs Speichern UND(!) Laden von Spielständen
 class iwSaveLoad : public IngameWindow
@@ -41,7 +42,7 @@ private:
     void Msg_TableSelectItem(unsigned ctrl_id, const boost::optional<unsigned>& selection) override;
 
     /// Callbackfunktion zum Eintragen eines Spielstandes in die Tabelle
-    static void FillSaveTable(const std::string& filePath, void* param);
+    static void FillSaveTable(const boost::filesystem::path& filePath, void* param);
 };
 
 class iwSave : public iwSaveLoad

--- a/libs/s25main/languages.cpp
+++ b/libs/s25main/languages.cpp
@@ -38,7 +38,7 @@ Languages::Languages() : loaded(false)
 {
     const char* domain = "rttr";
     mygettext::bind_textdomain_codeset(domain, "UTF-8");
-    mygettext::bindtextdomain(domain, RTTRCONFIG.ExpandPath(s25::folders::languages).c_str());
+    mygettext::bindtextdomain(domain, RTTRCONFIG.ExpandPath(s25::folders::languages).string().c_str());
     mygettext::textdomain(domain);
 }
 

--- a/libs/s25main/mapGenerator/MapGenerator.cpp
+++ b/libs/s25main/mapGenerator/MapGenerator.cpp
@@ -23,7 +23,7 @@
 #include "libsiedler2/libsiedler2.h"
 #include <stdexcept>
 
-void MapGenerator::Create(const std::string& filePath, const MapSettings& settings)
+void MapGenerator::Create(const boost::filesystem::path& filePath, const MapSettings& settings)
 {
     // create a random map generator based on the map style
     RandomConfig config;

--- a/libs/s25main/mapGenerator/MapGenerator.h
+++ b/libs/s25main/mapGenerator/MapGenerator.h
@@ -18,6 +18,7 @@
 #ifndef MapGenerator_h__
 #define MapGenerator_h__
 
+#include <boost/filesystem/path.hpp>
 #include <string>
 
 struct MapSettings;
@@ -33,7 +34,7 @@ public:
      * @param filePath path for the output file
      * @param settings used to generate the random map
      */
-    static void Create(const std::string& filePath, const MapSettings& settings);
+    static void Create(const boost::filesystem::path& filePath, const MapSettings& settings);
 };
 
 #endif // MapGenerator_h__

--- a/libs/s25main/network/GameClient.h
+++ b/libs/s25main/network/GameClient.h
@@ -91,17 +91,17 @@ public:
     bool Connect(const std::string& server, const std::string& password, ServerType servertyp, unsigned short port, bool host,
                  bool use_ipv6);
     /// Start the server and connect to it
-    bool HostGame(const CreateServerInfo& csi, const std::string& map_path, MapType map_type);
+    bool HostGame(const CreateServerInfo& csi, const boost::filesystem::path& map_path, MapType map_type);
     void Run();
     void Stop();
 
     /// Gibt Map-Titel zurück
     const std::string& GetMapTitle() const { return mapinfo.title; }
     /// Gibt Pfad zu der Map zurück
-    const std::string& GetMapPath() const { return mapinfo.filepath; }
+    const boost::filesystem::path& GetMapPath() const { return mapinfo.filepath; }
     /// Gibt Map-Typ zurück
     MapType GetMapType() const { return mapinfo.type; }
-    const std::string& GetLuaFilePath() const { return mapinfo.luaFilepath; }
+    const boost::filesystem::path& GetLuaFilePath() const { return mapinfo.luaFilepath; }
 
     // Initialisiert und startet das Spiel
     void StartGame(unsigned random_init);
@@ -139,7 +139,7 @@ public:
     void DecreaseSpeed();
 
     /// Lädt ein Replay und startet dementsprechend das Spiel
-    bool StartReplay(const std::string& path);
+    bool StartReplay(const boost::filesystem::path& path);
     void SetPause(bool pause);
     void TogglePause() { SetPause(!framesinfo.isPaused); }
     /// Schaltet FoW im Replaymodus ein/aus
@@ -152,7 +152,7 @@ public:
     std::string FormatGFTime(unsigned gf) const override;
 
     /// Gibt Replay-Dateiname zurück
-    const std::string& GetReplayFileName() const;
+    const boost::filesystem::path& GetReplayFilename() const;
     /// Wird ein Replay abgespielt?
     bool IsReplayModeOn() const { return replayMode; }
 
@@ -169,7 +169,7 @@ public:
     /// Spiel pausiert?
     bool IsPaused() const { return framesinfo.isPaused; }
     /// Schreibt Header der Save-Datei
-    bool SaveToFile(const std::string& filename);
+    bool SaveToFile(const boost::filesystem::path& filepath);
     /// Visuelle Einstellungen aus den richtigen ableiten
     void ResetVisualSettings();
     void SystemChat(const std::string& text) override;

--- a/libs/s25main/network/GameServer.h
+++ b/libs/s25main/network/GameServer.h
@@ -51,7 +51,7 @@ public:
     ~GameServer();
 
     /// Starts the server
-    bool Start(const CreateServerInfo& csi, const std::string& map_path, MapType map_type, const std::string& hostPw);
+    bool Start(const CreateServerInfo& csi, const boost::filesystem::path& map_path, MapType map_type, const std::string& hostPw);
 
     void Run();
 
@@ -129,8 +129,8 @@ private:
     void ExecuteNWF();
 
     bool CheckForAsync();
-    std::string SaveAsyncLog();
-    void SendAsyncLog(const std::string& asyncLogFilePath);
+    boost::filesystem::path SaveAsyncLog();
+    void SendAsyncLog(const boost::filesystem::path& asyncLogFilePath);
 
     void CheckAndKickLaggingPlayers();
     bool CheckForLaggingPlayers();

--- a/libs/s25main/ogl/saveBitmap.cpp
+++ b/libs/s25main/ogl/saveBitmap.cpp
@@ -28,6 +28,6 @@ void saveBitmap(const libsiedler2::PixelBufferBGRA& buffer, const boost::filesys
     bmp->create(buffer);
     libsiedler2::Archiv archive;
     archive.push(std::move(bmp));
-    if(int ec = libsiedler2::Write(path.string(), archive))
+    if(int ec = libsiedler2::Write(path, archive))
         throw std::runtime_error(libsiedler2::getErrorString(ec));
 }

--- a/libs/s25main/random/Random.cpp
+++ b/libs/s25main/random/Random.cpp
@@ -113,10 +113,10 @@ std::vector<typename Random<T_PRNG>::RandomEntry> Random<T_PRNG>::GetAsyncLog()
 }
 
 template<class T_PRNG>
-void Random<T_PRNG>::SaveLog(const std::string& filename)
+void Random<T_PRNG>::SaveLog(const boost::filesystem::path& filepath)
 {
     const std::vector<RandomEntry> log = GetAsyncLog();
-    boost::nowide::ofstream file(filename);
+    boost::nowide::ofstream file(filepath);
 
     for(const auto& curLog : log)
         file << curLog << std::endl;
@@ -161,7 +161,7 @@ int Random<T_PRNG>::RandomEntry::GetValue() const
 template<class T_PRNG>
 std::ostream& Random<T_PRNG>::RandomEntry::print(std::ostream& os) const
 {
-    static const std::string rttrSrcBaseName = std::string(RttrConfig::GetSourceDir().generic_string()) + "/";
+    static const std::string rttrSrcBaseName = RttrConfig::GetSourceDir().generic_string() + "/";
     std::string strippedSrcFile = boost::filesystem::path(src_name).generic_string();
     if(strippedSrcFile.find(rttrSrcBaseName) == 0)
         strippedSrcFile = strippedSrcFile.substr(rttrSrcBaseName.size());

--- a/libs/s25main/random/Random.h
+++ b/libs/s25main/random/Random.h
@@ -23,6 +23,7 @@
 #include "RTTR_Assert.h"
 #include "random/XorShift.h"
 #include "s25util/Singleton.h"
+#include <boost/filesystem/path.hpp>
 #include <array>
 #include <cstddef>
 #include <iosfwd>
@@ -87,7 +88,7 @@ public:
     std::vector<RandomEntry> GetAsyncLog();
 
     /// Save the log to a file
-    void SaveLog(const std::string& filename);
+    void SaveLog(const boost::filesystem::path& filepath);
 
 private:
     PRNG rng_; /// the PRNG

--- a/libs/s25main/world/GameWorld.cpp
+++ b/libs/s25main/world/GameWorld.cpp
@@ -32,8 +32,8 @@ GameWorld::GameWorld(const std::vector<PlayerInfo>& playerInfos, const GlobalGam
 {}
 
 /// Lädt eine Karte
-bool GameWorld::LoadMap(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, const std::string& mapFilePath,
-                        const std::string& luaFilePath)
+bool GameWorld::LoadMap(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, const boost::filesystem::path& mapFilePath,
+                        const boost::filesystem::path& luaFilePath)
 {
     // Map laden
     libsiedler2::Archiv mapArchiv;

--- a/libs/s25main/world/GameWorld.h
+++ b/libs/s25main/world/GameWorld.h
@@ -19,6 +19,7 @@
 #define GameWorld_h__
 
 #include "world/GameWorldGame.h"
+#include <boost/filesystem/path.hpp>
 #include <memory>
 #include <string>
 
@@ -32,8 +33,8 @@ public:
     GameWorld(const std::vector<PlayerInfo>& playerInfos, const GlobalGameSettings& gameSettings, EventManager& em);
 
     /// Lädt eine Karte
-    bool LoadMap(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, const std::string& mapFilePath,
-                 const std::string& luaFilePath);
+    bool LoadMap(const std::shared_ptr<Game>& game, ILocalGameState& localgameState, const boost::filesystem::path& mapFilePath,
+                 const boost::filesystem::path& luaFilePath);
 
     /// Serialisiert den gesamten GameWorld
     void Serialize(SerializedGameData& sgd) const;

--- a/tests/libGameData/testGameData.cpp
+++ b/tests/libGameData/testGameData.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(DetectRecursion)
         file2 << "include(\"default.lua\")\n";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get().string());
+    GameDataLoader loader(desc, tmp.get());
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("Maximum include depth", false);
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(DetectInvalidFilenames)
         file << "include(\"foo(=.lua\")\n";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get().string());
+    GameDataLoader loader(desc, tmp.get());
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("disallowed chars", false);
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(DetectNonexistingFile)
         file << "include(\"foo.lua\")\n";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get().string());
+    GameDataLoader loader(desc, tmp.get());
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("File not found", false);
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(DetectWrongExtension)
         bnw::ofstream file2(tmp.get() / "foo.txt");
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get().string());
+    GameDataLoader loader(desc, tmp.get());
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("File must have .lua as the extension", false);
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(DetectFolderEscape)
         bnw::ofstream file2(tmp.get() / "foo.lua");
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, basePath.string());
+    GameDataLoader loader(desc, basePath);
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("outside the lua data directory", false);
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(DetectAbsolute)
         file << "include(\"/tmp/foo.lua\")\n";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, basePath.string());
+    GameDataLoader loader(desc, basePath);
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("relative", false);
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(TextureCoords)
             pos = { 10, 20, 32, 31 }, texType = \"rotated\" }";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get().string());
+    GameDataLoader loader(desc, tmp.get());
     BOOST_REQUIRE(loader.Load());
     using PointF = TerrainDesc::PointF;
     // Border points are inset by half a pixel for OpenGL (sample middle of pixel!)

--- a/tests/s25Main/IO/testLoader.cpp
+++ b/tests/s25Main/IO/testLoader.cpp
@@ -80,14 +80,14 @@ static boost::test_tools::predicate_result compareTxts(const libsiedler2::Archiv
     return true;
 }
 
-const std::string mainFile = RTTR_BASE_DIR "/tests/testData/test.GER";
-const std::string overrideFolder1 = RTTR_BASE_DIR "/tests/testData/override1";
-const std::string overrideFolder2 = RTTR_BASE_DIR "/tests/testData/override2";
-const std::string overrideFolder3 = RTTR_BASE_DIR "/tests/testData/override3";
+const bfs::path mainFile = rttr::test::rttrBaseDir / "tests/testData/test.GER";
+const bfs::path overrideFolder1 = rttr::test::rttrBaseDir / "tests/testData/override1";
+const bfs::path overrideFolder2 = rttr::test::rttrBaseDir / "tests/testData/override2";
+const bfs::path overrideFolder3 = rttr::test::rttrBaseDir / "tests/testData/override3";
 
 BOOST_FIXTURE_TEST_CASE(TestPredicate, LoaderFixture)
 {
-    BOOST_REQUIRE(loader->Load(overrideFolder1 + "/test.GER"));
+    BOOST_REQUIRE(loader->Load(overrideFolder1 / "test.GER"));
     const auto& txt = loader->GetArchive("test");
     BOOST_REQUIRE(compareTxts(txt, "1||20"));
     BOOST_TEST(compareTxts(txt, "1|").message().str() == "Item count mismatch [3 != 2]");
@@ -154,8 +154,8 @@ BOOST_FIXTURE_TEST_CASE(BobOverrides, LoaderFixture)
     bmpRaw->create(buffer);
     libsiedler2::Archiv bmp;
     bmp.push(std::move(bmpRaw));
-    BOOST_TEST_REQUIRE(libsiedler2::Write((bobFile / "0.bmp").string(), bmp) == 0);
-    BOOST_TEST_REQUIRE(libsiedler2::Write((bobFile / "1.bmp").string(), bmp) == 0);
+    BOOST_TEST_REQUIRE(libsiedler2::Write((bobFile / "0.bmp"), bmp) == 0);
+    BOOST_TEST_REQUIRE(libsiedler2::Write((bobFile / "1.bmp"), bmp) == 0);
 
     libsiedler2::ArchivItem_Text txt;
     txt.setText("10 332\n11 334\n"); // mapping file

--- a/tests/s25Main/audio/testSounds.cpp
+++ b/tests/s25Main/audio/testSounds.cpp
@@ -28,6 +28,8 @@
 #include "s25util/warningSuppression.h"
 #include <boost/test/unit_test.hpp>
 
+namespace bfs = boost::filesystem;
+
 BOOST_TEST_DONT_PRINT_LOG_VALUE(EffectPlayId)
 // Doesn't fully work until Boost 1.69
 // BOOST_TEST_DONT_PRINT_LOG_VALUE(SoundHandle)
@@ -134,7 +136,7 @@ BOOST_FIXTURE_TEST_CASE(PlayFromFile, LoadMockupAudio)
 {
     {
         libsiedler2::Archiv snd;
-        BOOST_TEST_REQUIRE(libsiedler2::Load(RTTR_LIBSIEDLER2_TEST_FILES_DIR "/testMono.wav", snd) == 0);
+        BOOST_TEST_REQUIRE(libsiedler2::Load(rttr::test::libsiedler2TestFilesDir / "testMono.wav", snd) == 0);
         auto* effect = dynamic_cast<SoundEffectItem*>(snd[0]);
         BOOST_TEST_REQUIRE(effect);
 
@@ -165,13 +167,13 @@ BOOST_FIXTURE_TEST_CASE(PlayFromFile, LoadMockupAudio)
     BOOST_TEST_REQUIRE(MockupSoundData::numAlive == 0);
 
     // Same for different music types
-    for(const std::string musicFile : {"/test.ogg", "/testMidi.mid", "/testXMidi.xmi"})
+    for(const bfs::path musicFile : {"test.ogg", "testMidi.mid", "testXMidi.xmi"})
     {
         mock::sequence s;
         // All midi types are treated as .midi
-        const auto extension = (boost::filesystem::path(musicFile).extension() == ".ogg") ? ".ogg" : ".midi";
+        const auto extension = (musicFile.extension() == ".ogg") ? ".ogg" : ".midi";
         libsiedler2::Archiv musicArchiv;
-        BOOST_TEST_REQUIRE(libsiedler2::Load(RTTR_LIBSIEDLER2_TEST_FILES_DIR + musicFile, musicArchiv) == 0);
+        BOOST_TEST_REQUIRE(libsiedler2::Load(rttr::test::libsiedler2TestFilesDir / musicFile, musicArchiv) == 0);
         auto* music = dynamic_cast<MusicItem*>(musicArchiv[0]);
         BOOST_TEST_REQUIRE(music);
 

--- a/tests/s25Main/integration/testWorld.cpp
+++ b/tests/s25Main/integration/testWorld.cpp
@@ -30,13 +30,14 @@
 #include "nodeObjs/noBase.h"
 #include "libsiedler2/ArchivItem_Map_Header.h"
 #include "s25util/tmpFile.h"
+#include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>
 #include <vector>
 
 struct MapTestFixture
 {
-    const std::string testMapPath;
-    MapTestFixture() : testMapPath(RTTRCONFIG.ExpandPath(s25::folders::mapsRttr) + "/Bergruft.swd") {}
+    const boost::filesystem::path testMapPath;
+    MapTestFixture() : testMapPath(RTTRCONFIG.ExpandPath(s25::folders::mapsRttr) / "Bergruft.swd") {}
 };
 
 BOOST_FIXTURE_TEST_SUITE(MapTestSuite, MapTestFixture)
@@ -72,7 +73,7 @@ struct LoadWorldFromFileCreator : MapTestFixture
     {
         bnw::ifstream mapFile(testMapPath, std::ios::binary);
         if(map.load(mapFile, false) != 0)
-            throw std::runtime_error("Could not load file " + testMapPath); // LCOV_EXCL_LINE
+            throw std::runtime_error("Could not load file " + testMapPath.string()); // LCOV_EXCL_LINE
         MapLoader loader(world);
         if(!loader.Load(map, EXP_FOGOFWAR))
             throw std::runtime_error("Could not load map"); // LCOV_EXCL_LINE

--- a/tests/s25Main/locale/testLocalization.cpp
+++ b/tests/s25Main/locale/testLocalization.cpp
@@ -32,7 +32,7 @@ struct LocaleFixture
     {
         rttr::test::LogAccessor logAcc;
         LANGUAGES.setLanguage("en");
-        LOADER.Load(RTTRCONFIG.ExpandPath(s25::folders::lstsGlobal) + "/languages.ini", nullptr, true);
+        LOADER.Load(RTTRCONFIG.ExpandPath(s25::folders::lstsGlobal) / "languages.ini", nullptr, true);
         RTTR_REQUIRE_LOG_CONTAINS("Loading", true);
     }
     std::vector<std::string> getLanguageCodes()

--- a/tests/s25Main/testConfig.h.cmake
+++ b/tests/s25Main/testConfig.h.cmake
@@ -1,9 +1,19 @@
 #ifndef TESTCONFIG_H_INCLUDED
 #define TESTCONFIG_H_INCLUDED
 
+#include <boost/filesystem/path.hpp>
+
 /// Base directory with the sources
 #cmakedefine RTTR_BASE_DIR "@RTTR_BASE_DIR@"
 /// Path to libsiedler2 test files
 #cmakedefine RTTR_LIBSIEDLER2_TEST_FILES_DIR "@RTTR_LIBSIEDLER2_TEST_FILES_DIR@"
+namespace rttr
+{
+namespace test
+{
+  const boost::filesystem::path rttrBaseDir = RTTR_BASE_DIR;
+  const boost::filesystem::path libsiedler2TestFilesDir = RTTR_LIBSIEDLER2_TEST_FILES_DIR;
+}
+}
 
 #endif // !TESTCONFIG_H_INCLUDED

--- a/tests/testHelpers/rttr/test/Fixture.cpp
+++ b/tests/testHelpers/rttr/test/Fixture.cpp
@@ -27,7 +27,7 @@ rttr::test::Fixture::Fixture()
     if(!RTTRCONFIG.Init())
         throw std::runtime_error("Could not init working directory. Misplaced binary?");
     if(!bfs::is_directory(RTTRCONFIG.ExpandPath("<RTTR_RTTR>")))
-        throw std::runtime_error(RTTRCONFIG.ExpandPath("<RTTR_RTTR>") + " not found. Binary misplaced or RTTR folder not copied?");
+        throw std::runtime_error(RTTRCONFIG.ExpandPath("<RTTR_RTTR>").string() + " not found. Binary misplaced or RTTR folder not copied?");
 }
 
 rttr::test::Fixture::~Fixture() = default;


### PR DESCRIPTION
ExpandPath should return a bfs::path to distinguish it from an unresolved path.
This requires (or is made easier) by changing the API of functions taking or returning paths to also use bfs::path

I also fixed that in the submodules which made it possible to remove quite a few conversions between path and string as well as simplify the concatenation of paths.

Note: I'm basing my work on #1247 on this.