### PR TITLE
[CI] Set $USER on Jenkins

### DIFF
--- a/tools/ci/jenkins/build.sh
+++ b/tools/ci/jenkins/build.sh
@@ -32,6 +32,9 @@ architecture="%architecture%"
 src_dir=/source
 result_dir=/result
 
+# Required by the tests
+export USER="${USER:-TestUser}'"
+
 TOOLCHAIN_FILE=
 if [ "$(uname -s | tr "[:upper:]" "[:lower:]").$(uname -m)" != "$architecture" ] ; then
     TOOLCHAIN_FILE=$src_dir/cmake/toolchains/c.$architecture.cmake


### PR DESCRIPTION
Without mapping /etc/passwd too changing the docker user (done by Jenkins) doesn't pass in the remaining information (name, shell, ...)
The tests require $USER to be set, so do that manually in case it isn't set