### PR TITLE
Introduce new "smart" range-based team building options

### DIFF
--- a/libs/s25main/desktops/dskHostGame.cpp
+++ b/libs/s25main/desktops/dskHostGame.cpp
@@ -543,9 +543,9 @@ void dskHostGame::Msg_Group_ButtonClick(const unsigned group_id, const unsigned 
             if(playerId == localPlayerId_ || gameLobby->isHost())
             {
                 JoinPlayerInfo& player = gameLobby->getPlayer(playerId);
-                if(player.team >= TM_TEAM1 && player.team < Team(NUM_TEAMS)) // team: 1->2->3->4->0 //-V807
+                if(player.team >= TM_TEAM1 && player.team < Team(NUM_TEAM_OPTIONS)) // team: 1->2->3->4->0 //-V807
                 {
-                    player.team = Team((player.team + 1) % NUM_TEAMS);
+                    player.team = Team((player.team + 1) % NUM_TEAM_OPTIONS);
                 } else
                 {
                     if(player.team == TM_NOTEAM) // 0(noteam)->randomteam(1-4)
@@ -843,7 +843,7 @@ void dskHostGame::UpdateGGS()
 
 void dskHostGame::ChangeTeam(const unsigned i, const unsigned char nr)
 {
-    const std::array<std::string, 9> teams = {"-", "?", "1", "2", "3", "4", "?", "?", "?"};
+    const std::array<std::string, 12> teams = {"-", "?", "1", "2", "3", "4", "1-2", "1-3", "1-4", "?", "?", "?"};
 
     GetCtrl<ctrlGroup>(ID_PLAYER_GROUP_START + i)->GetCtrl<ctrlBaseText>(5)->SetText(teams[nr]);
 }

--- a/libs/s25main/gameTypes/TeamTypes.h
+++ b/libs/s25main/gameTypes/TeamTypes.h
@@ -25,10 +25,16 @@ enum Team
     TM_TEAM2,
     TM_TEAM3,
     TM_TEAM4,
+    TM_TEAM_1_TO_2, // Insert "smart" into teams 1 or 2
+    TM_TEAM_1_TO_3, // Insert "smart" into teams 1 or 2 or 3
+    TM_TEAM_1_TO_4, // Insert "smart" into teams 1 or 2 or 3 or 4
     TM_RANDOMTEAM2,
     TM_RANDOMTEAM3,
     TM_RANDOMTEAM4
 };
 
 /// Anzahl der Team-Optionen
-const unsigned NUM_TEAMS = 6; // teamrandom2,3,4 dont count
+const unsigned NUM_TEAM_OPTIONS = 9; // teamrandom2,3,4 dont count
+
+/// Number of playable teams.
+const unsigned NUM_TEAMS = 4;

--- a/libs/s25main/lua/LuaServerPlayer.cpp
+++ b/libs/s25main/lua/LuaServerPlayer.cpp
@@ -53,7 +53,7 @@ void LuaServerPlayer::SetNation(Nation nat)
 
 void LuaServerPlayer::SetTeam(Team team)
 {
-    lua::assertTrue(unsigned(team) < NUM_TEAMS, "Invalid team");
+    lua::assertTrue(unsigned(team) < NUM_TEAM_OPTIONS, "Invalid team");
     player.team = team;
     lobbyServerController_.SetTeam(playerId, team);
 }

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -21,6 +21,7 @@
 #include "GameMessage_GameCommand.h"
 #include "GameServerPlayer.h"
 #include "GlobalGameSettings.h"
+#include "JoinPlayerInfo.h"
 #include "RTTR_Version.h"
 #include "RttrConfig.h"
 #include "Savegame.h"
@@ -31,7 +32,9 @@
 #include "network/CreateServerInfo.h"
 #include "network/GameMessages.h"
 #include "ogl/glArchivItem_Map.h"
+#include "random/Random.h"
 #include "gameTypes/LanGameInfo.h"
+#include "gameTypes/TeamTypes.h"
 #include "gameData/GameConsts.h"
 #include "gameData/LanDiscoveryCfg.h"
 #include "liblobby/LobbyClient.h"
@@ -46,6 +49,7 @@
 #include <cmath>
 #include <helpers/chronoIO.h>
 #include <iomanip>
+#include <iterator>
 #include <mygettext/mygettext.h>
 
 inline std::ostream& operator<<(std::ostream& os, const AsyncChecksum& checksum)
@@ -430,12 +434,109 @@ void GameServer::Stop()
     LOG.write("server state changed to stop\n");
 }
 
+// Check if there are players that have not been assigned a team but only a
+// range. Those players are assigned a team now while we try to balanace the
+// number of players per team. Returns true iff players have been assigned.
+bool GameServer::assignPlayersOfRandomTeams(std::vector<JoinPlayerInfo>& playerInfos)
+{
+    static_assert(NUM_TEAMS == 4, "Expected exactly 4 playable teams!");
+
+    std::set<unsigned> potentialPlayers[NUM_TEAMS];
+    unsigned nPlayers[NUM_TEAMS] = {0};
+    unsigned unassignedPlayers = 0;
+
+    // First collect fixed players and potential ones.
+    for(unsigned player = 0; player < playerInfos.size(); ++player)
+    {
+        JoinPlayerInfo& playerInfo = playerInfos[player];
+        switch(playerInfo.team)
+        {
+            case TM_RANDOMTEAM:
+            case TM_TEAM1: ++nPlayers[0]; break;
+            case TM_RANDOMTEAM2:
+            case TM_TEAM2: ++nPlayers[1]; break;
+            case TM_RANDOMTEAM3:
+            case TM_TEAM3: ++nPlayers[2]; break;
+            case TM_RANDOMTEAM4:
+            case TM_TEAM4: ++nPlayers[3]; break;
+            case TM_TEAM_1_TO_2:
+                ++unassignedPlayers;
+                potentialPlayers[0].insert(player);
+                potentialPlayers[1].insert(player);
+                break;
+            case TM_TEAM_1_TO_3:
+                ++unassignedPlayers;
+                potentialPlayers[0].insert(player);
+                potentialPlayers[1].insert(player);
+                potentialPlayers[2].insert(player);
+                break;
+            case TM_TEAM_1_TO_4:
+                ++unassignedPlayers;
+                potentialPlayers[0].insert(player);
+                potentialPlayers[1].insert(player);
+                potentialPlayers[2].insert(player);
+                potentialPlayers[3].insert(player);
+                break;
+            case TM_NOTEAM: break;
+        }
+    }
+    // Check for unassigned players first.
+    if(unassignedPlayers == 0)
+        return false;
+
+    while(unassignedPlayers)
+    {
+        // Set of potential teams for the next player.
+        std::vector<int> teamsForNextPlayer;
+
+        // Determine the minimal team size for teams that can take an unassigned player.
+        unsigned minNextTeamSize = std::numeric_limits<unsigned>::max();
+        for(unsigned team = 0; team < NUM_TEAMS; ++team)
+        {
+            // Check if we can add a player to this team at all.
+            if(!potentialPlayers[team].empty())
+                minNextTeamSize = std::min(minNextTeamSize, nPlayers[team]);
+        }
+
+        for(unsigned team = 0; team < NUM_TEAMS; ++team)
+        {
+            // Check if we can add a player to this team at all.
+            if(potentialPlayers[team].empty())
+                continue;
+            // Check if this is a team with the minimal number of players amongst teams that can have unassigned ones.
+            if(nPlayers[team] <= minNextTeamSize)
+                teamsForNextPlayer.push_back(team);
+        }
+
+        RTTR_Assert_Msg(!teamsForNextPlayer.empty(), "Expected to have teams with potential players!");
+        int nextTeam = teamsForNextPlayer[rand() % teamsForNextPlayer.size()];
+        RTTR_Assert_Msg(!potentialPlayers[nextTeam].empty(), "Expected next team to have potential players!");
+
+        // Pick a random player that can go into this team.
+        int nextPlayer = *getRandomElement(potentialPlayers[nextTeam]);
+
+        // The player is now assigned and the team size increased.
+        for(auto& PotentialPlayer : potentialPlayers)
+            PotentialPlayer.erase(nextPlayer);
+        ++nPlayers[nextTeam];
+
+        playerInfos[nextPlayer].team = Team(TM_TEAM1 + nextTeam);
+        --unassignedPlayers;
+    }
+
+    return true;
+}
+
 /**
  *  startet das Spiel.
  */
 bool GameServer::StartGame()
 {
     lanAnnouncer.Stop();
+
+    // Finalize the team selection for unassigned players.
+    if(assignPlayersOfRandomTeams(playerInfos))
+        SendToAll(GameMessage_Player_List(playerInfos));
 
     // Bei Savegames wird der Startwert von den Clients aus der Datei gelesen!
     unsigned random_init;

--- a/libs/s25main/network/GameServer.h
+++ b/libs/s25main/network/GameServer.h
@@ -62,6 +62,9 @@ public:
 
     void Stop();
 
+    /// Assign players that do not have a fixed team, return true if any player was assigned.
+    static bool assignPlayersOfRandomTeams(std::vector<JoinPlayerInfo>& playerInfos);
+
 private:
     bool StartGame();
 

--- a/libs/s25main/random/Random.h
+++ b/libs/s25main/random/Random.h
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <iosfwd>
 #include <limits>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -139,3 +140,45 @@ public:
 
 /// Shortcut for creating an instance of RandomFunctor
 #define RANDOM_SHUFFLE(container) RandomFunctor::shuffleContainer(container, __FILE__, __LINE__)
+
+/// Return a random number in the interval [lowerBound, upperBound].
+template<typename RandomT>
+static unsigned getRandomNumber(const RandomT& rng, unsigned lowerBound, unsigned upperBound)
+{
+    std::uniform_int_distribution<typename RandomT::result_type> dist(lowerBound, upperBound);
+    return dist(rng);
+}
+
+/// Return a random number in the interval [0, upperBound).
+template<typename RandomT>
+static unsigned getRandomNumber(const RandomT& rng, unsigned upperBound)
+{
+    RTTR_Assert(upperBound > 0);
+    return getRandomNumber(rng, 0, upperBound - 1);
+}
+
+/// Return a random number in the interval [0, upperBound).
+static unsigned getRandomNumber(unsigned upperBound)
+{
+    std::mt19937 rng;
+    std::random_device rnd_dev;
+    rng.seed(rnd_dev());
+    RTTR_Assert(upperBound > 0);
+    return getRandomNumber(rng, upperBound);
+}
+
+/// Return an iterator to a random element of \p container. If \p isEnd is nonnull, set it to true if the returned
+/// iterator is the "end" iterator and false otherwise.
+template<typename ContainerT>
+static typename ContainerT::iterator getRandomElement(ContainerT& container, bool* isEnd = nullptr)
+{
+    unsigned size = container.size();
+    bool empty = size == 0;
+    if(isEnd)
+        *isEnd = empty;
+    if(empty)
+        return container.end();
+    auto it = container.begin();
+    std::advance(it, getRandomNumber(size));
+    return it;
+}

--- a/tests/s25Main/integration/testGameServerJointPlayerDistribution.cpp
+++ b/tests/s25Main/integration/testGameServerJointPlayerDistribution.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2016 - 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "BasePlayerInfo.h"
+#include "JoinPlayerInfo.h"
+#include "network/GameServer.h"
+#include "gameTypes/TeamTypes.h"
+#include <boost/test/unit_test.hpp>
+
+static unsigned getMaxTeamSizeDifference(std::vector<JoinPlayerInfo>& playerInfos, unsigned nTeams)
+{
+    unsigned nPlayers[4] = {0, 0, 0, 0};
+    for(auto& playerInfo : playerInfos)
+    {
+        switch(playerInfo.team)
+        {
+            case TM_RANDOMTEAM:
+            case TM_TEAM1: ++nPlayers[0]; break;
+            case TM_RANDOMTEAM2:
+            case TM_TEAM2: ++nPlayers[1]; break;
+            case TM_RANDOMTEAM3:
+            case TM_TEAM3: ++nPlayers[2]; break;
+            case TM_RANDOMTEAM4:
+            case TM_TEAM4: ++nPlayers[3]; break;
+            default: return -1;
+        };
+    }
+
+    std::sort(&nPlayers[0], &nPlayers[nTeams]);
+    BOOST_TEST_REQUIRE(nPlayers[0] <= nPlayers[nTeams - 1]);
+    return nPlayers[nTeams - 1] - nPlayers[0];
+}
+
+BOOST_AUTO_TEST_CASE(JoinPlayerAssignment)
+{
+    BasePlayerInfo BPI1, BPI2, BPI3, BPI4, BPI1_2, BPI1_3, BPI1_4, BPIRT1, BPIRT2, BPIRT3, BPIRT4;
+    BPI1.team = TM_TEAM1;
+    BPI2.team = TM_TEAM2;
+    BPI3.team = TM_TEAM3;
+    BPI4.team = TM_TEAM4;
+    BPIRT1.team = TM_RANDOMTEAM;
+    BPIRT2.team = TM_RANDOMTEAM2;
+    BPIRT3.team = TM_RANDOMTEAM3;
+    BPIRT4.team = TM_RANDOMTEAM4;
+    BPI1_2.team = TM_TEAM_1_TO_2;
+    BPI1_3.team = TM_TEAM_1_TO_3;
+    BPI1_4.team = TM_TEAM_1_TO_4;
+
+    std::vector<JoinPlayerInfo> playerInfos;
+
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1));
+    playerInfos.push_back(JoinPlayerInfo(BPIRT2));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    BOOST_REQUIRE(GameServer::assignPlayersOfRandomTeams(playerInfos));
+    BOOST_TEST(2u >= getMaxTeamSizeDifference(playerInfos, 4));
+
+    playerInfos.clear();
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1));
+    playerInfos.push_back(JoinPlayerInfo(BPIRT2));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    BOOST_REQUIRE(GameServer::assignPlayersOfRandomTeams(playerInfos));
+    BOOST_TEST(0u == getMaxTeamSizeDifference(playerInfos, 4));
+
+    playerInfos.clear();
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    playerInfos.push_back(JoinPlayerInfo(BPI1));
+    playerInfos.push_back(JoinPlayerInfo(BPIRT2));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    BOOST_REQUIRE(GameServer::assignPlayersOfRandomTeams(playerInfos));
+    BOOST_TEST(1u == getMaxTeamSizeDifference(playerInfos, 3));
+
+    playerInfos.clear();
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    BOOST_REQUIRE(GameServer::assignPlayersOfRandomTeams(playerInfos));
+    BOOST_TEST(0u == getMaxTeamSizeDifference(playerInfos, 4));
+
+    playerInfos.clear();
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_4));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_3));
+    BOOST_REQUIRE(GameServer::assignPlayersOfRandomTeams(playerInfos));
+    BOOST_TEST(2u >= getMaxTeamSizeDifference(playerInfos, 4));
+
+    playerInfos.clear();
+    playerInfos.push_back(JoinPlayerInfo(BPI3));
+    playerInfos.push_back(JoinPlayerInfo(BPI3));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_2));
+    playerInfos.push_back(JoinPlayerInfo(BPI1_2));
+    playerInfos.push_back(JoinPlayerInfo(BPIRT1));
+    playerInfos.push_back(JoinPlayerInfo(BPIRT1));
+    BOOST_REQUIRE(GameServer::assignPlayersOfRandomTeams(playerInfos));
+    BOOST_TEST(0u == getMaxTeamSizeDifference(playerInfos, 3));
+
+    playerInfos.clear();
+    playerInfos.push_back(JoinPlayerInfo(BPI3));
+    playerInfos.push_back(JoinPlayerInfo(BPI3));
+    playerInfos.push_back(JoinPlayerInfo(BPIRT1));
+    playerInfos.push_back(JoinPlayerInfo(BPIRT1));
+    BOOST_REQUIRE(!GameServer::assignPlayersOfRandomTeams(playerInfos));
+    BOOST_TEST(2u == getMaxTeamSizeDifference(playerInfos, 3));
+}


### PR DESCRIPTION
The old team building options where either fixed (1,2,3,4) or purely
random (?). The new options (1-2,1-3,1-4) allow players to be placed
in ranges of teams while they also ensure team sizes to be as even as
possible. That is, a player with the team `1-3` is placed in team 1,
2, or 3 in a way that minimizes the absolute difference in team size.