### PR TITLE
Fix a click through bug for combobox lists in addon window

### DIFF
--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -179,9 +179,7 @@ void Window::LockRegion(Window* window, const Rect& rect)
 
     // Also lock the region for all parents
     if(GetParent())
-    {
         GetParent()->LockRegion(this, rect);
-    }
 }
 
 /**
@@ -199,9 +197,7 @@ void Window::FreeRegion(Window* window)
 
     // Also free the locked region for all parents
     if(GetParent())
-    {
         GetParent()->FreeRegion(this);
-    }
 }
 
 void Window::SetPos(const DrawPoint& newPos)

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -176,6 +176,12 @@ void Window::LockRegion(Window* window, const Rect& rect)
     auto it = std::find(tofreeAreas_.begin(), tofreeAreas_.end(), window);
     if(it != tofreeAreas_.end())
         tofreeAreas_.erase(it);
+
+    // Also lock the region for all parents
+    if(GetParent())
+    {
+        GetParent()->LockRegion(this, rect);
+    }
 }
 
 /**
@@ -190,6 +196,12 @@ void Window::FreeRegion(Window* window)
         tofreeAreas_.push_back(window);
     else
         lockedAreas_.erase(window);
+
+    // Also free the locked region for all parents
+    if(GetParent())
+    {
+        GetParent()->FreeRegion(this);
+    }
 }
 
 void Window::SetPos(const DrawPoint& newPos)


### PR DESCRIPTION
As the title says, the addon options window has a bug where you can click through a combo box list item and also select the option below. This commit fixes this by not only locking the list region for the parent of the list, but recursively for all parents.