### PR TITLE
Fix client-side time synchronisation for simple cases

### DIFF
--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1299,10 +1299,16 @@ void GameClient::ExecuteGameFrame()
         // TODO: Run multiple GFs per call.
         // For now just make sure it is less than gf_length by skipping some simulation time,
         // until we are only a bit less than 1 GF behind
+        // However we allow the simulation to lack behind for a few frames, so if there was a single spike we can still
+        // catch up in the next visual frames
         using DurationType = decltype(framesinfo.gf_length);
+        constexpr auto maxLackFrames = 5;
+
         RTTR_Assert(framesinfo.gf_length > DurationType::zero());
         const auto maxFrameTime = framesinfo.gf_length - DurationType(1);
-        framesinfo.lastTime += framesinfo.frameTime - maxFrameTime;
+
+        if(framesinfo.frameTime > maxLackFrames * framesinfo.gf_length)
+            framesinfo.lastTime += framesinfo.frameTime - maxFrameTime; // Skip simulation time until caught up
         framesinfo.frameTime = maxFrameTime;
     }
     // This is assumed by drawing code for interpolation


### PR DESCRIPTION
Most simple implementation to avoid #1319 where actual simulation time will be lower than real time due to incrementing it essentially in chunks (similar to/of) VSync time.
This works for cases where the GF length is larger than the execution time for 1 GF + drawing and related.

This is only intermediate until we implement something better, see #1319, but improves the situation already. Similar to https://github.com/JonathanSteinbuch/s25client/commit/536a64fb9f83d55f1a4e5f0ce66ef052b3bbf5c1