### PR TITLE
Refactor credits window and timer control

### DIFF
--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -382,7 +382,7 @@ ctrlTable* Window::AddTable(unsigned id, const DrawPoint& pos, const Extent& siz
 
 ctrlTimer* Window::AddTimer(unsigned id, unsigned timeout)
 {
-    return AddCtrl(new ctrlTimer(this, id, timeout));
+    return AddCtrl(new ctrlTimer(this, id, std::chrono::milliseconds(timeout)));
 }
 
 /**

--- a/libs/s25main/controls/ctrlTimer.cpp
+++ b/libs/s25main/controls/ctrlTimer.cpp
@@ -19,57 +19,42 @@
 
 #include "drivers/VideoDriverWrapper.h"
 
-/** @var ctrlTimer::timer
- *
- *  Der Timer zum Abgleichen der Zeit.
- */
+ctrlTimer::ctrlTimer(Window* parent, unsigned id, std::chrono::milliseconds timeout)
+    : Window(parent, id, DrawPoint(0, 0)), timeout_(timeout), timer_(true)
+{}
 
-/** @var ctrlTimer::timeout
- *
- *  Die Zeit nach der der Timer zünden soll.
+/**
+ *  start the timer
  */
-
-ctrlTimer::ctrlTimer(Window* parent, unsigned id, unsigned timeout) : Window(parent, id, DrawPoint(0, 0))
+void ctrlTimer::Start(std::chrono::milliseconds timeout)
 {
-    Start(timeout);
+    timeout_ = timeout;
+    Start();
+}
+
+void ctrlTimer::Start()
+{
+    timer_.restart();
 }
 
 /**
- *  startet den Timer.
- */
-void ctrlTimer::Start(unsigned timeout)
-{
-    this->timeout_ = timeout;
-
-    // timer initialisieren
-    timer = VIDEODRIVER.GetTickCount();
-}
-
-/**
- *  stoppt den Timer
+ *  stop the timer
  */
 void ctrlTimer::Stop()
 {
-    timer = 0;
+    timer_.stop();
 }
 
 void ctrlTimer::Msg_PaintBefore()
 {
     Window::Msg_PaintBefore();
-    // timer ist deaktiviert, nix tun
-    if(timer == 0)
+
+    if(!timer_.isRunning())
         return;
 
-    // Bei Timeout weiterschalten
-    if(VIDEODRIVER.GetTickCount() - timer > timeout_)
+    if(timer_.getElapsed() >= timeout_)
     {
+        timer_.restart(); // Do this first so parent can stop or change duration
         GetParent()->Msg_Timer(GetID());
-
-        if(timer != 0)
-        {
-            timer = VIDEODRIVER.GetTickCount();
-            if(timer == 0)
-                timer = 1;
-        }
     }
 }

--- a/libs/s25main/controls/ctrlTimer.h
+++ b/libs/s25main/controls/ctrlTimer.h
@@ -17,15 +17,19 @@
 
 #pragma once
 
+#include "Timer.h"
 #include "Window.h"
 
 class ctrlTimer : public Window
 {
 public:
-    ctrlTimer(Window* parent, unsigned id, unsigned timeout);
+    ctrlTimer(Window* parent, unsigned id, std::chrono::milliseconds timeout);
 
-    void Start(unsigned timeout);
+    void Start();
+    void Start(std::chrono::milliseconds timeout);
     void Stop();
+    bool isRunning() const { return timer_.isRunning(); }
+    Timer::duration getElapsed() const { return timer_.getElapsed(); }
 
     void Msg_PaintBefore() override;
 
@@ -33,6 +37,6 @@ protected:
     void Draw_() override{};
 
 private:
-    unsigned timeout_;
-    unsigned timer;
+    std::chrono::milliseconds timeout_;
+    Timer timer_;
 };

--- a/libs/s25main/desktops/dskCredits.cpp
+++ b/libs/s25main/desktops/dskCredits.cpp
@@ -294,8 +294,7 @@ dskCredits::dskCredits() : Desktop(LOADER.GetImageN("setup013", 0)), itCurEntry(
     for(unsigned i = 0; i < NUM_NATIVE_NATIONS; i++)
         nations[i] = Nation(i);
 
-    if(!LOADER.Load(ResourceId("credits"))
-       || !LOADER.LoadFilesAtGame(worldDesc.get(DescIdx<LandscapeDesc>(0)).mapGfxPath, false, nations, {}))
+    if(!LOADER.LoadFilesAtGame(worldDesc.get(DescIdx<LandscapeDesc>(0)).mapGfxPath, false, nations, {}))
     {
         WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Error"), _("Failed to load game resources"), this, MSB_OK,
                                                       MSB_EXCLAMATIONRED, 0));

--- a/libs/s25main/desktops/dskCredits.cpp
+++ b/libs/s25main/desktops/dskCredits.cpp
@@ -380,19 +380,19 @@ T randEnum()
 void dskCredits::DrawBobs()
 {
     using namespace std::chrono_literals;
-    auto bobSpawnIntervall = 200ms;
+    auto bobSpawnInterval = 200ms;
 
     if(VIDEODRIVER.GetFPS() < 30)
-        bobSpawnIntervall = 0ms;
+        bobSpawnInterval = 0ms;
     else if(VIDEODRIVER.GetFPS() < 60)
-        bobSpawnIntervall = 1s;
+        bobSpawnInterval = 1s;
     else if(VIDEODRIVER.GetFPS() < 200)
-        bobSpawnIntervall = 500ms;
+        bobSpawnInterval = 500ms;
 
     const auto maxNumBos = 50 + VIDEODRIVER.GetRenderSize().x / 2;
 
     // add new bob
-    if(bobSpawnIntervall != 0ms && bobSpawnTimer.getElapsed() >= bobSpawnIntervall && bobs.size() < maxNumBos)
+    if(bobSpawnInterval != 0ms && bobSpawnTimer.getElapsed() >= bobSpawnInterval && bobs.size() < maxNumBos)
     {
         bobSpawnTimer.restart();
 

--- a/libs/s25main/desktops/dskCredits.h
+++ b/libs/s25main/desktops/dskCredits.h
@@ -19,12 +19,12 @@
 
 #include "Desktop.h"
 #include "Timer.h"
-
 #include "libsiedler2/ImgDir.h"
 #include <utility>
 #include <vector>
 
 struct KeyEvent;
+class ctrlTimer;
 class glArchivItem_Bitmap;
 
 /// Klasse des Credits Desktops.
@@ -37,6 +37,7 @@ public:
     bool Msg_LeftUp(const MouseCoords& mc) override;
     bool Msg_RightUp(const MouseCoords& mc) override;
     bool Msg_KeyDown(const KeyEvent& ke) override;
+    void Msg_Timer(unsigned timerId) override;
     void Draw_() override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult) override;
@@ -89,7 +90,6 @@ private:
 
     std::vector<Bob> bobs;
 
-    Timer timer;
-    unsigned bobTime;
-    unsigned bobSpawnTime;
+    ctrlTimer* pageTimer;
+    Timer bobSpawnTimer;
 };

--- a/libs/s25main/desktops/dskGameLoader.cpp
+++ b/libs/s25main/desktops/dskGameLoader.cpp
@@ -80,7 +80,8 @@ void dskGameLoader::Msg_Timer(const unsigned /*ctrl_id*/)
 {
     auto* timer = GetCtrl<ctrlTimer>(1);
     auto* text = GetCtrl<ctrlText>(10 + position);
-    int interval = 50;
+    using namespace std::chrono_literals;
+    const auto interval = 50ms;
 
     timer->Stop();
 

--- a/libs/s25main/ingameWindows/iwMapDebug.cpp
+++ b/libs/s25main/ingameWindows/iwMapDebug.cpp
@@ -34,6 +34,7 @@
 #include "gameTypes/TextureColor.h"
 #include "gameData/const_gui_ids.h"
 #include <boost/nowide/iostream.hpp>
+#include <chrono>
 
 namespace {
 enum
@@ -151,7 +152,8 @@ private:
     Subscription nodeSub;
 };
 
-static const std::array<unsigned, 6> BQ_CHECK_INTERVALS = {10000, 1000, 500, 250, 100, 50};
+using namespace std::chrono_literals;
+static const std::array<std::chrono::milliseconds, 6> BQ_CHECK_INTERVALS = {10s, 1s, 500ms, 250ms, 100ms, 50ms};
 
 iwMapDebug::iwMapDebug(GameWorldView& gwv, bool allowCheating)
     : IngameWindow(CGI_MAP_DEBUG, IngameWindow::posLastOrCenter, Extent(230, 135), _("Map Debug"),
@@ -166,9 +168,9 @@ iwMapDebug::iwMapDebug(GameWorldView& gwv, bool allowCheating)
     ctrlComboBox* cbCheckEvents =
       AddComboBox(ID_cbCheckEventForPlayer, DrawPoint(15, 50), Extent(200, 20), TC_GREY, NormalFont, 100);
     cbCheckEvents->AddString(_("BQ check disabled"));
-    for(unsigned ms : BQ_CHECK_INTERVALS)
+    for(const std::chrono::milliseconds ms : BQ_CHECK_INTERVALS)
     {
-        cbCheckEvents->AddString((boost::format(_("BQ check every %1%ms")) % ms).str());
+        cbCheckEvents->AddString((boost::format(_("BQ check every %1%ms")) % ms.count()).str());
     }
     cbCheckEvents->SetSelection(0);
     AddTimer(ID_tmrCheckEvents, 500)->Stop();


### PR DESCRIPTION
This uses a `Timer` in the ctrlTimer and explicit chrono units.

Then refactors the credits screen to make use of timers instead of hand-rolled timing.

It also fixes a bug introduced in the resources PR where the "credits" resource wasn't loaded so the pictures were missing