### PR TITLE
Fix message box window button id bug

### DIFF
--- a/libs/s25main/ingameWindows/iwMsgbox.cpp
+++ b/libs/s25main/ingameWindows/iwMsgbox.cpp
@@ -80,26 +80,26 @@ void iwMsgbox::Init(const std::string& text, const ResourceId& iconFile, unsigne
     switch(button)
     {
         case MsgboxButton::Ok:
-            AddButton(0, GetSize().x / 2 - 45, _("OK"), TextureColor::Green2);
+            AddButton(ID_BT_0, GetSize().x / 2 - 45, _("OK"), TextureColor::Green2);
             defaultBt = 0;
             break;
 
         case MsgboxButton::OkCancel:
-            AddButton(0, GetSize().x / 2 - 3 - 90, _("OK"), TextureColor::Green2);
-            AddButton(1, GetSize().x / 2 + 3, _("Cancel"), TextureColor::Red1);
+            AddButton(ID_BT_0, GetSize().x / 2 - 3 - 90, _("OK"), TextureColor::Green2);
+            AddButton(ID_BT_0 + 1, GetSize().x / 2 + 3, _("Cancel"), TextureColor::Red1);
             defaultBt = 1;
             break;
 
         case MsgboxButton::YesNo:
-            AddButton(0, GetSize().x / 2 - 3 - 90, _("Yes"), TextureColor::Green2);
-            AddButton(1, GetSize().x / 2 + 3, _("No"), TextureColor::Red1);
+            AddButton(ID_BT_0, GetSize().x / 2 - 3 - 90, _("Yes"), TextureColor::Green2);
+            AddButton(ID_BT_0 + 1, GetSize().x / 2 + 3, _("No"), TextureColor::Red1);
             defaultBt = 1;
             break;
 
         case MsgboxButton::YesNoCancel:
-            AddButton(0, GetSize().x / 2 - 45 - 6 - 90, _("Yes"), TextureColor::Green2);
-            AddButton(1, GetSize().x / 2 - 45, _("No"), TextureColor::Red1);
-            AddButton(2, GetSize().x / 2 + 45 + 6, _("Cancel"), TextureColor::Grey);
+            AddButton(ID_BT_0, GetSize().x / 2 - 45 - 6 - 90, _("Yes"), TextureColor::Green2);
+            AddButton(ID_BT_0 + 1, GetSize().x / 2 - 45, _("No"), TextureColor::Red1);
+            AddButton(ID_BT_0 + 2, GetSize().x / 2 + 45 + 6, _("Cancel"), TextureColor::Grey);
             defaultBt = 2;
             break;
     }
@@ -184,5 +184,5 @@ void iwMsgbox::Msg_ButtonClick(const unsigned ctrl_id)
 
 void iwMsgbox::AddButton(unsigned short id, int x, const std::string& text, const TextureColor tc)
 {
-    AddTextButton(ID_BT_0 + id, DrawPoint(x, GetRightBottomBoundary().y - btSize.y * 2), btSize, tc, text, NormalFont);
+    AddTextButton(id, DrawPoint(x, GetRightBottomBoundary().y - btSize.y * 2), btSize, tc, text, NormalFont);
 }

--- a/libs/s25main/ingameWindows/iwMsgbox.cpp
+++ b/libs/s25main/ingameWindows/iwMsgbox.cpp
@@ -80,26 +80,26 @@ void iwMsgbox::Init(const std::string& text, const ResourceId& iconFile, unsigne
     switch(button)
     {
         case MsgboxButton::Ok:
-            AddButton(ID_BT_0, GetSize().x / 2 - 45, _("OK"), TextureColor::Green2);
+            AddButton(0, GetSize().x / 2 - 45, _("OK"), TextureColor::Green2);
             defaultBt = 0;
             break;
 
         case MsgboxButton::OkCancel:
-            AddButton(ID_BT_0, GetSize().x / 2 - 3 - 90, _("OK"), TextureColor::Green2);
-            AddButton(ID_BT_0 + 1, GetSize().x / 2 + 3, _("Cancel"), TextureColor::Red1);
+            AddButton(0, GetSize().x / 2 - 3 - 90, _("OK"), TextureColor::Green2);
+            AddButton(1, GetSize().x / 2 + 3, _("Cancel"), TextureColor::Red1);
             defaultBt = 1;
             break;
 
         case MsgboxButton::YesNo:
-            AddButton(ID_BT_0, GetSize().x / 2 - 3 - 90, _("Yes"), TextureColor::Green2);
-            AddButton(ID_BT_0 + 1, GetSize().x / 2 + 3, _("No"), TextureColor::Red1);
+            AddButton(0, GetSize().x / 2 - 3 - 90, _("Yes"), TextureColor::Green2);
+            AddButton(1, GetSize().x / 2 + 3, _("No"), TextureColor::Red1);
             defaultBt = 1;
             break;
 
         case MsgboxButton::YesNoCancel:
-            AddButton(ID_BT_0, GetSize().x / 2 - 45 - 6 - 90, _("Yes"), TextureColor::Green2);
-            AddButton(ID_BT_0 + 1, GetSize().x / 2 - 45, _("No"), TextureColor::Red1);
-            AddButton(ID_BT_0 + 2, GetSize().x / 2 + 45 + 6, _("Cancel"), TextureColor::Grey);
+            AddButton(0, GetSize().x / 2 - 45 - 6 - 90, _("Yes"), TextureColor::Green2);
+            AddButton(1, GetSize().x / 2 - 45, _("No"), TextureColor::Red1);
+            AddButton(2, GetSize().x / 2 + 45 + 6, _("Cancel"), TextureColor::Grey);
             defaultBt = 2;
             break;
     }


### PR DESCRIPTION
Fixes a newly introduced bug where the results from a message box button click where wrongly registered.

ID_BT_0 was added twice as it is also added in AddButton itself.