### PR TITLE
Fix wrong type for GO_Type enum

### DIFF
--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -341,7 +341,7 @@ void SerializedGameData::PushObject_(const GameObject* go, const bool known)
 
     // Objekt nich bekannt? Dann Type-ID noch mit drauf
     if(!known)
-        PushEnum<uint8_t>(go->GetGOT());
+        PushEnum<uint16_t>(go->GetGOT());
 
     // Objekt serialisieren
     if(debugMode)

--- a/libs/s25main/gameTypes/GO_Type.h
+++ b/libs/s25main/gameTypes/GO_Type.h
@@ -21,7 +21,7 @@
 
 /// To be able to load old savegames and keep ids unique, please insert new
 /// items at the end of the list.
-enum class GO_Type : uint8_t
+enum class GO_Type : uint16_t
 {
     Unknown,
     Nothing,


### PR DESCRIPTION
Prior save games used 2 Bytes instead of 1 (while 1 would have been enough)
Fixes #1328

@Flow86 This is urgent as all savegames saved with the current nightly can't be loaded while the current nightly can't load older ones.