### PR TITLE
Performance boost for random map generation

### DIFF
--- a/libs/s25main/mapGenerator/Algorithms.h
+++ b/libs/s25main/mapGenerator/Algorithms.h
@@ -148,6 +148,33 @@ namespace rttr { namespace mapGenerator {
     void UpdateDistances(NodeMapBase<unsigned>& distances, std::queue<MapPoint>& queue);
 
     /**
+     * Computes a map of distance values describing the distance of each grid position to the closest flagged point.
+     *
+     * @param flaggedPoints contains all flagged points
+     * @param size size of  the map
+     *
+     * @return distance of each grid position to closest flagged point.
+     */
+    template<class T_Container>
+    NodeMapBase<unsigned> DistancesTo(const T_Container& flaggedPoints, const MapExtent& size)
+    {
+        const unsigned maximumDistance = size.x * size.y;
+        std::queue<MapPoint> queue;
+        NodeMapBase<unsigned> distances;
+        distances.Resize(size, maximumDistance);
+
+        for(const MapPoint& pt : flaggedPoints)
+        {
+            distances[pt] = 0;
+            queue.push(pt);
+        }
+
+        UpdateDistances(distances, queue);
+
+        return distances;
+    }
+
+    /**
      * Computes a map of distance values describing the distance of each grid position to the closest position for
      * which the evaluator returned `true`. The computation takes place only within the specified area - points outside
      * the area are set to a maximum value of width + height of the map.

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -47,14 +47,9 @@ namespace rttr { namespace mapGenerator {
     template<class T_Container>
     std::vector<MapPoint> FindHqPositions(const Map& map, const T_Container& area)
     {
-        std::vector<MapPoint> headQuarters;
-        for(const MapPoint& hq : map.headQuarters)
-        {
-            if(hq.isValid())
-            {
-                headQuarters.push_back(hq);
-            }
-        }
+        auto isHeadQuarter = [&map](const MapPoint& pt) {
+            return map.objectInfos[pt] == libsiedler2::OI_HeadquarterMask;
+        };
         auto isObstacle = [&map](MapPoint point) {
             return map.textureMap.Any(point, [](auto t) { return !t.Is(ETerrain::Buildable); });
         };
@@ -62,7 +57,7 @@ namespace rttr { namespace mapGenerator {
         // Quality of a map point as one player's HQ is a mix of:
         // 1. distance to other players' HQs (higher = better)
         // 2. distance to any other obstacle e.g. mountain & water (higher = better)
-        NodeMapBase<unsigned> potentialHeadQuarterQuality = DistancesTo(headQuarters, map.size);
+        NodeMapBase<unsigned> potentialHeadQuarterQuality = Distances(map.size, isHeadQuarter);
         const auto& obstacleDistance = Distances(map.size, isObstacle);
         const auto minDistance = helpers::clamp(GetMaximum(obstacleDistance, area), 2u, 4u);
 

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -48,7 +48,7 @@ namespace rttr { namespace mapGenerator {
     std::vector<MapPoint> FindHqPositions(const Map& map, const T_Container& area)
     {
         std::vector<MapPoint> headQuarters;
-        for(const MapPoint& hq : map.headQuarters)
+        for(const MapPoint& hq : map.hqPositions)
         {
             if(hq.isValid())
             {

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -47,9 +47,14 @@ namespace rttr { namespace mapGenerator {
     template<class T_Container>
     std::vector<MapPoint> FindHqPositions(const Map& map, const T_Container& area)
     {
-        auto isHeadQuarter = [&map](const MapPoint& pt) {
-            return map.objectInfos[pt] == libsiedler2::OI_HeadquarterMask;
-        };
+        std::vector<MapPoint> headQuarters;
+        for(const MapPoint& hq : map.headQuarters)
+        {
+            if(hq.isValid())
+            {
+                headQuarters.push_back(hq);
+            }
+        }
         auto isObstacle = [&map](MapPoint point) {
             return map.textureMap.Any(point, [](auto t) { return !t.Is(ETerrain::Buildable); });
         };
@@ -57,7 +62,7 @@ namespace rttr { namespace mapGenerator {
         // Quality of a map point as one player's HQ is a mix of:
         // 1. distance to other players' HQs (higher = better)
         // 2. distance to any other obstacle e.g. mountain & water (higher = better)
-        NodeMapBase<unsigned> potentialHeadQuarterQuality = Distances(map.size, isHeadQuarter);
+        NodeMapBase<unsigned> potentialHeadQuarterQuality = DistancesTo(headQuarters, map.size);
         const auto& obstacleDistance = Distances(map.size, isObstacle);
         const auto minDistance = helpers::clamp(GetMaximum(obstacleDistance, area), 2u, 4u);
 

--- a/libs/s25main/mapGenerator/Map.cpp
+++ b/libs/s25main/mapGenerator/Map.cpp
@@ -25,7 +25,7 @@ namespace rttr { namespace mapGenerator {
 
     Map::Map(const MapExtent& size, uint8_t players, const WorldDescription& worldDesc,
              DescIdx<LandscapeDesc> landscape, uint8_t maxHeight)
-        : hqPositions_(MAX_PLAYERS, MapPoint::Invalid()), textureMap(TextureMap(worldDesc, landscape, textures)),
+        : headQuarters(MAX_PLAYERS, MapPoint::Invalid()), textureMap(TextureMap(worldDesc, landscape, textures)),
           name("Random"), author("Auto"), height(0, maxHeight), players(players), size(size)
     {
         z.Resize(size);
@@ -38,9 +38,9 @@ namespace rttr { namespace mapGenerator {
 
     void Map::MarkAsHeadQuarter(const MapPoint& position, int index)
     {
-        auto oldPosition = hqPositions_[index];
+        auto oldPosition = headQuarters[index];
 
-        hqPositions_[index] = position;
+        headQuarters[index] = position;
 
         if(position.isValid())
         {
@@ -72,7 +72,7 @@ namespace rttr { namespace mapGenerator {
         // First 7 players go into the header
         for(unsigned i = 0; i < 7; i++)
         {
-            header->setPlayerHQ(i, hqPositions_[i].x, hqPositions_[i].y);
+            header->setPlayerHQ(i, headQuarters[i].x, headQuarters[i].y);
         }
 
         std::vector<uint8_t> z(numNodes);

--- a/libs/s25main/mapGenerator/Map.cpp
+++ b/libs/s25main/mapGenerator/Map.cpp
@@ -25,7 +25,7 @@ namespace rttr { namespace mapGenerator {
 
     Map::Map(const MapExtent& size, uint8_t players, const WorldDescription& worldDesc,
              DescIdx<LandscapeDesc> landscape, uint8_t maxHeight)
-        : headQuarters(MAX_PLAYERS, MapPoint::Invalid()), textureMap(TextureMap(worldDesc, landscape, textures)),
+        : hqPositions(MAX_PLAYERS, MapPoint::Invalid()), textureMap(TextureMap(worldDesc, landscape, textures)),
           name("Random"), author("Auto"), height(0, maxHeight), players(players), size(size)
     {
         z.Resize(size);
@@ -38,9 +38,9 @@ namespace rttr { namespace mapGenerator {
 
     void Map::MarkAsHeadQuarter(const MapPoint& position, int index)
     {
-        auto oldPosition = headQuarters[index];
+        auto oldPosition = hqPositions[index];
 
-        headQuarters[index] = position;
+        hqPositions[index] = position;
 
         if(position.isValid())
         {
@@ -72,7 +72,7 @@ namespace rttr { namespace mapGenerator {
         // First 7 players go into the header
         for(unsigned i = 0; i < 7; i++)
         {
-            header->setPlayerHQ(i, headQuarters[i].x, headQuarters[i].y);
+            header->setPlayerHQ(i, hqPositions[i].x, hqPositions[i].y);
         }
 
         std::vector<uint8_t> z(numNodes);

--- a/libs/s25main/mapGenerator/Map.cpp
+++ b/libs/s25main/mapGenerator/Map.cpp
@@ -25,7 +25,7 @@ namespace rttr { namespace mapGenerator {
 
     Map::Map(const MapExtent& size, uint8_t players, const WorldDescription& worldDesc,
              DescIdx<LandscapeDesc> landscape, uint8_t maxHeight)
-        : headQuarters(MAX_PLAYERS, MapPoint::Invalid()), textureMap(TextureMap(worldDesc, landscape, textures)),
+        : hqPositions_(MAX_PLAYERS, MapPoint::Invalid()), textureMap(TextureMap(worldDesc, landscape, textures)),
           name("Random"), author("Auto"), height(0, maxHeight), players(players), size(size)
     {
         z.Resize(size);
@@ -38,9 +38,9 @@ namespace rttr { namespace mapGenerator {
 
     void Map::MarkAsHeadQuarter(const MapPoint& position, int index)
     {
-        auto oldPosition = headQuarters[index];
+        auto oldPosition = hqPositions_[index];
 
-        headQuarters[index] = position;
+        hqPositions_[index] = position;
 
         if(position.isValid())
         {
@@ -72,7 +72,7 @@ namespace rttr { namespace mapGenerator {
         // First 7 players go into the header
         for(unsigned i = 0; i < 7; i++)
         {
-            header->setPlayerHQ(i, headQuarters[i].x, headQuarters[i].y);
+            header->setPlayerHQ(i, hqPositions_[i].x, hqPositions_[i].y);
         }
 
         std::vector<uint8_t> z(numNodes);

--- a/libs/s25main/mapGenerator/Map.h
+++ b/libs/s25main/mapGenerator/Map.h
@@ -32,6 +32,7 @@ namespace rttr { namespace mapGenerator {
     class Map
     {
     private:
+        std::vector<MapPoint> hqPositions_;
         std::vector<DescIdx<TerrainDesc>> terrains_;
         DescIdx<LandscapeDesc> landscape_;
 
@@ -43,7 +44,6 @@ namespace rttr { namespace mapGenerator {
         NodeMapBase<uint8_t> resources;
         NodeMapBase<libsiedler2::Animal> animals;
         std::vector<Triangle> harbors;
-        std::vector<MapPoint> headQuarters;
         TextureMap textureMap;
 
         const std::string name;

--- a/libs/s25main/mapGenerator/Map.h
+++ b/libs/s25main/mapGenerator/Map.h
@@ -43,7 +43,7 @@ namespace rttr { namespace mapGenerator {
         NodeMapBase<uint8_t> resources;
         NodeMapBase<libsiedler2::Animal> animals;
         std::vector<Triangle> harbors;
-        std::vector<MapPoint> headQuarters;
+        std::vector<MapPoint> hqPositions;
         TextureMap textureMap;
 
         const std::string name;

--- a/libs/s25main/mapGenerator/Map.h
+++ b/libs/s25main/mapGenerator/Map.h
@@ -32,7 +32,6 @@ namespace rttr { namespace mapGenerator {
     class Map
     {
     private:
-        std::vector<MapPoint> hqPositions_;
         std::vector<DescIdx<TerrainDesc>> terrains_;
         DescIdx<LandscapeDesc> landscape_;
 
@@ -44,6 +43,7 @@ namespace rttr { namespace mapGenerator {
         NodeMapBase<uint8_t> resources;
         NodeMapBase<libsiedler2::Animal> animals;
         std::vector<Triangle> harbors;
+        std::vector<MapPoint> headQuarters;
         TextureMap textureMap;
 
         const std::string name;

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -272,7 +272,7 @@ namespace rttr { namespace mapGenerator {
 
     void RandomMap::CreateLandMap()
     {
-        Restructure(map_, [this](const MapPoint& pt) { return rnd_.ByChance((pt.x + pt.y) % 6); });
+        Restructure(map_, [this](auto&&) { return rnd_.ByChance(5); });
         SmoothHeightMap(map_.z, map_.height);
 
         const double sea = rnd_.RandomDouble(0.1, 0.2);

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -187,7 +187,7 @@ namespace rttr { namespace mapGenerator {
 
         unsigned maxDistance = map_.z.CalcDistance(origin, center);
 
-        std::vector<MapPoint> focus;
+        std::set<MapPoint, MapPointLess> focus;
         RTTR_FOREACH_PT(MapPoint, map_.size)
         {
             auto weight = 1. - static_cast<float>(map_.z.CalcDistance(pt, center)) / maxDistance;
@@ -195,7 +195,7 @@ namespace rttr { namespace mapGenerator {
 
             if(rnd_.ByChance(percentage))
             {
-                focus.push_back(pt);
+                focus.insert(pt);
             }
         }
 
@@ -234,7 +234,7 @@ namespace rttr { namespace mapGenerator {
 
         unsigned maxDistance = map_.z.CalcDistance(origin, center);
 
-        std::vector<MapPoint> focus;
+        std::set<MapPoint, MapPointLess> focus;
 
         RTTR_FOREACH_PT(MapPoint, map_.size)
         {
@@ -243,7 +243,7 @@ namespace rttr { namespace mapGenerator {
 
             if(rnd_.ByChance(percentage))
             {
-                focus.push_back(pt);
+                focus.insert(pt);
             }
         }
 
@@ -293,13 +293,13 @@ namespace rttr { namespace mapGenerator {
 
     void RandomMap::CreateLandMap()
     {
-        std::vector<MapPoint> focus;
+        std::set<MapPoint, MapPointLess> focus;
 
         RTTR_FOREACH_PT(MapPoint, map_.size)
         {
             if(rnd_.ByChance(5))
             {
-                focus.push_back(pt);
+                focus.insert(pt);
             }
         }
 

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -182,24 +182,14 @@ namespace rttr { namespace mapGenerator {
 
     void RandomMap::CreateMixedMap()
     {
-        MapPoint origin(0, 0);
         MapPoint center(map_.size.x / 2, map_.size.y / 2);
+        unsigned maxDistance = map_.z.CalcDistance(MapPoint(0, 0), center);
 
-        unsigned maxDistance = map_.z.CalcDistance(origin, center);
-
-        std::set<MapPoint, MapPointLess> focus;
-        RTTR_FOREACH_PT(MapPoint, map_.size)
-        {
+        Restructure(map_, [this, &center, maxDistance](const MapPoint& pt) {
             auto weight = 1. - static_cast<float>(map_.z.CalcDistance(pt, center)) / maxDistance;
             auto percentage = static_cast<unsigned>(12 * weight);
-
-            if(rnd_.ByChance(percentage))
-            {
-                focus.insert(pt);
-            }
-        }
-
-        Restructure(map_, focus);
+            return rnd_.ByChance(percentage);
+        });
         SmoothHeightMap(map_.z, map_.height);
 
         const double sea = 0.5;
@@ -229,25 +219,14 @@ namespace rttr { namespace mapGenerator {
 
     void RandomMap::CreateWaterMap()
     {
-        MapPoint origin(0, 0);
         MapPoint center(map_.size.x / 2, map_.size.y / 2);
+        unsigned maxDistance = map_.z.CalcDistance(MapPoint(0, 0), center);
 
-        unsigned maxDistance = map_.z.CalcDistance(origin, center);
-
-        std::set<MapPoint, MapPointLess> focus;
-
-        RTTR_FOREACH_PT(MapPoint, map_.size)
-        {
+        Restructure(map_, [this, &center, maxDistance](const MapPoint& pt) {
             auto weight = 1. - static_cast<float>(map_.z.CalcDistance(pt, center)) / maxDistance;
             auto percentage = static_cast<unsigned>(15 * weight * weight);
-
-            if(rnd_.ByChance(percentage))
-            {
-                focus.insert(pt);
-            }
-        }
-
-        Restructure(map_, focus);
+            return rnd_.ByChance(percentage);
+        });
         SmoothHeightMap(map_.z, map_.height);
 
         // 20% of map is center island (100% - 80% water)
@@ -293,17 +272,7 @@ namespace rttr { namespace mapGenerator {
 
     void RandomMap::CreateLandMap()
     {
-        std::set<MapPoint, MapPointLess> focus;
-
-        RTTR_FOREACH_PT(MapPoint, map_.size)
-        {
-            if(rnd_.ByChance(5))
-            {
-                focus.insert(pt);
-            }
-        }
-
-        Restructure(map_, focus);
+        Restructure(map_, [this](const MapPoint& _) { return _.x >= 0 && rnd_.ByChance(5); });
         SmoothHeightMap(map_.z, map_.height);
 
         const double sea = rnd_.RandomDouble(0.1, 0.2);

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -272,7 +272,7 @@ namespace rttr { namespace mapGenerator {
 
     void RandomMap::CreateLandMap()
     {
-        Restructure(map_, [this](const MapPoint& _) { return _.x >= 0 && rnd_.ByChance(5); });
+        Restructure(map_, [this](const MapPoint& pt) { return rnd_.ByChance((pt.x + pt.y) % 6); });
         SmoothHeightMap(map_.z, map_.height);
 
         const double sea = rnd_.RandomDouble(0.1, 0.2);

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -81,16 +81,13 @@ namespace rttr { namespace mapGenerator {
                 {
                     forbiddenArea.insert(point);
                 }
-            } else
-            if(map.textureMap.Any(pt, IsSnowOrLava))
+            } else if(map.textureMap.Any(pt, IsSnowOrLava))
             {
                 forbiddenArea.insert(pt);
             }
         }
 
-        auto isForbiddenArea = [&forbiddenArea](const MapPoint& pt) {
-            return helpers::contains(forbiddenArea, pt);
-        };
+        auto isForbiddenArea = [&forbiddenArea](const MapPoint& pt) { return helpers::contains(forbiddenArea, pt); };
 
         auto distanceToForbiddenArea = Distances(map.size, isForbiddenArea);
 

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -77,19 +77,14 @@ namespace rttr { namespace mapGenerator {
             if(isForbidden(pt))
             {
                 auto suroundingArea = map.textures.GetPointsInRadiusWithCenter(pt, 5);
-                for(const auto& point : suroundingArea)
-                {
-                    forbiddenArea.insert(point);
-                }
+                forbiddenArea.insert(suroundingArea.begin(), suroundingArea.end());
             } else if(map.textureMap.Any(pt, IsSnowOrLava))
             {
                 forbiddenArea.insert(pt);
             }
         }
 
-        auto isForbiddenArea = [&forbiddenArea](const MapPoint& pt) { return helpers::contains(forbiddenArea, pt); };
-
-        auto distanceToForbiddenArea = Distances(map.size, isForbiddenArea);
+        auto distanceToForbiddenArea = DistancesTo(forbiddenArea, map.size);
 
         // 1) compute maximum water distance until mountain area
         // 2) probabilities

--- a/libs/s25main/mapGenerator/Terrain.cpp
+++ b/libs/s25main/mapGenerator/Terrain.cpp
@@ -24,14 +24,11 @@
 
 namespace rttr { namespace mapGenerator {
 
-    void Restructure(Map& map, const std::set<MapPoint, MapPointLess>& focusArea, double weight)
+    void Restructure(Map& map, std::function<bool(const MapPoint&)> predicate, double weight)
     {
         const MapExtent& size = map.size;
-
-        auto inFocusArea = [&focusArea](const MapPoint& pt) { return helpers::contains(focusArea, pt); };
-
         auto& z = map.z;
-        auto distances = Distances(size, inFocusArea);
+        auto distances = Distances(size, predicate);
         auto maximum = GetMaximum(distances);
 
         RTTR_FOREACH_PT(MapPoint, size)

--- a/libs/s25main/mapGenerator/Terrain.cpp
+++ b/libs/s25main/mapGenerator/Terrain.cpp
@@ -20,12 +20,11 @@
 #include "mapGenerator/TextureHelper.h"
 
 #include <algorithm>
-#include <set>
 #include <stdexcept>
 
 namespace rttr { namespace mapGenerator {
 
-    void Restructure(Map& map, const std::vector<MapPoint>& focusArea, double weight)
+    void Restructure(Map& map, const std::set<MapPoint, MapPointLess>& focusArea, double weight)
     {
         const MapExtent& size = map.size;
 

--- a/libs/s25main/mapGenerator/Terrain.cpp
+++ b/libs/s25main/mapGenerator/Terrain.cpp
@@ -24,7 +24,7 @@
 
 namespace rttr { namespace mapGenerator {
 
-    void Restructure(Map& map, std::function<bool(const MapPoint&)> predicate, double weight)
+    void Restructure(Map& map, const std::function<bool(const MapPoint&)>& predicate, double weight)
     {
         const MapExtent& size = map.size;
         auto& z = map.z;

--- a/libs/s25main/mapGenerator/Terrain.h
+++ b/libs/s25main/mapGenerator/Terrain.h
@@ -33,7 +33,7 @@ namespace rttr { namespace mapGenerator {
      * @param weight factor influencing the strength of elevation towards the focused area (default: 2 - quadratic drop
      * with distance)
      */
-    void Restructure(Map& map, std::function<bool(const MapPoint&)> predicate, double weight = 2.);
+    void Restructure(Map& map, const std::function<bool(const MapPoint&)>& predicate, double weight = 2.);
 
     /**
      * Resets the sea level to "0" by setting all sea nodes to "0" height and scaling the remaining nodes to a range

--- a/libs/s25main/mapGenerator/Terrain.h
+++ b/libs/s25main/mapGenerator/Terrain.h
@@ -20,6 +20,7 @@
 #include "mapGenerator/Algorithms.h"
 #include "mapGenerator/Map.h"
 #include "mapGenerator/RandomUtility.h"
+#include <functional>
 
 namespace rttr { namespace mapGenerator {
 
@@ -28,11 +29,11 @@ namespace rttr { namespace mapGenerator {
      * Nodes closer to the focus area experience more elevation than nodes further away from the focus area.
      *
      * @param map reference to the map to manipulate
-     * @param focusArea area defining the focus of elevation
+     * @param predicate predicate defining the focus of elevation
      * @param weight factor influencing the strength of elevation towards the focused area (default: 2 - quadratic drop
      * with distance)
      */
-    void Restructure(Map& map, const std::set<MapPoint, MapPointLess>& focusArea, double weight = 2.);
+    void Restructure(Map& map, std::function<bool(const MapPoint&)> predicate, double weight = 2.);
 
     /**
      * Resets the sea level to "0" by setting all sea nodes to "0" height and scaling the remaining nodes to a range

--- a/libs/s25main/mapGenerator/Terrain.h
+++ b/libs/s25main/mapGenerator/Terrain.h
@@ -32,7 +32,7 @@ namespace rttr { namespace mapGenerator {
      * @param weight factor influencing the strength of elevation towards the focused area (default: 2 - quadratic drop
      * with distance)
      */
-    void Restructure(Map& map, const std::vector<MapPoint>& focusArea, double weight = 2.);
+    void Restructure(Map& map, const std::set<MapPoint, MapPointLess>& focusArea, double weight = 2.);
 
     /**
      * Resets the sea level to "0" by setting all sea nodes to "0" height and scaling the remaining nodes to a range

--- a/tests/s25Main/mapGenerator/testAlgorithms.cpp
+++ b/tests/s25Main/mapGenerator/testAlgorithms.cpp
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(DistancesTo_returns_expected_distance_for_each_map_point)
                                             4u, 4u, 3u, 2u, 1u, 1u, 2u, 3u, 5u, 4u, 3u, 2u, 2u, 2u, 3u, 4u,
                                             5u, 5u, 4u, 3u, 3u, 3u, 3u, 4u, 6u, 5u, 4u, 4u, 4u, 4u, 4u, 5u};
 
-    std::set<MapPoint, MapPointLess> flaggedPoints { MapPoint(4, 3) };
+    std::set<MapPoint, MapPointLess> flaggedPoints{MapPoint(4, 3)};
     auto distances = DistancesTo(flaggedPoints, size);
 
     BOOST_REQUIRE(distances.GetSize() == size);

--- a/tests/s25Main/mapGenerator/testAlgorithms.cpp
+++ b/tests/s25Main/mapGenerator/testAlgorithms.cpp
@@ -210,6 +210,26 @@ BOOST_AUTO_TEST_CASE(Distances_returns_expected_distance_for_each_map_point)
     }
 }
 
+BOOST_AUTO_TEST_CASE(DistancesTo_returns_expected_distance_for_each_map_point)
+{
+    MapExtent size(8, 8);
+
+    std::vector<unsigned> expectedDistances{5u, 5u, 4u, 3u, 3u, 3u, 3u, 4u, 5u, 4u, 3u, 2u, 2u, 2u, 3u, 4u,
+                                            4u, 4u, 3u, 2u, 1u, 1u, 2u, 3u, 4u, 3u, 2u, 1u, 0u, 1u, 2u, 3u,
+                                            4u, 4u, 3u, 2u, 1u, 1u, 2u, 3u, 5u, 4u, 3u, 2u, 2u, 2u, 3u, 4u,
+                                            5u, 5u, 4u, 3u, 3u, 3u, 3u, 4u, 6u, 5u, 4u, 4u, 4u, 4u, 4u, 5u};
+
+    std::set<MapPoint, MapPointLess> flaggedPoints { MapPoint(4, 3) };
+    auto distances = DistancesTo(flaggedPoints, size);
+
+    BOOST_REQUIRE(distances.GetSize() == size);
+
+    RTTR_FOREACH_PT(MapPoint, size)
+    {
+        BOOST_REQUIRE_EQUAL(expectedDistances[pt.x + pt.y * size.x], distances[pt]);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(Count_all_nodes_within_thresholds_correctly)
 {
     MapExtent size(8, 16);

--- a/tests/s25Main/mapGenerator/testTerrain.cpp
+++ b/tests/s25Main/mapGenerator/testTerrain.cpp
@@ -44,10 +44,9 @@ BOOST_AUTO_TEST_CASE(Restructure_keeps_minimum_and_maximum_values_unchanged)
 {
     RunTest([](Map& map) {
         map.z.Resize(map.size, 5); // default height
+        auto predicate = [](const MapPoint& pt) { return pt.x == 4 && pt.y == 4; };
 
-        std::set<MapPoint, MapPointLess> focusArea = {MapPoint(4, 4)}; // center
-
-        Restructure(map, focusArea);
+        Restructure(map, predicate);
 
         RTTR_FOREACH_PT(MapPoint, map.size)
         {
@@ -61,11 +60,11 @@ BOOST_AUTO_TEST_CASE(Restructure_increases_height_of_focus_area)
 {
     RunTest([](Map& map) {
         MapPoint focus(4, 4);
-
+        auto predicate = [&focus](const MapPoint& pt) { return pt == focus; };
         const uint8_t heightBefore = 5;
         map.z.Resize(map.size, heightBefore);
 
-        Restructure(map, {focus});
+        Restructure(map, predicate);
 
         const uint8_t heightAfter = map.z[focus];
 
@@ -77,12 +76,13 @@ BOOST_AUTO_TEST_CASE(Restructure_increases_height_less_when_further_away_from_fo
 {
     RunTest([](Map& map) {
         MapPoint focus(4, 4);
+        auto predicate = [&focus](const MapPoint& pt) { return pt == focus; };
         MapPoint nonFocus(0, 3);
 
         const uint8_t heightBefore = 5;
         map.z.Resize(map.size, heightBefore);
 
-        Restructure(map, {focus});
+        Restructure(map, predicate);
 
         const int diffFocus = map.z[focus] - heightBefore;
         const int diffNonFocus = map.z[nonFocus] - heightBefore;

--- a/tests/s25Main/mapGenerator/testTerrain.cpp
+++ b/tests/s25Main/mapGenerator/testTerrain.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(Restructure_keeps_minimum_and_maximum_values_unchanged)
     RunTest([](Map& map) {
         map.z.Resize(map.size, 5); // default height
 
-        std::vector<MapPoint> focusArea = {MapPoint(4, 4)}; // center
+        std::set<MapPoint, MapPointLess> focusArea = {MapPoint(4, 4)}; // center
 
         Restructure(map, focusArea);
 


### PR DESCRIPTION
By replacing std::vector to std::set to boost helper::contains (log(n) vs. log(O(n)) random maps of size 1024 x 1024 are now generated in less than 25% of the time (40s vs. 8s). Thanks @JonathanSteinbuch !