### PR TITLE
Base ingame times on normal speed

### DIFF
--- a/libs/s25main/Game.cpp
+++ b/libs/s25main/Game.cpp
@@ -49,9 +49,8 @@ void Game::Start(bool startFromSave)
         if(ggs_.objective == GameObjective::EconomyMode)
         {
             unsigned int selection = ggs_.getSelection(AddonId::ECONOMY_MODE_GAME_LENGTH);
-            world_.econHandler =
-              std::make_unique<EconomyModeHandler>(std::chrono::minutes(AddonEconomyModeGameLengthList[selection])
-                                                   / std::chrono::milliseconds(SPEED_GF_LENGTHS[referenceSpeed]));
+            world_.econHandler = std::make_unique<EconomyModeHandler>(
+              std::chrono::minutes(AddonEconomyModeGameLengthList[selection]) / SPEED_GF_LENGTHS[referenceSpeed]);
         }
         StatisticStep();
     }
@@ -97,7 +96,7 @@ void Game::RunGF()
     if(world_.HasLua())
         world_.GetLua().EventGameFrame(em_->GetCurrentGF());
     // Update statistic every 30 seconds
-    constexpr unsigned GFsIn30s = 30 * 1000 / SPEED_GF_LENGTHS[referenceSpeed];
+    constexpr unsigned GFsIn30s = 30s / SPEED_GF_LENGTHS[referenceSpeed];
     if(em_->GetCurrentGF() % GFsIn30s == 0)
         StatisticStep();
     // If some players got defeated check objective

--- a/libs/s25main/Game.cpp
+++ b/libs/s25main/Game.cpp
@@ -51,7 +51,7 @@ void Game::Start(bool startFromSave)
             unsigned int selection = ggs_.getSelection(AddonId::ECONOMY_MODE_GAME_LENGTH);
             world_.econHandler =
               std::make_unique<EconomyModeHandler>(std::chrono::minutes(AddonEconomyModeGameLengthList[selection])
-                                                   / (std::chrono::milliseconds)SPEED_GF_LENGTHS[referenceSpeed]);
+                                                   / std::chrono::milliseconds(SPEED_GF_LENGTHS[referenceSpeed]));
         }
         StatisticStep();
     }

--- a/libs/s25main/Game.cpp
+++ b/libs/s25main/Game.cpp
@@ -96,7 +96,7 @@ void Game::RunGF()
     if(world_.HasLua())
         world_.GetLua().EventGameFrame(em_->GetCurrentGF());
     // Update statistic every 30 seconds
-    constexpr unsigned GFsIn30s = 30s / SPEED_GF_LENGTHS[referenceSpeed];
+    constexpr unsigned GFsIn30s = std::chrono::duration<unsigned>(30) / SPEED_GF_LENGTHS[referenceSpeed];
     if(em_->GetCurrentGF() % GFsIn30s == 0)
         StatisticStep();
     // If some players got defeated check objective

--- a/libs/s25main/controls/ctrlTable.cpp
+++ b/libs/s25main/controls/ctrlTable.cpp
@@ -110,40 +110,26 @@ static int Compare(const std::string& a, const std::string& b, ctrlTable::SortTy
             s25util::ClassicImbuedStream<std::istringstream> ss_a(a);
             s25util::ClassicImbuedStream<std::istringstream> ss_b(b);
 
-            int val_a[3], val_b[3];
+            int seconds_a = 0;
+            int seconds_b = 0;
             char c;
 
             // "h:mm:ss" or "mm:ss"
-            for(int i = 0; i < 3; i++)
+            int tmp;
+            while(ss_a >> tmp)
             {
-                ss_a >> val_a[i];
-                ss_b >> val_b[i];
-                if(!ss_a)
-                {
-                    RTTR_Assert(i == 2);
-                    for(int j = i; j > 0; j--)
-                    {
-                        val_a[j] = val_a[j - 1];
-                    }
-                    val_a[0] = 0;
-                }
-                if(!ss_b)
-                {
-                    RTTR_Assert(i == 2);
-                    for(int j = i; j > 0; j--)
-                    {
-                        val_b[j] = val_b[j - 1];
-                    }
-                    val_b[0] = 0;
-                }
+                seconds_a *= 60;
+                seconds_a += tmp;
                 ss_a >> c;
+            }
+            while(ss_b >> tmp)
+            {
+                seconds_b *= 60;
+                seconds_b += tmp;
                 ss_b >> c;
             }
-            for(int i = 0; i < 3; i++)
-            {
-                if(val_a[i] != val_b[i] || i >= 2)
-                    return val_a[i] - val_b[i];
-            }
+
+            return seconds_a - seconds_b;
         }
         break;
     }

--- a/libs/s25main/controls/ctrlTable.cpp
+++ b/libs/s25main/controls/ctrlTable.cpp
@@ -104,6 +104,47 @@ static int Compare(const std::string& a, const std::string& b, ctrlTable::SortTy
                 return h_a - h_b;
             return min_a - min_b;
         }
+        case SRT::Time:
+        {
+            // Sort by time with format h:mm:ss or mm:ss
+            s25util::ClassicImbuedStream<std::istringstream> ss_a(a);
+            s25util::ClassicImbuedStream<std::istringstream> ss_b(b);
+
+            int val_a[3], val_b[3];
+            char c;
+
+            // "h:mm:ss" or "mm:ss"
+            for(int i = 0; i < 3; i++)
+            {
+                ss_a >> val_a[i];
+                ss_b >> val_b[i];
+                if(!ss_a)
+                {
+                    RTTR_Assert(i == 2);
+                    for(int j = i; j > 0; j--)
+                    {
+                        val_a[j] = val_a[j - 1];
+                    }
+                    val_a[0] = 0;
+                }
+                if(!ss_b)
+                {
+                    RTTR_Assert(i == 2);
+                    for(int j = i; j > 0; j--)
+                    {
+                        val_b[j] = val_b[j - 1];
+                    }
+                    val_b[0] = 0;
+                }
+                ss_a >> c;
+                ss_b >> c;
+            }
+            for(int i = 0; i < 3; i++)
+            {
+                if(val_a[i] != val_b[i] || i >= 2)
+                    return val_a[i] - val_b[i];
+            }
+        }
         break;
     }
     return 0;

--- a/libs/s25main/controls/ctrlTable.h
+++ b/libs/s25main/controls/ctrlTable.h
@@ -33,6 +33,7 @@ enum class TableSortType
     MapSize,
     Number,
     Date,
+    Time,
     Default
 };
 enum class TableSortDir

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -369,8 +369,8 @@ void dskGameInterface::Msg_PaintAfter()
     }
 
     // Draw speed indicator icon
-    const int startSpeed = SPEED_GF_LENGTHS[game_->ggs_.speed];
-    const int speedStep = startSpeed / 10 - static_cast<int>(GAMECLIENT.GetGFLength() / std::chrono::milliseconds(10));
+    const int speedStep =
+      static_cast<int>(SPEED_GF_LENGTHS[referenceSpeed] / 10ms) - static_cast<int>(GAMECLIENT.GetGFLength() / 10ms);
 
     if(speedStep != 0)
     {

--- a/libs/s25main/gameData/GameConsts.h
+++ b/libs/s25main/gameData/GameConsts.h
@@ -25,6 +25,9 @@
 /// Geschwindigkeitsabstufungen - Längen der GFs in ms
 constexpr helpers::EnumArray<unsigned, GameSpeed> SUPPRESS_UNUSED SPEED_GF_LENGTHS = {{80, 60, 50, 40, 30}};
 
+/// Normal speed as reference speed for ingame time computations
+constexpr GameSpeed referenceSpeed = GameSpeed::Normal;
+
 /// Reichweite der Bergarbeiter
 constexpr unsigned MINER_RADIUS = 2;
 

--- a/libs/s25main/gameData/GameConsts.h
+++ b/libs/s25main/gameData/GameConsts.h
@@ -20,6 +20,7 @@
 #include "helpers/EnumArray.h"
 #include "helpers/make_array.h"
 #include "gameTypes/GameSettingTypes.h"
+#include <chrono>
 #include <limits>
 
 using namespace std::chrono_literals;

--- a/libs/s25main/gameData/GameConsts.h
+++ b/libs/s25main/gameData/GameConsts.h
@@ -22,8 +22,10 @@
 #include "gameTypes/GameSettingTypes.h"
 #include <limits>
 
+using namespace std::chrono_literals;
 /// Geschwindigkeitsabstufungen - Längen der GFs in ms
-constexpr helpers::EnumArray<unsigned, GameSpeed> SUPPRESS_UNUSED SPEED_GF_LENGTHS = {{80, 60, 50, 40, 30}};
+constexpr helpers::EnumArray<std::chrono::duration<unsigned, std::milli>, GameSpeed> SUPPRESS_UNUSED
+  SPEED_GF_LENGTHS = {{80ms, 60ms, 50ms, 40ms, 30ms}};
 
 /// Normal speed as reference speed for ingame time computations
 constexpr GameSpeed referenceSpeed = GameSpeed::Normal;

--- a/libs/s25main/ingameWindows/iwPlayReplay.cpp
+++ b/libs/s25main/ingameWindows/iwPlayReplay.cpp
@@ -64,7 +64,7 @@ iwPlayReplay::iwPlayReplay()
              ctrlTable::Columns{{("Filename"), 300, SRT::String},
                                 {_("Stocktaking date"), 220, SRT::Date},
                                 {_("Player"), 360, SRT::String},
-                                {_("Length"), 120, SRT::Number},
+                                {_("Length"), 120, SRT::Time},
                                 {}});
 
     AddTextButton(2, DrawPoint(20, 260), Extent(100, 22), TextureColor::Red1, _("Clear"), NormalFont);
@@ -128,10 +128,10 @@ void iwPlayReplay::PopulateTable()
         if(!path.has_filename())
             continue;
         std::string fileName = path.filename().string();
-        std::string lastGF = helpers::toString(replay.GetLastGF());
+        std::string length = GAMECLIENT.FormatGFTime(replay.GetLastGF());
 
         // Und das Zeug zur Tabelle hinzufügen
-        table->AddRow({fileName, dateStr, tmp_players, lastGF, path.string()});
+        table->AddRow({fileName, dateStr, tmp_players, length, path.string()});
     }
 
     // Erst einmal nach Dateiname sortieren

--- a/libs/s25main/ingameWindows/iwPostWindow.cpp
+++ b/libs/s25main/ingameWindows/iwPostWindow.cpp
@@ -291,7 +291,8 @@ void iwPostWindow::DisplayPostMessage()
 
     // We have a message, display its status...
     std::stringstream ss;
-    ss << _("Message") << " " << curMsgId + 1 << " " << _("of") << " " << size << " - GF: " << curMsg->GetSendFrame();
+    ss << _("Message") << " " << curMsgId + 1 << "/" << size << " - " << _("Time") << ": "
+       << GAMECLIENT.FormatGFTime(curMsg->GetSendFrame());
     GetCtrl<ctrlText>(ID_INFO)->SetText(ss.str());
     GetCtrl<ctrlText>(ID_INFO)->SetVisible(true);
     // ...and delete button

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -102,10 +102,10 @@ void iwSaveLoad::RefreshTable()
         // Just filename w/o extension
         const auto fileName = saveFile.stem().string();
 
-        std::string startGF = GAMECLIENT.FormatGFTime(save.start_gf);
+        std::string gameTime = GAMECLIENT.FormatGFTime(save.start_gf);
 
         // Und das Zeug zur Tabelle hinzufügen
-        GetCtrl<ctrlTable>(0)->AddRow({fileName, save.GetMapName(), dateStr, startGF, saveFile.string()});
+        GetCtrl<ctrlTable>(0)->AddRow({fileName, save.GetMapName(), dateStr, gameTime, saveFile.string()});
     }
 
     // Nach Zeit Sortieren

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -156,8 +156,7 @@ iwSave::iwSave() : iwSaveLoad(40, _("Save game!"))
     bool found = false;
     for(unsigned i = 0; i < AUTO_SAVE_INTERVALS.size(); ++i)
     {
-        if(SETTINGS.interface.autosave_interval
-           == AUTO_SAVE_INTERVALS[i] / std::chrono::milliseconds(SPEED_GF_LENGTHS[referenceSpeed]))
+        if(SETTINGS.interface.autosave_interval == AUTO_SAVE_INTERVALS[i] / SPEED_GF_LENGTHS[referenceSpeed])
         {
             combo->SetSelection(i + 1);
             found = true;
@@ -188,8 +187,7 @@ void iwSave::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsigned sele
     else
     {
         // ansonsten jeweilige GF-Zahl eintragen
-        SETTINGS.interface.autosave_interval =
-          AUTO_SAVE_INTERVALS[selection - 1] / std::chrono::milliseconds(SPEED_GF_LENGTHS[referenceSpeed]);
+        SETTINGS.interface.autosave_interval = AUTO_SAVE_INTERVALS[selection - 1] / SPEED_GF_LENGTHS[referenceSpeed];
     }
 }
 

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -30,6 +30,7 @@
 #include "helpers/toString.h"
 #include "iwPleaseWait.h"
 #include "network/GameClient.h"
+#include "gameData/GameConsts.h"
 #include "gameData/const_gui_ids.h"
 #include "liblobby/LobbyClient.h"
 #include "s25util/Log.h"
@@ -49,7 +50,7 @@ iwSaveLoad::iwSaveLoad(const unsigned short add_height, const std::string& windo
              ctrlTable::Columns{{_("Filename"), 270, SRT::String},
                                 {_("Map"), 250, SRT::String},
                                 {_("Time"), 250, SRT::Date},
-                                {_("Start GF"), 320, SRT::Number},
+                                {_("Game Time"), 320, SRT::Time},
                                 {}});
 }
 
@@ -101,7 +102,7 @@ void iwSaveLoad::RefreshTable()
         // Just filename w/o extension
         const auto fileName = saveFile.stem().string();
 
-        std::string startGF = helpers::toString(save.start_gf);
+        std::string startGF = GAMECLIENT.FormatGFTime(save.start_gf);
 
         // Und das Zeug zur Tabelle hinzufügen
         GetCtrl<ctrlTable>(0)->AddRow({fileName, save.GetMapName(), dateStr, startGF, saveFile.string()});
@@ -147,7 +148,7 @@ iwSave::iwSave() : iwSaveLoad(40, _("Save game!"))
 
     // Die Intervalle
     for(unsigned i = 0; i < numIntervalls; ++i)
-        combo->AddString(helpers::toString(AUTO_SAVE_INTERVALS[i]) + " GF");
+        combo->AddString(helpers::toString(AUTO_SAVE_INTERVALS[i] * SPEED_GF_LENGTHS[referenceSpeed] / 1000) + " s");
 
     // Richtigen Eintrag auswählen
     bool found = false;

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1719,7 +1719,7 @@ std::string GameClient::FormatGFTime(const unsigned gf) const
     using std::chrono::duration_cast;
 
     // In Sekunden umrechnen
-    seconds numSeconds = duration_cast<seconds>(gf * (std::chrono::milliseconds)SPEED_GF_LENGTHS[referenceSpeed]);
+    seconds numSeconds = duration_cast<seconds>(gf * std::chrono::milliseconds(SPEED_GF_LENGTHS[referenceSpeed]));
 
     // Angaben rausfiltern
     hours numHours = duration_cast<hours>(numSeconds);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -260,7 +260,7 @@ void GameClient::StartGame(const unsigned random_init)
     framesinfo.isPaused = true;
 
     // Je nach Geschwindigkeit GF-Länge einstellen
-    framesinfo.gf_length = FramesInfo::milliseconds32_t(SPEED_GF_LENGTHS[gameLobby->getSettings().speed]);
+    framesinfo.gf_length = SPEED_GF_LENGTHS[gameLobby->getSettings().speed];
     framesinfo.gfLengthReq = framesinfo.gf_length;
 
     // Random-Generator initialisieren
@@ -1719,7 +1719,7 @@ std::string GameClient::FormatGFTime(const unsigned gf) const
     using std::chrono::duration_cast;
 
     // In Sekunden umrechnen
-    seconds numSeconds = duration_cast<seconds>(gf * std::chrono::milliseconds(SPEED_GF_LENGTHS[referenceSpeed]));
+    seconds numSeconds = duration_cast<seconds>(gf * SPEED_GF_LENGTHS[referenceSpeed]);
 
     // Angaben rausfiltern
     hours numHours = duration_cast<hours>(numSeconds);
@@ -1759,7 +1759,7 @@ unsigned GameClient::GetTournamentModeDuration() const
             < rttr::enum_cast(GameObjective::Tournament1) + NUM_TOURNAMENT_MODES)
     {
         const auto turnamentMode = rttr::enum_cast(game->ggs_.objective) - rttr::enum_cast(GameObjective::Tournament1);
-        return minutes(TOURNAMENT_MODES_DURATION[turnamentMode]) / milliseconds(SPEED_GF_LENGTHS[referenceSpeed]);
+        return minutes(TOURNAMENT_MODES_DURATION[turnamentMode]) / SPEED_GF_LENGTHS[referenceSpeed];
     } else
         return 0;
 }

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1719,7 +1719,7 @@ std::string GameClient::FormatGFTime(const unsigned gf) const
     using std::chrono::duration_cast;
 
     // In Sekunden umrechnen
-    seconds numSeconds = duration_cast<seconds>(gf * framesinfo.gf_length);
+    seconds numSeconds = duration_cast<seconds>(gf * (std::chrono::milliseconds)SPEED_GF_LENGTHS[referenceSpeed]);
 
     // Angaben rausfiltern
     hours numHours = duration_cast<hours>(numSeconds);
@@ -1729,7 +1729,7 @@ std::string GameClient::FormatGFTime(const unsigned gf) const
 
     // ganze Stunden mit dabei? Dann entsprechend anderes format, ansonsten ignorieren wir die einfach
     if(numHours.count())
-        return helpers::format("%02u:%02u:%02u", numHours.count(), numMinutes.count(), numSeconds.count());
+        return helpers::format("%u:%02u:%02u", numHours.count(), numMinutes.count(), numSeconds.count());
     else
         return helpers::format("%02u:%02u", numMinutes.count(), numSeconds.count());
 }
@@ -1759,7 +1759,7 @@ unsigned GameClient::GetTournamentModeDuration() const
             < rttr::enum_cast(GameObjective::Tournament1) + NUM_TOURNAMENT_MODES)
     {
         const auto turnamentMode = rttr::enum_cast(game->ggs_.objective) - rttr::enum_cast(GameObjective::Tournament1);
-        return minutes(TOURNAMENT_MODES_DURATION[turnamentMode]) / framesinfo.gf_length;
+        return minutes(TOURNAMENT_MODES_DURATION[turnamentMode]) / milliseconds(SPEED_GF_LENGTHS[referenceSpeed]);
     } else
         return 0;
 }

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -460,7 +460,7 @@ bool GameServer::StartGame()
         }
     }
 
-    framesinfo.gfLengthReq = framesinfo.gf_length = FramesInfo::milliseconds32_t(SPEED_GF_LENGTHS[ggs_.speed]);
+    framesinfo.gfLengthReq = framesinfo.gf_length = SPEED_GF_LENGTHS[ggs_.speed];
 
     // NetworkFrame-Länge bestimmen, je schlechter (also höher) die Pings, desto länger auch die Framelänge
     framesinfo.nwf_length = CalcNWFLenght(FramesInfo::milliseconds32_t(highest_ping));


### PR DESCRIPTION
This addresses issue #1317 

Although there was no consensus on which speed to base ingame time there was a consensus that it should be consistent and without reference to game frames.

So as a preliminary solution I changed every time representation based on the assumption of normal speed. 

In the save dialog, the playReplay window and the post window in particular that meant changing GFs to time. 
![timePostWindowNew](https://user-images.githubusercontent.com/711115/104506990-6a592c00-55e6-11eb-9044-1d88dc5a83fa.png)

The only thing that maybe looks a bit silly is the autosave pulldown, because I didn't change the intervals (should I?):
![autosave](https://user-images.githubusercontent.com/711115/104506996-6decb300-55e6-11eb-8af2-685c0ac2dc18.png)

Note: I didn't remove the display of GFs in the debug line at the top and for jumping/skipping as they are mostly debug/expert features