### PR TITLE
Rivers should end when going into sea or lakes

### DIFF
--- a/libs/s25main/mapGenerator/Rivers.cpp
+++ b/libs/s25main/mapGenerator/Rivers.cpp
@@ -30,7 +30,7 @@ namespace rttr { namespace mapGenerator {
         std::vector<Direction> exlcuded{direction + 2, direction + 3, direction + 4};
 
         auto& textures = map.textureMap;
-        auto water = textures.Find(IsWater);
+        const auto water = textures.Find(IsWater);
 
         MapPoint currentNode = source;
         Direction currentDir = direction;
@@ -48,6 +48,11 @@ namespace rttr { namespace mapGenerator {
                 {
                     river.insert(edge);
                 }
+            }
+
+            if(map.z[currentNode] == map.height.minimum)
+            {
+                return river;
             }
 
             const auto lastDir = currentDir;

--- a/libs/s25main/mapGenerator/TextureHelper.cpp
+++ b/libs/s25main/mapGenerator/TextureHelper.cpp
@@ -63,8 +63,7 @@ namespace rttr { namespace mapGenerator {
 
     bool IsMountainOrSnowOrLava(const TerrainDesc& terrain)
     {
-        return terrain.kind == TerrainKind::Mountain || terrain.kind == TerrainKind::Snow
-               || terrain.kind == TerrainKind::Lava;
+        return terrain.kind == TerrainKind::Mountain || IsSnowOrLava(terrain);
     }
 
 }} // namespace rttr::mapGenerator


### PR DESCRIPTION
Rivers should end at sea level (= minimum height of the map after ResetSeaLevel). This make avoids rivers from a main island to "swap" over to another island which looks a bit odd.