### PR TITLE
Refactor AI and teach it about unlimitted resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,26 +8,6 @@ endif()
 
 project(s25client)
 
-if(NOT MSVC)
-    #Check for ccache
-    if(APPLE)
-        find_program(CCACHE_PROGRAM NAMES ccache-lipo ccache)
-    else()
-        find_program(CCACHE_PROGRAM ccache)
-    endif()
-    mark_as_advanced(CCACHE_PROGRAM)
-    if(CCACHE_PROGRAM)
-        foreach(lang C CXX)
-            # Do only set ccache compiler if we don't already use a ccache wrapper
-            # Example: /usr/lib/ccache/g++
-            if(NOT CMAKE_${lang}_COMPILER MATCHES "ccache")
-                message(STATUS "Using ccache(${CCACHE_PROGRAM}) for ${lang} to speed up builds")
-                set(CMAKE_${lang}_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
-            endif()
-        endforeach()
-    endif()
-endif()
-
 message(STATUS "Using CMake ${CMAKE_VERSION}")
 
 if(DEFINED CMAKE_TOOLCHAIN_FILE)
@@ -38,6 +18,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules" "${CMAKE_SOURC
 if(CMAKE_VERSION VERSION_LESS 3.14)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/external/libutil/cmake/cmake_3.14")
 endif()
+
+include(EnableCCache)
 
 set(checkSubmodules FALSE)
 # Figure out RTTR_REVISION (git hash) and RTTR_VERSION (date)

--- a/libs/s25main/ai/AIInterface.h
+++ b/libs/s25main/ai/AIInterface.h
@@ -52,9 +52,9 @@ public:
 
     bool IsDefeated() const { return player_.IsDefeated(); }
     /// Return the resource buried on a given spot (gold, coal, ironore, granite (sub), fish, nothing)
-    AIResource GetSubsurfaceResource(MapPoint pt) const;
+    AISubSurfaceResource GetSubsurfaceResource(MapPoint pt) const;
     /// Return the resource on top on a given spot (wood, stones, nothing)
-    AIResource GetSurfaceResource(MapPoint pt) const;
+    AISurfaceResource GetSurfaceResource(MapPoint pt) const;
     /// Calculate the surface resource value on a given spot (wood/ stones/ farmland)
     /// when given a direction and lastvalue the calculation will be much faster O(n) vs O(n^2)
     int CalcResourceValue(MapPoint pt, AIResource res, helpers::OptionalEnum<Direction> direction = boost::none,

--- a/libs/s25main/ai/AIInterface.h
+++ b/libs/s25main/ai/AIInterface.h
@@ -43,12 +43,11 @@ struct Inventory;
 class AIInterface : public GameCommandFactory
 {
 public:
-    AIInterface(const GameWorldBase& gwb, std::vector<gc::GameCommandPtr>& gcs, unsigned char playerID)
-        : gwb(gwb), player_(gwb.GetPlayer(playerID)), gcs(gcs), playerID_(playerID)
-    {}
+    AIInterface(const GameWorldBase& gwb, std::vector<gc::GameCommandPtr>& gcs, unsigned char playerID);
 
     unsigned char GetPlayerId() const { return playerID_; }
     unsigned GetNumPlayers() const { return gwb.GetNumPlayers(); }
+    const std::vector<unsigned>& getUsableHarbors() const { return usableHarbors_; }
 
     bool IsDefeated() const { return player_.IsDefeated(); }
     /// Return the resource buried on a given spot (gold, coal, ironore, granite (sub), fish, nothing)
@@ -144,6 +143,13 @@ public:
     {
         return player_.GetBuildingRegister().GetStorehouses();
     }
+
+    /// Check if there is a building of the given type in a radius of at most maxDistance
+    bool isBuildingNearby(BuildingType bldType, MapPoint pt, unsigned maxDistance) const;
+    /// Check if there is a (useful) harbor spot in at most the given distance. onlyEmpty=True -> No harbor building
+    /// there yet
+    bool isHarborPosClose(MapPoint pt, unsigned maxDistance, bool onlyEmpty = false) const;
+
     /// Return the inventory of the AI player
     const Inventory& GetInventory() const { return player_.GetInventory(); }
     /// Return the number of ships
@@ -207,4 +213,6 @@ private:
     std::vector<gc::GameCommandPtr>& gcs;
     /// ID of AI player
     const unsigned char playerID_;
+    /// Harbor ids which have at least one other harbor at the same sea
+    std::vector<unsigned> usableHarbors_;
 };

--- a/libs/s25main/ai/AIResource.h
+++ b/libs/s25main/ai/AIResource.h
@@ -17,35 +17,96 @@
 
 #pragma once
 
+#include "helpers/EnumArray.h"
 #include "s25util/warningSuppression.h"
-#include <array>
 
-enum class AIResource : unsigned
+// Note: This enums are constructed for performance and easy conversion.
+// AIResource must be contiguous and it is assumed that only valid enumerators are used
+
+/// Resources stored on AI nodes. Starts with all values from AIResource in that order!
+enum class AINodeResource
 {
-    Wood,
-    Stones,
     Gold,
     Ironore,
     Coal,
     Granite,
+    Fish,
+    Wood,
+    Stones,
     Plantspace,
     Borderland,
-    Fish,
-    Multiple,
     // special:
-    Blocked = 254,
-    Nothing = 255
+    Multiple,
+    Blocked,
+    Nothing,
 };
 
-const unsigned NUM_AIRESOURCES = 9;
-const std::array<unsigned, NUM_AIRESOURCES> SUPPRESS_UNUSED RES_RADIUS = {{
-  8, // Wood
-  8, // Stones
+/// Resources handled by AI. Keep in sync with AINodeResource
+enum class AIResource
+{
+    Gold,
+    Ironore,
+    Coal,
+    Granite,
+    Fish,
+    Wood,
+    Stones,
+    Plantspace,
+    Borderland,
+};
+
+constexpr auto maxEnumValue(AIResource)
+{
+    return AIResource::Borderland;
+}
+
+/// AI resources which can be above the surface
+enum class AISurfaceResource
+{
+    Wood = static_cast<unsigned>(AINodeResource::Wood),
+    Stones,
+    Blocked = static_cast<unsigned>(AINodeResource::Blocked),
+    Nothing = static_cast<unsigned>(AINodeResource::Nothing),
+};
+
+/// AI resources which can be above the surface
+enum class AISubSurfaceResource
+{
+    Gold,
+    Ironore,
+    Coal,
+    Granite,
+    Fish,
+    Nothing = static_cast<unsigned>(AINodeResource::Nothing),
+};
+
+/// Mapping functions, valid by construction of the enums
+constexpr AINodeResource convertToNodeResource(AIResource res)
+{
+    return static_cast<AINodeResource>(static_cast<unsigned>(res));
+}
+constexpr AINodeResource convertToNodeResource(AISurfaceResource res)
+{
+    return static_cast<AINodeResource>(static_cast<unsigned>(res));
+}
+constexpr AINodeResource convertToNodeResource(AISubSurfaceResource res)
+{
+    return static_cast<AINodeResource>(static_cast<unsigned>(res));
+}
+
+constexpr bool operator==(AINodeResource lhs, AIResource rhs)
+{
+    return lhs == convertToNodeResource(rhs);
+}
+
+constexpr helpers::EnumArray<unsigned, AIResource> SUPPRESS_UNUSED RES_RADIUS = {
   2, // Gold
   2, // Ironore
   2, // Coal
   2, // Granite
+  5, // Fish
+  8, // Wood
+  8, // Stones
   3, // Plantspace
   5, // Borderland
-  5  // Fish
-}};
+};

--- a/libs/s25main/ai/aijh/AIConstruction.cpp
+++ b/libs/s25main/ai/aijh/AIConstruction.cpp
@@ -486,7 +486,8 @@ helpers::OptionalEnum<BuildingType> AIConstruction::ChooseMilitaryBuilding(const
     if(((rand() % 3) == 0 || inventory.people[Job::Private] < 15)
        && (inventory.goods[GoodType::Stones] > 6 || bldPlanner.GetNumBuildings(BuildingType::Quarry) > 0))
         bld = BuildingType::Guardhouse;
-    if(aijh.HarborPosClose(pt, 20) && rand() % 10 != 0 && aijh.ggs.getSelection(AddonId::SEA_ATTACK) != 2)
+    if(aijh.getAIInterface().isHarborPosClose(pt, 19) && rand() % 10 != 0
+       && aijh.ggs.getSelection(AddonId::SEA_ATTACK) != 2)
     {
         if(aii.CanBuildBuildingtype(BuildingType::Watchtower))
             return BuildingType::Watchtower;

--- a/libs/s25main/ai/aijh/AIMap.h
+++ b/libs/s25main/ai/aijh/AIMap.h
@@ -25,7 +25,7 @@ namespace AIJH {
 struct Node
 {
     BuildingQuality bq;
-    AIResource res;
+    AINodeResource res;
     bool owned;
     bool reachable;
     char failed_penalty; // when a node was marked reachable, but building failed, this field is >0

--- a/libs/s25main/ai/aijh/AIMap.h
+++ b/libs/s25main/ai/aijh/AIMap.h
@@ -25,7 +25,7 @@ namespace AIJH {
 struct Node
 {
     BuildingQuality bq;
-    AINodeResource res;
+    AINodeResource res; // TODO: Fixup to keep in sync
     bool owned;
     bool reachable;
     char failed_penalty; // when a node was marked reachable, but building failed, this field is >0

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -667,12 +667,6 @@ void AIPlayerJH::SetFarmedNodes(const MapPoint pt, bool set)
         aiMap[curPt].farmed = set;
 }
 
-MapPoint AIPlayerJH::FindGoodPosition(const MapPoint& pt, AIResource res, int threshold, BuildingQuality size,
-                                      int radius, bool inTerritory) const
-{
-    return resourceMaps[res].FindGoodPosition(pt, threshold, size, radius, inTerritory);
-}
-
 MapPoint AIPlayerJH::FindBestPositionDiminishingResource(const MapPoint& pt, AIResource res, BuildingQuality size,
                                                          int minimum, int radius, bool inTerritory)
 {

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -942,31 +942,32 @@ MapPoint AIPlayerJH::SimpleFindPosition(const MapPoint& pt, BuildingQuality size
 
 MapPoint AIPlayerJH::FindPositionForBuildingAround(BuildingType type, const MapPoint& around)
 {
+    constexpr unsigned searchRadius = 11;
     MapPoint foundPos = MapPoint::Invalid();
     switch(type)
     {
         case BuildingType::Woodcutter:
         {
-            foundPos = FindBestPosition(around, AIResource::Wood, BUILDING_SIZE[type], 11, 20);
+            foundPos = FindBestPosition(around, AIResource::Wood, BUILDING_SIZE[type], searchRadius, 20);
             break;
         }
         case BuildingType::Forester:
             // ensure some distance to other foresters and an minimal amount of plantspace
             if(!construction->OtherUsualBuildingInRadius(around, 12, BuildingType::Forester)
                && GetDensity(around, AIResource::Plantspace, 7) > 15)
-                foundPos = FindBestPosition(around, AIResource::Wood, BUILDING_SIZE[type], 11, 0);
+                foundPos = FindBestPosition(around, AIResource::Wood, BUILDING_SIZE[type], searchRadius, 0);
             break;
         case BuildingType::Hunter:
         {
             // check if there are any animals in range
             if(HuntablesinRange(around, (2 << GetBldPlanner().GetNumBuildings(BuildingType::Hunter))))
-                foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], 11);
+                foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], searchRadius);
             break;
         }
         case BuildingType::Quarry:
         {
             unsigned numQuarries = GetBldPlanner().GetNumBuildings(BuildingType::Quarry);
-            foundPos = FindBestPosition(around, AIResource::Stones, BUILDING_SIZE[type], 11,
+            foundPos = FindBestPosition(around, AIResource::Stones, BUILDING_SIZE[type], searchRadius,
                                         std::min(40u, 1 + numQuarries * 10));
             if(foundPos.isValid() && !ValidStoneinRange(foundPos))
             {
@@ -979,27 +980,27 @@ MapPoint AIPlayerJH::FindPositionForBuildingAround(BuildingType type, const MapP
         case BuildingType::Guardhouse:
         case BuildingType::Watchtower:
         case BuildingType::Fortress:
-            foundPos = FindBestPosition(around, AIResource::Borderland, BUILDING_SIZE[type], 11);
+            foundPos = FindBestPosition(around, AIResource::Borderland, BUILDING_SIZE[type], searchRadius);
             break;
         case BuildingType::GoldMine:
-            foundPos = FindBestPosition(around, AIResource::Gold, BuildingQuality::Mine, 11);
+            foundPos = FindBestPosition(around, AIResource::Gold, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::CoalMine:
-            foundPos = FindBestPosition(around, AIResource::Coal, BuildingQuality::Mine, 11);
+            foundPos = FindBestPosition(around, AIResource::Coal, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::IronMine:
-            foundPos = FindBestPosition(around, AIResource::Ironore, BuildingQuality::Mine, 11);
+            foundPos = FindBestPosition(around, AIResource::Ironore, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::GraniteMine:
             if(!ggs.isEnabled(
                  AddonId::INEXHAUSTIBLE_GRANITEMINES)) // inexhaustible granite mines do not require granite
-                foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, 11);
+                foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, searchRadius);
             else
-                foundPos = SimpleFindPosition(around, BuildingQuality::Mine, 11);
+                foundPos = SimpleFindPosition(around, BuildingQuality::Mine, searchRadius);
             break;
 
         case BuildingType::Fishery:
-            foundPos = FindBestPosition(around, AIResource::Fish, BUILDING_SIZE[type], 11);
+            foundPos = FindBestPosition(around, AIResource::Fish, BUILDING_SIZE[type], searchRadius);
             if(foundPos.isValid() && !ValidFishInRange(foundPos))
             {
                 resourceMaps[AIResource::Fish].avoidPosition(foundPos);
@@ -1008,30 +1009,30 @@ MapPoint AIPlayerJH::FindPositionForBuildingAround(BuildingType type, const MapP
             break;
         case BuildingType::Storehouse:
             if(!construction->OtherStoreInRadius(around, 15))
-                foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], 11);
+                foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], searchRadius);
             break;
         case BuildingType::HarborBuilding:
-            foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], 11);
+            foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], searchRadius);
             if(foundPos.isValid()
                && !HarborPosRelevant(GetWorld().GetHarborPointID(foundPos))) // bad harborspot detected DO NOT USE
                 foundPos = MapPoint::Invalid();
             break;
         case BuildingType::Shipyard:
-            foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], 11);
+            foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], searchRadius);
             if(foundPos.isValid() && IsInvalidShipyardPosition(foundPos))
                 foundPos = MapPoint::Invalid();
             break;
         case BuildingType::Farm:
-            foundPos = FindBestPosition(around, AIResource::Plantspace, BUILDING_SIZE[type], 11, 85);
+            foundPos = FindBestPosition(around, AIResource::Plantspace, BUILDING_SIZE[type], searchRadius, 85);
             if(foundPos.isValid())
-                foundPos = FindBestPosition(around, AIResource::Plantspace, BUILDING_SIZE[type], 11, 85);
+                foundPos = FindBestPosition(around, AIResource::Plantspace, BUILDING_SIZE[type], searchRadius, 85);
             break;
         case BuildingType::Catapult:
-            foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], 11);
+            foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], searchRadius);
             if(foundPos.isValid() && aii.isBuildingNearby(BuildingType::Catapult, foundPos, 7))
                 foundPos = MapPoint::Invalid();
             break;
-        default: foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], 11); break;
+        default: foundPos = SimpleFindPosition(around, BUILDING_SIZE[type], searchRadius); break;
     }
     return foundPos;
 }

--- a/libs/s25main/ai/aijh/AIPlayerJH.h
+++ b/libs/s25main/ai/aijh/AIPlayerJH.h
@@ -131,7 +131,7 @@ public:
     /// Updates the nodes around a position
     void UpdateNodesAround(MapPoint pt, unsigned radius);
     /// Returns the resource on a specific point
-    AIResource CalcResource(MapPoint pt);
+    AINodeResource CalcResource(MapPoint pt);
     /// Initialize the resource maps
     void InitResourceMaps();
     /// Initialize the Store and Military building lists (only required when loading games but the AI doesnt know
@@ -248,9 +248,9 @@ public:
 
     bool NoEnemyHarbor();
 
-    void SetResourceMap(AIResource res, MapPoint pt, int newvalue)
+    void SetResourceMapValue(AIResource res, MapPoint pt, int newvalue)
     {
-        resourceMaps[static_cast<unsigned>(res)][pt] = newvalue;
+        resourceMaps[res][pt] = newvalue;
     }
 
     MapPoint UpgradeBldPos;
@@ -265,7 +265,7 @@ private:
     /// Nodes containing some information about every map node
     AIMap aiMap;
     /// Resource maps, containing a rating for every map point concerning a resource
-    boost::container::static_vector<AIResourceMap, NUM_AIRESOURCES> resourceMaps;
+    helpers::EnumArray<AIResourceMap, AIResource> resourceMaps;
 
     unsigned attack_interval;
     unsigned build_interval;

--- a/libs/s25main/ai/aijh/AIPlayerJH.h
+++ b/libs/s25main/ai/aijh/AIPlayerJH.h
@@ -78,13 +78,13 @@ public:
     int GetResMapValue(MapPoint pt, AIResource res) const;
     const AIResourceMap& GetResMap(AIResource res) const;
 
+    Node& GetAINode(const MapPoint pt) { return aiMap[pt]; }
     const Node& GetAINode(const MapPoint pt) const { return aiMap[pt]; }
+
     unsigned GetNumPlannedConnectedInlandMilitaryBlds()
     {
         return std::max<unsigned>(6u, aii.GetMilitaryBuildings().size() / 5u);
     }
-    /// checks distance to all harborpositions
-    bool HarborPosClose(MapPoint pt, unsigned range, bool onlyempty = false) const;
     /// returns the percentage*100 of possible normal building places
     unsigned BQsurroundcheck(MapPoint pt, unsigned range, bool includeexisting, unsigned limit = 0);
     /// returns list entry of the building the ai uses for troop upgrades
@@ -97,7 +97,6 @@ public:
 
     void SendAIEvent(std::unique_ptr<AIEvent::Base> ev);
 
-    Node& GetAINode(const MapPoint pt) { return aiMap[pt]; }
     /// Executes a job form the job queue
     void ExecuteAIJob();
     /// Tries to build a bld of the given type at that point.
@@ -110,9 +109,6 @@ public:
     /// adds buildjobs for a buildingtype around every warehouse or military building
     void AddBuildJobAroundEveryWarehouse(BuildingType bt);
     void AddBuildJobAroundEveryMilBld(BuildingType bt);
-    /// Checks the list of military buildingsites and puts the coordinates into the list of military buildings if
-    /// building is finished
-    void CheckNewMilitaryBuildings();
     /// blocks goods in each warehouse that has at least limit amount of that good - if all warehouses have enough they
     /// unblock
     void DistributeGoodsByBlocking(GoodType good, unsigned limit);
@@ -145,24 +141,14 @@ public:
                             helpers::OptionalEnum<Direction> excludeDir, std::vector<const noFlag*> oldFlags);
     /// Finds the best position for a specific resource in an area using the resource maps,
     /// satisfying the minimum value, returns false if no such position is found
-    MapPoint FindBestPosition(const MapPoint& pt, AIResource res, BuildingQuality size, int minimum, int radius = -1,
-                              bool inTerritory = true);
-    MapPoint FindBestPosition(const MapPoint& pt, AIResource res, BuildingQuality size, int radius = -1,
-                              bool inTerritory = true)
-    {
-        return FindBestPosition(pt, res, size, 1, radius, inTerritory);
-    }
-    /// finds the best position for a resource that cannot increase (fish,iron,coal,gold,granite,stones)
-    MapPoint FindBestPositionDiminishingResource(const MapPoint& pt, AIResource res, BuildingQuality size, int minimum,
-                                                 int radius = -1, bool inTerritory = true);
+    MapPoint FindBestPosition(const MapPoint& pt, AIResource res, BuildingQuality size, unsigned radius,
+                              int minimum = 1);
     /// Finds a position for the desired building size
-    MapPoint SimpleFindPosition(const MapPoint& pt, BuildingQuality size, int radius = -1) const;
+    MapPoint SimpleFindPosition(const MapPoint& pt, BuildingQuality size, unsigned radius) const;
     /// Find a position for a specific building around a given point
     MapPoint FindPositionForBuildingAround(BuildingType type, const MapPoint& around);
     /// Density in percent (0-100)
     unsigned GetDensity(MapPoint pt, AIResource res, int radius);
-    /// Recalculate the Buildingquality around a certain point
-    void RecalcBQAround(MapPoint pt);
     /// Does some actions after a new military building is occupied
     void HandleNewMilitaryBuildingOccupied(MapPoint pt);
     /// Does some actions after a military building is lost
@@ -205,9 +191,6 @@ public:
     /// checks if there is at least 1 sea id connected to the harbor spot with at least 2 harbor spots! when
     /// onlyempty=true there has to be at least 1 other free harborid
     bool HarborPosRelevant(unsigned harborid, bool onlyempty = false) const;
-    /// returns true when a building of the given type is closer to the given position than min (ONLY NOBUSUAL (=no
-    /// warehouse/military))
-    bool BuildingNearby(MapPoint pt, BuildingType bldType, unsigned min);
     /// Update BQ and farming ground around new building site + road
     void RecalcGround(MapPoint buildingPos, std::vector<Direction>& route_road);
 
@@ -243,8 +226,6 @@ public:
     void ExecuteLuaConstructionOrder(MapPoint pt, BuildingType bt, bool forced = false);
 
     bool NoEnemyHarbor();
-
-    void SetResourceMapValue(AIResource res, MapPoint pt, int newvalue) { resourceMaps[res][pt] = newvalue; }
 
     MapPoint UpgradeBldPos;
 

--- a/libs/s25main/ai/aijh/AIPlayerJH.h
+++ b/libs/s25main/ai/aijh/AIPlayerJH.h
@@ -143,10 +143,6 @@ public:
     // returns true if we can get to the startflag in <maxlen without turning back
     bool IsFlagPartofCircle(const noFlag& startFlag, unsigned maxlen, const noFlag& curFlag,
                             helpers::OptionalEnum<Direction> excludeDir, std::vector<const noFlag*> oldFlags);
-    /// Finds a good position for a specific resource in an area using the resource maps,
-    /// first position satisfying threshold is returned, returns false if no such position found
-    MapPoint FindGoodPosition(const MapPoint& pt, AIResource res, int threshold, BuildingQuality size, int radius = -1,
-                              bool inTerritory = true) const;
     /// Finds the best position for a specific resource in an area using the resource maps,
     /// satisfying the minimum value, returns false if no such position is found
     MapPoint FindBestPosition(const MapPoint& pt, AIResource res, BuildingQuality size, int minimum, int radius = -1,
@@ -248,10 +244,7 @@ public:
 
     bool NoEnemyHarbor();
 
-    void SetResourceMapValue(AIResource res, MapPoint pt, int newvalue)
-    {
-        resourceMaps[res][pt] = newvalue;
-    }
+    void SetResourceMapValue(AIResource res, MapPoint pt, int newvalue) { resourceMaps[res][pt] = newvalue; }
 
     MapPoint UpgradeBldPos;
 

--- a/libs/s25main/ai/aijh/AIResourceMap.cpp
+++ b/libs/s25main/ai/aijh/AIResourceMap.cpp
@@ -102,31 +102,6 @@ void AIResourceMap::Change(const MapPoint pt, unsigned radius, int value)
     aii.gwb.CheckPointsInRadius(pt, radius, ValueAdjuster(map, radius, value), true);
 }
 
-MapPoint AIResourceMap::FindGoodPosition(const MapPoint& pt, int threshold, BuildingQuality size, int radius,
-                                         bool inTerritory) const
-{
-    RTTR_Assert(pt.x < map.GetWidth() && pt.y < map.GetHeight());
-
-    // TODO was besseres wär schön ;)
-    if(radius == -1)
-        radius = 30;
-
-    std::vector<MapPoint> pts = aii.gwb.GetPointsInRadiusWithCenter(pt, radius);
-    for(const MapPoint& curPt : pts)
-    {
-        const unsigned idx = map.GetIdx(curPt);
-        if(map[idx] >= threshold)
-        {
-            if((inTerritory && !aiMap[idx].owned) || aiMap[idx].farmed)
-                continue;
-            RTTR_Assert(aii.GetBuildingQuality(curPt) == aiMap[curPt].bq);
-            if(canUseBq(aii.GetBuildingQuality(curPt), size)) //(*nodes)[idx].bq; TODO: Update nodes BQ and use that
-                return curPt;
-        }
-    }
-    return MapPoint::Invalid();
-}
-
 MapPoint AIResourceMap::FindBestPosition(const MapPoint& pt, BuildingQuality size, int minimum, int radius,
                                          bool inTerritory) const
 {

--- a/libs/s25main/ai/aijh/AIResourceMap.cpp
+++ b/libs/s25main/ai/aijh/AIResourceMap.cpp
@@ -26,7 +26,7 @@
 namespace AIJH {
 
 AIResourceMap::AIResourceMap(const AIResource res, const AIInterface& aii, const AIMap& aiMap)
-    : res(res), resRadius(RES_RADIUS[static_cast<unsigned>(res)]), aii(aii), aiMap(aiMap)
+    : res(res), resRadius(RES_RADIUS[res]), aii(aii), aiMap(aiMap)
 {}
 
 AIResourceMap::~AIResourceMap() = default;
@@ -44,8 +44,9 @@ void AIResourceMap::Init()
         else if(aii.gwb.GetDescription().get(aii.gwb.GetNode(pt).t1).Is(ETerrain::Walkable))
         {
             if((res != AIResource::Borderland && node.res == res) || (res == AIResource::Borderland && aii.IsBorder(pt))
-               || (node.res == AIResource::Multiple
-                   && (aii.GetSubsurfaceResource(pt) == res || aii.GetSurfaceResource(pt) == res)))
+               || (node.res == AINodeResource::Multiple
+                   && (convertToNodeResource(aii.GetSubsurfaceResource(pt)) == res
+                       || convertToNodeResource(aii.GetSurfaceResource(pt)) == res)))
                 Change(pt, 1);
         }
     }

--- a/libs/s25main/ai/aijh/AIResourceMap.h
+++ b/libs/s25main/ai/aijh/AIResourceMap.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -29,31 +29,34 @@ namespace AIJH {
 class AIResourceMap
 {
 public:
-    AIResourceMap(AIResource res, const AIInterface& aii, const AIMap& aiMap);
+    AIResourceMap(AIResource res, bool isInfinite, const AIInterface& aii, const AIMap& aiMap);
     ~AIResourceMap();
 
     /// Initialize the resource map
-    void Init();
-    void Recalc();
-    /// Changes every point around pt in radius; to every point around pt distanceFromCenter * value is added
-    void Change(MapPoint pt, unsigned radius, int value);
-    void Change(const MapPoint pt, int value) { Change(pt, resRadius, value); }
+    void init();
+
+    void updateAround(const MapPoint& pt, int radius);
+
     /// Finds the best position for a specific resource in an area using the resource maps,
     /// satisfying the minimum value, returns false if no such position is found
-    MapPoint FindBestPosition(const MapPoint& pt, BuildingQuality size, int minimum, int radius = -1,
-                              bool inTerritory = true) const;
-    MapPoint FindBestPosition(const MapPoint& pt, BuildingQuality size, int radius = -1, bool inTerritory = true) const
-    {
-        return FindBestPosition(pt, size, 1, radius, inTerritory);
-    }
+    MapPoint findBestPosition(const MapPoint& pt, BuildingQuality size, unsigned radius, int minimum) const;
 
-    int& operator[](const MapPoint& pt) { return map[pt]; }
+    /// Marks a position to be avoided.
+    /// Only has an effect on diminishable resources where this blocks this point forever
+    void avoidPosition(const MapPoint& pt);
+
     int operator[](const MapPoint& pt) const { return map[pt]; }
 
 private:
-    void AdjustRatingForBlds(BuildingType bld, unsigned radius, int value);
+    /// Update algorithm for resources which cannot be regrown
+    void updateAroundDiminishable(const MapPoint& pt, int radius);
+    /// Update algorithm for resources which can be replenished
+    void updateAroundReplinishable(const MapPoint& pt, int radius);
+
     /// Which resource is stored in the map and radius of affected nodes
     const AIResource res;
+    const bool isInfinite;
+    const bool isDiminishableResource;
     const unsigned resRadius;
 
     NodeMapBase<int> map;

--- a/libs/s25main/ai/aijh/AIResourceMap.h
+++ b/libs/s25main/ai/aijh/AIResourceMap.h
@@ -38,10 +38,6 @@ public:
     /// Changes every point around pt in radius; to every point around pt distanceFromCenter * value is added
     void Change(MapPoint pt, unsigned radius, int value);
     void Change(const MapPoint pt, int value) { Change(pt, resRadius, value); }
-    /// Finds a good position for a specific resource in an area using the resource maps,
-    /// first position satisfying threshold is returned, returns false if no such position found
-    MapPoint FindGoodPosition(const MapPoint& pt, int threshold, BuildingQuality size, int radius = -1,
-                              bool inTerritory = true) const;
     /// Finds the best position for a specific resource in an area using the resource maps,
     /// satisfying the minimum value, returns false if no such position is found
     MapPoint FindBestPosition(const MapPoint& pt, BuildingQuality size, int minimum, int radius = -1,

--- a/libs/s25main/gameTypes/GameTypesOutput.h
+++ b/libs/s25main/gameTypes/GameTypesOutput.h
@@ -38,9 +38,6 @@
 #include <boost/preprocessor/variadic/to_seq.hpp>
 #include <ostream>
 
-#define RTTR_CASE_OUT(Enum, Enumerator) \
-    case Enum::Enumerator: os << #Enumerator; break
-
 // LCOV_EXCL_START
 
 #define RTTR_ENUM_CASE_SINGLE(s, EnumName, Enumerator) \
@@ -105,5 +102,3 @@ std::ostream& operator<<(std::ostream& out, const DescIdx<T>& d)
 }
 
 // LCOV_EXCL_STOP
-
-#undef RTTR_CASE_OUT

--- a/tests/s25Main/lua/GameWithLuaAccess.h
+++ b/tests/s25Main/lua/GameWithLuaAccess.h
@@ -44,15 +44,7 @@
 class GameWithLuaAccess : public Game
 {
 public:
-    GameWithLuaAccess() : Game(GlobalGameSettings(), 0u, CreatePlayers())
-    {
-        for(unsigned id = 0; id < world_.GetNumPlayers(); id++)
-        {
-            GamePlayer& player = world_.GetPlayer(id);
-            if(!player.isHuman() && player.isUsed())
-                AddAIPlayer(AIFactory::Create(world_.GetPlayer(id).aiInfo, id, world_));
-        }
-    }
+    GameWithLuaAccess() : Game(GlobalGameSettings(), 0u, CreatePlayers()) {}
 
     void executeAICommands()
     {
@@ -118,6 +110,13 @@ public:
         playerNations.push_back(world.GetPlayer(0).nation);
         playerNations.push_back(world.GetPlayer(1).nation);
         BOOST_TEST_REQUIRE(MapLoader::PlaceHQs(world, hqPositions, false));
+
+        for(unsigned id = 0; id < world.GetNumPlayers(); id++)
+        {
+            GamePlayer& player = world.GetPlayer(id);
+            if(!player.isHuman() && player.isUsed())
+                game->AddAIPlayer(AIFactory::Create(world.GetPlayer(id).aiInfo, id, world));
+        }
     }
 
     virtual GameWorldGame& GetWorld() override { return world; }

--- a/tests/s25Main/simple/testGameTypes.cpp
+++ b/tests/s25Main/simple/testGameTypes.cpp
@@ -15,10 +15,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
+#include "ai/AIResource.h"
 #include "helpers/EnumRange.h"
 #include "gameTypes/GameTypesOutput.h"
 #include "gameTypes/Resource.h"
 #include "gameData/JobConsts.h"
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(GameTypes)
@@ -121,6 +125,28 @@ BOOST_AUTO_TEST_CASE(NationSpecificJobBobs)
                != JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Africans));
     BOOST_TEST(JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Vikings)
                < JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Babylonians));
+}
+
+BOOST_AUTO_TEST_CASE(AIResourcesMatchValues)
+{
+    // This simply tests that the convertToNodeResource function works, which is enough to verify the correctness of the
+    // enumerator values
+
+#define TEST_AIRESOURCE_SINGLE(s, EnumName, Enumerator)                                      \
+    static_assert(convertToNodeResource(EnumName::Enumerator) == AINodeResource::Enumerator, \
+                  "Mismatch for " BOOST_PP_STRINGIZE(EnumName) "::" BOOST_PP_STRINGIZE(Enumerator));
+
+    // Generate a static assert for each enumerator
+#define TEST_AIRESOURCE(EnumName, ...) \
+    BOOST_PP_SEQ_FOR_EACH(TEST_AIRESOURCE_SINGLE, EnumName, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
+    TEST_AIRESOURCE(AIResource, Gold, Ironore, Coal, Granite, Fish, Wood, Stones, Plantspace, Borderland)
+
+    TEST_AIRESOURCE(AISurfaceResource, Wood, Stones, Blocked, Nothing)
+
+    TEST_AIRESOURCE(AISubSurfaceResource, Gold, Ironore, Coal, Granite, Fish, Nothing)
+
+    BOOST_TEST(true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The current AI didn't know about inexhaustible granite mines and fish

I also started changing the resourceMaps array to an EnumArray which lead to a bunch of related changes by introducing separate enums for surface, subsurface, and node resources which makes the intention clearer:
- AIResource is what the AI cares about
- Surface and SubSurface resources are the ones from AIResource which are above/below the surface and includes `Nothing` (the enums aren't contiguous so can't use OptionalEnum)
- AINodeResource is all AIResources + a few special ones like "blocked" and "multiple". I kept this during refactoring but might remove later as the aiMap.res entries aren't updated so they become out of date fast. Might fix that later or remove

Most importantly I merged the resource rating calculation and position search into the resource maps and removed what was in there. It was almost the same but unused so now we have only a single algorithm and rating mechanism. Check the commit message for details

I know that the current resource rating calculation is broken, see #933. I'll fix that in a follow-up PR together with tests but I want to get this refactoring in first. It has no functional changes except for a few trivial bugfixes.