### PR TITLE
HQ positions on random maps consider mountain distance

### DIFF
--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -98,7 +98,7 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
         combo->AddString(_(desc.get(DescIdx<LandscapeDesc>(i)).name));
 
     curPos.y += 30;
-    AddText(CTRL_TXT_MOUNTAIN_DIST, curPos, _("Mountain Distance"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddText(CTRL_TXT_MOUNTAIN_DIST, curPos, _("HQ distance to mountain"), COLOR_YELLOW, FontStyle{}, NormalFont);
     curPos.y += 20;
     combo = AddComboBox(CTRL_MOUNTAIN_DIST, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     combo->AddString(_("Close"));

--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -71,8 +71,7 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
     const Extent buttonSize(100, 20);
 
     curPos.y += 30;
-    ctrlComboBox* combo =
-      AddComboBox(CTRL_PLAYER_NUMBER, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
+    ctrlComboBox* combo = AddComboBox(CTRL_PLAYER_NUMBER, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     for(unsigned n = 2; n <= MAX_PLAYERS; n++)
         combo->AddString(boost::str(boost::format(_("%1% players")) % n));
 

--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -64,49 +64,67 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
         return;
     }
 
-    AddTextButton(CTRL_BTN_BACK, DrawPoint(20, 370), Extent(100, 20), TextureColor::Red1, _("Back"), NormalFont);
-    AddTextButton(CTRL_BTN_APPLY, DrawPoint(130, 370), Extent(100, 20), TextureColor::Green2, _("Apply"), NormalFont);
+    DrawPoint curPos(20, 0);
 
+    const Extent comboSize(210, 20);
+    const Extent progressSize(130, 20);
+    const Extent buttonSize(100, 20);
+
+    curPos.y += 30;
     ctrlComboBox* combo =
-      AddComboBox(CTRL_PLAYER_NUMBER, DrawPoint(20, 30), Extent(210, 20), TextureColor::Grey, NormalFont, 100);
+      AddComboBox(CTRL_PLAYER_NUMBER, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     for(unsigned n = 2; n <= MAX_PLAYERS; n++)
         combo->AddString(boost::str(boost::format(_("%1% players")) % n));
 
-    combo = AddComboBox(CTRL_MAP_STYLE, DrawPoint(20, 60), Extent(210, 20), TextureColor::Grey, NormalFont, 100);
+    curPos.y += 30;
+    combo = AddComboBox(CTRL_MAP_STYLE, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     combo->AddString(_("Water"));
     combo->AddString(_("Land"));
     combo->AddString(_("Mixed"));
 
-    combo = AddComboBox(CTRL_MAP_SIZE, DrawPoint(20, 90), Extent(210, 20), TextureColor::Grey, NormalFont, 100);
+    curPos.y += 30;
+    combo = AddComboBox(CTRL_MAP_SIZE, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     combo->AddString("64 x 64");
     combo->AddString("128 x 128");
     combo->AddString("256 x 256");
     combo->AddString("512 x 512");
     combo->AddString("1024 x 1024");
 
-    AddText(CTRL_TXT_LANDSCAPE, DrawPoint(20, 120), _("Landscape"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    combo = AddComboBox(CTRL_MAP_TYPE, DrawPoint(20, 140), Extent(210, 20), TextureColor::Grey, NormalFont, 100);
+    curPos.y += 30;
+    AddText(CTRL_TXT_LANDSCAPE, curPos, _("Landscape"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    curPos.y += 20;
+    combo = AddComboBox(CTRL_MAP_TYPE, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     for(unsigned i = 0; i < desc.landscapes.size(); i++)
         combo->AddString(_(desc.get(DescIdx<LandscapeDesc>(i)).name));
 
-    AddText(CTRL_TXT_MOUNTAIN_DIST, DrawPoint(20, 170), _("Mountain Distance"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    combo = AddComboBox(CTRL_MOUNTAIN_DIST, DrawPoint(20, 190), Extent(210, 20), TextureColor::Grey, NormalFont, 100);
+    curPos.y += 30;
+    AddText(CTRL_TXT_MOUNTAIN_DIST, curPos, _("Mountain Distance"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    curPos.y += 20;
+    combo = AddComboBox(CTRL_MOUNTAIN_DIST, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     combo->AddString(_("Close"));
     combo->AddString(_("Normal"));
     combo->AddString(_("Far"));
     combo->AddString(_("Very far"));
 
-    AddText(CTRL_TXT_GOAL, DrawPoint(20, 225), _("Gold:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_GOLD, DrawPoint(100, 220), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
-    AddText(CTRL_TXT_IRON, DrawPoint(20, 255), _("Iron:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_IRON, DrawPoint(100, 250), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
-    AddText(CTRL_TXT_COAL, DrawPoint(20, 285), _("Coal:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_COAL, DrawPoint(100, 280), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
-    AddText(CTRL_TXT_GRANITE, DrawPoint(20, 315), _("Granite:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_GRANITE, DrawPoint(100, 310), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+    curPos.y += 35;
+    AddText(CTRL_TXT_GOAL, curPos, _("Gold:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_GOLD, DrawPoint(100, curPos.y - 5), progressSize, TextureColor::Grey, 139, 138, 100);
+    curPos.y += 30;
+    AddText(CTRL_TXT_IRON, curPos, _("Iron:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_IRON, DrawPoint(100, curPos.y - 5), progressSize, TextureColor::Grey, 139, 138, 100);
+    curPos.y += 30;
+    AddText(CTRL_TXT_COAL, curPos, _("Coal:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_COAL, DrawPoint(100, curPos.y - 5), progressSize, TextureColor::Grey, 139, 138, 100);
+    curPos.y += 30;
+    AddText(CTRL_TXT_GRANITE, curPos, _("Granite:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_GRANITE, DrawPoint(100, curPos.y - 5), progressSize, TextureColor::Grey, 139, 138, 100);
+    curPos.y += 30;
+    AddText(CTRL_TXT_RIVERS, curPos, _("Rivers:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RIVERS, DrawPoint(100, curPos.y - 5), progressSize, TextureColor::Grey, 139, 138, 100);
 
-    AddText(CTRL_TXT_RIVERS, DrawPoint(20, 345), _("Rivers:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RIVERS, DrawPoint(100, 340), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+    curPos.y += 25;
+    AddTextButton(CTRL_BTN_BACK, curPos, buttonSize, TextureColor::Red1, _("Back"), NormalFont);
+    AddTextButton(CTRL_BTN_APPLY, DrawPoint(130, curPos.y), buttonSize, TextureColor::Green2, _("Apply"), NormalFont);
 
     Reset();
 }

--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -38,6 +38,7 @@ enum
     CTRL_TXT_COAL,
     CTRL_TXT_GRANITE,
     CTRL_TXT_RIVERS,
+    CTRL_TXT_MOUNTAIN_DIST,
     CTRL_PLAYER_NUMBER,
     CTRL_MAP_STYLE,
     CTRL_MAP_SIZE,
@@ -46,11 +47,12 @@ enum
     CTRL_RATIO_IRON,
     CTRL_RATIO_COAL,
     CTRL_RATIO_GRANITE,
-    CTRL_RIVERS
+    CTRL_RIVERS,
+    CTRL_MOUNTAIN_DIST
 };
 
 iwMapGenerator::iwMapGenerator(MapSettings& settings)
-    : IngameWindow(CGI_MAP_GENERATOR, IngameWindow::posLastOrCenter, Extent(250, 380), _("Map Generator"),
+    : IngameWindow(CGI_MAP_GENERATOR, IngameWindow::posLastOrCenter, Extent(250, 410), _("Map Generator"),
                    LOADER.GetImageN("resource", 41), true),
       mapSettings(settings)
 {
@@ -62,8 +64,8 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
         return;
     }
 
-    AddTextButton(CTRL_BTN_BACK, DrawPoint(20, 340), Extent(100, 20), TextureColor::Red1, _("Back"), NormalFont);
-    AddTextButton(CTRL_BTN_APPLY, DrawPoint(130, 340), Extent(100, 20), TextureColor::Green2, _("Apply"), NormalFont);
+    AddTextButton(CTRL_BTN_BACK, DrawPoint(20, 370), Extent(100, 20), TextureColor::Red1, _("Back"), NormalFont);
+    AddTextButton(CTRL_BTN_APPLY, DrawPoint(130, 370), Extent(100, 20), TextureColor::Green2, _("Apply"), NormalFont);
 
     ctrlComboBox* combo =
       AddComboBox(CTRL_PLAYER_NUMBER, DrawPoint(20, 30), Extent(210, 20), TextureColor::Grey, NormalFont, 100);
@@ -87,17 +89,24 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
     for(unsigned i = 0; i < desc.landscapes.size(); i++)
         combo->AddString(_(desc.get(DescIdx<LandscapeDesc>(i)).name));
 
-    AddText(CTRL_TXT_GOAL, DrawPoint(20, 175), _("Gold:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_GOLD, DrawPoint(100, 170), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
-    AddText(CTRL_TXT_IRON, DrawPoint(20, 205), _("Iron:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_IRON, DrawPoint(100, 200), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
-    AddText(CTRL_TXT_COAL, DrawPoint(20, 235), _("Coal:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_COAL, DrawPoint(100, 230), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
-    AddText(CTRL_TXT_GRANITE, DrawPoint(20, 265), _("Granite:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RATIO_GRANITE, DrawPoint(100, 260), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+    AddText(CTRL_TXT_MOUNTAIN_DIST, DrawPoint(20, 170), _("Mountain Distance"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    combo = AddComboBox(CTRL_MOUNTAIN_DIST, DrawPoint(20, 190), Extent(210, 20), TextureColor::Grey, NormalFont, 100);
+    combo->AddString(_("Close"));
+    combo->AddString(_("Normal"));
+    combo->AddString(_("Far"));
+    combo->AddString(_("Very far"));
 
-    AddText(CTRL_TXT_RIVERS, DrawPoint(20, 295), _("Rivers:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddProgress(CTRL_RIVERS, DrawPoint(100, 290), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+    AddText(CTRL_TXT_GOAL, DrawPoint(20, 225), _("Gold:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_GOLD, DrawPoint(100, 220), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+    AddText(CTRL_TXT_IRON, DrawPoint(20, 255), _("Iron:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_IRON, DrawPoint(100, 250), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+    AddText(CTRL_TXT_COAL, DrawPoint(20, 285), _("Coal:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_COAL, DrawPoint(100, 280), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+    AddText(CTRL_TXT_GRANITE, DrawPoint(20, 315), _("Granite:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RATIO_GRANITE, DrawPoint(100, 310), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
+
+    AddText(CTRL_TXT_RIVERS, DrawPoint(20, 345), _("Rivers:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    AddProgress(CTRL_RIVERS, DrawPoint(100, 340), Extent(130, 20), TextureColor::Grey, 139, 138, 100);
 
     Reset();
 }
@@ -128,6 +137,14 @@ void iwMapGenerator::Apply()
     mapSettings.ratioGranite = GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->GetPosition();
     mapSettings.rivers = GetCtrl<ctrlProgress>(CTRL_RIVERS)->GetPosition();
 
+    switch (GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST)->GetSelection().get())
+    {
+        case 0: mapSettings.mountainDistance = MountainDistance::Close; break;
+        case 1: mapSettings.mountainDistance = MountainDistance::Normal; break;
+        case 2: mapSettings.mountainDistance = MountainDistance::Far; break;
+        case 3: mapSettings.mountainDistance = MountainDistance::VeryFar; break;
+        default: break;
+    }
     switch(GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->GetSelection().get())
     {
         case 0: mapSettings.style = MapStyle::Water; break;
@@ -162,6 +179,16 @@ void iwMapGenerator::Reset()
     GetCtrl<ctrlProgress>(CTRL_RATIO_COAL)->SetPosition(mapSettings.ratioCoal);
     GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->SetPosition(mapSettings.ratioGranite);
     GetCtrl<ctrlProgress>(CTRL_RIVERS)->SetPosition(mapSettings.rivers);
+
+    combo = GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST);
+    switch(mapSettings.mountainDistance)
+    {
+        case MountainDistance::Close: combo->SetSelection(0); break;
+        case MountainDistance::Normal: combo->SetSelection(1); break;
+        case MountainDistance::Far: combo->SetSelection(2); break;
+        case MountainDistance::VeryFar: combo->SetSelection(3); break;
+        default: break;
+    }
 
     combo = GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE);
     switch(mapSettings.style)

--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -137,7 +137,7 @@ void iwMapGenerator::Apply()
     mapSettings.ratioGranite = GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->GetPosition();
     mapSettings.rivers = GetCtrl<ctrlProgress>(CTRL_RIVERS)->GetPosition();
 
-    switch (GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST)->GetSelection().get())
+    switch(GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST)->GetSelection().get())
     {
         case 0: mapSettings.mountainDistance = MountainDistance::Close; break;
         case 1: mapSettings.mountainDistance = MountainDistance::Normal; break;

--- a/libs/s25main/mapGenerator/HeadQuarters.cpp
+++ b/libs/s25main/mapGenerator/HeadQuarters.cpp
@@ -57,7 +57,7 @@ namespace rttr { namespace mapGenerator {
         return connectedArea;
     }
 
-    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, int retries)
+    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, unsigned playerDistanceToMountains, int retries)
     {
         auto maxRetries = retries;
         auto success = false;
@@ -70,7 +70,7 @@ namespace rttr { namespace mapGenerator {
 
             for(int index = 0; index < number; index++)
             {
-                auto possiblePositions = FindHqPositions(map, area);
+                auto possiblePositions = FindHqPositions(map, area, playerDistanceToMountains);
 
                 if(possiblePositions.empty())
                 {

--- a/libs/s25main/mapGenerator/HeadQuarters.cpp
+++ b/libs/s25main/mapGenerator/HeadQuarters.cpp
@@ -74,17 +74,14 @@ namespace rttr { namespace mapGenerator {
 
                 if(possiblePositions.empty())
                 {
-                    for(int i = 0; i < number; i++)
-                    {
-                        map.hqPositions[i] = MapPoint::Invalid();
-                    }
+                    map.hqPositions.clear();
                     success = false;
                     break;
                 }
 
                 auto hq = retries == maxRetries ? possiblePositions.front() : rnd.RandomItem(possiblePositions);
 
-                map.hqPositions[index] = hq;
+                map.hqPositions.push_back(hq);
             }
 
             retries--;

--- a/libs/s25main/mapGenerator/HeadQuarters.cpp
+++ b/libs/s25main/mapGenerator/HeadQuarters.cpp
@@ -57,7 +57,7 @@ namespace rttr { namespace mapGenerator {
         return connectedArea;
     }
 
-    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, unsigned playerDistanceToMountains, int retries)
+    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, MountainDistance distance, int retries)
     {
         auto maxRetries = retries;
         auto success = false;
@@ -70,7 +70,7 @@ namespace rttr { namespace mapGenerator {
 
             for(int index = 0; index < number; index++)
             {
-                auto possiblePositions = FindHqPositions(map, area, playerDistanceToMountains);
+                auto possiblePositions = FindHqPositions(map, area, distance);
 
                 if(possiblePositions.empty())
                 {

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -77,7 +77,8 @@ namespace rttr { namespace mapGenerator {
         // Ensure HQ positions keep desired distance to mountains
         const auto mountain = [&map](const MapPoint& pt) { return map.textureMap.Any(pt, IsMinableMountain); };
         const auto mountainDistance = DistancesTo(map.size, mountain);
-        const auto desiredDistance = std::max(GetMinimum(mountainDistance, possiblePositions), playerDistanceToMountains);
+        const auto desiredDistance =
+          std::max(GetMinimum(mountainDistance, possiblePositions), playerDistanceToMountains);
         const auto maxDistance = static_cast<unsigned>(map.size.x + map.size.y) / 4;
 
         std::vector<MapPoint> positions;
@@ -86,7 +87,8 @@ namespace rttr { namespace mapGenerator {
         {
             for(const MapPoint& pt : possiblePositions)
             {
-                if(obstacleDistance[pt] >= minObstacleDistance && mountainDistance[pt] < allowedMountainDistance + 5 && mountainDistance[pt] > allowedMountainDistance - 5)
+                if(obstacleDistance[pt] >= minObstacleDistance && mountainDistance[pt] < allowedMountainDistance + 5
+                   && mountainDistance[pt] > allowedMountainDistance - 5)
                 {
                     positions.push_back(pt);
                 }
@@ -143,6 +145,7 @@ namespace rttr { namespace mapGenerator {
      *
      * @throw runtime_error
      */
-    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, unsigned playerDistanceToMountains, int retries = 10);
+    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, unsigned playerDistanceToMountains,
+                           int retries = 10);
 
 }} // namespace rttr::mapGenerator

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -78,7 +78,7 @@ namespace rttr { namespace mapGenerator {
         // Keep minimum distance to other HQs and desired distance to mountains
         const auto mountain = [&map](const MapPoint& pt) { return map.textureMap.Any(pt, IsMinableMountain); };
         const auto mountainDistances = DistancesTo(map.size, mountain);
-        const unsigned desiredDistance = static_cast<unsigned>(distance);
+        const auto desiredDistance = static_cast<unsigned>(distance);
         const auto distanceToOtherHqs = DistancesTo(map.hqPositions, map.size);
         const unsigned minimumHqDistance = (map.size.x + map.size.y) / 16;
         const int maximumRadius = (map.size.x + map.size.y) / 4;

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -96,7 +96,7 @@ namespace rttr { namespace mapGenerator {
         }
 
         // fallback in case all points within desired mountain distance are too close to other HQs
-        if (positions.empty())
+        if(positions.empty())
         {
             positions = possiblePositions;
         }

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -88,7 +88,7 @@ namespace rttr { namespace mapGenerator {
         {
             for(const MapPoint& pt : possiblePositions)
             {
-                if(obstacleDistance[pt] >= minObstacleDistance && mountainDistance[pt] < allowedMountainDistance + 5
+                if(mountainDistance[pt] < allowedMountainDistance + 5
                    && mountainDistance[pt] > allowedMountainDistance - 5)
                 {
                     positions.push_back(pt);

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -88,18 +88,19 @@ namespace rttr { namespace mapGenerator {
         const unsigned minHqDistance = (map.size.x + map.size.y) / 16;
 
         const auto desiredDistanceOffset = [&mountainDistances, desiredDistance](const MapPoint& pt) {
-            return mountainDistances[pt] > desiredDistance
-                ? mountainDistances[pt] - desiredDistance : desiredDistance - mountainDistances[pt];
+            return mountainDistances[pt] > desiredDistance ? mountainDistances[pt] - desiredDistance :
+                                                             desiredDistance - mountainDistances[pt];
         };
         const auto byDesiredMountainDistanceOffset = [desiredDistanceOffset](MapPoint p1, MapPoint p2) {
             return desiredDistanceOffset(p1) < desiredDistanceOffset(p2);
         };
-        const auto farFromOtherHqs = [&distanceToOtherHqs, minHqDistance](const MapPoint&  pt) {
+        const auto farFromOtherHqs = [&distanceToOtherHqs, minHqDistance](const MapPoint& pt) {
             return distanceToOtherHqs[pt] > minHqDistance;
         };
 
         std::vector<MapPoint> positions;
-        std::copy_if(possiblePositions.begin(), possiblePositions.end(), std::back_inserter(positions), farFromOtherHqs);
+        std::copy_if(possiblePositions.begin(), possiblePositions.end(), std::back_inserter(positions),
+                     farFromOtherHqs);
         std::sort(positions.begin(), positions.end(), byDesiredMountainDistanceOffset);
 
         return positions.empty() ? possiblePositions : positions;

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -88,8 +88,7 @@ namespace rttr { namespace mapGenerator {
         {
             for(const MapPoint& pt : possiblePositions)
             {
-                if(mountainDistance[pt] < allowedMountainDistance + 5
-                   && mountainDistance[pt] > allowedMountainDistance - 5)
+                if(std::abs(static_cast<int>(mountainDistance[pt] - allowedMountainDistance)) < 5)
                 {
                     positions.push_back(pt);
                 }

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -20,6 +20,7 @@
 #include "helpers/mathFuncs.h"
 #include "mapGenerator/Map.h"
 #include "mapGenerator/RandomUtility.h"
+#include "mapGenerator/TextureHelper.h"
 #include <stdexcept>
 
 namespace rttr { namespace mapGenerator {
@@ -42,12 +43,13 @@ namespace rttr { namespace mapGenerator {
      *
      * @param map map to search for suitable HQ positions
      * @param area area within the HQ position should be
+     * @param playerDistanceToMountains desired player distance to mountain
      *
      * @return all suitable HQ positions witihn the specified area (or the entire map if the area is empty).
      * @throw runtime_error
      */
     template<class T_Container>
-    std::vector<MapPoint> FindHqPositions(const Map& map, const T_Container& area)
+    std::vector<MapPoint> FindHqPositions(const Map& map, const T_Container& area, unsigned playerDistanceToMountains)
     {
         if(area.empty())
         {
@@ -55,31 +57,56 @@ namespace rttr { namespace mapGenerator {
         }
 
         const auto isValid = [](const MapPoint& pt) { return pt.isValid(); };
-        const auto isObstacle = [&map](MapPoint point) {
-            return map.textureMap.Any(point, [](auto t) { return !t.Is(ETerrain::Buildable); });
+        const auto isObstacle = [&map](const MapPoint& pt) {
+            return map.textureMap.Any(pt, [](auto t) { return !t.Is(ETerrain::Buildable); });
         };
+        const auto isMountain = [&map](const MapPoint& pt) { return map.textureMap.Any(pt, IsMinableMountain); };
         std::vector<MapPoint> hqs;
         std::copy_if(map.hqPositions.begin(), map.hqPositions.end(), std::back_inserter(hqs), isValid);
 
-        // Quality of a map point as one player's HQ is a mix of:
-        // 1. distance to other players' HQs (higher = better)
-        // 2. distance to any other obstacle e.g. mountain & water (higher = better)
+        // Too consider a MapPoint as possible HQ position it requires:
+        // 1. a minimum distances to obstacle
+        // 2. a maximum distances to mountains
+        // Quality of a possible HQ position depends on the distance to other HQ positions.
         NodeMapBase<unsigned> potentialHqQuality = DistancesTo(hqs, map.size);
         const auto obstacleDistance = DistancesTo(map.size, isObstacle);
-        const auto minDistance = helpers::clamp(GetMaximum(obstacleDistance, area), 2u, 4u);
+        const auto minObstacleDistance = helpers::clamp(GetMaximum(obstacleDistance, area), 2u, 4u);
+        const auto mountainDistance = DistancesTo(map.size, isMountain);
+        const auto minMountainDistance = std::max(GetMinimum(mountainDistance, area), playerDistanceToMountains);
+        const auto maxMountainDistance = static_cast<unsigned>(map.size.x + map.size.y);
+        const auto noMountainsAvailable = minMountainDistance > maxMountainDistance;
 
         std::vector<MapPoint> positions;
-        for(const MapPoint& pt : area)
+        auto allowedMountainDistance = minMountainDistance;
+        while(positions.empty())
         {
-            if(obstacleDistance[pt] >= minDistance)
+            for(const MapPoint& pt : area)
             {
-                positions.push_back(pt);
+                const auto mountainsInReach = mountainDistance[pt] < allowedMountainDistance + 5 && mountainDistance[pt] > allowedMountainDistance - 5;
+
+                if(obstacleDistance[pt] >= minObstacleDistance && (noMountainsAvailable || mountainsInReach))
+                {
+                    positions.push_back(pt);
+                }
+            }
+            if(allowedMountainDistance < maxMountainDistance)
+            {
+                allowedMountainDistance++;
             } else
             {
-                potentialHqQuality[pt] = 0;
+                // fall back to ignore desired mountain distance
+                for(const MapPoint& pt : area)
+                {
+                    if(obstacleDistance[pt] >= minObstacleDistance)
+                    {
+                        positions.push_back(pt);
+                    }
+                }
+                break;
             }
         }
-        auto isBetter = [&potentialHqQuality](MapPoint p1, MapPoint p2) {
+
+        const auto isBetter = [&potentialHqQuality](MapPoint p1, MapPoint p2) {
             return potentialHqQuality[p1] > potentialHqQuality[p2];
         };
         std::sort(positions.begin(), positions.end(), isBetter);
@@ -92,13 +119,14 @@ namespace rttr { namespace mapGenerator {
      * @param map reference to the map to place the HQ on
      * @param index player index for the HQ
      * @param area area to place the HQ in
+     * @param playerDistanceToMountains desired player distance to mountain
      *
      * @throw runtime_error
      */
     template<class T_Container>
-    void PlaceHeadquarter(Map& map, int index, const T_Container& area)
+    void PlaceHeadquarter(Map& map, int index, const T_Container& area, unsigned playerDistanceToMountains)
     {
-        auto positions = FindHqPositions(map, area);
+        const auto positions = FindHqPositions(map, area, playerDistanceToMountains);
         if(positions.empty())
         {
             throw std::runtime_error("Could not find any valid HQ position!");
@@ -113,9 +141,10 @@ namespace rttr { namespace mapGenerator {
      * @param rnd random number generated used for retrying HQ placement on failures
      * @param number number of HQs to place - equal to the number of players
      * @param retries number of retries to place valid HQs on this map
+     * @param playerDistanceToMountains desired player distance to mountain
      *
      * @throw runtime_error
      */
-    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, int retries = 10);
+    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, unsigned playerDistanceToMountains, int retries = 10);
 
 }} // namespace rttr::mapGenerator

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -19,6 +19,7 @@
 
 #include "helpers/mathFuncs.h"
 #include "mapGenerator/Map.h"
+#include "mapGenerator/MapSettings.h"
 #include "mapGenerator/RandomUtility.h"
 #include "mapGenerator/TextureHelper.h"
 #include <stdexcept>
@@ -43,13 +44,13 @@ namespace rttr { namespace mapGenerator {
      *
      * @param map map to search for suitable HQ positions
      * @param area area within the HQ position should be
-     * @param playerDistanceToMountains desired player distance to mountain
+     * @param distance desired player distance to mountain
      *
      * @return all suitable HQ positions witihn the specified area (or the entire map if the area is empty).
      * @throw runtime_error
      */
     template<class T_Container>
-    std::vector<MapPoint> FindHqPositions(const Map& map, const T_Container& area, unsigned playerDistanceToMountains)
+    std::vector<MapPoint> FindHqPositions(const Map& map, const T_Container& area, MountainDistance distance)
     {
         if(area.empty())
         {
@@ -78,7 +79,7 @@ namespace rttr { namespace mapGenerator {
         const auto mountain = [&map](const MapPoint& pt) { return map.textureMap.Any(pt, IsMinableMountain); };
         const auto mountainDistance = DistancesTo(map.size, mountain);
         const auto desiredDistance =
-          std::max(GetMinimum(mountainDistance, possiblePositions), playerDistanceToMountains);
+          std::max(GetMinimum(mountainDistance, possiblePositions), static_cast<unsigned>(distance));
         const auto maxDistance = static_cast<unsigned>(map.size.x + map.size.y) / 4;
 
         std::vector<MapPoint> positions;
@@ -119,14 +120,14 @@ namespace rttr { namespace mapGenerator {
      * @param map reference to the map to place the HQ on
      * @param index player index for the HQ
      * @param area area to place the HQ in
-     * @param playerDistanceToMountains desired player distance to mountain
+     * @param distance desired player distance to mountain
      *
      * @throw runtime_error
      */
     template<class T_Container>
-    void PlaceHeadquarter(Map& map, int index, const T_Container& area, unsigned playerDistanceToMountains)
+    void PlaceHeadquarter(Map& map, int index, const T_Container& area, MountainDistance distance)
     {
-        const auto positions = FindHqPositions(map, area, playerDistanceToMountains);
+        const auto positions = FindHqPositions(map, area, distance);
         if(positions.empty())
         {
             throw std::runtime_error("Could not find any valid HQ position!");
@@ -141,11 +142,10 @@ namespace rttr { namespace mapGenerator {
      * @param rnd random number generated used for retrying HQ placement on failures
      * @param number number of HQs to place - equal to the number of players
      * @param retries number of retries to place valid HQs on this map
-     * @param playerDistanceToMountains desired player distance to mountain
+     * @param distance desired player distance to mountain
      *
      * @throw runtime_error
      */
-    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, unsigned playerDistanceToMountains,
-                           int retries = 10);
+    void PlaceHeadquarters(Map& map, RandomUtility& rnd, int number, MountainDistance distance, int retries = 10);
 
 }} // namespace rttr::mapGenerator

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -118,21 +118,20 @@ namespace rttr { namespace mapGenerator {
      * Tries to place a head quarter (HQ) for a single player within the specified area.
      *
      * @param map reference to the map to place the HQ on
-     * @param index player index for the HQ
      * @param area area to place the HQ in
      * @param distance desired player distance to mountain
      *
      * @throw runtime_error
      */
     template<class T_Container>
-    void PlaceHeadquarter(Map& map, int index, const T_Container& area, MountainDistance distance)
+    void PlaceHeadquarter(Map& map, const T_Container& area, MountainDistance distance)
     {
         const auto positions = FindHqPositions(map, area, distance);
         if(positions.empty())
         {
             throw std::runtime_error("Could not find any valid HQ position!");
         }
-        map.hqPositions[index] = positions.front();
+        map.hqPositions.push_back(positions.front());
     }
 
     /**

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -38,8 +38,8 @@ namespace rttr { namespace mapGenerator {
     std::vector<MapPoint> FindLargestConnectedArea(const Map& map);
 
     /**
-     * Finds suitable positions for a HQ in the specified area of the map. The resulting HQ positions are sorted by quality.
-     * To find suitable positions, this function does:
+     * Finds suitable positions for a HQ in the specified area of the map. The resulting HQ positions are sorted by
+     * quality. To find suitable positions, this function does:
      * 1. look for points within a buildable area of radius 2 (min. req. of HQ)
      * 2. if no such point exists return empty
      * 3. sort all those points by their distance to existing HQs
@@ -66,9 +66,7 @@ namespace rttr { namespace mapGenerator {
         const auto obstacleDistance = DistancesTo(map.size, [&map](const MapPoint& pt) {
             return map.textureMap.Any(pt, [](auto t) { return !t.Is(ETerrain::Buildable); });
         });
-        const auto hasEnoughSpace = [&obstacleDistance](const MapPoint& pt) {
-            return obstacleDistance[pt] >= 2;
-        };
+        const auto hasEnoughSpace = [&obstacleDistance](const MapPoint& pt) { return obstacleDistance[pt] >= 2; };
         std::vector<MapPoint> possiblePositions;
         std::copy_if(area.begin(), area.end(), std::back_inserter(possiblePositions), hasEnoughSpace);
 
@@ -99,7 +97,7 @@ namespace rttr { namespace mapGenerator {
         {
             return possiblePositions;
         }
-        
+
         // 6. sort remaining points by how close they're to desired mountain distance
         const auto mountain = [&map](const MapPoint& pt) { return map.textureMap.Any(pt, IsMinableMountain); };
         const auto mountainDistances = DistancesTo(map.size, mountain);

--- a/libs/s25main/mapGenerator/HeadQuarters.h
+++ b/libs/s25main/mapGenerator/HeadQuarters.h
@@ -41,11 +41,10 @@ namespace rttr { namespace mapGenerator {
      * Finds suitable positions for a HQ in the specified area of the map. The resulting HQ positions are sorted by
      * quality. To find suitable positions, this function does:
      * 1. look for points within a buildable area of radius 2 (min. req. of HQ)
-     * 2. if no such point exists return empty
-     * 3. sort all those points by their distance to existing HQs
-     * 4. filter out points within minimum distance to existing HQs
-     * 5. if no remaining points just return result of 3.
-     * 6. sort remaining points by how close they're to desired mountain distance
+     * 2. sort all those points by their distance to existing HQs
+     * 3. filter out points within minimum distance to existing HQs
+     * 4. if no remaining points just return result of 3.
+     * 5. sort remaining points by how close they're to desired mountain distance
      *
      * @param map map to search for suitable HQ positions
      * @param area area within the HQ position should be
@@ -70,20 +69,19 @@ namespace rttr { namespace mapGenerator {
         std::vector<MapPoint> possiblePositions;
         std::copy_if(area.begin(), area.end(), std::back_inserter(possiblePositions), hasEnoughSpace);
 
-        // 2. if no such point exists return empty
         if(possiblePositions.empty())
         {
             return possiblePositions;
         }
 
-        // 3. sort all those points by their distance to existing HQs
+        // 2. sort all those points by their distance to existing HQs
         const auto distanceToOtherHqs = DistancesTo(map.hqPositions, map.size);
         const auto byDistanceToOtherHqs = [&distanceToOtherHqs](MapPoint p1, MapPoint p2) {
             return distanceToOtherHqs[p1] > distanceToOtherHqs[p2];
         };
         std::sort(possiblePositions.begin(), possiblePositions.end(), byDistanceToOtherHqs);
 
-        // 4. filter out points within minimum distance to existing HQs
+        // 3. filter out points within minimum distance to existing HQs
         const unsigned minHqDistance = (map.size.x + map.size.y) / 16;
         const auto farFromOtherHqs = [&distanceToOtherHqs, minHqDistance](const MapPoint& pt) {
             return distanceToOtherHqs[pt] > minHqDistance;
@@ -92,13 +90,13 @@ namespace rttr { namespace mapGenerator {
         std::copy_if(possiblePositions.begin(), possiblePositions.end(), std::back_inserter(positions),
                      farFromOtherHqs);
 
-        // 5. if no remaining points just return result of 3.
+        // 4. if no remaining points just return result of 3.
         if(positions.empty())
         {
             return possiblePositions;
         }
 
-        // 6. sort remaining points by how close they're to desired mountain distance
+        // 5. sort remaining points by how close they're to desired mountain distance
         const auto mountain = [&map](const MapPoint& pt) { return map.textureMap.Any(pt, IsMinableMountain); };
         const auto mountainDistances = DistancesTo(map.size, mountain);
         const auto desiredDistance = static_cast<unsigned>(distance);
@@ -109,7 +107,7 @@ namespace rttr { namespace mapGenerator {
         const auto byDesiredMountainDistanceOffset = [desiredDistanceOffset](MapPoint p1, MapPoint p2) {
             return desiredDistanceOffset(p1) < desiredDistanceOffset(p2);
         };
-        std::sort(positions.begin(), positions.end(), byDesiredMountainDistanceOffset);
+        std::stable_sort(positions.begin(), positions.end(), byDesiredMountainDistanceOffset);
 
         return positions;
     }

--- a/libs/s25main/mapGenerator/Map.cpp
+++ b/libs/s25main/mapGenerator/Map.cpp
@@ -25,7 +25,7 @@ namespace rttr { namespace mapGenerator {
 
     Map::Map(const MapExtent& size, uint8_t players, const WorldDescription& worldDesc,
              DescIdx<LandscapeDesc> landscape, uint8_t maxHeight)
-        : hqPositions(MAX_PLAYERS, MapPoint::Invalid()), textureMap(TextureMap(worldDesc, landscape, textures)),
+        : textureMap(TextureMap(worldDesc, landscape, textures)),
           name("Random"), author("Auto"), height(0, maxHeight), players(players), size(size)
     {
         z.Resize(size);

--- a/libs/s25main/mapGenerator/Map.cpp
+++ b/libs/s25main/mapGenerator/Map.cpp
@@ -25,8 +25,8 @@ namespace rttr { namespace mapGenerator {
 
     Map::Map(const MapExtent& size, uint8_t players, const WorldDescription& worldDesc,
              DescIdx<LandscapeDesc> landscape, uint8_t maxHeight)
-        : textureMap(TextureMap(worldDesc, landscape, textures)),
-          name("Random"), author("Auto"), height(0, maxHeight), players(players), size(size)
+        : textureMap(TextureMap(worldDesc, landscape, textures)), name("Random"), author("Auto"), height(0, maxHeight),
+          players(players), size(size)
     {
         z.Resize(size);
         textures.Resize(size);

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -41,24 +41,19 @@ namespace rttr { namespace mapGenerator {
 
     struct MapSettings
     {
-        MapSettings()
-            : numPlayers(2), size(MapExtent::all(128)), ratioGold(9), ratioIron(36), ratioCoal(40), ratioGranite(15),
-              rivers(15), mountainDistance(MountainDistance::Normal), type(0), style(MapStyle::Mixed)
-        {}
-
         void MakeValid();
 
         std::string name, author;
-        unsigned numPlayers;
-        MapExtent size;
-        unsigned short ratioGold;
-        unsigned short ratioIron;
-        unsigned short ratioCoal;
-        unsigned short ratioGranite;
-        unsigned short rivers;
-        MountainDistance mountainDistance;
-        DescIdx<LandscapeDesc> type;
-        MapStyle style;
+        unsigned numPlayers = 2;
+        MapExtent size = MapExtent::all(128);
+        unsigned short ratioGold = 9;
+        unsigned short ratioIron = 36;
+        unsigned short ratioCoal = 40;
+        unsigned short ratioGranite = 15;
+        unsigned short rivers = 15;
+        MountainDistance mountainDistance = MountainDistance::Normal;
+        DescIdx<LandscapeDesc> type = DescIdx<LandscapeDesc>(0);
+        MapStyle style = MapStyle::Mixed;
     };
 
 }} // namespace rttr::mapGenerator

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -31,12 +31,16 @@ namespace rttr { namespace mapGenerator {
         Mixed
     };
 
-    enum class MountainDistance
+    enum class MountainDistance : uint8_t
     {
         Close = 5,
         Normal = 15,
         Far = 30,
         VeryFar = 50
+    };
+    constexpr auto maxEnumValue(MountainDistance)
+    {
+        return MountainDistance::VeryFar;
     };
 
     struct MapSettings

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -34,7 +34,7 @@ namespace rttr { namespace mapGenerator {
     enum class MountainDistance
     {
         Close = 5,
-        Normal = 20,
+        Normal = 15,
         Far = 30,
         VeryFar = 50
     };

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -33,9 +33,9 @@ namespace rttr { namespace mapGenerator {
 
     enum class MountainDistance
     {
-        Close   = 5,
-        Normal  = 20,
-        Far     = 30,
+        Close = 5,
+        Normal = 20,
+        Far = 30,
         VeryFar = 50
     };
 

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -38,10 +38,7 @@ namespace rttr { namespace mapGenerator {
         Far = 25,
         VeryFar = 30
     };
-    constexpr auto maxEnumValue(MountainDistance)
-    {
-        return MountainDistance::VeryFar;
-    };
+    constexpr auto maxEnumValue(MountainDistance) { return MountainDistance::VeryFar; }
 
     struct MapSettings
     {

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -31,11 +31,19 @@ namespace rttr { namespace mapGenerator {
         Mixed
     };
 
+    enum class MountainDistance
+    {
+        Close   = 5,
+        Normal  = 20,
+        Far     = 30,
+        VeryFar = 50
+    };
+
     struct MapSettings
     {
         MapSettings()
             : numPlayers(2), size(MapExtent::all(128)), ratioGold(9), ratioIron(36), ratioCoal(40), ratioGranite(15),
-              rivers(15), type(0), style(MapStyle::Mixed)
+              rivers(15), mountainDistance(MountainDistance::Normal), type(0), style(MapStyle::Mixed)
         {}
 
         void MakeValid();
@@ -48,6 +56,7 @@ namespace rttr { namespace mapGenerator {
         unsigned short ratioCoal;
         unsigned short ratioGranite;
         unsigned short rivers;
+        MountainDistance mountainDistance;
         DescIdx<LandscapeDesc> type;
         MapStyle style;
     };

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -35,8 +35,8 @@ namespace rttr { namespace mapGenerator {
     {
         Close = 5,
         Normal = 15,
-        Far = 30,
-        VeryFar = 50
+        Far = 25,
+        VeryFar = 30
     };
     constexpr auto maxEnumValue(MountainDistance)
     {

--- a/libs/s25main/mapGenerator/NodeMapUtilities.h
+++ b/libs/s25main/mapGenerator/NodeMapUtilities.h
@@ -86,19 +86,35 @@ namespace rttr { namespace mapGenerator {
     }
 
     /**
-     * Finds the maximum value of the map.
+     * Finds the maximum value of the map within the specified area.
      *
      * @param values reference to the node map to search for the maximum
      * @param area container of map points to compute maximum value for
      *
-     * @returns the maximum value of the map.
+     * @returns the maximum value of the map within the area.
      */
     template<typename T_Value, class T_Container>
     const T_Value& GetMaximum(const NodeMapBase<T_Value>& values, const T_Container& area)
     {
-        auto compare = [&values](const MapPoint& rhs, const MapPoint& lhs) { return values[rhs] < values[lhs]; };
-        auto maximum = std::max_element(area.begin(), area.end(), compare);
+        const auto compare = [&values](const MapPoint& rhs, const MapPoint& lhs) { return values[rhs] < values[lhs]; };
+        const auto maximum = std::max_element(area.begin(), area.end(), compare);
         return values[*maximum];
+    }
+
+    /**
+     * Finds the minimum value of the map within the specified area.
+     *
+     * @param values reference to the node map to search for the minimum
+     * @param area container of map points to compute minimum value for
+     *
+     * @returns the minimum value of the map within the area.
+     */
+    template<typename T_Value, class T_Container>
+    const T_Value& GetMinimum(const NodeMapBase<T_Value>& values, const T_Container& area)
+    {
+        const auto compare = [&values](const MapPoint& rhs, const MapPoint& lhs) { return values[rhs] < values[lhs]; };
+        const auto minimum = std::min_element(area.begin(), area.end(), compare);
+        return values[*minimum];
     }
 
     /**

--- a/libs/s25main/mapGenerator/NodeMapUtilities.h
+++ b/libs/s25main/mapGenerator/NodeMapUtilities.h
@@ -102,22 +102,6 @@ namespace rttr { namespace mapGenerator {
     }
 
     /**
-     * Finds the minimum value of the map within the specified area.
-     *
-     * @param values reference to the node map to search for the minimum
-     * @param area container of map points to compute minimum value for
-     *
-     * @returns the minimum value of the map within the area.
-     */
-    template<typename T_Value, class T_Container>
-    const T_Value& GetMinimum(const NodeMapBase<T_Value>& values, const T_Container& area)
-    {
-        const auto compare = [&values](const MapPoint& rhs, const MapPoint& lhs) { return values[rhs] < values[lhs]; };
-        const auto minimum = std::min_element(area.begin(), area.end(), compare);
-        return values[*minimum];
-    }
-
-    /**
      * Computes the range of values covered by the map.
      *
      * @param values reference to the node map to compute the range for

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -279,7 +279,7 @@ namespace rttr { namespace mapGenerator {
 
         for(unsigned i = 0; i < map_.players; i++)
         {
-            PlaceHeadquarter(map_, i, islands[i], settings_.mountainDistance);
+            PlaceHeadquarter(map_, islands[i], settings_.mountainDistance);
         }
     }
 

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -224,7 +224,7 @@ namespace rttr { namespace mapGenerator {
         texturizer_.AddTextures(mountainLevel, GetCoastline(map_.size));
 
         PlaceHarbors(map_, rivers, (map_.size.x + map_.size.y) / 2);
-        PlaceHeadquarters(map_, rnd_, map_.players);
+        PlaceHeadquarters(map_, rnd_, map_.players, static_cast<unsigned>(settings_.mountainDistance));
     }
 
     void RandomMap::CreateWaterMap()
@@ -279,7 +279,7 @@ namespace rttr { namespace mapGenerator {
 
         for(unsigned i = 0; i < map_.players; i++)
         {
-            PlaceHeadquarter(map_, i, islands[i]);
+            PlaceHeadquarter(map_, i, islands[i], static_cast<unsigned>(settings_.mountainDistance));
         }
     }
 
@@ -299,7 +299,7 @@ namespace rttr { namespace mapGenerator {
 
         texturizer_.AddTextures(mountainLevel, GetCoastline(map_.size));
 
-        PlaceHeadquarters(map_, rnd_, map_.players);
+        PlaceHeadquarters(map_, rnd_, map_.players, static_cast<unsigned>(settings_.mountainDistance));
     }
 
     Map GenerateRandomMap(RandomUtility& rnd, const WorldDescription& worldDesc, const MapSettings& settings)

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -224,7 +224,7 @@ namespace rttr { namespace mapGenerator {
         texturizer_.AddTextures(mountainLevel, GetCoastline(map_.size));
 
         PlaceHarbors(map_, rivers, (map_.size.x + map_.size.y) / 2);
-        PlaceHeadquarters(map_, rnd_, map_.players, static_cast<unsigned>(settings_.mountainDistance));
+        PlaceHeadquarters(map_, rnd_, map_.players, settings_.mountainDistance);
     }
 
     void RandomMap::CreateWaterMap()
@@ -279,7 +279,7 @@ namespace rttr { namespace mapGenerator {
 
         for(unsigned i = 0; i < map_.players; i++)
         {
-            PlaceHeadquarter(map_, i, islands[i], static_cast<unsigned>(settings_.mountainDistance));
+            PlaceHeadquarter(map_, i, islands[i], settings_.mountainDistance);
         }
     }
 
@@ -299,7 +299,7 @@ namespace rttr { namespace mapGenerator {
 
         texturizer_.AddTextures(mountainLevel, GetCoastline(map_.size));
 
-        PlaceHeadquarters(map_, rnd_, map_.players, static_cast<unsigned>(settings_.mountainDistance));
+        PlaceHeadquarters(map_, rnd_, map_.players, settings_.mountainDistance);
     }
 
     Map GenerateRandomMap(RandomUtility& rnd, const WorldDescription& worldDesc, const MapSettings& settings)

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -289,7 +289,7 @@ namespace rttr { namespace mapGenerator {
         SmoothHeightMap(map_.z, map_.height);
 
         const double sea = rnd_.RandomDouble(0.1, 0.2);
-        const double mountain = rnd_.RandomDouble(0.2, 0.5 - sea);
+        const double mountain = rnd_.RandomDouble(0.15, 0.4 - sea);
         const double land = 1. - sea - mountain;
 
         ResetSeaLevel(map_, rnd_, LimitFor(map_.z, sea, map_.height.minimum));

--- a/tests/s25Main/mapGenerator/testHeadQuarters.cpp
+++ b/tests/s25Main/mapGenerator/testHeadQuarters.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_with_suitable_position_for_player)
         map.textures[obstacle] = TexturePair(mountain);
 
         std::vector<MapPoint> area{hq};
-        BOOST_REQUIRE_NO_THROW(PlaceHeadquarter(map, 0, area, MountainDistance::Normal));
+        BOOST_REQUIRE_NO_THROW(PlaceHeadquarter(map, area, MountainDistance::Normal));
     });
 }
 
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_with_suitable_position_without_mountain)
         MapPoint hq(4, 4);
         map.textures.Resize(size, TexturePair(buildable));
         std::vector<MapPoint> area{hq};
-        BOOST_REQUIRE_NO_THROW(PlaceHeadquarter(map, 0, area, mntDist));
+        BOOST_REQUIRE_NO_THROW(PlaceHeadquarter(map, area, mntDist));
     });
 }
 
@@ -167,9 +167,9 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_places_hq_on_map_at_suitable_position)
 
         std::vector<MapPoint> area{hq};
 
-        PlaceHeadquarter(map, 3, area, mntDist);
+        PlaceHeadquarter(map, area, mntDist);
 
-        BOOST_REQUIRE(map.hqPositions[3] == hq);
+        BOOST_REQUIRE(map.hqPositions[0] == hq);
     });
 }
 
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_with_empty_area_throws_exception)
         const auto water = textures.Find(IsShipableWater);
         map.textures.Resize(size, TexturePair(water));
         std::vector<MapPoint> area;
-        BOOST_CHECK_THROW(PlaceHeadquarter(map, 0, area, mntDist), std::runtime_error);
+        BOOST_CHECK_THROW(PlaceHeadquarter(map, area, mntDist), std::runtime_error);
     });
 }
 
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_without_suitable_position_throws_exception
         const auto water = textures.Find(IsShipableWater);
         map.textures.Resize(size, TexturePair(water));
         std::vector<MapPoint> area{MapPoint(0, 0)};
-        BOOST_CHECK_THROW(PlaceHeadquarter(map, 0, area, mntDist), std::runtime_error);
+        BOOST_CHECK_THROW(PlaceHeadquarter(map, area, mntDist), std::runtime_error);
     });
 }
 

--- a/tests/s25Main/mapGenerator/testHeadQuarters.cpp
+++ b/tests/s25Main/mapGenerator/testHeadQuarters.cpp
@@ -62,11 +62,11 @@ BOOST_AUTO_TEST_CASE(FindLargestConnectedArea_returns_expected_nodes)
 {
     MapExtent size(32, 32);
     RunTest(size, [&size](Map& map, TextureMap& textures) {
-        auto water = textures.Find(IsShipableWater);
-        auto land = textures.Find(IsBuildableLand);
+        const auto water = textures.Find(IsShipableWater);
+        const auto land = textures.Find(IsBuildableLand);
         map.textures.Resize(size, TexturePair(water));
         MapPoint centerOfLargeArea(3, 3);
-        auto largeArea = map.textures.GetPointsInRadiusWithCenter(centerOfLargeArea, 3);
+        const auto largeArea = map.textures.GetPointsInRadiusWithCenter(centerOfLargeArea, 3);
 
         for(auto node : largeArea)
         {
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(FindLargestConnectedArea_returns_expected_nodes)
         }
 
         MapPoint centerOfSmallArea(15, 15);
-        auto smallArea = map.textures.GetPointsInRadiusWithCenter(centerOfSmallArea, 2);
+        const auto smallArea = map.textures.GetPointsInRadiusWithCenter(centerOfSmallArea, 2);
 
         for(auto node : smallArea)
         {
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(FindHqPositions_returns_empty_for_map_without_suitable_posi
     MapExtent size(32, 32);
     RunTestForArea(size, [&size](Map& map, TextureMap& textures, const auto& area) {
         map.textures.Resize(size, TexturePair(textures.Find(IsShipableWater)));
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         const auto positions = FindHqPositions(map, area, mntDist);
 
         BOOST_REQUIRE(positions.empty());
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(FindHqPositions_returns_suitable_position_for_single_player
         map.textures.Resize(size, TexturePair(buildable));
         map.textures[obstacle] = TexturePair(water);
 
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         const auto positions = FindHqPositions(map, area, mntDist);
 
         BOOST_REQUIRE(!positions.empty());
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_with_suitable_position_for_player)
         map.textures[obstacle] = TexturePair(mountain);
 
         std::vector<MapPoint> area{hq};
-        BOOST_REQUIRE_NO_THROW(PlaceHeadquarter(map, 0, area, 20));
+        BOOST_REQUIRE_NO_THROW(PlaceHeadquarter(map, 0, area, MountainDistance::Normal));
     });
 }
 
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_with_suitable_position_without_mountain)
 {
     MapExtent size(8, 8);
     RunTest(size, [&size](Map& map, TextureMap& textures) {
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         const auto buildable = textures.Find(IsBuildableLand);
         MapPoint hq(4, 4);
         map.textures.Resize(size, TexturePair(buildable));
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_places_hq_on_map_at_suitable_position)
 {
     MapExtent size(8, 8);
     RunTest(size, [&size](Map& map, TextureMap& textures) {
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         const MapPoint obstacle(0, 0);
         const MapPoint hq(4, 4);
 
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_with_empty_area_throws_exception)
 {
     MapExtent size(8, 8);
     RunTest(size, [&size](Map& map, TextureMap& textures) {
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         const auto water = textures.Find(IsShipableWater);
         map.textures.Resize(size, TexturePair(water));
         std::vector<MapPoint> area;
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarter_without_suitable_position_throws_exception
 {
     MapExtent size(8, 8);
     RunTest(size, [&size](Map& map, TextureMap& textures) {
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         const auto water = textures.Find(IsShipableWater);
         map.textures.Resize(size, TexturePair(water));
         std::vector<MapPoint> area{MapPoint(0, 0)};
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarters_with_suitable_positions_for_all_players)
     RandomUtility rnd(0);
     const int players = rttr::test::randomValue(1, 8);
     RunTest(size, [&size, &rnd, players](Map& map, TextureMap& textures) {
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         map.textures.Resize(size, TexturePair(textures.Find(IsBuildableLand)));
         map.textures[MapPoint(0, 0)] = TexturePair(textures.Find(IsWater));
         BOOST_REQUIRE_NO_THROW(PlaceHeadquarters(map, rnd, players, mntDist));
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarters_places_hqs_for_any_player_number_on_suita
     RandomUtility rnd(0);
     const int players = rttr::test::randomValue(1, 8);
     RunTest(size, [&size, &rnd, players](Map& map, TextureMap& textures) {
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         map.textures.Resize(size, textures.Find(IsBuildableLand));
         map.textures[MapPoint(0, 0)] = TexturePair(textures.Find(IsWater));
         PlaceHeadquarters(map, rnd, players, mntDist);
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(PlaceHeadquarters_without_suitable_position_throws_exceptio
     RandomUtility rnd(0);
     const int players = rttr::test::randomValue(1, 8);
     RunTest(size, [&size, &rnd, players](Map& map, TextureMap& textures) {
-        const auto mntDist = rttr::test::randomValue(2u, 50u);
+        const auto mntDist = rttr::test::randomEnum<MountainDistance>();
         map.textures.Resize(size, textures.Find(IsWater));
         BOOST_CHECK_THROW(PlaceHeadquarters(map, rnd, players, mntDist), std::runtime_error);
     });

--- a/tests/s25Main/mapGenerator/testResources.cpp
+++ b/tests/s25Main/mapGenerator/testResources.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(AddObjects_keeps_area_around_hqs_empty)
     RunTest([](Map& map) {
         RandomUtility rnd(0);
         MapPoint hq(3, 3);
-        map.hqPositions[0] = hq;
+        map.hqPositions.push_back(hq);
 
         AddObjects(map, rnd);
 


### PR DESCRIPTION
Hi guys, 

This is basically a new feature for random maps to consider the distance of HQs to mountains for HQ placement. That should generate more competitive maps with fairer HQs. Also added a configuration option to specify how fair away players should be positioned. Also, I hope the coed & comment changes make the workflow of `FindHqPositions` easier to follow!

![image](https://user-images.githubusercontent.com/3286924/105643263-ab72fb00-5e86-11eb-8866-68d02ce82650.png)

Example map - mountain distance "close":
![image](https://user-images.githubusercontent.com/3286924/105643336-2fc57e00-5e87-11eb-9825-ef47f5cfbecb.png)

Example map - mountain distance "far":
![image](https://user-images.githubusercontent.com/3286924/105643359-4bc91f80-5e87-11eb-949c-bc60e51349f0.png)

Let me know if you have any suggestions for improvement! 