### PR TITLE
Improve island generation on random water maps

### DIFF
--- a/libs/s25main/mapGenerator/Islands.cpp
+++ b/libs/s25main/mapGenerator/Islands.cpp
@@ -28,16 +28,12 @@ namespace rttr { namespace mapGenerator {
 
         const auto land = [&map](const MapPoint& pt) { return map.z[pt] > map.height.minimum; };
         const auto distances = DistancesTo(map.size, land);
-
-        const auto findSuitableIslandCenter = [&rnd, &distances, distanceToLand]() {
-            const auto possibleCenters = SelectPoints(
-              [&distances, distanceToLand](const MapPoint& pt) {
-                  return distances[pt] > distanceToLand * 10; // keep proper distance to land
-              },
-              distances.GetSize());
-            return possibleCenters.empty() ? GetMaximumPoint(distances) : rnd.RandomItem(possibleCenters);
-        };
-        const MapPoint center = findSuitableIslandCenter();
+        const unsigned maxDistance = *std::max_element(distances.begin(), distances.end());
+        const unsigned minDistance = std::min(maxDistance, distanceToLand * 10);
+        const auto possibleCenters = SelectPoints([&distances, minDistance](const MapPoint& pt) {
+            return distances[pt] >= minDistance;
+        }, distances.GetSize());
+        const MapPoint center = rnd.RandomItem(possibleCenters);
 
         const auto compare = [&distances, &center](const MapPoint& rhs, const MapPoint& lhs) {
             // computes prefered extension points for the island by considering distance to

--- a/libs/s25main/mapGenerator/Islands.cpp
+++ b/libs/s25main/mapGenerator/Islands.cpp
@@ -30,9 +30,8 @@ namespace rttr { namespace mapGenerator {
         const auto distances = DistancesTo(map.size, land);
         const unsigned maxDistance = *std::max_element(distances.begin(), distances.end());
         const unsigned minDistance = std::min(maxDistance, distanceToLand * 10);
-        const auto possibleCenters = SelectPoints([&distances, minDistance](const MapPoint& pt) {
-            return distances[pt] >= minDistance;
-        }, distances.GetSize());
+        const auto possibleCenters = SelectPoints(
+          [&distances, minDistance](const MapPoint& pt) { return distances[pt] >= minDistance; }, distances.GetSize());
         const MapPoint center = rnd.RandomItem(possibleCenters);
 
         const auto compare = [&distances, &center](const MapPoint& rhs, const MapPoint& lhs) {

--- a/libs/s25main/mapGenerator/Islands.cpp
+++ b/libs/s25main/mapGenerator/Islands.cpp
@@ -27,10 +27,13 @@ namespace rttr { namespace mapGenerator {
         Island island;
 
         const auto isLand = [&map](const MapPoint& pt) { return map.z[pt] > map.height.minimum; };
-        const auto distances = DistancesTo(map.size, isLand);
-        const auto center = GetMaximumPoint(distances);
-
-        auto compare = [&distances, &center](const MapPoint& rhs, const MapPoint& lhs) {
+        const auto distances = DistancesTo(SelectPoints(isLand, map.size), map.size);
+        const auto possibleCenters = SelectPoints([&distances, distanceToLand](const MapPoint& pt) {
+            return distances[pt] > distanceToLand * 10;
+        }, map.size);
+        const auto center = possibleCenters.empty() ? GetMaximumPoint(distances) : rnd.RandomItem(possibleCenters);
+        
+        const auto compare = [&distances, &center](const MapPoint& rhs, const MapPoint& lhs) {
             // computes prefered extension points for the island by considering distance to
             // center of the island and maximizing distance to other land
 

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -98,28 +98,6 @@ namespace rttr { namespace mapGenerator {
         return 6;
     }
 
-    unsigned GetIslandNodes(const MapExtent& size, unsigned waterNodes)
-    {
-        const unsigned combinedSize = size.x + size.y;
-        if(combinedSize <= 256)
-        {
-            return static_cast<unsigned>(.5 * waterNodes);
-        }
-        if(combinedSize <= 512)
-        {
-            return static_cast<unsigned>(.3 * waterNodes);
-        }
-        if(combinedSize <= 1024)
-        {
-            return static_cast<unsigned>(.2 * waterNodes);
-        }
-        if(combinedSize <= 2048)
-        {
-            return static_cast<unsigned>(.1 * waterNodes);
-        }
-        return static_cast<unsigned>(.05 * waterNodes);
-    }
-
     unsigned GetSmoothRadius(const MapExtent& size)
     {
         const unsigned combinedSize = size.x + size.y;
@@ -276,7 +254,7 @@ namespace rttr { namespace mapGenerator {
 
         const auto land = 1. - static_cast<double>(waterNodes) / (map_.size.x * map_.size.y) - mountain;
         const auto mountainLevel = LimitFor(map_.z, land, static_cast<uint8_t>(1)) + 1;
-        const auto islandNodes = GetIslandNodes(map_.size, waterNodes);
+        const auto islandNodes = static_cast<unsigned>(.5 * waterNodes);
         const unsigned nodesPerIsland = islandNodes / 8;
         const auto islandRadius = GetIslandRadius(map_.size);
         const auto distanceToLand = islandRadius;

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -98,6 +98,28 @@ namespace rttr { namespace mapGenerator {
         return 6;
     }
 
+    unsigned GetIslandNodes(const MapExtent& size, unsigned waterNodes)
+    {
+        const unsigned combinedSize = size.x + size.y;
+        if(combinedSize <= 256)
+        {
+            return static_cast<unsigned>(.5 * waterNodes);
+        }
+        if(combinedSize <= 512)
+        {
+            return static_cast<unsigned>(.3 * waterNodes);
+        }
+        if(combinedSize <= 1024)
+        {
+            return static_cast<unsigned>(.2 * waterNodes);
+        }
+        if(combinedSize <= 2048)
+        {
+            return static_cast<unsigned>(.1 * waterNodes);
+        }
+        return static_cast<unsigned>(.05 * waterNodes);
+    }
+
     unsigned GetSmoothRadius(const MapExtent& size)
     {
         const unsigned combinedSize = size.x + size.y;
@@ -254,13 +276,8 @@ namespace rttr { namespace mapGenerator {
 
         const auto land = 1. - static_cast<double>(waterNodes) / (map_.size.x * map_.size.y) - mountain;
         const auto mountainLevel = LimitFor(map_.z, land, static_cast<uint8_t>(1)) + 1;
-
-        // 40% of map reserved for player island (80% * 50%)
-        const auto islandNodes = static_cast<unsigned>(.5 * waterNodes);
-
-        // 5% of map per player island (40% / 8 = 5%)
+        const auto islandNodes = GetIslandNodes(map_.size, waterNodes);
         const unsigned nodesPerIsland = islandNodes / 8;
-
         const auto islandRadius = GetIslandRadius(map_.size);
         const auto distanceToLand = islandRadius;
 

--- a/libs/s25main/mapGenerator/RandomMap.h
+++ b/libs/s25main/mapGenerator/RandomMap.h
@@ -29,6 +29,7 @@ namespace rttr { namespace mapGenerator {
     unsigned GetMaximumHeight(const MapExtent& size);
     unsigned GetCoastline(const MapExtent& size);
     unsigned GetIslandRadius(const MapExtent& size);
+    unsigned GetIslandNodes(const MapExtent& size, unsigned waterNodes);
     unsigned GetSmoothRadius(const MapExtent& size);
     unsigned GetSmoothIterations(const MapExtent& size);
 

--- a/libs/s25main/mapGenerator/RandomMap.h
+++ b/libs/s25main/mapGenerator/RandomMap.h
@@ -29,7 +29,6 @@ namespace rttr { namespace mapGenerator {
     unsigned GetMaximumHeight(const MapExtent& size);
     unsigned GetCoastline(const MapExtent& size);
     unsigned GetIslandRadius(const MapExtent& size);
-    unsigned GetIslandNodes(const MapExtent& size, unsigned waterNodes);
     unsigned GetSmoothRadius(const MapExtent& size);
     unsigned GetSmoothIterations(const MapExtent& size);
 


### PR DESCRIPTION
**Current state**
The center of each player island is calculated by finding the `MapPoint` with the greatest distance to any land. Therefore, the first island depends only on the distance to the center island (which is not populated by any HQ). There are usually multiple points with equal distance to the center island. Therefore the algorithm chooses the first one starting from `x=0/y=0` and iterating through the points with the maximum distance like a standard iteration over the map (`x=0,1,2,...width-1` etc.). That usually leads to the first island (blue player) being placed in the top-right corner of the map. Other players' islands are similar predictable. 

**Suggested improvement**
Choose a minimum distance of every island-center to any land. Then randomly choose one of the `MapPoints` keeping this distance. If there's no such point available just fall back to using the point with maximum distance to land. 

As a separate (fairly Independent) change, I decided to make player island for larger maps a bit smaller. On tiny maps each player should have a reasonably sized island to have at list a tiny mountain available on the home island. On larger maps, currently the islands become huge that it becomes even challenging to find a harbor position to get away from the home island. Therefore, I think it makes sense to decrease the size a little bit. Maybe instead of the current approach I could just add an upper boundary for home islands, happy to discuss! 
