### PR TITLE
Add noexcept specifications to Point and DescIdx and modernize Point.h 

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,8 @@ jobs:
           - { compiler: clang-7,  os: ubuntu-18.04, buildType: Release }
           - { compiler: clang-7,  os: ubuntu-18.04, buildType: Debug }
           - { compiler: clang  ,  os: macos-10.15,  buildType: Debug, boostVersion: 1.74.0 } # Multiple bugs with recent OSX until 1.74
+          # GCC 9 is know to show a few warnings that GCC 10 has "fixed", make sure this doesn't happen for us
+          - { compiler: gcc-9,    os: ubuntu-18.04, buildType: Debug }
           # Latest GCC
           - { compiler: gcc-10,   os: ubuntu-18.04, buildType: Debug }
           - { compiler: gcc-10,   os: ubuntu-18.04, buildType: Release }

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
           - { compiler: clang-7,  os: ubuntu-18.04, buildType: Release }
           - { compiler: clang-7,  os: ubuntu-18.04, buildType: Debug }
           - { compiler: clang  ,  os: macos-10.15,  buildType: Debug, boostVersion: 1.74.0 } # Multiple bugs with recent OSX until 1.74
-          # GCC 9 is know to show a few warnings that GCC 10 has "fixed", make sure this doesn't happen for us
+          # GCC 9 is known to show a few warnings that GCC 10 has "fixed", make sure this doesn't happen for us
           - { compiler: gcc-9,    os: ubuntu-18.04, buildType: Debug }
           # Latest GCC
           - { compiler: gcc-10,   os: ubuntu-18.04, buildType: Debug }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ endif()
 # Better portability
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Hidden visibility by default to reduce binary size and possibly increase performance
+set(CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING "Default symbol visibility")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON CACHE BOOL "Inline symbol visibility")
+
 ################################################################################
 # ClangFormat
 ################################################################################

--- a/libs/common/include/Point.h
+++ b/libs/common/include/Point.h
@@ -191,7 +191,7 @@ RTTR_GEN_ARITH(/)
 // Scaling operators
 
 template<typename T, typename U, class = detail::require_nonLossyOp<T, U>>
-constexpr Point<T>& operator*=(Point<T>& lhs, const U factor) noexcept
+constexpr Point<T>& operator*=(Point<T>& lhs, U factor) noexcept
 {
     return lhs *= Point<T>::all(factor);
 }
@@ -209,7 +209,7 @@ constexpr auto operator*(const T left, const Point<U>& factor) noexcept
 }
 
 template<typename T, typename U, class = detail::require_nonLossyOp<T, U>>
-constexpr Point<T>& operator/=(Point<T>& lhs, const U div) noexcept
+constexpr Point<T>& operator/=(Point<T>& lhs, U div) noexcept
 {
     return lhs /= Point<T>::all(div);
 }

--- a/libs/libGamedata/gameData/DescIdx.h
+++ b/libs/libGamedata/gameData/DescIdx.h
@@ -27,12 +27,12 @@ struct DescIdx
     /// Invalid index
     static constexpr uint8_t INVALID = 0xFF;
     uint8_t value;
-    explicit constexpr DescIdx(uint8_t value = INVALID) : value(value) {}
-    constexpr bool operator!() const { return value == INVALID; }
-    constexpr bool operator==(DescIdx rhs) const { return value == rhs.value; }
-    constexpr bool operator!=(DescIdx rhs) const { return value != rhs.value; }
-    constexpr bool operator<(DescIdx rhs) const { return value < rhs.value; }
-    constexpr bool operator>(DescIdx rhs) const { return value > rhs.value; }
-    constexpr bool operator<=(DescIdx rhs) const { return value <= rhs.value; }
-    constexpr bool operator>=(DescIdx rhs) const { return value >= rhs.value; }
+    explicit constexpr DescIdx(uint8_t value = INVALID) noexcept : value(value) {}
+    constexpr bool operator!() const noexcept { return value == INVALID; }
+    constexpr bool operator==(DescIdx rhs) const noexcept { return value == rhs.value; }
+    constexpr bool operator!=(DescIdx rhs) const noexcept { return value != rhs.value; }
+    constexpr bool operator<(DescIdx rhs) const noexcept { return value < rhs.value; }
+    constexpr bool operator>(DescIdx rhs) const noexcept { return value > rhs.value; }
+    constexpr bool operator<=(DescIdx rhs) const noexcept { return value <= rhs.value; }
+    constexpr bool operator>=(DescIdx rhs) const noexcept { return value >= rhs.value; }
 };

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -528,7 +528,8 @@ int main(int argc, char** argv)
     try
     {
         po::store(po::command_line_parser(argc, argv).options(desc).positional(positionalOptions).run(), options);
-    } catch(const po::error& e)
+        // Catch the generic stdlib exception as hidden visibility messes up boost typeinfo on OSX
+    } catch(const std::exception& e)
     {
         bnw::cerr << "Error: " << e.what() << "\n\n";
         bnw::cerr << desc << "\n";

--- a/libs/s25main/animation/MoveAnimation.cpp
+++ b/libs/s25main/animation/MoveAnimation.cpp
@@ -26,7 +26,7 @@ MoveAnimation::MoveAnimation(Window* element, DrawPoint newPos, unsigned animTim
 {
     Point<double> diff(newPos_ - origPos_);
     diff = elMax(Point<double>::all(1), diff); // Avoid division by zero
-    Point<double> msPerPixel(static_cast<double>(animTime) / diff);
+    Point<double> msPerPixel(Point<double>::all(animTime) / diff);
     double frameRate = std::max(1., std::floor(std::min(msPerPixel.x, msPerPixel.y)));
     setFrameRate(static_cast<unsigned>(frameRate));
     setNumFrames(static_cast<unsigned>(std::ceil(animTime / frameRate)) + 1u);

--- a/tests/common/testPoint.cpp
+++ b/tests/common/testPoint.cpp
@@ -30,7 +30,7 @@ using SignedTypes = boost::mpl::list<int8_t, int16_t, int32_t, int64_t, float, d
 // Custom trait to support float/double
 template<typename T>
 using make_unsigned_t =
-  typename std::conditional_t<std::is_floating_point<T>::value, std::common_type<T>, std::make_unsigned<T>>::type;
+  typename std::conditional_t<std::is_floating_point<T>::value, detail::type_identity<T>, std::make_unsigned<T>>::type;
 
 template<typename T>
 constexpr T abs(T val)
@@ -264,14 +264,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unscale_point, T, SignedTypes)
 
     pt2 /= scale;
     TEST_POINTS_CLOSE(pt2, resultUnsigned, epsilon);
-
-    x = randomValue<T>(1, 100);
-    y = randomValue<T>(1, 100);
-    const auto scale2 = randomValue<T>();
-    pt = SignedPoint(x, y);
-    const auto resultPt = scale2 / pt;
-    static_assert(std::is_same<decltype(resultPt.x), T>::value, "Result must be signed");
-    TEST_POINTS_CLOSE(resultPt, SignedPoint::all(scale2) / pt, epsilon);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(symetric_operators, T, SignedTypes)


### PR DESCRIPTION
I reduced the repetition of the Point class by using the preprocessor to stamp out the arithmetic functions. Adding of `noexcept` should also help and avoid the compiler warning from #1358

I also validated the codegen on godbolt for GCC, Clang and MSVC to be optimal (as-if handwritten)