### PR TITLE
Add more generic serialization functions

### DIFF
--- a/libs/common/include/helpers/MultiArray.h
+++ b/libs/common/include/helpers/MultiArray.h
@@ -85,7 +85,7 @@ namespace detail {
     {
         static constexpr bool is1D = sizeof...(T_ns) == 0;
         using reference = MultiArrayRef<T, T_ns...>;
-        using const_reference = const MultiArrayRef<T, T_ns...>;
+        using const_reference = MultiArrayRef<const T, T_ns...>;
         static constexpr size_t stride = product(T_ns...);
 
         T* elems;

--- a/libs/common/include/helpers/serializeContainers.h
+++ b/libs/common/include/helpers/serializeContainers.h
@@ -67,14 +67,14 @@ namespace detail {
         container.resize(ser.PopVarSize());
     }
     template<typename T>
-    std::enable_if_t<!isResizableContainer<T>::value> maybePopSizeAndResize(Serializer& ser, T& container)
+    std::enable_if_t<!isResizableContainer<T>::value> maybePopSizeAndResize(Serializer&, T&)
     {}
 
     template<typename T>
-    void popContainer(Serializer& ser, T& container, long)
+    void popContainer(Serializer& ser, T&& container, long)
     {
-        using Type = typename T::value_type;
-        for(auto& el : container)
+        using Type = typename std::remove_reference_t<T>::value_type;
+        for(auto&& el : container) // auto&& required for vector<bool> proxy object
             el = popEnumOrIntegral<Type>(ser);
     }
     template<typename T>
@@ -99,9 +99,9 @@ void pushContainer(Serializer& ser, const T& container, bool ignoreSize = false)
 }
 
 template<typename T>
-void popContainer(Serializer& ser, T& result, bool ignoreSize = false)
+void popContainer(Serializer& ser, T&& result, bool ignoreSize = false)
 {
-    using Type = typename T::value_type;
+    using Type = typename std::remove_reference_t<T>::value_type;
     static_assert(std::is_integral<Type>::value || std::is_enum<Type>::value,
                   "Only integral types and enums are possible");
 

--- a/libs/common/include/helpers/serializePoint.h
+++ b/libs/common/include/helpers/serializePoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 - 2017 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (c) 2021 - 2021 Settlers Freaks (sf-team at siedler25.org)
 //
 // This file is part of Return To The Roots.
 //
@@ -15,25 +15,29 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
-#include "world/TradePath.h"
-#include "SerializedGameData.h"
+#pragma once
 
-TradePath::TradePath(SerializedGameData& sgd) : start(sgd.PopMapPoint()), goal(sgd.PopMapPoint())
+#include "Point.h"
+#include "s25util/Serializer.h"
+#include <type_traits>
+
+namespace helpers {
+
+template<typename T>
+void pushPoint(Serializer& ser, Point<T> pt)
 {
-    route.resize(sgd.PopUnsignedInt());
-    for(Direction& dir : route)
-    {
-        dir = sgd.Pop<Direction>();
-    }
+    ser.Push(pt.x);
+    ser.Push(pt.y);
 }
 
-void TradePath::Serialize(SerializedGameData& sgd) const
+template<typename PointT>
+PointT popPoint(Serializer& ser)
 {
-    helpers::pushPoint(sgd, start);
-    helpers::pushPoint(sgd, goal);
-    sgd.PushUnsignedInt(route.size());
-    for(const Direction& dir : route)
-    {
-        sgd.PushEnum<uint8_t>(dir);
-    }
+    using ElementType = typename PointT::ElementType;
+    std::remove_const_t<PointT> pt;
+    pt.x = ser.Pop<ElementType>();
+    pt.y = ser.Pop<ElementType>();
+    return pt;
 }
+
+} // namespace helpers

--- a/libs/common/include/helpers/serializePoint.h
+++ b/libs/common/include/helpers/serializePoint.h
@@ -31,7 +31,7 @@ void pushPoint(Serializer& ser, Point<T> pt)
 }
 
 template<typename PointT>
-PointT popPoint(Serializer& ser)
+auto popPoint(Serializer& ser)
 {
     using ElementType = typename PointT::ElementType;
     std::remove_const_t<PointT> pt;

--- a/libs/s25main/CatapultStone.cpp
+++ b/libs/s25main/CatapultStone.cpp
@@ -40,16 +40,17 @@ CatapultStone::CatapultStone(const MapPoint dest_building, const MapPoint dest_m
 
 CatapultStone::CatapultStone(SerializedGameData& sgd, const unsigned obj_id)
     : GameObject(sgd, obj_id), dest_building(sgd.PopMapPoint()), dest_map(sgd.PopMapPoint()),
-      startPos(sgd.PopPoint<int>()), destPos(sgd.PopPoint<int>()), explode(sgd.PopBool()), event(sgd.PopEvent())
+      startPos(helpers::popPoint<Position>(sgd)), destPos(helpers::popPoint<Position>(sgd)), explode(sgd.PopBool()),
+      event(sgd.PopEvent())
 {}
 
 /// Serialisierungsfunktionen
 void CatapultStone::Serialize(SerializedGameData& sgd) const
 {
-    sgd.PushMapPoint(dest_building);
-    sgd.PushMapPoint(dest_map);
-    sgd.PushPoint<int>(startPos);
-    sgd.PushPoint<int>(destPos);
+    helpers::pushPoint(sgd, dest_building);
+    helpers::pushPoint(sgd, dest_map);
+    helpers::pushPoint(sgd, startPos);
+    helpers::pushPoint(sgd, destPos);
     sgd.PushBool(explode);
     sgd.PushEvent(event);
 }

--- a/libs/s25main/EconomyModeHandler.cpp
+++ b/libs/s25main/EconomyModeHandler.cpp
@@ -16,7 +16,6 @@
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
 #include "EconomyModeHandler.h"
-
 #include "EventManager.h"
 #include "GameInterface.h"
 #include "GamePlayer.h"
@@ -24,6 +23,7 @@
 #include "SerializedGameData.h"
 #include "helpers/containerUtils.h"
 #include "helpers/make_array.h"
+#include "helpers/serializeContainers.h"
 #include "random/Random.h"
 #include "world/GameWorld.h"
 #include "world/GameWorldGame.h"
@@ -95,10 +95,10 @@ EconomyModeHandler::EconomyModeHandler(unsigned endFrame) : endFrame(endFrame), 
 EconomyModeHandler::EconomyModeHandler(SerializedGameData& sgd, unsigned objId)
     : GameObject(sgd, objId), endFrame(sgd.PopUnsignedInt()), gfLastUpdated(0)
 {
-    sgd.PopContainer(goodsToCollect);
+    helpers::popContainer(sgd, goodsToCollect);
 
     std::vector<unsigned> teamBitMasks;
-    sgd.PopContainer(teamBitMasks);
+    helpers::popContainer(sgd, teamBitMasks);
     for(auto& teamMask : teamBitMasks)
     {
         economyModeTeams.emplace_back(teamMask, goodsToCollect.size());
@@ -114,13 +114,13 @@ void EconomyModeHandler::Destroy() {}
 void EconomyModeHandler::Serialize(SerializedGameData& sgd) const
 {
     sgd.PushUnsignedInt(endFrame);
-    sgd.PushContainer(goodsToCollect);
+    helpers::pushContainer(sgd, goodsToCollect);
     std::vector<unsigned> teamBitMasks;
     for(const EconomyModeHandler::EconTeam& curTeam : economyModeTeams)
     {
         teamBitMasks.push_back(curTeam.playersInTeam.to_ulong());
     }
-    sgd.PushContainer(teamBitMasks);
+    helpers::pushContainer(sgd, teamBitMasks);
 }
 
 void EconomyModeHandler::DetermineTeams()

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -74,9 +74,9 @@ GamePlayer::GamePlayer(unsigned playerId, const PlayerInfo& playerInfo, GameWorl
     global_inventory.clear();
 
     // Statistiken mit 0en füllen
-    memset(&statistic, 0, sizeof(statistic));
-    memset(&statisticCurrentData, 0, sizeof(statisticCurrentData));
-    memset(&statisticCurrentMerchandiseData, 0, sizeof(statisticCurrentMerchandiseData));
+    statistic = {};
+    statisticCurrentData = {};
+    statisticCurrentMerchandiseData = {};
 
     RecalcDistribution();
 }

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -1405,7 +1405,7 @@ void GamePlayer::SetStatisticValue(StatisticType type, unsigned value)
 
 void GamePlayer::ChangeStatisticValue(StatisticType type, int change)
 {
-    assert(statisticCurrentData[type] + change >= 0);
+    RTTR_Assert(change >= 0 || statisticCurrentData[type] >= static_cast<unsigned>(-change));
     statisticCurrentData[type] += change;
 }
 

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -194,7 +194,7 @@ void GamePlayer::Serialize(SerializedGameData& sgd) const
 
     helpers::pushContainer(sgd, shouldSendDefenderList);
 
-    sgd.PushMapPoint(hqPos);
+    helpers::pushPoint(sgd, hqPos);
 
     for(const Distribution& dist : distribution)
     {

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -74,10 +74,7 @@ GamePlayer::GamePlayer(unsigned playerId, const PlayerInfo& playerInfo, GameWorl
     global_inventory.clear();
 
     // Statistiken mit 0en füllen
-    memset(&statistic[StatisticTime::T15Minutes], 0, sizeof(statistic[StatisticTime::T15Minutes]));
-    memset(&statistic[StatisticTime::T1Hour], 0, sizeof(statistic[StatisticTime::T1Hour]));
-    memset(&statistic[StatisticTime::T4Hours], 0, sizeof(statistic[StatisticTime::T4Hours]));
-    memset(&statistic[StatisticTime::T16Hours], 0, sizeof(statistic[StatisticTime::T16Hours]));
+    memset(&statistic, 0, sizeof(statistic));
     memset(&statisticCurrentData, 0, sizeof(statisticCurrentData));
     memset(&statisticCurrentMerchandiseData, 0, sizeof(statisticCurrentMerchandiseData));
 

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -192,7 +192,7 @@ void GamePlayer::Serialize(SerializedGameData& sgd) const
     sgd.PushObjectContainer(flagworkers);
     sgd.PushObjectContainer(ships, true);
 
-    sgd.PushContainer(shouldSendDefenderList);
+    helpers::pushContainer(sgd, shouldSendDefenderList);
 
     sgd.PushMapPoint(hqPos);
 

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -71,7 +71,7 @@ class GamePlayer : public GamePlayerInfo
 public:
     struct Statistic
     {
-        helpers::EnumArray<std::array<unsigned, NUM_STAT_STEPS>, StatisticType> data;
+        helpers::EnumArray<std::array<uint32_t, NUM_STAT_STEPS>, StatisticType> data;
         helpers::MultiArray<uint16_t, NUM_STAT_MERCHANDISE_TYPES, NUM_STAT_STEPS> merchandiseData;
         // Index, der gerade 'vorne' (rechts im Statistikfenster) ist
         uint16_t currentIndex;
@@ -397,7 +397,7 @@ private:
     /// Werkzeugeinstellungen (in der Reihenfolge wie im Fenster!)
     ToolSettings toolsSettings_;
     // qx:tools
-    std::array<unsigned char, NUM_TOOLS> tools_ordered;
+    std::array<uint8_t, NUM_TOOLS> tools_ordered;
 
     /// Bündnisse mit anderen Spielern
     struct Pact
@@ -412,7 +412,7 @@ private:
         bool want_cancel;
 
         Pact() : duration(0), start(0), accepted(false), want_cancel(false) {}
-        Pact(SerializedGameData& sgd);
+        explicit Pact(SerializedGameData& sgd);
         void Serialize(SerializedGameData& sgd) const;
     };
     /// Bündnisse dieses Spielers mit anderen Spielern
@@ -422,8 +422,8 @@ private:
     helpers::EnumArray<Statistic, StatisticTime> statistic;
 
     // Die Statistikwerte die 'aktuell' gemessen werden
-    helpers::EnumArray<int, StatisticType> statisticCurrentData;
-    std::array<int, NUM_STAT_MERCHANDISE_TYPES> statisticCurrentMerchandiseData;
+    helpers::EnumArray<uint32_t, StatisticType> statisticCurrentData;
+    std::array<uint16_t, NUM_STAT_MERCHANDISE_TYPES> statisticCurrentMerchandiseData;
 
     // Notfall-Programm aktiviert ja/nein (Es gehen nur noch Res an Holzfäller- und Sägewerk-Baustellen raus)
     bool emergency;

--- a/libs/s25main/RoadSegment.cpp
+++ b/libs/s25main/RoadSegment.cpp
@@ -36,8 +36,7 @@ RoadSegment::RoadSegment(const RoadType rt, noRoadNode* const f1, noRoadNode* co
 }
 
 RoadSegment::RoadSegment(SerializedGameData& sgd, const unsigned obj_id)
-    : GameObject(sgd, obj_id), rt(sgd.Pop<RoadType>()), f1(sgd.PopObject<noRoadNode>()),
-      f2(sgd.PopObject<noRoadNode>())
+    : GameObject(sgd, obj_id), rt(sgd.Pop<RoadType>()), f1(sgd.PopObject<noRoadNode>()), f2(sgd.PopObject<noRoadNode>())
 {
     if(sgd.GetGameDataVersion() < 7)
         route.resize(sgd.PopUnsignedShort());

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -198,7 +198,7 @@ std::unique_ptr<FOWObject> SerializedGameData::Create_FOWObject(const FoW_Type f
 }
 
 SerializedGameData::SerializedGameData()
-    : debugMode(false), gameDataVersion(0), expectedNumObjects(0), em(nullptr), writeEm(nullptr), isReading(false)
+    : debugMode(false), expectedNumObjects(0), em(nullptr), writeEm(nullptr), isReading(false)
 {}
 
 void SerializedGameData::Prepare(bool reading)

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -104,7 +104,8 @@
 /// 5: Make RoadPathDirection contiguous and use optional for ware in nofBuildingWorker
 /// 6: Make TradeDirection contiguous, Serialize only nobUsuals in BuildingRegister::buildings,
 ///    include water and fish in geologists resourceFound
-static const unsigned currentGameDataVersion = 6;
+/// 7: Use helpers::push/popContainer (uses var size)
+static const unsigned currentGameDataVersion = 7;
 // clang-format on
 
 std::unique_ptr<GameObject> SerializedGameData::Create_GameObject(const GO_Type got, const unsigned obj_id)

--- a/libs/s25main/SerializedGameData.h
+++ b/libs/s25main/SerializedGameData.h
@@ -25,6 +25,7 @@
 #include "helpers/ReserveElements.hpp"
 #include "helpers/serializeContainers.h"
 #include "helpers/serializeEnums.h"
+#include "helpers/serializePoint.h"
 #include "gameTypes/GO_Type.h"
 #include "gameTypes/MapCoordinates.h"
 #include "s25util/Serializer.h"
@@ -90,12 +91,6 @@ public:
     /// FoW-Objekt
     void PushFOWObject(const FOWObject* fowobj);
 
-    template<typename T>
-    void PushPoint(const Point<T>& pt);
-
-    /// Point of map coords
-    void PushMapPoint(const MapPoint pt) { PushPoint(pt); }
-
     /// Serialize an enum as T_SavedType which must be the underlying type (as that is what is deserialized by Pop<T>)
     /// Requires MaxEnumValue<T> to be specialized and T_SavedType to be able to hold all enumerators (checked only for
     /// max value)
@@ -142,12 +137,6 @@ public:
     void PopContainer(T& result);
 
     template<typename T>
-    Point<T> PopPoint();
-
-    /// Point of map coords
-    MapPoint PopMapPoint() { return PopPoint<MapPoint::ElementType>(); }
-
-    template<typename T>
     helpers::OptionalEnum<T> PopOptionalEnum();
 
     /// Read a trivial type (integral, enum, ...)
@@ -155,6 +144,8 @@ public:
     std::enable_if_t<std::is_enum<T>::value, T> Pop();
     template<typename T>
     std::enable_if_t<!std::is_enum<T>::value, T> Pop();
+
+    MapPoint PopMapPoint() { return helpers::popPoint<MapPoint>(*this); }
 
     /// Adds a deserialized object to the storage. Must be called exactly once per read GameObject
     void AddObject(GameObject* go);
@@ -245,22 +236,6 @@ void SerializedGameData::PopContainer(T& result)
         result.resize(PopUnsignedInt());
         helpers::popContainer(*this, result, true);
     }
-}
-
-template<typename T>
-void SerializedGameData::PushPoint(const Point<T>& pt)
-{
-    Push(pt.x);
-    Push(pt.y);
-}
-
-template<typename T>
-Point<T> SerializedGameData::PopPoint()
-{
-    Point<T> pt;
-    pt.x = Pop<T>();
-    pt.y = Pop<T>();
-    return pt;
 }
 
 template<typename T>

--- a/libs/s25main/Ware.cpp
+++ b/libs/s25main/Ware.cpp
@@ -69,7 +69,7 @@ void Ware::Serialize(SerializedGameData& sgd) const
     sgd.PushObject(location);
     sgd.PushEnum<uint8_t>(type);
     sgd.PushObject(goal);
-    sgd.PushMapPoint(next_harbor);
+    helpers::pushPoint(sgd, next_harbor);
 }
 
 static RoadPathDirection PopRoadPathDirection(SerializedGameData& sgd)

--- a/libs/s25main/buildings/BurnedWarehouse.cpp
+++ b/libs/s25main/buildings/BurnedWarehouse.cpp
@@ -40,8 +40,7 @@ BurnedWarehouse::BurnedWarehouse(const MapPoint pos, const unsigned char player,
 BurnedWarehouse::BurnedWarehouse(SerializedGameData& sgd, const unsigned obj_id)
     : noCoordBase(sgd, obj_id), player(sgd.PopUnsignedChar()), go_out_phase(sgd.PopUnsignedInt())
 {
-    for(unsigned& it : people)
-        it = sgd.PopUnsignedInt();
+    helpers::popContainer(sgd, people);
 }
 
 BurnedWarehouse::~BurnedWarehouse() = default;
@@ -58,9 +57,7 @@ void BurnedWarehouse::Serialize(SerializedGameData& sgd) const
 
     sgd.PushUnsignedChar(player);
     sgd.PushUnsignedInt(go_out_phase);
-
-    for(unsigned it : people)
-        sgd.PushUnsignedInt(it);
+    helpers::pushContainer(sgd, people);
 }
 
 void BurnedWarehouse::HandleEvent(const unsigned /*id*/)

--- a/libs/s25main/buildings/BurnedWarehouse.h
+++ b/libs/s25main/buildings/BurnedWarehouse.h
@@ -27,7 +27,7 @@ class SerializedGameData;
 class BurnedWarehouse : public noCoordBase
 {
 public:
-    using PeopleArray = helpers::EnumArray<unsigned, Job>;
+    using PeopleArray = helpers::EnumArray<uint32_t, Job>;
 
     BurnedWarehouse(MapPoint pos, unsigned char player, const PeopleArray& people);
     BurnedWarehouse(SerializedGameData& sgd, unsigned obj_id);

--- a/libs/s25main/buildings/nobHarborBuilding.cpp
+++ b/libs/s25main/buildings/nobHarborBuilding.cpp
@@ -175,13 +175,13 @@ void nobHarborBuilding::Serialize(SerializedGameData& sgd) const
     sgd.PushUnsignedInt(figures_for_ships.size());
     for(const auto& figures_for_ship : figures_for_ships)
     {
-        sgd.PushMapPoint(figures_for_ship.dest);
+        helpers::pushPoint(sgd, figures_for_ship.dest);
         sgd.PushObject(figures_for_ship.fig);
     }
     sgd.PushUnsignedInt(soldiers_for_ships.size());
     for(const auto& soldiers_for_ship : soldiers_for_ships)
     {
-        sgd.PushMapPoint(soldiers_for_ship.dest);
+        helpers::pushPoint(sgd, soldiers_for_ship.dest);
         sgd.PushObject(soldiers_for_ship.attacker, true);
     }
 }

--- a/libs/s25main/buildings/nobHarborBuilding.cpp
+++ b/libs/s25main/buildings/nobHarborBuilding.cpp
@@ -169,8 +169,7 @@ void nobHarborBuilding::Serialize(SerializedGameData& sgd) const
     expedition.Serialize(sgd);
     exploration_expedition.Serialize(sgd);
     sgd.PushEvent(orderware_ev);
-    for(unsigned short seaId : seaIds)
-        sgd.PushUnsignedShort(seaId);
+    helpers::pushContainer(sgd, seaIds);
     sgd.PushObjectContainer(wares_for_ships, true);
     sgd.PushUnsignedInt(figures_for_ships.size());
     for(const auto& figures_for_ship : figures_for_ships)
@@ -192,8 +191,7 @@ nobHarborBuilding::nobHarborBuilding(SerializedGameData& sgd, const unsigned obj
     // ins Militärquadrat einfügen
     gwg->GetMilitarySquares().Add(this);
 
-    for(unsigned short& seaId : seaIds)
-        seaId = sgd.PopUnsignedShort();
+    helpers::popContainer(sgd, seaIds);
 
     sgd.PopObjectContainer(wares_for_ships, GO_Type::Ware);
 

--- a/libs/s25main/buildings/nobHarborBuilding.h
+++ b/libs/s25main/buildings/nobHarborBuilding.h
@@ -64,7 +64,7 @@ class nobHarborBuilding : public nobBaseWarehouse
     /// Bestell-Ware-Event
     const GameEvent* orderware_ev;
     /// Die Meeres-IDs aller angrenzenden Meere (jeweils für die 6 drumherumliegenden Küstenpunkte)
-    helpers::EnumArray<unsigned short, Direction> seaIds;
+    helpers::EnumArray<uint16_t, Direction> seaIds;
     /// Liste von Waren, die weggeschifft werden sollen
     std::list<Ware*> wares_for_ships;
     /// Liste von Menschen, die weggeschifft werden sollen

--- a/libs/s25main/buildings/nobUsual.cpp
+++ b/libs/s25main/buildings/nobUsual.cpp
@@ -62,15 +62,13 @@ nobUsual::nobUsual(SerializedGameData& sgd, const unsigned obj_id)
       numGfNotWorking(sgd.PopUnsignedShort()), since_not_working(sgd.PopUnsignedInt()),
       outOfRessourcesMsgSent(sgd.PopBool()), is_working(sgd.PopBool())
 {
-    for(unsigned i = 0; i < 3; ++i)
-        numWares[i] = sgd.PopUnsignedChar();
+    helpers::popContainer(sgd, numWares);
 
     ordered_wares.resize(BLD_WORK_DESC[bldType_].waresNeeded.size());
 
     for(std::list<Ware*>& orderedWare : ordered_wares)
         sgd.PopObjectContainer(orderedWare, GO_Type::Ware);
-    for(unsigned short& last_productivitie : last_productivities)
-        last_productivitie = sgd.PopUnsignedShort();
+    helpers::popContainer(sgd, last_productivities);
 }
 
 void nobUsual::Serialize(SerializedGameData& sgd) const
@@ -88,12 +86,10 @@ void nobUsual::Serialize(SerializedGameData& sgd) const
     sgd.PushBool(outOfRessourcesMsgSent);
     sgd.PushBool(is_working);
 
-    for(unsigned i = 0; i < 3; ++i)
-        sgd.PushUnsignedChar(numWares[i]);
+    helpers::pushContainer(sgd, numWares);
     for(const std::list<Ware*>& orderedWare : ordered_wares)
         sgd.PushObjectContainer(orderedWare, true);
-    for(unsigned short last_productivitie : last_productivities)
-        sgd.PushUnsignedShort(last_productivitie);
+    helpers::pushContainer(sgd, last_productivities);
 }
 
 nobUsual::~nobUsual() = default;

--- a/libs/s25main/buildings/nobUsual.h
+++ b/libs/s25main/buildings/nobUsual.h
@@ -42,7 +42,7 @@ class nobUsual : public noBuilding
     /// Warentyp, den er zuletzt bestellt hatte (bei >1 Waren)
     unsigned char last_ordered_ware;
     /// Rohstoffe, die zur Produktion benötigt werden
-    std::array<unsigned char, 3> numWares;
+    std::array<uint8_t, 3> numWares;
     /// Bestellte Waren
     std::vector<std::list<Ware*>> ordered_wares;
     /// Bestell-Ware-Event
@@ -50,7 +50,7 @@ class nobUsual : public noBuilding
     /// Rechne-Produktivität-aus-Event
     const GameEvent* productivity_ev;
     /// Letzte Produktivitäten (Durchschnitt = Gesamt produktivität), vorne das neuste !
-    std::array<unsigned short, 6> last_productivities;
+    std::array<uint16_t, 6> last_productivities;
     /// How many GFs he did not work since the last productivity calculation
     unsigned short numGfNotWorking;
     /// Since which GF he did not work (0xFFFFFFFF = currently working)

--- a/libs/s25main/figures/noFigure.cpp
+++ b/libs/s25main/figures/noFigure.cpp
@@ -105,7 +105,7 @@ void noFigure::Serialize(SerializedGameData& sgd) const
     {
         sgd.PushUnsignedShort(wander_way);
         sgd.PushUnsignedShort(wander_tryings);
-        sgd.PushMapPoint(flagPos_);
+        helpers::pushPoint(sgd, flagPos_);
         sgd.PushUnsignedInt(flag_obj_id);
         sgd.PushUnsignedInt(burned_wh_id);
     }

--- a/libs/s25main/figures/nofActiveSoldier.cpp
+++ b/libs/s25main/figures/nofActiveSoldier.cpp
@@ -44,7 +44,7 @@ void nofActiveSoldier::Serialize(SerializedGameData& sgd) const
 
     sgd.PushEnum<uint8_t>(state);
     sgd.PushObject(enemy);
-    sgd.PushMapPoint(fightSpot_);
+    helpers::pushPoint(sgd, fightSpot_);
 }
 
 nofActiveSoldier::nofActiveSoldier(SerializedGameData& sgd, const unsigned obj_id)

--- a/libs/s25main/figures/nofAttacker.cpp
+++ b/libs/s25main/figures/nofAttacker.cpp
@@ -84,7 +84,7 @@ void nofAttacker::Serialize(SerializedGameData& sgd) const
     {
         sgd.PushObject(attacked_goal);
         sgd.PushBool(mayBeHunted);
-        sgd.PushContainer(canPlayerSendAggDefender);
+        helpers::pushContainer(sgd, canPlayerSendAggDefender);
         sgd.PushObject(huntingDefender, true);
         sgd.PushUnsignedShort(radius);
 

--- a/libs/s25main/figures/nofAttacker.cpp
+++ b/libs/s25main/figures/nofAttacker.cpp
@@ -91,8 +91,8 @@ void nofAttacker::Serialize(SerializedGameData& sgd) const
         if(state == SoldierState::AttackingWaitingForDefender)
             sgd.PushEvent(blocking_event);
 
-        sgd.PushMapPoint(harborPos);
-        sgd.PushMapPoint(shipPos);
+        helpers::pushPoint(sgd, harborPos);
+        helpers::pushPoint(sgd, shipPos);
         sgd.PushUnsignedInt(ship_obj_id);
     } else
     {

--- a/libs/s25main/figures/nofBuilder.cpp
+++ b/libs/s25main/figures/nofBuilder.cpp
@@ -56,15 +56,16 @@ void nofBuilder::Serialize(SerializedGameData& sgd) const
 
     sgd.PushEnum<uint8_t>(state);
     sgd.PushObject(building_site, true);
-    sgd.PushPoint(offsetSite);
-    sgd.PushPoint(nextOffsetSite);
+    helpers::pushPoint(sgd, offsetSite);
+    helpers::pushPoint(sgd, nextOffsetSite);
     sgd.PushUnsignedChar(building_steps_available);
 }
 
 nofBuilder::nofBuilder(SerializedGameData& sgd, const unsigned obj_id)
     : noFigure(sgd, obj_id), state(sgd.Pop<BuilderState>()),
-      building_site(sgd.PopObject<noBuildingSite>(GO_Type::Buildingsite)), offsetSite(sgd.PopPoint<short>()),
-      nextOffsetSite(sgd.PopPoint<short>()), building_steps_available(sgd.PopUnsignedChar())
+      building_site(sgd.PopObject<noBuildingSite>(GO_Type::Buildingsite)),
+      offsetSite(helpers::popPoint<Point<int16_t>>(sgd)), nextOffsetSite(helpers::popPoint<Point<int16_t>>(sgd)),
+      building_steps_available(sgd.PopUnsignedChar())
 {}
 
 void nofBuilder::GoalReached()

--- a/libs/s25main/figures/nofBuilder.h
+++ b/libs/s25main/figures/nofBuilder.h
@@ -47,7 +47,7 @@ private:
 
     /// X,Y relativ zur Baustelle in Pixeln
     /// next ist der angesteuerte Punkt
-    Point<short> offsetSite, nextOffsetSite;
+    Point<int16_t> offsetSite, nextOffsetSite;
 
     /// Wie viele Bauschritte noch verfügbar sind, bis der nächste Rohstoff geholt werden muss
     unsigned char building_steps_available;

--- a/libs/s25main/figures/nofCarrier.cpp
+++ b/libs/s25main/figures/nofCarrier.cpp
@@ -100,9 +100,12 @@ nofCarrier::nofCarrier(SerializedGameData& sgd, unsigned obj_id)
 {
     if(state == CarrierState::BoatcarrierWanderOnWater)
     {
-        shore_path.resize(sgd.PopUnsignedInt());
-        for(auto& it : shore_path)
-            it = sgd.Pop<Direction>();
+        if(sgd.GetGameDataVersion() < 7)
+        {
+            shore_path.resize(sgd.PopUnsignedInt());
+            helpers::popContainer(sgd, shore_path, true);
+        } else
+            helpers::popContainer(sgd, shore_path);
     }
 }
 
@@ -122,9 +125,7 @@ void nofCarrier::Serialize(SerializedGameData& sgd) const
 
     if(state == CarrierState::BoatcarrierWanderOnWater)
     {
-        sgd.PushUnsignedInt(shore_path.size());
-        for(auto it : shore_path)
-            sgd.PushEnum<uint8_t>(it);
+        helpers::pushContainer(sgd, shore_path);
     }
 }
 

--- a/libs/s25main/figures/nofCatapultMan.cpp
+++ b/libs/s25main/figures/nofCatapultMan.cpp
@@ -39,7 +39,7 @@ nofCatapultMan::PossibleTarget::PossibleTarget(SerializedGameData& sgd)
 
 void nofCatapultMan::PossibleTarget::Serialize(SerializedGameData& sgd) const
 {
-    sgd.PushMapPoint(pos);
+    helpers::pushPoint(sgd, pos);
     sgd.PushUnsignedInt(distance);
 }
 

--- a/libs/s25main/figures/nofFarmhand.cpp
+++ b/libs/s25main/figures/nofFarmhand.cpp
@@ -33,7 +33,7 @@ void nofFarmhand::Serialize(SerializedGameData& sgd) const
 {
     nofBuildingWorker::Serialize(sgd);
 
-    sgd.PushMapPoint(dest);
+    helpers::pushPoint(sgd, dest);
 }
 
 nofFarmhand::nofFarmhand(SerializedGameData& sgd, const unsigned obj_id)

--- a/libs/s25main/figures/nofGeologist.cpp
+++ b/libs/s25main/figures/nofGeologist.cpp
@@ -55,9 +55,7 @@ void nofGeologist::Serialize(SerializedGameData& sgd) const
     }
 
     helpers::pushPoint(sgd, node_goal);
-
-    for(const bool found : resAlreadyFound)
-        sgd.PushBool(found);
+    helpers::pushContainer(sgd, resAlreadyFound);
 }
 
 nofGeologist::nofGeologist(SerializedGameData& sgd, const unsigned obj_id)
@@ -80,10 +78,7 @@ nofGeologist::nofGeologist(SerializedGameData& sgd, const unsigned obj_id)
                 resAlreadyFound[res] = sgd.PopBool();
         }
     } else
-    {
-        for(bool& found : resAlreadyFound)
-            found = sgd.PopBool();
-    }
+        helpers::popContainer(sgd, resAlreadyFound);
 }
 
 void nofGeologist::Draw(DrawPoint drawPt)

--- a/libs/s25main/figures/nofGeologist.cpp
+++ b/libs/s25main/figures/nofGeologist.cpp
@@ -51,10 +51,10 @@ void nofGeologist::Serialize(SerializedGameData& sgd) const
     sgd.PushUnsignedInt(available_nodes.size());
     for(const auto& available_node : available_nodes)
     {
-        sgd.PushMapPoint(available_node);
+        helpers::pushPoint(sgd, available_node);
     }
 
-    sgd.PushMapPoint(node_goal);
+    helpers::pushPoint(sgd, node_goal);
 
     for(const bool found : resAlreadyFound)
         sgd.PushBool(found);

--- a/libs/s25main/figures/nofHunter.cpp
+++ b/libs/s25main/figures/nofHunter.cpp
@@ -50,7 +50,7 @@ void nofHunter::Serialize(SerializedGameData& sgd) const
     if(state != State::FigureWork && state != State::Waiting1)
     {
         sgd.PushObject(animal, true);
-        sgd.PushMapPoint(shootingPos);
+        helpers::pushPoint(sgd, shootingPos);
         sgd.PushEnum<uint8_t>(shooting_dir);
     }
 }

--- a/libs/s25main/figures/nofScout_Free.cpp
+++ b/libs/s25main/figures/nofScout_Free.cpp
@@ -34,7 +34,7 @@ nofScout_Free::nofScout_Free(const MapPoint pos, const unsigned char player, noR
 void nofScout_Free::Serialize(SerializedGameData& sgd) const
 {
     nofFlagWorker::Serialize(sgd);
-    sgd.PushMapPoint(nextPos);
+    helpers::pushPoint(sgd, nextPos);
     sgd.PushUnsignedInt(rest_way);
 }
 

--- a/libs/s25main/figures/nofShipWright.cpp
+++ b/libs/s25main/figures/nofShipWright.cpp
@@ -163,7 +163,7 @@ void nofShipWright::Serialize(SerializedGameData& sgd) const
 {
     nofWorkman::Serialize(sgd);
 
-    sgd.PushMapPoint(curShipBuildPos);
+    helpers::pushPoint(sgd, curShipBuildPos);
 }
 
 /// Startet das Laufen zu der Arbeitsstelle, dem Schiff

--- a/libs/s25main/figures/nofTradeDonkey.cpp
+++ b/libs/s25main/figures/nofTradeDonkey.cpp
@@ -47,7 +47,7 @@ nofTradeDonkey::nofTradeDonkey(SerializedGameData& sgd, const unsigned obj_id)
         for(const auto dir : next_dirs_raw)
             next_dirs.push_back(dir == 0xDD ? TradeDirection::ReachedGoal : TradeDirection(dir));
     } else
-        sgd.PopContainer(next_dirs);
+        helpers::popContainer(sgd, next_dirs);
 }
 
 void nofTradeDonkey::Serialize(SerializedGameData& sgd) const
@@ -56,7 +56,7 @@ void nofTradeDonkey::Serialize(SerializedGameData& sgd) const
 
     sgd.PushObject(successor, true);
     sgd.PushOptionalEnum<uint8_t>(gt);
-    sgd.PushContainer(next_dirs);
+    helpers::pushContainer(sgd, next_dirs);
 }
 
 void nofTradeDonkey::GoalReached()

--- a/libs/s25main/figures/nofTradeLeader.cpp
+++ b/libs/s25main/figures/nofTradeLeader.cpp
@@ -51,8 +51,8 @@ void nofTradeLeader::Serialize(SerializedGameData& sgd) const
     tr.Serialize(sgd);
 
     sgd.PushObject(successor, true);
-    sgd.PushMapPoint(homePos);
-    sgd.PushMapPoint(goalPos);
+    helpers::pushPoint(sgd, homePos);
+    helpers::pushPoint(sgd, goalPos);
 }
 
 void nofTradeLeader::GoalReached()

--- a/libs/s25main/gameTypes/FoWNode.cpp
+++ b/libs/s25main/gameTypes/FoWNode.cpp
@@ -34,11 +34,9 @@ void FoWNode::Serialize(SerializedGameData& sgd) const
     {
         sgd.PushUnsignedInt(last_update_time);
         sgd.PushFOWObject(object.get());
-        for(const PointRoad road : roads)
-            sgd.PushEnum<uint8_t>(road);
+        helpers::pushContainer(sgd, roads);
         sgd.PushUnsignedChar(owner);
-        for(unsigned char boundary_stone : boundary_stones)
-            sgd.PushUnsignedChar(boundary_stone);
+        helpers::pushContainer(sgd, boundary_stones);
     }
 }
 
@@ -50,11 +48,9 @@ void FoWNode::Deserialize(SerializedGameData& sgd)
     {
         last_update_time = sgd.PopUnsignedInt();
         object = sgd.PopFOWObject();
-        for(PointRoad& road : roads)
-            road = sgd.Pop<PointRoad>();
+        helpers::popContainer(sgd, roads);
         owner = sgd.PopUnsignedChar();
-        for(uint8_t& boundary_stone : boundary_stones)
-            boundary_stone = sgd.PopUnsignedChar();
+        helpers::popContainer(sgd, boundary_stones);
     } else
     {
         last_update_time = 0;

--- a/libs/s25main/gameTypes/HarborPos.h
+++ b/libs/s25main/gameTypes/HarborPos.h
@@ -24,11 +24,6 @@
 
 struct HarborPos
 {
-    MapPoint pos;
-
-    /// Seas at the neighbor points in each direction
-    helpers::EnumArray<uint16_t, Direction> seaIds;
-
     struct Neighbor
     {
         unsigned id;
@@ -42,6 +37,9 @@ struct HarborPos
         }
     };
 
+    MapPoint pos;
+    /// Seas at the neighbor points in each direction
+    helpers::EnumArray<uint16_t, Direction> seaIds = {};
     helpers::EnumArray<std::vector<Neighbor>, ShipDirection> neighbors;
 
     explicit HarborPos(const MapPoint pt) noexcept : pos(pt) {}

--- a/libs/s25main/gameTypes/HarborPos.h
+++ b/libs/s25main/gameTypes/HarborPos.h
@@ -26,11 +26,8 @@ struct HarborPos
 {
     MapPoint pos;
 
-    struct CoastalPoint
-    {
-        unsigned short seaId = 0;
-    };
-    helpers::EnumArray<CoastalPoint, Direction> cps;
+    /// Seas at the neighbor points in each direction
+    helpers::EnumArray<uint16_t, Direction> seaIds;
 
     struct Neighbor
     {
@@ -47,5 +44,5 @@ struct HarborPos
 
     helpers::EnumArray<std::vector<Neighbor>, ShipDirection> neighbors;
 
-    HarborPos(const MapPoint pt) noexcept : pos(pt) {}
+    explicit HarborPos(const MapPoint pt) noexcept : pos(pt) {}
 };

--- a/libs/s25main/gameTypes/InventorySetting.h
+++ b/libs/s25main/gameTypes/InventorySetting.h
@@ -29,17 +29,17 @@ enum class EInventorySetting : unsigned
 
 struct InventorySetting
 {
-    constexpr InventorySetting() = default;
-    constexpr InventorySetting(const EInventorySetting setting) : state(MakeBitField(setting)) {}
-    constexpr explicit InventorySetting(uint8_t state) : state(state) { MakeValid(); }
-    constexpr bool IsSet(EInventorySetting setting) const;
-    constexpr InventorySetting Toggle(EInventorySetting setting);
-    constexpr void MakeValid();
-    constexpr explicit operator uint8_t() const { return state; }
+    constexpr InventorySetting() noexcept = default;
+    constexpr InventorySetting(const EInventorySetting setting) noexcept : state(MakeBitField(setting)) {}
+    constexpr explicit InventorySetting(uint8_t state) noexcept : state(state) { MakeValid(); }
+    constexpr bool IsSet(EInventorySetting setting) const noexcept;
+    constexpr InventorySetting Toggle(EInventorySetting setting) noexcept;
+    constexpr void MakeValid() noexcept;
+    constexpr explicit operator uint8_t() const noexcept { return state; }
     friend constexpr bool operator==(const InventorySetting& lhs, const InventorySetting& rhs);
 
 private:
-    static constexpr uint8_t MakeBitField(EInventorySetting setting);
+    static constexpr uint8_t MakeBitField(EInventorySetting setting) noexcept;
     // Current state as a bitfield!
     uint8_t state = 0;
 };
@@ -48,12 +48,12 @@ private:
 // Implementation
 //////////////////////////////////////////////////////////////////////////
 
-constexpr bool InventorySetting::IsSet(const EInventorySetting setting) const
+constexpr bool InventorySetting::IsSet(const EInventorySetting setting) const noexcept
 {
     return (state & MakeBitField(setting)) != 0;
 }
 
-constexpr InventorySetting InventorySetting::Toggle(const EInventorySetting setting)
+constexpr InventorySetting InventorySetting::Toggle(const EInventorySetting setting) noexcept
 {
     state ^= MakeBitField(setting);
     // If we changed collect, then allow only collect to be set
@@ -65,12 +65,12 @@ constexpr InventorySetting InventorySetting::Toggle(const EInventorySetting sett
     return *this;
 }
 
-constexpr uint8_t InventorySetting::MakeBitField(const EInventorySetting setting)
+constexpr uint8_t InventorySetting::MakeBitField(const EInventorySetting setting) noexcept
 {
     return static_cast<uint8_t>(1 << static_cast<unsigned>(setting));
 }
 
-constexpr void InventorySetting::MakeValid()
+constexpr void InventorySetting::MakeValid() noexcept
 {
     switch(state)
     {

--- a/libs/s25main/gameTypes/MapNode.cpp
+++ b/libs/s25main/gameTypes/MapNode.cpp
@@ -32,9 +32,7 @@ MapNode::MapNode()
 
 void MapNode::Serialize(SerializedGameData& sgd, const unsigned numPlayers, const WorldDescription& desc) const
 {
-    for(PointRoad road : roads)
-        sgd.PushEnum<uint8_t>(road);
-
+    helpers::pushContainer(sgd, roads);
     sgd.PushUnsignedChar(altitude);
     sgd.PushUnsignedChar(shadow);
     sgd.PushString(desc.get(t1).name);
@@ -42,8 +40,7 @@ void MapNode::Serialize(SerializedGameData& sgd, const unsigned numPlayers, cons
     sgd.PushUnsignedChar(resources.getValue());
     sgd.PushBool(reserved);
     sgd.PushUnsignedChar(owner);
-    for(unsigned char boundary_stone : boundary_stones)
-        sgd.PushUnsignedChar(boundary_stone);
+    helpers::pushContainer(sgd, boundary_stones);
     sgd.PushEnum<uint8_t>(bq);
     RTTR_Assert(numPlayers <= fow.size());
     for(unsigned z = 0; z < numPlayers; ++z)
@@ -57,8 +54,7 @@ void MapNode::Serialize(SerializedGameData& sgd, const unsigned numPlayers, cons
 void MapNode::Deserialize(SerializedGameData& sgd, const unsigned numPlayers, const WorldDescription& desc,
                           const std::vector<DescIdx<TerrainDesc>>& landscapeTerrains)
 {
-    for(PointRoad& road : roads)
-        road = sgd.Pop<PointRoad>();
+    helpers::popContainer(sgd, roads);
 
     altitude = sgd.PopUnsignedChar();
     shadow = sgd.PopUnsignedChar();
@@ -82,8 +78,7 @@ void MapNode::Deserialize(SerializedGameData& sgd, const unsigned numPlayers, co
     resources = Resource(sgd.PopUnsignedChar());
     reserved = sgd.PopBool();
     owner = sgd.PopUnsignedChar();
-    for(uint8_t& boundary_stone : boundary_stones)
-        boundary_stone = sgd.PopUnsignedChar();
+    helpers::popContainer(sgd, boundary_stones);
     bq = sgd.Pop<BuildingQuality>();
     RTTR_Assert(numPlayers <= fow.size());
     for(unsigned z = 0; z < numPlayers; ++z)

--- a/libs/s25main/network/GameMessages.cpp
+++ b/libs/s25main/network/GameMessages.cpp
@@ -18,6 +18,7 @@
 #include "GameMessages.h"
 #include "JoinPlayerInfo.h"
 #include "enum_cast.hpp"
+#include "helpers/serializeContainers.h"
 
 GameMessage_Player_List::GameMessage_Player_List() : GameMessage(NMS_PLAYER_LIST) {}
 
@@ -58,4 +59,16 @@ bool GameMessage_Player_List::Run(GameMessageInterface* callback) const
           % (playerInfo.isReady ? "true" : "false");
     }
     return callback->OnGameMessage(*this);
+}
+
+void GameMessage_Server_Async::Serialize(Serializer& ser) const
+{
+    GameMessage::Serialize(ser);
+    helpers::pushContainer(ser, checksums);
+}
+
+void GameMessage_Server_Async::Deserialize(Serializer& ser)
+{
+    GameMessage::Deserialize(ser);
+    helpers::popContainer(ser, checksums);
 }

--- a/libs/s25main/network/GameMessages.h
+++ b/libs/s25main/network/GameMessages.h
@@ -316,22 +316,9 @@ public:
         LOG.writeToFile(">>> NMS_SERVER_ASYNC(%d)\n") % checksums.size();
     }
 
-    void Serialize(Serializer& ser) const override
-    {
-        GameMessage::Serialize(ser);
-        ser.PushUnsignedInt(unsigned(checksums.size()));
-        for(unsigned int checksum : checksums)
-            ser.PushUnsignedInt(checksum);
-    }
+    void Serialize(Serializer& ser) const override;
 
-    void Deserialize(Serializer& ser) override
-    {
-        GameMessage::Deserialize(ser);
-        unsigned size = ser.PopUnsignedInt();
-        checksums.resize(size);
-        for(unsigned i = 0; i < size; ++i)
-            checksums[i] = ser.PopUnsignedInt();
-    }
+    void Deserialize(Serializer& ser) override;
 
     bool Run(GameMessageInterface* callback) const override
     {

--- a/libs/s25main/nodeObjs/noCoordBase.cpp
+++ b/libs/s25main/nodeObjs/noCoordBase.cpp
@@ -24,7 +24,7 @@ void noCoordBase::Serialize(SerializedGameData& sgd) const
 {
     noBase::Serialize(sgd);
 
-    sgd.PushMapPoint(pos);
+    helpers::pushPoint(sgd, pos);
 }
 
 noCoordBase::noCoordBase(SerializedGameData& sgd, const unsigned obj_id) : noBase(sgd, obj_id), pos(sgd.PopMapPoint())

--- a/libs/s25main/nodeObjs/noShip.cpp
+++ b/libs/s25main/nodeObjs/noShip.cpp
@@ -95,13 +95,11 @@ void noShip::Serialize(SerializedGameData& sgd) const
     sgd.PushUnsignedChar(goal_dir);
     sgd.PushString(name);
     sgd.PushUnsignedInt(curRouteIdx);
-    sgd.PushUnsignedInt(route_.size());
     sgd.PushBool(lost);
     sgd.PushUnsignedInt(remaining_sea_attackers);
     sgd.PushUnsignedInt(home_harbor);
     sgd.PushUnsignedInt(covered_distance);
-    for(auto i : route_)
-        sgd.PushEnum<uint8_t>(i);
+    helpers::pushContainer(sgd, route_);
     sgd.PushObjectContainer(figures);
     sgd.PushObjectContainer(wares, true);
 }
@@ -110,11 +108,11 @@ noShip::noShip(SerializedGameData& sgd, const unsigned obj_id)
     : noMovable(sgd, obj_id), ownerId_(sgd.PopUnsignedChar()), state(sgd.Pop<State>()), seaId_(sgd.PopUnsignedShort()),
       goal_harborId(sgd.PopUnsignedInt()), goal_dir(sgd.PopUnsignedChar()),
       name(sgd.GetGameDataVersion() < 2 ? sgd.PopLongString() : sgd.PopString()), curRouteIdx(sgd.PopUnsignedInt()),
-      route_(sgd.PopUnsignedInt()), lost(sgd.PopBool()), remaining_sea_attackers(sgd.PopUnsignedInt()),
-      home_harbor(sgd.PopUnsignedInt()), covered_distance(sgd.PopUnsignedInt())
+      route_(sgd.GetGameDataVersion() < 7 ? sgd.PopUnsignedInt() : 0), lost(sgd.PopBool()),
+      remaining_sea_attackers(sgd.PopUnsignedInt()), home_harbor(sgd.PopUnsignedInt()),
+      covered_distance(sgd.PopUnsignedInt())
 {
-    for(auto& dir : route_)
-        dir = sgd.Pop<Direction>();
+    helpers::popContainer(sgd, route_, sgd.GetGameDataVersion() < 7);
     sgd.PopObjectContainer(figures);
     sgd.PopObjectContainer(wares, GO_Type::Ware);
 }

--- a/libs/s25main/world/MapLoader.cpp
+++ b/libs/s25main/world/MapLoader.cpp
@@ -411,7 +411,8 @@ bool MapLoader::PlaceHQs(GameWorldBase& world, std::vector<MapPoint> hqPositions
 
 bool MapLoader::InitSeasAndHarbors(World& world, const std::vector<MapPoint>& additionalHarbors)
 {
-    world.harbor_pos.insert(world.harbor_pos.end(), additionalHarbors.begin(), additionalHarbors.end());
+    for(MapPoint pt : additionalHarbors)
+        world.harbor_pos.push_back(HarborPos(pt));
     // Clear current harbors and seas
     RTTR_FOREACH_PT(MapPoint, world.GetSize()) //-V807
     {

--- a/libs/s25main/world/MapLoader.cpp
+++ b/libs/s25main/world/MapLoader.cpp
@@ -130,7 +130,7 @@ bool MapLoader::InitNodes(const glArchivItem_Map& map, Exploration exploration)
 
         // Hafenplatz?
         if((t1 & libsiedler2::HARBOR_MASK) != 0)
-            world_.harbor_pos.push_back(pt);
+            world_.harbor_pos.push_back(HarborPos(pt));
 
         // Will be set later
         node.harborId = 0;
@@ -449,7 +449,7 @@ bool MapLoader::InitSeasAndHarbors(World& world, const std::vector<MapPoint>& ad
             else
                 hasCoastAtSea[seaId] = true;
 
-            it->cps[dir].seaId = seaId;
+            it->seaIds[dir] = seaId;
             if(seaId)
                 foundCoast = true;
         }
@@ -611,8 +611,8 @@ void MapLoader::CalcHarborPosNeighbors(World& world)
                         RTTR_Assert(seaId);
                         for(const auto hbDir : helpers::EnumRange<Direction>{})
                         {
-                            if(otherHb.cps[hbDir].seaId == seaId && world.GetNeighbour(otherHb.pos, hbDir) != curPt)
-                                otherHb.cps[hbDir].seaId = 0;
+                            if(otherHb.seaIds[hbDir] == seaId && world.GetNeighbour(otherHb.pos, hbDir) != curPt)
+                                otherHb.seaIds[hbDir] = 0;
                         }
                     }
                 }

--- a/libs/s25main/world/MapSerializer.cpp
+++ b/libs/s25main/world/MapSerializer.cpp
@@ -27,7 +27,7 @@
 void MapSerializer::Serialize(const World& world, const unsigned numPlayers, SerializedGameData& sgd)
 {
     // Headinformationen
-    sgd.PushPoint(world.GetSize());
+    helpers::pushPoint(sgd, world.GetSize());
     sgd.PushString(world.GetDescription().get(world.GetLandscapeType()).name);
 
     sgd.PushUnsignedInt(GameObject::GetObjIDCounter());
@@ -50,7 +50,7 @@ void MapSerializer::Serialize(const World& world, const unsigned numPlayers, Ser
     sgd.PushUnsignedInt(world.harbor_pos.size());
     for(const auto& curHarborPos : world.harbor_pos)
     {
-        sgd.PushMapPoint(curHarborPos.pos);
+        helpers::pushPoint(sgd, curHarborPos.pos);
         for(const auto& cp : curHarborPos.cps)
             sgd.PushUnsignedShort(cp.seaId);
         for(const auto& curNeighbors : curHarborPos.neighbors)
@@ -74,7 +74,7 @@ void MapSerializer::Deserialize(World& world, const unsigned numPlayers, Seriali
         throw SerializedGameData::Error(_("Failed to load game data!"));
 
     // Headinformationen
-    const MapExtent size = sgd.PopPoint<MapExtent::ElementType>();
+    const auto size = helpers::popPoint<MapExtent>(sgd);
     DescIdx<LandscapeDesc> lt(0);
     if(sgd.GetGameDataVersion() < 3)
     {

--- a/libs/s25main/world/MapSerializer.cpp
+++ b/libs/s25main/world/MapSerializer.cpp
@@ -51,8 +51,7 @@ void MapSerializer::Serialize(const World& world, const unsigned numPlayers, Ser
     for(const auto& curHarborPos : world.harbor_pos)
     {
         helpers::pushPoint(sgd, curHarborPos.pos);
-        for(const auto& cp : curHarborPos.cps)
-            sgd.PushUnsignedShort(cp.seaId);
+        helpers::pushContainer(sgd, curHarborPos.seaIds);
         for(const auto& curNeighbors : curHarborPos.neighbors)
         {
             sgd.PushUnsignedInt(curNeighbors.size());
@@ -144,8 +143,7 @@ void MapSerializer::Deserialize(World& world, const unsigned numPlayers, Seriali
         RTTR_UNUSED(i);
         world.harbor_pos.emplace_back(sgd.PopMapPoint());
         auto& curHarborPos = world.harbor_pos.back();
-        for(auto& cp : curHarborPos.cps)
-            cp.seaId = sgd.PopUnsignedShort();
+        helpers::popContainer(sgd, curHarborPos.seaIds);
         for(auto& neighbor : curHarborPos.neighbors)
         {
             const unsigned numNeighbors = sgd.PopUnsignedInt();

--- a/libs/s25main/world/TradeRoute.cpp
+++ b/libs/s25main/world/TradeRoute.cpp
@@ -33,7 +33,7 @@ TradeRoute::TradeRoute(SerializedGameData& sgd, const GameWorldGame& gwg, const 
 void TradeRoute::Serialize(SerializedGameData& sgd) const
 {
     path.Serialize(sgd);
-    sgd.PushMapPoint(curPos);
+    helpers::pushPoint(sgd, curPos);
     sgd.PushUnsignedInt(curRouteIdx);
 }
 

--- a/libs/s25main/world/World.cpp
+++ b/libs/s25main/world/World.cpp
@@ -49,7 +49,7 @@ void World::Init(const MapExtent& mapSize, DescIdx<LandscapeDesc> lt)
     GameObject::ResetCounters();
 
     // Dummy so that the harbor "0" might be used for ships with no particular destination
-    harbor_pos.push_back(MapPoint::Invalid());
+    harbor_pos.push_back(HarborPos(MapPoint::Invalid()));
     noNodeObj = std::make_unique<noNothing>();
 }
 
@@ -316,7 +316,7 @@ unsigned World::GetSeaSize(const unsigned seaId) const
 unsigned short World::GetSeaId(const unsigned harborId, const Direction dir) const
 {
     RTTR_Assert(harborId);
-    return harbor_pos[harborId].cps[dir].seaId;
+    return harbor_pos[harborId].seaIds[dir];
 }
 
 /// Grenzt der Hafen an ein bestimmtes Meer an?
@@ -330,11 +330,10 @@ MapPoint World::GetCoastalPoint(const unsigned harborId, const unsigned short se
     RTTR_Assert(harborId);
     RTTR_Assert(seaId);
 
-    for(auto dir : helpers::EnumRange<Direction>{})
+    // Take point at NW last as often there is no path from it if the harbor is north of an island
+    for(auto dir : helpers::enumRange(Direction::NorthEast))
     {
-        // Take point at NW last as often there is no path from it if the harbor is north of an island
-        dir += 2u;
-        if(harbor_pos[harborId].cps[dir].seaId == seaId)
+        if(harbor_pos[harborId].seaIds[dir] == seaId)
             return GetNeighbour(harbor_pos[harborId].pos, dir);
     }
 

--- a/tests/common/testMathHelpers.cpp
+++ b/tests/common/testMathHelpers.cpp
@@ -19,9 +19,9 @@
 #include "helpers/mathFuncs.h"
 #include "helpers/roundToNextPow2.h"
 #include <rttr/test/random.hpp>
-#include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>
 #include <chrono>
+#include <utility>
 
 BOOST_AUTO_TEST_SUITE(MathHelperTests)
 
@@ -135,8 +135,7 @@ BOOST_AUTO_TEST_CASE(DivCeilResults)
     BOOST_TEST(helpers::divCeil(9, 8) == 2u);
 }
 
-using TimeTypes =
-  boost::mpl::list<std::chrono::duration<int32_t, std::milli>, std::chrono::duration<uint32_t, std::milli>>;
+using TimeTypes = std::tuple<std::chrono::duration<int32_t, std::milli>, std::chrono::duration<uint32_t, std::milli>>;
 template<typename T>
 struct Rep
 {

--- a/tests/common/testOptionalEnum.cpp
+++ b/tests/common/testOptionalEnum.cpp
@@ -17,8 +17,8 @@
 
 #include "helpers/OptionalEnum.h"
 #include "helpers/OptionalIO.h"
-#include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>
+#include <utility>
 
 namespace testEnums {
 enum class DefaultEnum
@@ -62,7 +62,7 @@ constexpr auto maxEnumValue(UnsignedEnum)
 
 using namespace testEnums;
 
-using EnumsToTest = boost::mpl::list<DefaultEnum, SignedEnum, UnsignedEnum>;
+using EnumsToTest = std::tuple<DefaultEnum, SignedEnum, UnsignedEnum>;
 
 BOOST_AUTO_TEST_SUITE(OptionalEnum)
 

--- a/tests/common/testPoint.cpp
+++ b/tests/common/testPoint.cpp
@@ -18,15 +18,15 @@
 #include "Point.h"
 #include "PointOutput.h"
 #include <rttr/test/random.hpp>
-#include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>
 #include <type_traits>
+#include <utility>
 
 using boost::test_tools::tolerance;
 using rttr::test::randomPoint;
 using rttr::test::randomValue;
 
-using SignedTypes = boost::mpl::list<int8_t, int16_t, int32_t, int64_t, float, double>;
+using SignedTypes = std::tuple<int8_t, int16_t, int32_t, int64_t, float, double>;
 // Custom trait to support float/double
 template<typename T>
 using make_unsigned_t =

--- a/tests/common/testSerializationHelpers.cpp
+++ b/tests/common/testSerializationHelpers.cpp
@@ -15,9 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
+#include "Point.h"
+#include "PointOutput.h"
 #include "helpers/EnumArray.h"
 #include "helpers/MaxEnumValue.h"
 #include "helpers/serializeContainers.h"
+#include "helpers/serializePoint.h"
 #include <rttr/test/random.hpp>
 #include <s25util/Serializer.h>
 #include <boost/test/unit_test.hpp>
@@ -148,6 +151,24 @@ BOOST_AUTO_TEST_CASE(SerializeResizableIgnoringSize)
     BOOST_TEST(outIntArray == intArray, per_element());
     BOOST_TEST(outU8Array == u8Array, per_element());
     BOOST_TEST(outBoolArray == boolArray, per_element());
+};
+
+BOOST_AUTO_TEST_CASE(SerializePoints)
+{
+    using rttr::test::randomPoint;
+    const auto pt1 = randomPoint<Point<uint8_t>>();
+    const auto pt2 = randomPoint<Point<int16_t>>();
+    const auto pt3 = randomPoint<Point<uint32_t>>();
+    const auto pt4 = randomPoint<Point<int64_t>>();
+    Serializer ser;
+    helpers::pushPoint(ser, pt1);
+    helpers::pushPoint(ser, pt2);
+    helpers::pushPoint(ser, pt3);
+    helpers::pushPoint(ser, pt4);
+    BOOST_TEST_REQUIRE(helpers::popPoint<decltype(pt1)>(ser) == pt1);
+    BOOST_TEST_REQUIRE(helpers::popPoint<decltype(pt2)>(ser) == pt2);
+    BOOST_TEST_REQUIRE(helpers::popPoint<decltype(pt3)>(ser) == pt3);
+    BOOST_TEST_REQUIRE(helpers::popPoint<decltype(pt4)>(ser) == pt4);
 };
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/common/testSerializationHelpers.cpp
+++ b/tests/common/testSerializationHelpers.cpp
@@ -126,4 +126,28 @@ BOOST_AUTO_TEST_CASE(SerializeFixedSizeContainers)
     BOOST_TEST_REQUIRE(helpers::popContainer<decltype(intEnumArray)>(ser) == intEnumArray, per_element());
 }
 
+BOOST_AUTO_TEST_CASE(SerializeResizableIgnoringSize)
+{
+    using rttr::test::randomBool;
+    using rttr::test::randomValue;
+    const std::vector<int> intArray = {randomValue<int>(), randomValue<int>(), randomValue<int>()};
+    const std::vector<uint8_t> u8Array = {randomValue<uint8_t>(), randomValue<uint8_t>(), randomValue<uint8_t>(),
+                                          randomValue<uint8_t>()};
+    const std::array<bool, 6> boolArray = {randomBool(), randomBool(), randomBool(),
+                                           randomBool(), randomBool(), randomBool()};
+    Serializer ser;
+    helpers::pushContainer(ser, intArray, true);
+    helpers::pushContainer(ser, u8Array, true);
+    helpers::pushContainer(ser, boolArray, true);
+    std::vector<int> outIntArray(intArray.size());
+    std::vector<uint8_t> outU8Array(u8Array.size());
+    std::array<bool, 6> outBoolArray;
+    helpers::popContainer(ser, outIntArray, true);
+    helpers::popContainer(ser, outU8Array, true);
+    helpers::popContainer(ser, outBoolArray, true);
+    BOOST_TEST(outIntArray == intArray, per_element());
+    BOOST_TEST(outU8Array == u8Array, per_element());
+    BOOST_TEST(outBoolArray == boolArray, per_element());
+};
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/common/testSerializationHelpers.cpp
+++ b/tests/common/testSerializationHelpers.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2018 - 2018 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "helpers/EnumArray.h"
+#include "helpers/MaxEnumValue.h"
+#include "helpers/serializeContainers.h"
+#include <rttr/test/random.hpp>
+#include <s25util/Serializer.h>
+#include <boost/test/unit_test.hpp>
+#include <utility>
+
+using boost::test_tools::per_element;
+
+namespace {
+enum class TestEnum : uint8_t
+{
+    Value1,
+    Value2,
+    Value3,
+    Value4,
+};
+constexpr auto maxEnumValue(TestEnum)
+{
+    return TestEnum::Value4;
+}
+// LCOV_EXCL_START
+std::ostream& operator<<(std::ostream& os, TestEnum e)
+{
+    return os << static_cast<unsigned>(e);
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(Serialization)
+
+using ResizableContainers = std::tuple<std::vector<int>, std::vector<uint8_t>, std::list<int>, std::list<uint8_t>>;
+using ResizableBoolContainers = std::tuple<std::vector<bool>, std::list<bool>>;
+using ResizableEnumContainers = std::tuple<std::vector<TestEnum>, std::list<TestEnum>>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(SerializeResizable, T, ResizableContainers)
+{
+    T empty;
+    T single = {rttr::test::randomValue<typename T::value_type>()};
+    T many = {13, 17, 23, 27, 31};
+    Serializer ser;
+    helpers::pushContainer(ser, empty);
+    helpers::pushContainer(ser, single);
+    helpers::pushContainer(ser, many);
+
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == empty, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == single, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == many, per_element());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(SerializeResizableBool, T, ResizableBoolContainers)
+{
+    T empty;
+    T single = {rttr::test::randomBool()};
+    T many = {true, false, false, true, true, false};
+    Serializer ser;
+    helpers::pushContainer(ser, empty);
+    helpers::pushContainer(ser, single);
+    helpers::pushContainer(ser, many);
+
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == empty, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == single, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == many, per_element());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(SerializeResizableEnum, T, ResizableEnumContainers)
+{
+    T empty;
+    T single = {TestEnum(rttr::test::randomValue(0u, helpers::MaxEnumValue_v<TestEnum>))};
+    T many = {
+      TestEnum::Value1, TestEnum::Value4, TestEnum::Value3, TestEnum::Value2, TestEnum::Value1,
+    };
+    Serializer ser;
+    helpers::pushContainer(ser, empty);
+    helpers::pushContainer(ser, single);
+    helpers::pushContainer(ser, many);
+
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == empty, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == single, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<T>(ser) == many, per_element());
+}
+
+BOOST_AUTO_TEST_CASE(SerializeFixedSizeContainers)
+{
+    using rttr::test::randomBool;
+    using rttr::test::randomValue;
+
+    std::array<int, 3> intArray = {randomValue<int>(), randomValue<int>(), randomValue<int>()};
+    std::array<uint8_t, 4> u8Array = {randomValue<uint8_t>(), randomValue<uint8_t>(), randomValue<uint8_t>(),
+                                      randomValue<uint8_t>()};
+    std::array<bool, 6> boolArray = {randomBool(), randomBool(), randomBool(),
+                                     randomBool(), randomBool(), randomBool()};
+    std::array<TestEnum, 3> enumArray = {TestEnum(randomValue(0u, helpers::MaxEnumValue_v<TestEnum>)), TestEnum::Value1,
+                                         TestEnum::Value2};
+    helpers::EnumArray<int, TestEnum> intEnumArray = {randomValue<int>(), randomValue<int>(), randomValue<int>(),
+                                                      randomValue<int>()};
+
+    Serializer ser;
+    helpers::pushContainer(ser, intArray);
+    helpers::pushContainer(ser, u8Array);
+    helpers::pushContainer(ser, boolArray);
+    helpers::pushContainer(ser, enumArray);
+    helpers::pushContainer(ser, intEnumArray);
+
+    BOOST_TEST_REQUIRE(helpers::popContainer<decltype(intArray)>(ser) == intArray, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<decltype(u8Array)>(ser) == u8Array, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<decltype(boolArray)>(ser) == boolArray, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<decltype(enumArray)>(ser) == enumArray, per_element());
+    BOOST_TEST_REQUIRE(helpers::popContainer<decltype(intEnumArray)>(ser) == intEnumArray, per_element());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/common/testSerializationHelpers.cpp
+++ b/tests/common/testSerializationHelpers.cpp
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(SerializeResizableIgnoringSize)
     BOOST_TEST(outIntArray == intArray, per_element());
     BOOST_TEST(outU8Array == u8Array, per_element());
     BOOST_TEST(outBoolArray == boolArray, per_element());
-};
+}
 
 BOOST_AUTO_TEST_CASE(SerializePoints)
 {
@@ -169,6 +169,6 @@ BOOST_AUTO_TEST_CASE(SerializePoints)
     BOOST_TEST_REQUIRE(helpers::popPoint<decltype(pt2)>(ser) == pt2);
     BOOST_TEST_REQUIRE(helpers::popPoint<decltype(pt3)>(ser) == pt3);
     BOOST_TEST_REQUIRE(helpers::popPoint<decltype(pt4)>(ser) == pt4);
-};
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/UI/testSmartBitmap.cpp
+++ b/tests/s25Main/UI/testSmartBitmap.cpp
@@ -173,8 +173,13 @@ BOOST_AUTO_TEST_CASE(MultiRegularBitmap)
                     expectedColor = color;
             }
         }
-        BOOST_TEST_INFO("Position" << pt);
-        BOOST_TEST(buffer.get(pt.x, pt.y) == expectedColor);
+        if(buffer.get(pt.x, pt.y) != expectedColor)
+        {
+            // LCOV_EXCL_START
+            BOOST_TEST_INFO("Position" << pt);
+            BOOST_TEST(buffer.get(pt.x, pt.y) != expectedColor);
+            // LCOV_EXCL_STOP
+        }
     }
 }
 
@@ -209,8 +214,13 @@ BOOST_AUTO_TEST_CASE(PlayerBitmap)
             } else if(bmpPos.x < bmp->getWidth())
                 expectedColor = bmp->getPixel(bmpPos.x, bmpPos.y);
         }
-        BOOST_TEST_INFO("Position" << pt);
-        BOOST_TEST(buffer.get(pt.x, pt.y) == expectedColor);
+        if(buffer.get(pt.x, pt.y) != expectedColor)
+        {
+            // LCOV_EXCL_START
+            BOOST_TEST_INFO("Position" << pt);
+            BOOST_TEST(buffer.get(pt.x, pt.y) != expectedColor);
+            // LCOV_EXCL_STOP
+        }
     }
 }
 
@@ -271,8 +281,13 @@ BOOST_AUTO_TEST_CASE(MultiPlayerBitmap)
                     expectedColor = pal->get(bmp->getPlayerColorIdx(bmpPos.x, bmpPos.y) + 128);
             }
         }
-        BOOST_TEST_INFO("Position" << pt);
-        BOOST_TEST_REQUIRE(buffer.get(pt.x, pt.y) == expectedColor);
+        if(buffer.get(pt.x, pt.y) != expectedColor)
+        {
+            // LCOV_EXCL_START
+            BOOST_TEST_INFO("Position" << pt);
+            BOOST_TEST(buffer.get(pt.x, pt.y) != expectedColor);
+            // LCOV_EXCL_STOP
+        }
     }
 }
 

--- a/tests/s25Main/integration/testSerialization.cpp
+++ b/tests/s25Main/integration/testSerialization.cpp
@@ -175,30 +175,6 @@ void CheckReplayCmds(Replay& loadReplay, const PlayerGameCommands& recordedCmds)
 
 BOOST_AUTO_TEST_SUITE(Serialization)
 
-BOOST_AUTO_TEST_CASE(Serializer)
-{
-    SerializedGameData sgd;
-    // Test corner cases of var size
-    sgd.PushVarSize(0);
-    sgd.PushVarSize(0x7F);
-    sgd.PushVarSize(0x80);
-    sgd.PushVarSize(0x3FFF);
-    sgd.PushVarSize(0x4000);
-    sgd.PushVarSize(0x1FFFFF);
-    sgd.PushVarSize(0xFFFFFFF);
-    sgd.PushVarSize(0x10000000);
-    sgd.PushVarSize(0xFFFFFFFF);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0u);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0x7Fu);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0x80u);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0x3FFFu);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0x4000u);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0x1FFFFFu);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0xFFFFFFFu);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0x10000000u);
-    BOOST_TEST_REQUIRE(sgd.PopVarSize() == 0xFFFFFFFFu);
-}
-
 BOOST_AUTO_TEST_CASE(SerializeGGS)
 {
     GlobalGameSettings ggs;

--- a/tests/s25Main/simple/testRandom.cpp
+++ b/tests/s25Main/simple/testRandom.cpp
@@ -20,10 +20,10 @@
 #include "random/Random.h"
 #include "random/XorShift.h"
 #include "s25util/Serializer.h"
-#include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>
 #include <limits>
 #include <random>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -34,7 +34,7 @@ struct SeedFixture
     std::vector<unsigned> seeds = {0, 0x1337, std::numeric_limits<unsigned>::max(),
                                    std::numeric_limits<unsigned short>::max()};
 };
-using TestedRNGS = boost::mpl::list<DefaultLCG, XorShift>;
+using TestedRNGS = std::tuple<DefaultLCG, XorShift>;
 
 } // namespace
 


### PR DESCRIPTION
Some improvements for the (serialization) tests.

Add functions for serializing containers, including fixed size ones with best possible speed by potentially reading/writing the whole container at once where possible. This often is as we have many arrays and vectors of uint8_t values or enums.
Also adding functions for serializing points.

This now allows to use those in e.g. the GameCommands.

The most crucial commit is "Use helpers push/popPoint and push/popContainer", I checked with a savegame but some manual checking could be a good idea.