### PR TITLE
Configurable number of islands for water & mixed maps

### DIFF
--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -28,35 +28,6 @@
 
 using namespace rttr::mapGenerator;
 
-enum
-{
-    CTRL_BTN_BACK = 0,
-    CTRL_BTN_APPLY,
-    CTRL_TXT_LANDSCAPE,
-    CTRL_TXT_GOAL,
-    CTRL_TXT_IRON,
-    CTRL_TXT_COAL,
-    CTRL_TXT_GRANITE,
-    CTRL_TXT_RIVERS,
-    CTRL_TXT_MOUNTAIN_DIST,
-    CTRL_TXT_TREES,
-    CTRL_TXT_STONE_PILES,
-    CTRL_TXT_ISLANDS,
-    CTRL_PLAYER_NUMBER,
-    CTRL_MAP_STYLE,
-    CTRL_MAP_SIZE,
-    CTRL_MAP_TYPE,
-    CTRL_RATIO_GOLD,
-    CTRL_RATIO_IRON,
-    CTRL_RATIO_COAL,
-    CTRL_RATIO_GRANITE,
-    CTRL_RIVERS,
-    CTRL_MOUNTAIN_DIST,
-    CTRL_TREES,
-    CTRL_STONE_PILES,
-    CTRL_ISLANDS
-};
-
 iwMapGenerator::iwMapGenerator(MapSettings& settings)
     : IngameWindow(CGI_MAP_GENERATOR, IngameWindow::posLastOrCenter, Extent(270, 520), _("Map Generator"),
                    LOADER.GetImageN("resource", 41), true),

--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -41,6 +41,7 @@ enum
     CTRL_TXT_MOUNTAIN_DIST,
     CTRL_TXT_TREES,
     CTRL_TXT_STONE_PILES,
+    CTRL_TXT_ISLANDS,
     CTRL_PLAYER_NUMBER,
     CTRL_MAP_STYLE,
     CTRL_MAP_SIZE,
@@ -52,11 +53,12 @@ enum
     CTRL_RIVERS,
     CTRL_MOUNTAIN_DIST,
     CTRL_TREES,
-    CTRL_STONE_PILES
+    CTRL_STONE_PILES,
+    CTRL_ISLANDS
 };
 
 iwMapGenerator::iwMapGenerator(MapSettings& settings)
-    : IngameWindow(CGI_MAP_GENERATOR, IngameWindow::posLastOrCenter, Extent(270, 470), _("Map Generator"),
+    : IngameWindow(CGI_MAP_GENERATOR, IngameWindow::posLastOrCenter, Extent(270, 520), _("Map Generator"),
                    LOADER.GetImageN("resource", 41), true),
       mapSettings(settings)
 {
@@ -108,6 +110,14 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
     combo->AddString(_("Normal"));
     combo->AddString(_("Far"));
     combo->AddString(_("Very far"));
+
+    curPos.y += 30;
+    AddText(CTRL_TXT_ISLANDS, curPos, _("Islands"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    curPos.y += 20;
+    combo = AddComboBox(CTRL_ISLANDS, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
+    combo->AddString(_("Few"));
+    combo->AddString(_("Medium"));
+    combo->AddString(_("Many"));
 
     const int pgrOffset = 120;
     curPos.y += 35;
@@ -192,6 +202,13 @@ void iwMapGenerator::Apply()
         case 4: mapSettings.size = MapExtent::all(1024); break;
         default: break;
     }
+    switch(GetCtrl<ctrlComboBox>(CTRL_ISLANDS)->GetSelection().get())
+    {
+        case 0: mapSettings.islands = IslandAmount::Few; break;
+        case 1: mapSettings.islands = IslandAmount::Normal; break;
+        case 2: mapSettings.islands = IslandAmount::Many; break;
+        default: break;
+    }
     int mapType = GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->GetSelection().get();
     if(mapType >= 0)
         mapSettings.type = DescIdx<LandscapeDesc>(mapType);
@@ -240,6 +257,15 @@ void iwMapGenerator::Reset()
         case 256: combo->SetSelection(2); break;
         case 512: combo->SetSelection(3); break;
         case 1024: combo->SetSelection(4); break;
+        default: break;
+    }
+
+    combo = GetCtrl<ctrlComboBox>(CTRL_ISLANDS);
+    switch(mapSettings.islands)
+    {
+        case IslandAmount::Few: combo->SetSelection(0); break;
+        case IslandAmount::Normal: combo->SetSelection(1); break;
+        case IslandAmount::Many: combo->SetSelection(2); break;
         default: break;
     }
 

--- a/libs/s25main/ingameWindows/iwMapGenerator.h
+++ b/libs/s25main/ingameWindows/iwMapGenerator.h
@@ -27,7 +27,6 @@
 class iwMapGenerator : public IngameWindow
 {
 public:
-
     enum Controls
     {
         CTRL_BTN_BACK,

--- a/libs/s25main/ingameWindows/iwMapGenerator.h
+++ b/libs/s25main/ingameWindows/iwMapGenerator.h
@@ -27,6 +27,36 @@
 class iwMapGenerator : public IngameWindow
 {
 public:
+
+    enum Controls
+    {
+        CTRL_BTN_BACK,
+        CTRL_BTN_APPLY,
+        CTRL_TXT_LANDSCAPE,
+        CTRL_TXT_GOAL,
+        CTRL_TXT_IRON,
+        CTRL_TXT_COAL,
+        CTRL_TXT_GRANITE,
+        CTRL_TXT_RIVERS,
+        CTRL_TXT_MOUNTAIN_DIST,
+        CTRL_TXT_TREES,
+        CTRL_TXT_STONE_PILES,
+        CTRL_TXT_ISLANDS,
+        CTRL_PLAYER_NUMBER,
+        CTRL_MAP_STYLE,
+        CTRL_MAP_SIZE,
+        CTRL_MAP_TYPE,
+        CTRL_RATIO_GOLD,
+        CTRL_RATIO_IRON,
+        CTRL_RATIO_COAL,
+        CTRL_RATIO_GRANITE,
+        CTRL_RIVERS,
+        CTRL_MOUNTAIN_DIST,
+        CTRL_TREES,
+        CTRL_STONE_PILES,
+        CTRL_ISLANDS
+    };
+
     /**
      * Creates a new ingame window to configure the random map generator.
      * @param settings reference to the settings to be manipulated

--- a/libs/s25main/ingameWindows/iwMapGenerator.h
+++ b/libs/s25main/ingameWindows/iwMapGenerator.h
@@ -35,7 +35,6 @@ public:
 
     ~iwMapGenerator() override;
 
-protected:
     void Msg_ButtonClick(unsigned ctrl_id) override;
 
 private:

--- a/libs/s25main/mapGenerator/Islands.cpp
+++ b/libs/s25main/mapGenerator/Islands.cpp
@@ -21,15 +21,14 @@
 
 namespace rttr { namespace mapGenerator {
 
-    Island CreateIsland(Map& map, RandomUtility& rnd, unsigned distanceToLand, unsigned size, unsigned radius,
-                        double mountainCoverage)
+    Island CreateIsland(Map& map, RandomUtility& rnd, unsigned size, unsigned minLandDist, double mountainCoverage)
     {
         Island island;
 
         const auto land = [&map](const MapPoint& pt) { return map.z[pt] > map.height.minimum; };
         const auto distances = DistancesTo(map.size, land);
         const unsigned maxDistance = *std::max_element(distances.begin(), distances.end());
-        const unsigned minDistance = std::min(maxDistance, distanceToLand * 10);
+        const unsigned minDistance = std::min(maxDistance, minLandDist * 10);
         const auto possibleCenters = SelectPoints(
           [&distances, minDistance](const MapPoint& pt) { return distances[pt] >= minDistance; }, distances.GetSize());
         const MapPoint center = rnd.RandomItem(possibleCenters);
@@ -46,8 +45,6 @@ namespace rttr { namespace mapGenerator {
 
         std::priority_queue<MapPoint, std::vector<MapPoint>, decltype(compare)> queue(compare);
 
-        const unsigned minimumDistance = distanceToLand + radius;
-
         queue.push(center);
         island.insert(center);
 
@@ -57,11 +54,11 @@ namespace rttr { namespace mapGenerator {
 
             queue.pop();
 
-            const auto& points = map.z.GetPointsInRadius(currentPoint, radius);
+            const auto& points = map.z.GetPointsInRadius(currentPoint, minLandDist);
 
             for(const MapPoint& pt : points)
             {
-                if(distances[pt] >= minimumDistance)
+                if(distances[pt] >= 2 * minLandDist)
                 {
                     if(island.insert(pt).second)
                     {

--- a/libs/s25main/mapGenerator/Islands.h
+++ b/libs/s25main/mapGenerator/Islands.h
@@ -29,15 +29,13 @@ namespace rttr { namespace mapGenerator {
      *
      * @param map reference to the map to place the island on (manipulates textures and z-values of the map)
      * @param rnd random number generator
-     * @param distanceToLand minimum distance of the island to land textures
      * @param size number of nodes the island should cover (in case there's not sufficient water the island will be
      * smaller)
-     * @param radius radius of the brush to paint the island with
+     * @param minLandDist minimum distance of the island to land textures
      * @param mountainCoverage preferred mountain coverage for the island in percentage (between 0 and 1)
      *
      * @returns a vector of nodes the new island covers.
      */
-    Island CreateIsland(Map& map, RandomUtility& rnd, unsigned distanceToLand, unsigned size, unsigned radius,
-                        double mountainCoverage);
+    Island CreateIsland(Map& map, RandomUtility& rnd, unsigned size, unsigned minLandDist, double mountainCoverage);
 
 }} // namespace rttr::mapGenerator

--- a/libs/s25main/mapGenerator/MapSettings.h
+++ b/libs/s25main/mapGenerator/MapSettings.h
@@ -40,6 +40,14 @@ namespace rttr { namespace mapGenerator {
     };
     constexpr auto maxEnumValue(MountainDistance) { return MountainDistance::VeryFar; }
 
+    enum class IslandAmount : uint8_t
+    {
+        Few = 0,
+        Normal = 10,
+        Many = 30
+    };
+    constexpr auto maxEnumValue(IslandAmount) { return IslandAmount::Many; }
+
     struct MapSettings
     {
         void MakeValid();
@@ -54,6 +62,7 @@ namespace rttr { namespace mapGenerator {
         unsigned short rivers = 15;
         unsigned short trees = 40;
         unsigned short stonePiles = 5;
+        IslandAmount islands = IslandAmount::Few;
         MountainDistance mountainDistance = MountainDistance::Normal;
         DescIdx<LandscapeDesc> type = DescIdx<LandscapeDesc>(0);
         MapStyle style = MapStyle::Mixed;

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -210,8 +210,9 @@ namespace rttr { namespace mapGenerator {
 
         const auto mountainLevel = LimitFor(map_.z, land, static_cast<uint8_t>(map_.height.minimum + 1)) + 1;
         const auto rivers = CreateRivers(center);
+        const auto waterNodes = static_cast<unsigned>(std::count(map_.z.begin(), map_.z.end(), map_.height.minimum));
 
-        CreateFreeIslands(std::count(map_.z.begin(), map_.z.end(), map_.height.minimum));
+        CreateFreeIslands(waterNodes);
 
         texturizer_.AddTextures(mountainLevel, GetCoastline(map_.size));
 

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -82,11 +82,11 @@ namespace rttr { namespace mapGenerator {
         if(combinedSize <= 64 * 64)
             return 200;
         else if(combinedSize <= 128 * 128)
-            return 800;
+            return 400;
         else if(combinedSize <= 256 * 256)
-            return 1000;
+            return 600;
         else if(combinedSize <= 512 * 512)
-            return 1100;
+            return 900;
         else
             return 1200;
     }
@@ -231,12 +231,8 @@ namespace rttr { namespace mapGenerator {
         });
         SmoothHeightMap(map_.z, map_.height);
 
-        // 20% of map is center island (100% - 80% water)
-        const double sea = 0.80;
-
-        // 20% of center island is mountain (5% of 20% land)
-        const double mountain = 0.05;
-
+        const double sea = 0.80;      // 20% of map is center island (100% - 80% water)
+        const double mountain = 0.05; // 20% of center island is mountain (5% of 20% land)
         const auto seaLevel = LimitFor(map_.z, sea, map_.height.minimum);
 
         ResetSeaLevel(map_, rnd_, seaLevel);

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -116,7 +116,7 @@ namespace rttr { namespace mapGenerator {
         else if(combinedSize <= 512)
             return 9;
         else if(combinedSize <= 1024)
-            return 11;
+            return 12;
         else if(combinedSize <= 2048)
             return 15;
         else
@@ -241,7 +241,7 @@ namespace rttr { namespace mapGenerator {
 
         ResetSeaLevel(map_, rnd_, seaLevel);
 
-        const auto waterNodes = std::count(map_.z.begin(), map_.z.end(), map_.height.minimum);
+        const auto waterNodes = static_cast<unsigned>(std::count(map_.z.begin(), map_.z.end(), map_.height.minimum));
         const auto land = 1. - static_cast<double>(waterNodes) / (map_.size.x * map_.size.y) - mountain;
         const auto mountainLevel = LimitFor(map_.z, land, static_cast<uint8_t>(1)) + 1;
         const auto islandSize = GetIslandSize(map_.size);

--- a/libs/s25main/mapGenerator/RandomMap.cpp
+++ b/libs/s25main/mapGenerator/RandomMap.cpp
@@ -33,16 +33,16 @@ namespace rttr { namespace mapGenerator {
 
     unsigned GetMaximumHeight(const MapExtent& size)
     {
-        const unsigned combinedSize = size.x + size.y;
-        if(combinedSize <= 128)
+        const unsigned combinedSize = size.x * size.y;
+        if(combinedSize <= 64 * 64)
             return 32;
-        else if(combinedSize <= 256)
+        else if(combinedSize <= 128 * 128)
             return 64;
-        else if(combinedSize <= 512)
+        else if(combinedSize <= 256 * 256)
             return 128;
-        else if(combinedSize <= 1024)
+        else if(combinedSize <= 512 * 512)
             return 150;
-        else if(combinedSize <= 2048)
+        else if(combinedSize <= 1024 * 1024)
             return 200;
         else
             return 60;
@@ -50,12 +50,12 @@ namespace rttr { namespace mapGenerator {
 
     unsigned GetCoastline(const MapExtent& size)
     {
-        const unsigned combinedSize = size.x + size.y;
-        if(combinedSize <= 256)
+        const unsigned combinedSize = size.x * size.y;
+        if(combinedSize <= 128 * 128)
             return 1;
-        else if(combinedSize <= 1024)
+        else if(combinedSize <= 512 * 512)
             return 2;
-        else if(combinedSize <= 2048)
+        else if(combinedSize <= 1024 * 1024)
             return 3;
         else
             return 4;
@@ -63,14 +63,14 @@ namespace rttr { namespace mapGenerator {
 
     unsigned GetIslandRadius(const MapExtent& size)
     {
-        const unsigned combinedSize = size.x + size.y;
-        if(combinedSize <= 256)
+        const unsigned combinedSize = size.x * size.y;
+        if(combinedSize <= 128 * 128)
             return 2;
-        else if(combinedSize <= 512)
+        else if(combinedSize <= 256 * 256)
             return 3;
-        else if(combinedSize <= 1024)
+        else if(combinedSize <= 512 * 512)
             return 4;
-        else if(combinedSize <= 2048)
+        else if(combinedSize <= 1024 * 1024)
             return 5;
         else
             return 6;
@@ -93,14 +93,14 @@ namespace rttr { namespace mapGenerator {
 
     unsigned GetSmoothRadius(const MapExtent& size)
     {
-        const unsigned combinedSize = size.x + size.y;
-        if(combinedSize <= 256)
+        const unsigned combinedSize = size.x * size.y;
+        if(combinedSize <= 128 * 128)
             return 2;
-        else if(combinedSize <= 512)
+        else if(combinedSize <= 256 * 256)
             return 3;
-        else if(combinedSize <= 1024)
+        else if(combinedSize <= 512 * 512)
             return 4;
-        else if(combinedSize <= 2048)
+        else if(combinedSize <= 1024 * 1024)
             return 6;
         else
             return 7;
@@ -108,16 +108,16 @@ namespace rttr { namespace mapGenerator {
 
     unsigned GetSmoothIterations(const MapExtent& size)
     {
-        const unsigned combinedSize = size.x + size.y;
-        if(combinedSize <= 128)
+        const unsigned combinedSize = size.x * size.y;
+        if(combinedSize <= 64 * 64)
             return 10;
-        else if(combinedSize <= 256)
+        else if(combinedSize <= 128 * 128)
             return 11;
-        else if(combinedSize <= 512)
+        else if(combinedSize <= 256 * 256)
             return 9;
-        else if(combinedSize <= 1024)
+        else if(combinedSize <= 512 * 512)
             return 12;
-        else if(combinedSize <= 2048)
+        else if(combinedSize <= 1024 * 1024)
             return 15;
         else
             return 13;
@@ -180,13 +180,15 @@ namespace rttr { namespace mapGenerator {
     {
         const auto islandRadius = GetIslandRadius(map_.size);
         const auto islandAmount = static_cast<double>(settings_.islands) / 100;
+        const auto maxIslandSize = GetIslandSize(map_.size);
+        const auto minIslandSize = std::min(200u, maxIslandSize);
         auto islandNodes = static_cast<unsigned>(islandAmount * waterNodes);
-        auto islandSize = rnd_.RandomValue(200u, GetIslandSize(map_.size));
-        while(islandNodes > islandSize)
+        auto islandSize = rnd_.RandomValue(minIslandSize, maxIslandSize);
+        while(islandNodes >= islandSize)
         {
             islandNodes -= islandSize;
             CreateIsland(map_, rnd_, islandSize, islandRadius, .2);
-            islandSize = rnd_.RandomValue(200u, GetIslandSize(map_.size));
+            islandSize = rnd_.RandomValue(minIslandSize, maxIslandSize);
         }
     }
 

--- a/libs/s25main/mapGenerator/RandomMap.h
+++ b/libs/s25main/mapGenerator/RandomMap.h
@@ -29,6 +29,7 @@ namespace rttr { namespace mapGenerator {
     unsigned GetMaximumHeight(const MapExtent& size);
     unsigned GetCoastline(const MapExtent& size);
     unsigned GetIslandRadius(const MapExtent& size);
+    unsigned GetIslandSize(const MapExtent& size);
     unsigned GetSmoothRadius(const MapExtent& size);
     unsigned GetSmoothIterations(const MapExtent& size);
 
@@ -43,6 +44,7 @@ namespace rttr { namespace mapGenerator {
         MapSettings settings_;
 
         std::vector<River> CreateRivers(MapPoint source = MapPoint::Invalid());
+        void CreateFreeIslands(unsigned waterNodes);
         void CreateMixedMap();
         void CreateLandMap();
         void CreateWaterMap();

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -50,34 +50,6 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::IslandAmount)
 
 BOOST_AUTO_TEST_CASE(IwMapGenerator)
 {
-    enum
-    {
-        CTRL_BTN_BACK = 0,
-        CTRL_BTN_APPLY,
-        CTRL_TXT_LANDSCAPE,
-        CTRL_TXT_GOAL,
-        CTRL_TXT_IRON,
-        CTRL_TXT_COAL,
-        CTRL_TXT_GRANITE,
-        CTRL_TXT_RIVERS,
-        CTRL_TXT_MOUNTAIN_DIST,
-        CTRL_TXT_TREES,
-        CTRL_TXT_STONE_PILES,
-        CTRL_TXT_ISLANDS,
-        CTRL_PLAYER_NUMBER,
-        CTRL_MAP_STYLE,
-        CTRL_MAP_SIZE,
-        CTRL_MAP_TYPE,
-        CTRL_RATIO_GOLD,
-        CTRL_RATIO_IRON,
-        CTRL_RATIO_COAL,
-        CTRL_RATIO_GRANITE,
-        CTRL_RIVERS,
-        CTRL_MOUNTAIN_DIST,
-        CTRL_TREES,
-        CTRL_STONE_PILES,
-        CTRL_ISLANDS
-    };
     const auto expectedNumPlayers = rttr::test::randomValue(2u, 7u);
     const auto expectedMapType = rttr::test::randomValue<uint8_t>(0, 2);
     const auto expectedGoldRatio = rttr::test::randomValue<unsigned short>(0, 100);
@@ -91,20 +63,20 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
     uiHelper::initGUITests();
     rttr::mapGenerator::MapSettings settings;
     iwMapGenerator wnd(settings);
-    wnd.GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->SetSelection(expectedNumPlayers - 2);
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->SetSelection(expectedMapType);
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->SetSelection(1);     // MapStyle::Land
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->SetSelection(4);      // 1024x1024
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST)->SetSelection(3); // MountainDistance::VeryFar
-    wnd.GetCtrl<ctrlComboBox>(CTRL_ISLANDS)->SetSelection(2);       // IslandAmount::Many
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GOLD)->SetPosition(expectedGoldRatio);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_IRON)->SetPosition(expectedIronRatio);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_COAL)->SetPosition(expectedCoalRatio);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->SetPosition(expectedGraniteRatio);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RIVERS)->SetPosition(expectedRivers);
-    wnd.GetCtrl<ctrlProgress>(CTRL_TREES)->SetPosition(expectedTrees);
-    wnd.GetCtrl<ctrlProgress>(CTRL_STONE_PILES)->SetPosition(expectedStonePiles);
-    wnd.Msg_ButtonClick(CTRL_BTN_APPLY);
+    wnd.GetCtrl<ctrlComboBox>(iwMapGenerator::CTRL_PLAYER_NUMBER)->SetSelection(expectedNumPlayers - 2);
+    wnd.GetCtrl<ctrlComboBox>(iwMapGenerator::CTRL_MAP_TYPE)->SetSelection(expectedMapType);
+    wnd.GetCtrl<ctrlComboBox>(iwMapGenerator::CTRL_MAP_STYLE)->SetSelection(1);     // MapStyle::Land
+    wnd.GetCtrl<ctrlComboBox>(iwMapGenerator::CTRL_MAP_SIZE)->SetSelection(4);      // 1024x1024
+    wnd.GetCtrl<ctrlComboBox>(iwMapGenerator::CTRL_MOUNTAIN_DIST)->SetSelection(3); // VeryFar
+    wnd.GetCtrl<ctrlComboBox>(iwMapGenerator::CTRL_ISLANDS)->SetSelection(2);       // IslandAmount::Many
+    wnd.GetCtrl<ctrlProgress>(iwMapGenerator::CTRL_RATIO_GOLD)->SetPosition(expectedGoldRatio);
+    wnd.GetCtrl<ctrlProgress>(iwMapGenerator::CTRL_RATIO_IRON)->SetPosition(expectedIronRatio);
+    wnd.GetCtrl<ctrlProgress>(iwMapGenerator::CTRL_RATIO_COAL)->SetPosition(expectedCoalRatio);
+    wnd.GetCtrl<ctrlProgress>(iwMapGenerator::CTRL_RATIO_GRANITE)->SetPosition(expectedGraniteRatio);
+    wnd.GetCtrl<ctrlProgress>(iwMapGenerator::CTRL_RIVERS)->SetPosition(expectedRivers);
+    wnd.GetCtrl<ctrlProgress>(iwMapGenerator::CTRL_TREES)->SetPosition(expectedTrees);
+    wnd.GetCtrl<ctrlProgress>(iwMapGenerator::CTRL_STONE_PILES)->SetPosition(expectedStonePiles);
+    wnd.Msg_ButtonClick(iwMapGenerator::CTRL_BTN_APPLY);
 
     BOOST_TEST(settings.numPlayers == expectedNumPlayers);
     BOOST_TEST(settings.type == DescIdx<LandscapeDesc>(expectedMapType));

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -18,10 +18,10 @@
 #include "PointOutput.h"
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlProgress.h"
-#include "gameTypes/GameTypesOutput.h"
 #include "ingameWindows/iwHelp.h"
 #include "ingameWindows/iwMapGenerator.h"
 #include "uiHelper/uiHelpers.hpp"
+#include "gameTypes/GameTypesOutput.h"
 #include "rttr/test/random.hpp"
 #include <boost/test/unit_test.hpp>
 

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
     uiHelper::initGUITests();
     rttr::mapGenerator::MapSettings settings;
     iwMapGenerator wnd(settings);
-    wnd.GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->SetSelection(expectedNumPlayers-2);
+    wnd.GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->SetSelection(expectedNumPlayers - 2);
     wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->SetSelection(expectedMapType);
     wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->SetSelection(1);     // MapStyle::Land
     wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->SetSelection(4);      // 1024x1024

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -16,7 +16,10 @@
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
 #include "PointOutput.h"
+#include "controls/ctrlComboBox.h"
+#include "controls/ctrlProgress.h"
 #include "ingameWindows/iwHelp.h"
+#include "ingameWindows/iwMapGenerator.h"
 #include "uiHelper/uiHelpers.hpp"
 #include <boost/test/unit_test.hpp>
 
@@ -35,4 +38,68 @@ BOOST_AUTO_TEST_CASE(IngameWnd)
     // And fully expand to old size
     wnd.SetMinimized(false);
     BOOST_TEST_REQUIRE(wnd.GetSize() == oldSize);
+}
+
+BOOST_AUTO_TEST_CASE(IwMapGenerator)
+{
+    enum
+    {
+        CTRL_BTN_BACK = 0,
+        CTRL_BTN_APPLY,
+        CTRL_TXT_LANDSCAPE,
+        CTRL_TXT_GOAL,
+        CTRL_TXT_IRON,
+        CTRL_TXT_COAL,
+        CTRL_TXT_GRANITE,
+        CTRL_TXT_RIVERS,
+        CTRL_TXT_MOUNTAIN_DIST,
+        CTRL_TXT_TREES,
+        CTRL_TXT_STONE_PILES,
+        CTRL_TXT_ISLANDS,
+        CTRL_PLAYER_NUMBER,
+        CTRL_MAP_STYLE,
+        CTRL_MAP_SIZE,
+        CTRL_MAP_TYPE,
+        CTRL_RATIO_GOLD,
+        CTRL_RATIO_IRON,
+        CTRL_RATIO_COAL,
+        CTRL_RATIO_GRANITE,
+        CTRL_RIVERS,
+        CTRL_MOUNTAIN_DIST,
+        CTRL_TREES,
+        CTRL_STONE_PILES,
+        CTRL_ISLANDS
+    };
+
+    uiHelper::initGUITests();
+    rttr::mapGenerator::MapSettings settings;
+    iwMapGenerator wnd(settings);
+    wnd.GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->SetSelection(2); // 4 players
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->SetSelection(2); // LandscapeDesc(2)
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->SetSelection(1); // MapStyle::Land
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->SetSelection(4); // 1024x1024
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST)->SetSelection(3); // MountainDistance::VeryFar
+    wnd.GetCtrl<ctrlComboBox>(CTRL_ISLANDS)->SetSelection(2); // IslandAmount::Many
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GOLD)->SetPosition(25);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_IRON)->SetPosition(25);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_COAL)->SetPosition(25);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->SetPosition(25);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RIVERS)->SetPosition(33);
+    wnd.GetCtrl<ctrlProgress>(CTRL_TREES)->SetPosition(33);
+    wnd.GetCtrl<ctrlProgress>(CTRL_STONE_PILES)->SetPosition(33);
+    wnd.Window::Msg_ButtonClick(CTRL_BTN_APPLY); // press apply button
+
+    BOOST_TEST(settings.numPlayers == 4);
+    BOOST_TEST(settings.type == DescIdx<LandscapeDesc>(2));
+    BOOST_TEST(settings.size == MapExtent(1024, 1024));
+    BOOST_TEST(settings.style == rttr::mapGenerator::MapStyle::Land);
+    BOOST_TEST(settings.mountainDistance == rttr::mapGenerator::MountainDistance::VeryFar);
+    BOOST_TEST(settings.islands == rttr::mapGenerator::IslandAmount::Many);
+    BOOST_TEST(settings.ratioGold == 25);
+    BOOST_TEST(settings.ratioIron == 25);
+    BOOST_TEST(settings.ratioCoal == 25);
+    BOOST_TEST(settings.ratioGranite == 25);
+    BOOST_TEST(settings.rivers == 33);
+    BOOST_TEST(settings.trees == 33);
+    BOOST_TEST(settings.stonePiles == 33);
 }

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -42,9 +42,11 @@ BOOST_AUTO_TEST_CASE(IngameWnd)
     BOOST_TEST_REQUIRE(wnd.GetSize() == oldSize);
 }
 
+// LCOV_EXCL_START
 BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MapStyle)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MountainDistance)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::IslandAmount)
+// LCOV_EXCL_STOP
 
 BOOST_AUTO_TEST_CASE(IwMapGenerator)
 {

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -20,6 +20,8 @@
 #include "controls/ctrlProgress.h"
 #include "ingameWindows/iwHelp.h"
 #include "ingameWindows/iwMapGenerator.h"
+#include "mapGenerator/MapSettings.h"
+#include "rttr/test/random.hpp"
 #include "uiHelper/uiHelpers.hpp"
 #include <boost/test/unit_test.hpp>
 
@@ -70,36 +72,45 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
         CTRL_STONE_PILES,
         CTRL_ISLANDS
     };
+    const auto expectedNumPlayers = rttr::test::randomValue(2u, 7u);
+    const auto expectedMapType = rttr::test::randomValue(0, 2);
+    const auto expectedGoldRatio = rttr::test::randomValue(0u, 100u);
+    const auto expectedIronRatio = rttr::test::randomValue(0u, 100u);
+    const auto expectedCoalRatio = rttr::test::randomValue(0u, 100u);
+    const auto expectedGraniteRatio = rttr::test::randomValue(0u, 100u);
+    const auto expectedRivers = rttr::test::randomValue(0u, 100u);
+    const auto expectedTrees = rttr::test::randomValue(0u, 100u);
+    const auto expectedStonePiles = rttr::test::randomValue(0u, 100u);
 
     uiHelper::initGUITests();
     rttr::mapGenerator::MapSettings settings;
     iwMapGenerator wnd(settings);
-    wnd.GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->SetSelection(2); // 4 players
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->SetSelection(2);      // LandscapeDesc(2)
+    wnd.GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->SetSelection(expectedNumPlayers-2);
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->SetSelection(expectedMapType);
     wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->SetSelection(1);     // MapStyle::Land
     wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->SetSelection(4);      // 1024x1024
     wnd.GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST)->SetSelection(3); // MountainDistance::VeryFar
     wnd.GetCtrl<ctrlComboBox>(CTRL_ISLANDS)->SetSelection(2);       // IslandAmount::Many
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GOLD)->SetPosition(25);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_IRON)->SetPosition(25);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_COAL)->SetPosition(25);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->SetPosition(25);
-    wnd.GetCtrl<ctrlProgress>(CTRL_RIVERS)->SetPosition(33);
-    wnd.GetCtrl<ctrlProgress>(CTRL_TREES)->SetPosition(33);
-    wnd.GetCtrl<ctrlProgress>(CTRL_STONE_PILES)->SetPosition(33);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GOLD)->SetPosition(expectedGoldRatio);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_IRON)->SetPosition(expectedIronRatio);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_COAL)->SetPosition(expectedCoalRatio);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GRANITE)->SetPosition(expectedGraniteRatio);
+    wnd.GetCtrl<ctrlProgress>(CTRL_RIVERS)->SetPosition(expectedRivers);
+    wnd.GetCtrl<ctrlProgress>(CTRL_TREES)->SetPosition(expectedTrees);
+    wnd.GetCtrl<ctrlProgress>(CTRL_STONE_PILES)->SetPosition(expectedStonePiles);
     wnd.Window::Msg_ButtonClick(CTRL_BTN_APPLY);
 
-    BOOST_TEST(settings.numPlayers == 4);
-    BOOST_TEST(settings.type == DescIdx<LandscapeDesc>(2));
+    BOOST_TEST(settings.numPlayers == expectedNumPlayers);
+    BOOST_TEST(settings.type == DescIdx<LandscapeDesc>(expectedMapType));
     BOOST_TEST(settings.size == MapExtent(1024, 1024));
     BOOST_TEST(settings.style == rttr::mapGenerator::MapStyle::Land);
     BOOST_TEST(settings.mountainDistance == rttr::mapGenerator::MountainDistance::VeryFar);
     BOOST_TEST(settings.islands == rttr::mapGenerator::IslandAmount::Many);
-    BOOST_TEST(settings.ratioGold == 25);
-    BOOST_TEST(settings.ratioIron == 25);
-    BOOST_TEST(settings.ratioCoal == 25);
-    BOOST_TEST(settings.ratioGranite == 25);
-    BOOST_TEST(settings.rivers == 33);
-    BOOST_TEST(settings.trees == 33);
-    BOOST_TEST(settings.stonePiles == 33);
+    BOOST_TEST(settings.ratioGold == expectedGoldRatio);
+    BOOST_TEST(settings.ratioIron == expectedIronRatio);
+    BOOST_TEST(settings.ratioCoal == expectedCoalRatio);
+    BOOST_TEST(settings.ratioGranite == expectedGraniteRatio);
+    BOOST_TEST(settings.rivers == expectedRivers);
+    BOOST_TEST(settings.trees == expectedTrees);
+    BOOST_TEST(settings.stonePiles == expectedStonePiles);
 }

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -21,8 +21,8 @@
 #include "ingameWindows/iwHelp.h"
 #include "ingameWindows/iwMapGenerator.h"
 #include "mapGenerator/MapSettings.h"
-#include "rttr/test/random.hpp"
 #include "uiHelper/uiHelpers.hpp"
+#include "rttr/test/random.hpp"
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE(IngameWnd)

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -18,9 +18,9 @@
 #include "PointOutput.h"
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlProgress.h"
+#include "gameTypes/GameTypesOutput.h"
 #include "ingameWindows/iwHelp.h"
 #include "ingameWindows/iwMapGenerator.h"
-#include "mapGenerator/MapSettings.h"
 #include "uiHelper/uiHelpers.hpp"
 #include "rttr/test/random.hpp"
 #include <boost/test/unit_test.hpp>
@@ -41,6 +41,10 @@ BOOST_AUTO_TEST_CASE(IngameWnd)
     wnd.SetMinimized(false);
     BOOST_TEST_REQUIRE(wnd.GetSize() == oldSize);
 }
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MapStyle);
+BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MountainDistance);
+BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::IslandAmount);
 
 BOOST_AUTO_TEST_CASE(IwMapGenerator)
 {

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -42,9 +42,9 @@ BOOST_AUTO_TEST_CASE(IngameWnd)
     BOOST_TEST_REQUIRE(wnd.GetSize() == oldSize);
 }
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MapStyle);
-BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MountainDistance);
-BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::IslandAmount);
+BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MapStyle)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MountainDistance)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::IslandAmount)
 
 BOOST_AUTO_TEST_CASE(IwMapGenerator)
 {
@@ -77,14 +77,14 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
         CTRL_ISLANDS
     };
     const auto expectedNumPlayers = rttr::test::randomValue(2u, 7u);
-    const auto expectedMapType = rttr::test::randomValue(0, 2);
-    const auto expectedGoldRatio = rttr::test::randomValue(0u, 100u);
-    const auto expectedIronRatio = rttr::test::randomValue(0u, 100u);
-    const auto expectedCoalRatio = rttr::test::randomValue(0u, 100u);
-    const auto expectedGraniteRatio = rttr::test::randomValue(0u, 100u);
-    const auto expectedRivers = rttr::test::randomValue(0u, 100u);
-    const auto expectedTrees = rttr::test::randomValue(0u, 100u);
-    const auto expectedStonePiles = rttr::test::randomValue(0u, 100u);
+    const auto expectedMapType = rttr::test::randomValue<uint8_t>(0, 2);
+    const auto expectedGoldRatio = rttr::test::randomValue<unsigned short>(0, 100);
+    const auto expectedIronRatio = rttr::test::randomValue<unsigned short>(0, 100);
+    const auto expectedCoalRatio = rttr::test::randomValue<unsigned short>(0, 100);
+    const auto expectedGraniteRatio = rttr::test::randomValue<unsigned short>(0, 100);
+    const auto expectedRivers = rttr::test::randomValue<unsigned short>(0, 100);
+    const auto expectedTrees = rttr::test::randomValue<unsigned short>(0, 100);
+    const auto expectedStonePiles = rttr::test::randomValue<unsigned short>(0, 100);
 
     uiHelper::initGUITests();
     rttr::mapGenerator::MapSettings settings;

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
     wnd.GetCtrl<ctrlProgress>(CTRL_RIVERS)->SetPosition(expectedRivers);
     wnd.GetCtrl<ctrlProgress>(CTRL_TREES)->SetPosition(expectedTrees);
     wnd.GetCtrl<ctrlProgress>(CTRL_STONE_PILES)->SetPosition(expectedStonePiles);
-    wnd.Window::Msg_ButtonClick(CTRL_BTN_APPLY);
+    wnd.Msg_ButtonClick(CTRL_BTN_APPLY);
 
     BOOST_TEST(settings.numPlayers == expectedNumPlayers);
     BOOST_TEST(settings.type == DescIdx<LandscapeDesc>(expectedMapType));

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -75,11 +75,11 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
     rttr::mapGenerator::MapSettings settings;
     iwMapGenerator wnd(settings);
     wnd.GetCtrl<ctrlComboBox>(CTRL_PLAYER_NUMBER)->SetSelection(2); // 4 players
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->SetSelection(2); // LandscapeDesc(2)
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->SetSelection(1); // MapStyle::Land
-    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->SetSelection(4); // 1024x1024
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_TYPE)->SetSelection(2);      // LandscapeDesc(2)
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_STYLE)->SetSelection(1);     // MapStyle::Land
+    wnd.GetCtrl<ctrlComboBox>(CTRL_MAP_SIZE)->SetSelection(4);      // 1024x1024
     wnd.GetCtrl<ctrlComboBox>(CTRL_MOUNTAIN_DIST)->SetSelection(3); // MountainDistance::VeryFar
-    wnd.GetCtrl<ctrlComboBox>(CTRL_ISLANDS)->SetSelection(2); // IslandAmount::Many
+    wnd.GetCtrl<ctrlComboBox>(CTRL_ISLANDS)->SetSelection(2);       // IslandAmount::Many
     wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_GOLD)->SetPosition(25);
     wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_IRON)->SetPosition(25);
     wnd.GetCtrl<ctrlProgress>(CTRL_RATIO_COAL)->SetPosition(25);
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
     wnd.GetCtrl<ctrlProgress>(CTRL_RIVERS)->SetPosition(33);
     wnd.GetCtrl<ctrlProgress>(CTRL_TREES)->SetPosition(33);
     wnd.GetCtrl<ctrlProgress>(CTRL_STONE_PILES)->SetPosition(33);
-    wnd.Window::Msg_ButtonClick(CTRL_BTN_APPLY); // press apply button
+    wnd.Window::Msg_ButtonClick(CTRL_BTN_APPLY);
 
     BOOST_TEST(settings.numPlayers == 4);
     BOOST_TEST(settings.type == DescIdx<LandscapeDesc>(2));

--- a/tests/s25Main/mapGenerator/testIslands.cpp
+++ b/tests/s25Main/mapGenerator/testIslands.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 - 2017 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "PointOutput.h"
+#include "mapGenFixtures.h"
+#include "mapGenerator/Islands.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace rttr::mapGenerator;
+
+BOOST_FIXTURE_TEST_SUITE(IslandsTests, MapGenFixture)
+
+BOOST_AUTO_TEST_CASE(CreateIsland_keeps_minimum_distance_to_land)
+{
+    RandomUtility rnd(0);
+    Map map = createMap(MapExtent(26, 34));
+    MapPoint land(0, 0);
+    map.z.Resize(map.size, map.height.minimum); // all sea
+    map.z[land] = map.height.minimum + 1;
+
+    const double mountainCoverage = 0.1;
+    const unsigned minLandDist = 5;
+    const unsigned size = 800;
+    const auto island = CreateIsland(map, rnd, size, minLandDist, mountainCoverage);
+
+    for(MapPoint p : island)
+    {
+        BOOST_TEST(map.z.CalcDistance(p, land) >= minLandDist);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/mapGenerator/testRandomMap.cpp
+++ b/tests/s25Main/mapGenerator/testRandomMap.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(GenerateRandomMap_returns_valid_water_map)
     loadGameData(worldDesc);
     MapSettings settings;
 
-    settings.size = getRandomMapSize(78, 90); // Need enough space for player islands
+    settings.size = getRandomMapSize(83, 100); // Need enough space for player islands
     settings.numPlayers = rttr::test::randomValue(2u, MAX_PLAYERS);
     settings.style = MapStyle::Water;
 

--- a/tests/s25Main/mapGenerator/testRandomMap.cpp
+++ b/tests/s25Main/mapGenerator/testRandomMap.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(GenerateRandomMap_returns_valid_water_map)
     loadGameData(worldDesc);
     MapSettings settings;
 
-    settings.size = getRandomMapSize(83, 100); // Need enough space for player islands
+    settings.size = getRandomMapSize(84, 100); // Need enough space for player islands
     settings.numPlayers = rttr::test::randomValue(2u, MAX_PLAYERS);
     settings.style = MapStyle::Water;
 

--- a/tests/s25Main/mapGenerator/testRandomMap.cpp
+++ b/tests/s25Main/mapGenerator/testRandomMap.cpp
@@ -95,6 +95,22 @@ BOOST_AUTO_TEST_CASE(GenerateRandomMap_returns_valid_mixed_map)
     ValidateMap(map, settings.size, settings.numPlayers);
 }
 
+BOOST_AUTO_TEST_CASE(GenerateRandomMap_for_many_islands_returns_valid_map)
+{
+    RandomUtility rnd(0);
+    WorldDescription worldDesc;
+    loadGameData(worldDesc);
+    MapSettings settings;
+
+    settings.islands = rttr::mapGenerator::IslandAmount::Many;
+    settings.size = getRandomMapSize();
+    settings.numPlayers = 2u;
+    settings.style = MapStyle::Mixed;
+
+    Map map = GenerateRandomMap(rnd, worldDesc, settings);
+    ValidateMap(map, settings.size, settings.numPlayers);
+}
+
 BOOST_AUTO_TEST_CASE(GenerateRandomMap_returns_valid_map_with_max_players)
 {
     RandomUtility rnd(0);

--- a/tests/s25Main/mapGenerator/testRandomMap.cpp
+++ b/tests/s25Main/mapGenerator/testRandomMap.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(GenerateRandomMap_returns_valid_water_map)
     loadGameData(worldDesc);
     MapSettings settings;
 
-    settings.size = getRandomMapSize(84, 100); // Need enough space for player islands
+    settings.size = getRandomMapSize(78, 90); // Need enough space for player islands
     settings.numPlayers = rttr::test::randomValue(2u, MAX_PLAYERS);
     settings.style = MapStyle::Water;
 


### PR DESCRIPTION
First, I fixed the size of players' home islands to a value depending on the map size (200-1200 nodes). Also, I added configurable "extra" islands (few/medium/many) of random size (range between 200 & 1200 nodes). This makes water & mixed maps slightly more interesting to play I think.

At the moment, I did not bind the central island to a specific size. I liked the idea of having a big island where multiple players can meet eventually. But up to discussion, could also make it optional/configurable as well. 

Also, I have to increase the test coverage, I'll look at that this weekend. 