### PR TITLE
Fix some problems with unexpected behaviour during and after pauses

### DIFF
--- a/libs/s25main/buildings/nobBaseWarehouse.cpp
+++ b/libs/s25main/buildings/nobBaseWarehouse.cpp
@@ -1328,17 +1328,9 @@ bool nobBaseWarehouse::DefendersAvailable() const
     return false;
 }
 
-unsigned nobBaseWarehouse::IncreaseReserveVisual(unsigned rank)
+void nobBaseWarehouse::SetReserveVisual(const unsigned rank, const unsigned count)
 {
-    return ++reserve_soldiers_claimed_visual[rank];
-}
-
-unsigned nobBaseWarehouse::DecreaseReserveVisual(unsigned rank)
-{
-    if(reserve_soldiers_claimed_visual[rank])
-        --reserve_soldiers_claimed_visual[rank];
-
-    return reserve_soldiers_claimed_visual[rank];
+    reserve_soldiers_claimed_visual[rank] = count;
 }
 
 void nobBaseWarehouse::SetRealReserve(const unsigned rank, const unsigned count)

--- a/libs/s25main/buildings/nobBaseWarehouse.h
+++ b/libs/s25main/buildings/nobBaseWarehouse.h
@@ -270,9 +270,8 @@ public:
     /// Sind noch Truppen drinne, die dieses Gebäude verteidigen könnten?
     bool DefendersAvailable() const override;
 
-    /// Verändert Reserveeinstellung - visuell (nur das geforderte natürlich) und gibt neue Anzahl zurück
-    unsigned IncreaseReserveVisual(unsigned rank);
-    unsigned DecreaseReserveVisual(unsigned rank);
+    /// Verändert Reserveeinstellung
+    void SetReserveVisual(unsigned rank, unsigned count);
     void SetRealReserve(unsigned rank, unsigned count);
 
     /// Versucht, die geforderten Reserve-Soldaten bereitzustellen

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -930,8 +930,8 @@ void dskGameInterface::Run()
 
 void dskGameInterface::GI_StartRoadBuilding(const MapPoint startPt, bool waterRoad)
 {
-    // Im Replay und in der Pause keine Straßen bauen
-    if(GAMECLIENT.IsReplayModeOn() || GAMECLIENT.IsPaused())
+    // Im Replay keine Straßen bauen
+    if(GAMECLIENT.IsReplayModeOn())
         return;
 
     road.mode = waterRoad ? RoadBuildMode::Boat : RoadBuildMode::Normal;
@@ -1079,9 +1079,11 @@ void dskGameInterface::OnChatCommand(const std::string& cmd)
 
 void dskGameInterface::GI_BuildRoad()
 {
-    GAMECLIENT.BuildRoad(road.start, road.mode == RoadBuildMode::Boat, road.route);
-    road.mode = RoadBuildMode::Disabled;
-    WINDOWMANAGER.SetCursor(Cursor::Hand);
+    if(GAMECLIENT.BuildRoad(road.start, road.mode == RoadBuildMode::Boat, road.route))
+    {
+        road.mode = RoadBuildMode::Disabled;
+        WINDOWMANAGER.SetCursor(Cursor::Hand);
+    }
 }
 
 void dskGameInterface::GI_WindowClosed(Window* wnd)
@@ -1155,16 +1157,16 @@ void dskGameInterface::CI_GamePaused()
     messenger.AddMessage(_("SYSTEM"), COLOR_GREY, ChatDestination::System, _("Game was paused."));
 
     /// Straßenbau ggf. abbrechen, wenn aktiviert
-    if(road.mode != RoadBuildMode::Disabled)
-    {
-        // Fenster schließen
-        if(roadwindow)
-        {
-            roadwindow->Close();
-            roadwindow = nullptr;
-        }
-        GI_CancelRoadBuilding();
-    }
+    /*   if(road.mode != RoadBuildMode::Disabled)
+       {
+           // Fenster schließen
+           if(roadwindow)
+           {
+               roadwindow->Close();
+               roadwindow = nullptr;
+           }
+           GI_CancelRoadBuilding();
+       }*/
 }
 
 void dskGameInterface::CI_GameResumed()

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -1155,18 +1155,6 @@ void dskGameInterface::CI_ReplayEndReached(const std::string& msg)
 void dskGameInterface::CI_GamePaused()
 {
     messenger.AddMessage(_("SYSTEM"), COLOR_GREY, ChatDestination::System, _("Game was paused."));
-
-    /// Straßenbau ggf. abbrechen, wenn aktiviert
-    /*   if(road.mode != RoadBuildMode::Disabled)
-       {
-           // Fenster schließen
-           if(roadwindow)
-           {
-               roadwindow->Close();
-               roadwindow = nullptr;
-           }
-           GI_CancelRoadBuilding();
-       }*/
 }
 
 void dskGameInterface::CI_GameResumed()

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -68,7 +68,7 @@ public:
     void SetPos(DrawPoint newPos);
 
     /// merkt das Fenster zum Schließen vor.
-    void Close();
+    virtual void Close();
     /// soll das Fenster geschlossen werden.
     bool ShouldBeClosed() const { return closeme; }
 

--- a/libs/s25main/ingameWindows/TransmitSettingsIgwAdapter.h
+++ b/libs/s25main/ingameWindows/TransmitSettingsIgwAdapter.h
@@ -19,26 +19,26 @@
 
 #include "IngameWindow.h"
 
-class TransmittingSettingsWindow : public IngameWindow
+class TransmitSettingsIgwAdapter : public IngameWindow
 {
 protected:
     /// whether any settings where changed after the last successful transmission
     bool settings_changed;
 
+    static constexpr unsigned firstCtrlID = 1000000u;
+
 public:
-    TransmittingSettingsWindow(unsigned id, const DrawPoint& pos, const Extent& size, std::string title,
+    TransmitSettingsIgwAdapter(unsigned id, const DrawPoint& pos, const Extent& size, const std::string& title,
                                glArchivItem_Bitmap* background, bool modal = false, bool closeOnRightClick = true,
                                Window* parent = nullptr);
 
-    virtual ~TransmittingSettingsWindow() {}
-
     /// Updates the control elements with values from visual settings
-    virtual void UpdateSettings() {}
+    virtual void UpdateSettings() = 0;
     /// sends potential changes to the client
-    virtual void TransmitSettings() {}
+    virtual void TransmitSettings() = 0;
 
     void Close() override;
 
-    virtual void Msg_Timer(unsigned ctrl_id) override;
-    void Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult mbr) override;
+    void Msg_Timer(unsigned ctrl_id) override;
+    void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
 };

--- a/libs/s25main/ingameWindows/TransmittingSettingsWindow.cpp
+++ b/libs/s25main/ingameWindows/TransmittingSettingsWindow.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "TransmittingSettingsWindow.h"
+#include "WindowManager.h"
+#include "iwMsgbox.h"
+#include "network/GameClient.h"
+#include <mygettext/mygettext.h>
+
+TransmittingSettingsWindow::TransmittingSettingsWindow(unsigned id, const DrawPoint& pos, const Extent& size,
+                                                       std::string title, glArchivItem_Bitmap* background, bool modal,
+                                                       bool closeOnRightClick, Window* parent)
+    : IngameWindow(id, pos, size, title, background, modal, closeOnRightClick, parent), settings_changed(false)
+{
+    // Timer for transmitting changes every 2 seconds
+    using namespace std::chrono_literals;
+    AddTimer(1001, 2s);
+}
+
+void TransmittingSettingsWindow::Close()
+{
+    TransmitSettings();
+    if(!settings_changed)
+    {
+        IngameWindow::Close();
+    } else
+    {
+        WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(GetTitle(),
+                                                      _("The changes could not be applied and will be discarded. A "
+                                                        "potential reason for this is that the game is paused."),
+                                                      this, MsgboxButton::OkCancel, MsgboxIcon::ExclamationRed, 1000));
+    }
+}
+
+void TransmittingSettingsWindow::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult mbr)
+{
+    switch(msgbox_id)
+    {
+        case 1000: // Close?
+        {
+            if(mbr == MsgboxResult::Ok)
+            {
+                IngameWindow::Close();
+            }
+        }
+        break;
+    }
+}
+
+void TransmittingSettingsWindow::Msg_Timer(const unsigned /*ctrl_id*/)
+{
+    if(GAMECLIENT.IsReplayModeOn())
+        UpdateSettings();
+    else
+        TransmitSettings();
+}

--- a/libs/s25main/ingameWindows/TransmittingSettingsWindow.h
+++ b/libs/s25main/ingameWindows/TransmittingSettingsWindow.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "IngameWindow.h"
+
+class TransmittingSettingsWindow : public IngameWindow
+{
+protected:
+    /// whether any settings where changed after the last successful transmission
+    bool settings_changed;
+
+public:
+    TransmittingSettingsWindow(unsigned id, const DrawPoint& pos, const Extent& size, std::string title,
+                               glArchivItem_Bitmap* background, bool modal = false, bool closeOnRightClick = true,
+                               Window* parent = nullptr);
+
+    virtual ~TransmittingSettingsWindow() {}
+
+    /// Updates the control elements with values from visual settings
+    virtual void UpdateSettings() {}
+    /// sends potential changes to the client
+    virtual void TransmitSettings() {}
+
+    void Close() override;
+
+    virtual void Msg_Timer(unsigned ctrl_id) override;
+    void Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult mbr) override;
+};

--- a/libs/s25main/ingameWindows/iwAction.cpp
+++ b/libs/s25main/ingameWindows/iwAction.cpp
@@ -345,7 +345,7 @@ bool iwAction::DoUpgradeRoad()
     if(flag)
         return GAMECLIENT.UpgradeRoad(flag->GetPos(), flag_dir);
     else
-        return false;
+        return true;
 }
 
 /// Fügt Angriffs-Steuerelemente für bestimmte Gruppe hinzu
@@ -692,7 +692,7 @@ void iwAction::Msg_ButtonClick_TabSetFlag(const unsigned ctrl_id)
 
 void iwAction::Msg_ButtonClick_TabCutRoad(const unsigned ctrl_id)
 {
-    bool success = false;
+    bool success = true;
     switch(ctrl_id)
     {
         case 1: // Straße abreißen

--- a/libs/s25main/ingameWindows/iwAction.cpp
+++ b/libs/s25main/ingameWindows/iwAction.cpp
@@ -667,8 +667,10 @@ void iwAction::Msg_ButtonClick_TabBuild(const unsigned ctrl_id)
                                                 ->GetCurrentGroup()
                                                 ->GetCtrl<ctrlBuildingIcon>(ctrl_id)
                                                 ->GetType()))
+    {
         // Fenster schließen
         Close();
+    }
 }
 
 void iwAction::Msg_ButtonClick_TabSetFlag(const unsigned ctrl_id)

--- a/libs/s25main/ingameWindows/iwAction.h
+++ b/libs/s25main/ingameWindows/iwAction.h
@@ -109,5 +109,5 @@ private:
     /// Fügt Angriffs-Steuerelemente für bestimmte Gruppe hinzu
     void AddAttackControls(ctrlGroup* group, unsigned attackers_count);
     void AddUpgradeRoad(ctrlGroup* group, unsigned& x, unsigned& width);
-    void DoUpgradeRoad();
+    bool DoUpgradeRoad();
 };

--- a/libs/s25main/ingameWindows/iwBuildOrder.cpp
+++ b/libs/s25main/ingameWindows/iwBuildOrder.cpp
@@ -18,6 +18,7 @@
 #include "iwBuildOrder.h"
 #include "GamePlayer.h"
 #include "Loader.h"
+#include "WindowManager.h"
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlImage.h"
 #include "controls/ctrlList.h"
@@ -26,12 +27,10 @@
 #include "gameData/BuildingConsts.h"
 #include "gameData/const_gui_ids.h"
 
-using namespace std::chrono_literals;
-
 iwBuildOrder::iwBuildOrder(const GameWorldViewer& gwv)
-    : IngameWindow(CGI_BUILDORDER, IngameWindow::posLastOrCenter, Extent(320, 300), _("Building sequence"),
-                   LOADER.GetImageN("io", 5)),
-      gwv(gwv), settings_changed(false)
+    : TransmittingSettingsWindow(CGI_BUILDORDER, IngameWindow::posLastOrCenter, Extent(320, 300),
+                                 _("Building sequence"), LOADER.GetImageN("io", 5)),
+      gwv(gwv)
 {
     ctrlList* list = AddList(0, DrawPoint(15, 60), Extent(150, 220), TextureColor::Grey, NormalFont);
 
@@ -66,21 +65,7 @@ iwBuildOrder::iwBuildOrder(const GameWorldViewer& gwv)
     AddImageButton(10, DrawPoint(200, 250), Extent(48, 30), TextureColor::Grey, LOADER.GetImageN("io", 191),
                    _("Default"));
 
-    // Absendetimer, in 2s-Abschnitten wird jeweils das ganze als Netzwerknachricht ggf. abgeschickt
-    AddTimer(11, 2s);
-
     list->SetSelection(0);
-}
-
-iwBuildOrder::~iwBuildOrder()
-{
-    try
-    {
-        TransmitSettings();
-    } catch(...)
-    {
-        // Ignored
-    }
 }
 
 void iwBuildOrder::TransmitSettings()
@@ -99,16 +84,6 @@ void iwBuildOrder::TransmitSettings()
             settings_changed = false;
         }
     }
-}
-
-void iwBuildOrder::Msg_Timer(const unsigned /*ctrl_id*/)
-{
-    if(GAMECLIENT.IsReplayModeOn())
-        // Im Replay aktualisieren wir die Werte
-        UpdateSettings();
-    else
-        // Im normalen Spielmodus schicken wir den ganzen Spaß ab
-        TransmitSettings();
 }
 
 void iwBuildOrder::Msg_ListSelectItem(const unsigned ctrl_id, const int selection)

--- a/libs/s25main/ingameWindows/iwBuildOrder.cpp
+++ b/libs/s25main/ingameWindows/iwBuildOrder.cpp
@@ -28,7 +28,7 @@
 #include "gameData/const_gui_ids.h"
 
 iwBuildOrder::iwBuildOrder(const GameWorldViewer& gwv)
-    : TransmittingSettingsWindow(CGI_BUILDORDER, IngameWindow::posLastOrCenter, Extent(320, 300),
+    : TransmitSettingsIgwAdapter(CGI_BUILDORDER, IngameWindow::posLastOrCenter, Extent(320, 300),
                                  _("Building sequence"), LOADER.GetImageN("io", 5)),
       gwv(gwv)
 {

--- a/libs/s25main/ingameWindows/iwBuildOrder.cpp
+++ b/libs/s25main/ingameWindows/iwBuildOrder.cpp
@@ -36,8 +36,8 @@ iwBuildOrder::iwBuildOrder(const GameWorldViewer& gwv)
     ctrlList* list = AddList(0, DrawPoint(15, 60), Extent(150, 220), TextureColor::Grey, NormalFont);
 
     // Liste füllen
-    BuildOrders buildOrders = GAMECLIENT.visual_settings.build_order;
-    for(const auto buildOrder : buildOrders)
+    pendingBuildOrder = GAMECLIENT.visual_settings.build_order;
+    for(const auto buildOrder : pendingBuildOrder)
         list->AddString(_(BUILDING_NAMES[buildOrder])); //-V807
 
     // Nach ganz oben
@@ -52,14 +52,15 @@ iwBuildOrder::iwBuildOrder(const GameWorldViewer& gwv)
 
     // Bild der Auswahl
     AddImage(5, DrawPoint(240, 150),
-             LOADER.GetNationImage(gwv.GetPlayer().nation, 250 + rttr::enum_cast(buildOrders[0]) * 5));
+             LOADER.GetNationImage(gwv.GetPlayer().nation, 250 + rttr::enum_cast(pendingBuildOrder[0]) * 5));
 
     ctrlComboBox* combo = AddComboBox(6, DrawPoint(15, 30), Extent(290, 20), TextureColor::Grey, NormalFont, 100);
     combo->AddString(_("Sequence of given order"));   // "Reihenfolge der Auftraggebung"
     combo->AddString(_("After the following order")); // "Nach folgender Reihenfolge"
 
     // Eintrag in Combobox auswählen
-    combo->SetSelection(GAMECLIENT.visual_settings.useCustomBuildOrder ? 1 : 0);
+    useCustomBuildOrder = GAMECLIENT.visual_settings.useCustomBuildOrder;
+    combo->SetSelection(useCustomBuildOrder ? 1 : 0);
 
     // Standard
     AddImageButton(10, DrawPoint(200, 250), Extent(48, 30), TextureColor::Grey, LOADER.GetImageN("io", 191),
@@ -75,8 +76,6 @@ iwBuildOrder::~iwBuildOrder()
 {
     try
     {
-        GAMECLIENT.visual_settings.useCustomBuildOrder = GetCtrl<ctrlComboBox>(6)->GetSelection() == 1u;
-
         TransmitSettings();
     } catch(...)
     {
@@ -92,9 +91,13 @@ void iwBuildOrder::TransmitSettings()
     if(settings_changed)
     {
         // Einstellungen speichern
-        GAMECLIENT.ChangeBuildOrder(GetCtrl<ctrlComboBox>(6)->GetSelection() != 0u,
-                                    GAMECLIENT.visual_settings.build_order);
-        settings_changed = false;
+        useCustomBuildOrder = GetCtrl<ctrlComboBox>(6)->GetSelection() != 0u;
+        if(GAMECLIENT.ChangeBuildOrder(useCustomBuildOrder, pendingBuildOrder))
+        {
+            GAMECLIENT.visual_settings.build_order = pendingBuildOrder;
+            GAMECLIENT.visual_settings.useCustomBuildOrder = useCustomBuildOrder;
+            settings_changed = false;
+        }
     }
 }
 
@@ -118,10 +121,19 @@ void iwBuildOrder::Msg_ListSelectItem(const unsigned ctrl_id, const int selectio
 
         case 0:
         {
-            GetCtrl<ctrlImage>(5)->SetImage(LOADER.GetNationTex(
-              gwv.GetPlayer().nation, 250 + rttr::enum_cast(GAMECLIENT.visual_settings.build_order[selection]) * 5));
+            GetCtrl<ctrlImage>(5)->SetImage(
+              LOADER.GetNationTex(gwv.GetPlayer().nation, 250 + rttr::enum_cast(pendingBuildOrder[selection]) * 5));
         }
         break;
+    }
+}
+
+void iwBuildOrder::Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection)
+{
+    if(ctrl_id == 6)
+    {
+        useCustomBuildOrder = selection != 0u;
+        settings_changed = true;
     }
 }
 
@@ -147,8 +159,7 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
         {
             while(selection > 0)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[selection - 1],
-                          GAMECLIENT.visual_settings.build_order[selection]);
+                std::swap(pendingBuildOrder[selection - 1], pendingBuildOrder[selection]);
                 list->Swap(selection - 1, selection);
                 --selection;
             }
@@ -159,8 +170,7 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
         {
             if(selection > 0)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[selection - 1],
-                          GAMECLIENT.visual_settings.build_order[selection]);
+                std::swap(pendingBuildOrder[selection - 1], pendingBuildOrder[selection]);
                 list->Swap(selection - 1, selection);
             }
             settings_changed = true;
@@ -170,8 +180,7 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
         {
             if(selection < numOptions - 1u)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[selection + 1],
-                          GAMECLIENT.visual_settings.build_order[selection]);
+                std::swap(pendingBuildOrder[selection + 1], pendingBuildOrder[selection]);
                 list->Swap(selection + 1, selection);
             }
             settings_changed = true;
@@ -181,8 +190,7 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
         {
             while(selection < numOptions - 1u)
             {
-                std::swap(GAMECLIENT.visual_settings.build_order[selection + 1],
-                          GAMECLIENT.visual_settings.build_order[selection]);
+                std::swap(pendingBuildOrder[selection + 1], pendingBuildOrder[selection]);
                 list->Swap(selection + 1, selection);
                 ++selection;
             }
@@ -192,18 +200,18 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
         case 10: // Standardwerte
         {
             // Baureihenfolge vom Spieler kopieren
-            GAMECLIENT.visual_settings.build_order = GAMECLIENT.default_settings.build_order;
+            pendingBuildOrder = GAMECLIENT.default_settings.build_order;
 
             auto* list = GetCtrl<ctrlList>(0);
             list->DeleteAllItems();
 
             // Liste füllen
             for(unsigned char i = 0; i < 31; ++i)
-                list->AddString(_(BUILDING_NAMES[GAMECLIENT.default_settings.build_order[i]]));
+                list->AddString(_(BUILDING_NAMES[pendingBuildOrder[i]]));
             list->SetSelection(0);
 
-            GetCtrl<ctrlImage>(5)->SetImage(LOADER.GetNationTex(
-              gwv.GetPlayer().nation, 250 + rttr::enum_cast(GAMECLIENT.visual_settings.build_order[0]) * 5));
+            GetCtrl<ctrlImage>(5)->SetImage(
+              LOADER.GetNationTex(gwv.GetPlayer().nation, 250 + rttr::enum_cast(pendingBuildOrder[0]) * 5));
 
             settings_changed = true;
         }
@@ -214,8 +222,12 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
 void iwBuildOrder::UpdateSettings()
 {
     if(GAMECLIENT.IsReplayModeOn())
+    {
         gwv.GetPlayer().FillVisualSettings(GAMECLIENT.visual_settings);
-    GetCtrl<ctrlComboBox>(6)->SetSelection(GAMECLIENT.visual_settings.useCustomBuildOrder ? 1 : 0);
+        pendingBuildOrder = GAMECLIENT.visual_settings.build_order;
+        useCustomBuildOrder = GAMECLIENT.visual_settings.useCustomBuildOrder;
+    }
+    GetCtrl<ctrlComboBox>(6)->SetSelection(useCustomBuildOrder ? 1 : 0);
     for(unsigned char i = 0; i < 31; ++i)
-        GetCtrl<ctrlList>(0)->SetString(_(BUILDING_NAMES[GAMECLIENT.visual_settings.build_order[i]]), i);
+        GetCtrl<ctrlList>(0)->SetString(_(BUILDING_NAMES[pendingBuildOrder[i]]), i);
 }

--- a/libs/s25main/ingameWindows/iwBuildOrder.h
+++ b/libs/s25main/ingameWindows/iwBuildOrder.h
@@ -17,31 +17,27 @@
 
 #pragma once
 
-#include "IngameWindow.h"
+#include "TransmittingSettingsWindow.h"
 #include "gameTypes/SettingsTypes.h"
 
 class GameWorldViewer;
 
-class iwBuildOrder : public IngameWindow
+class iwBuildOrder : public TransmittingSettingsWindow
 {
     const GameWorldViewer& gwv;
-    /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
-    bool settings_changed;
 
     BuildOrders pendingBuildOrder;
     bool useCustomBuildOrder;
 
 public:
     iwBuildOrder(const GameWorldViewer& gwv);
-    ~iwBuildOrder() override;
 
 private:
     /// Updates the control elements with the pending build order
-    void UpdateSettings();
+    void UpdateSettings() override;
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
-    void TransmitSettings();
+    void TransmitSettings() override;
 
-    void Msg_Timer(unsigned ctrl_id) override;
     void Msg_ListSelectItem(unsigned ctrl_id, int selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;

--- a/libs/s25main/ingameWindows/iwBuildOrder.h
+++ b/libs/s25main/ingameWindows/iwBuildOrder.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include "TransmittingSettingsWindow.h"
+#include "TransmitSettingsIgwAdapter.h"
 #include "gameTypes/SettingsTypes.h"
 
 class GameWorldViewer;
 
-class iwBuildOrder : public TransmittingSettingsWindow
+class iwBuildOrder : public TransmitSettingsIgwAdapter
 {
     const GameWorldViewer& gwv;
 

--- a/libs/s25main/ingameWindows/iwBuildOrder.h
+++ b/libs/s25main/ingameWindows/iwBuildOrder.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "IngameWindow.h"
+#include "gameTypes/SettingsTypes.h"
 
 class GameWorldViewer;
 
@@ -27,12 +28,15 @@ class iwBuildOrder : public IngameWindow
     /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
     bool settings_changed;
 
+    BuildOrders pendingBuildOrder;
+    bool useCustomBuildOrder;
+
 public:
     iwBuildOrder(const GameWorldViewer& gwv);
     ~iwBuildOrder() override;
 
 private:
-    /// Updatet die Steuerelemente mit den aktuellen Einstellungen aus dem Spiel
+    /// Updates the control elements with the pending build order
     void UpdateSettings();
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
     void TransmitSettings();
@@ -40,4 +44,5 @@ private:
     void Msg_Timer(unsigned ctrl_id) override;
     void Msg_ListSelectItem(unsigned ctrl_id, int selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
 };

--- a/libs/s25main/ingameWindows/iwDemolishBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwDemolishBuilding.cpp
@@ -52,16 +52,19 @@ void iwDemolishBuilding::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 0:
         {
+            bool success = false;
             if(flag)
             {
                 // Flagge (mitsamt Gebäude) wegreißen
-                GAMECLIENT.DestroyFlag(gwv.GetViewer().GetNeighbour(building->GetPos(), Direction::SouthEast));
+                success =
+                  GAMECLIENT.DestroyFlag(gwv.GetViewer().GetNeighbour(building->GetPos(), Direction::SouthEast));
             } else
             {
-                GAMECLIENT.DestroyBuilding(building->GetPos());
+                success = GAMECLIENT.DestroyBuilding(building->GetPos());
             }
 
-            Close();
+            if(success)
+                Close();
         }
         break;
         case 1:

--- a/libs/s25main/ingameWindows/iwDiplomacy.cpp
+++ b/libs/s25main/ingameWindows/iwDiplomacy.cpp
@@ -258,6 +258,6 @@ void iwSuggestPact::Msg_ButtonClick(const unsigned /*ctrl_id*/)
     /// Dauer auswählen (wenn id == NUM_DURATIONS, dann "für alle Ewigkeit" ausgewählt)
     unsigned selected_id = GetCtrl<ctrlComboBox>(6)->GetSelection().get();
     unsigned duration = (selected_id == NUM_DURATIONS) ? DURATION_INFINITE : DURATIONS[selected_id];
-    gcFactory.SuggestPact(player.GetPlayerId(), this->pt, duration);
-    Close();
+    if(gcFactory.SuggestPact(player.GetPlayerId(), this->pt, duration))
+        Close();
 }

--- a/libs/s25main/ingameWindows/iwDistribution.cpp
+++ b/libs/s25main/ingameWindows/iwDistribution.cpp
@@ -44,7 +44,7 @@ std::vector<iwDistribution::DistributionGroup> iwDistribution::groups;
 const unsigned PROGRESS_BORDER_DISTANCE = 20;
 
 iwDistribution::iwDistribution(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
-    : TransmittingSettingsWindow(CGI_DISTRIBUTION, IngameWindow::posLastOrCenter, Extent(290, 312),
+    : TransmitSettingsIgwAdapter(CGI_DISTRIBUTION, IngameWindow::posLastOrCenter, Extent(290, 312),
                                  _("Distribution of goods"), LOADER.GetImageN("resource", 41)),
       gwv(gwv), gcFactory(gcFactory)
 {
@@ -82,7 +82,7 @@ iwDistribution::iwDistribution(const GameWorldViewer& gwv, GameCommandFactory& g
     AddImageButton(10, GetSize() - DrawPoint::all(15) - btSize, btSize, TextureColor::Grey, LOADER.GetImageN("io", 191),
                    _("Default"));
 
-    UpdateSettings();
+    iwDistribution::UpdateSettings();
 }
 
 void iwDistribution::TransmitSettings()

--- a/libs/s25main/ingameWindows/iwDistribution.cpp
+++ b/libs/s25main/ingameWindows/iwDistribution.cpp
@@ -87,7 +87,7 @@ iwDistribution::iwDistribution(const GameWorldViewer& gwv, GameCommandFactory& g
     AddImageButton(10, GetSize() - DrawPoint::all(15) - btSize, btSize, TextureColor::Grey, LOADER.GetImageN("io", 191),
                    _("Default"));
 
-    UpdateSettings();
+    UpdateSettings(GAMECLIENT.visual_settings.distribution);
 }
 
 iwDistribution::~iwDistribution()
@@ -136,17 +136,17 @@ void iwDistribution::Msg_Group_ProgressChange(const unsigned /*group_id*/, const
 void iwDistribution::Msg_Timer(const unsigned /*ctrl_id*/)
 {
     if(GAMECLIENT.IsReplayModeOn())
+    {
         // Im Replay aktualisieren wir die Werte
-        UpdateSettings();
-    else
+        gwv.GetPlayer().FillVisualSettings(GAMECLIENT.visual_settings);
+        UpdateSettings(GAMECLIENT.visual_settings.distribution);
+    } else
         // Im normalen Spielmodus schicken wir den ganzen Spaß ab
         TransmitSettings();
 }
 
-void iwDistribution::UpdateSettings()
+void iwDistribution::UpdateSettings(const Distributions& distribution)
 {
-    if(GAMECLIENT.IsReplayModeOn())
-        gwv.GetPlayer().FillVisualSettings(GAMECLIENT.visual_settings);
     unsigned distIdx = 0;
     for(unsigned g = 0; g < groups.size(); ++g)
     {
@@ -155,7 +155,7 @@ void iwDistribution::UpdateSettings()
         ctrlGroup* tab = GetCtrl<ctrlTab>(0)->GetGroup(g);
         // And correct entry
         for(unsigned i = 0; i < group.entries.size(); ++i, ++distIdx)
-            tab->GetCtrl<ctrlProgress>(i)->SetPosition(GAMECLIENT.visual_settings.distribution[distIdx]);
+            tab->GetCtrl<ctrlProgress>(i)->SetPosition(distribution[distIdx]);
     }
     RTTR_Assert(distIdx == std::tuple_size<Distributions>::value);
 }
@@ -179,8 +179,7 @@ void iwDistribution::Msg_ButtonClick(const unsigned ctrl_id)
         // Default button
         case 10:
         {
-            GAMECLIENT.visual_settings.distribution = GAMECLIENT.default_settings.distribution;
-            UpdateSettings();
+            UpdateSettings(GAMECLIENT.default_settings.distribution);
             settings_changed = true;
         }
         break;

--- a/libs/s25main/ingameWindows/iwDistribution.cpp
+++ b/libs/s25main/ingameWindows/iwDistribution.cpp
@@ -126,7 +126,7 @@ void iwDistribution::Msg_Group_ProgressChange(const unsigned /*group_id*/, const
 void iwDistribution::UpdateSettings(const Distributions& distribution)
 {
     if(GAMECLIENT.IsReplayModeOn())
-        GAMECLIENT.ResetVisualSettings();
+        gwv.GetPlayer().FillVisualSettings(GAMECLIENT.visual_settings);
     unsigned distIdx = 0;
     for(unsigned g = 0; g < groups.size(); ++g)
     {

--- a/libs/s25main/ingameWindows/iwDistribution.h
+++ b/libs/s25main/ingameWindows/iwDistribution.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "IngameWindow.h"
+#include "gameTypes/SettingsTypes.h"
 #include <vector>
 
 class GameCommandFactory;
@@ -37,8 +38,8 @@ private:
     /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
     bool settings_changed;
 
-    /// Updatet die Steuerelemente mit den aktuellen Einstellungen aus dem Spiel
-    void UpdateSettings();
+    /// Updatet die Steuerelemente mit den übergebenen Einstellungen
+    void UpdateSettings(const Distributions& distribution);
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
     void TransmitSettings();
 

--- a/libs/s25main/ingameWindows/iwDistribution.h
+++ b/libs/s25main/ingameWindows/iwDistribution.h
@@ -17,14 +17,14 @@
 
 #pragma once
 
-#include "TransmittingSettingsWindow.h"
+#include "TransmitSettingsIgwAdapter.h"
 #include "gameTypes/SettingsTypes.h"
 #include <vector>
 
 class GameCommandFactory;
 class GameWorldViewer;
 
-class iwDistribution : public TransmittingSettingsWindow
+class iwDistribution : public TransmitSettingsIgwAdapter
 {
     struct DistributionGroup;
 

--- a/libs/s25main/ingameWindows/iwDistribution.h
+++ b/libs/s25main/ingameWindows/iwDistribution.h
@@ -17,34 +17,31 @@
 
 #pragma once
 
-#include "IngameWindow.h"
+#include "TransmittingSettingsWindow.h"
 #include "gameTypes/SettingsTypes.h"
 #include <vector>
 
 class GameCommandFactory;
 class GameWorldViewer;
 
-class iwDistribution : public IngameWindow
+class iwDistribution : public TransmittingSettingsWindow
 {
     struct DistributionGroup;
 
 public:
     iwDistribution(const GameWorldViewer& gwv, GameCommandFactory& gcFactory);
-    ~iwDistribution() override;
 
 private:
     const GameWorldViewer& gwv;
     GameCommandFactory& gcFactory;
-    /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
-    bool settings_changed;
 
     /// Updatet die Steuerelemente mit den übergebenen Einstellungen
     void UpdateSettings(const Distributions& distribution);
+    void UpdateSettings() override;
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
-    void TransmitSettings();
+    void TransmitSettings() override;
 
     void Msg_Group_ProgressChange(unsigned group_id, unsigned ctrl_id, unsigned short position) override;
-    void Msg_Timer(unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
 
     /// Groups for the settings

--- a/libs/s25main/ingameWindows/iwHQ.cpp
+++ b/libs/s25main/ingameWindows/iwHQ.cpp
@@ -59,8 +59,8 @@ void iwHQ::Msg_Group_ButtonClick(const unsigned group_id, const unsigned ctrl_id
 {
     if(group_id == grpIdReserve)
     {
-   	  RTTR_Assert(ctrl_id >= 11 && ctrl_id < 21);
-   	  unsigned rank = 0, newReserve = 0, oldReserve = 0;
+        RTTR_Assert(ctrl_id >= 11 && ctrl_id < 21);
+        unsigned rank = 0, newReserve = 0, oldReserve = 0;
 
         // Minus-Button
         if(ctrl_id >= 11 && ctrl_id < 16)

--- a/libs/s25main/ingameWindows/iwHQ.cpp
+++ b/libs/s25main/ingameWindows/iwHQ.cpp
@@ -59,18 +59,26 @@ void iwHQ::Msg_Group_ButtonClick(const unsigned group_id, const unsigned ctrl_id
 {
     if(group_id == grpIdReserve)
     {
+        unsigned rank, newReserve, oldReserve;
+
         // Minus-Button
         if(ctrl_id >= 11 && ctrl_id < 16)
         {
-            // Netzwerk-Nachricht generieren
-            GAMECLIENT.ChangeReserve(wh->GetPos(), ctrl_id - 11, wh->DecreaseReserveVisual(ctrl_id - 11));
+            rank = ctrl_id - 11;
+            oldReserve = *(wh->GetReserveClaimedVisualPointer(rank));
+            newReserve = oldReserve > 0 ? oldReserve - 1 : oldReserve;
         }
         // Plus-Button
         else if(ctrl_id >= 16 && ctrl_id < 21)
         {
-            // Netzwerk-Nachricht generieren
-            GAMECLIENT.ChangeReserve(wh->GetPos(), ctrl_id - 16, wh->IncreaseReserveVisual(ctrl_id - 16));
+            rank = ctrl_id - 16;
+            oldReserve = *(wh->GetReserveClaimedVisualPointer(rank));
+            newReserve = oldReserve + 1;
         }
+
+        // Netzwerk-Nachricht generieren
+        if(newReserve != oldReserve && GAMECLIENT.ChangeReserve(wh->GetPos(), rank, newReserve))
+            wh->SetReserveVisual(rank, newReserve);
     }
 
     // an Basis weiterleiten

--- a/libs/s25main/ingameWindows/iwHQ.cpp
+++ b/libs/s25main/ingameWindows/iwHQ.cpp
@@ -59,7 +59,8 @@ void iwHQ::Msg_Group_ButtonClick(const unsigned group_id, const unsigned ctrl_id
 {
     if(group_id == grpIdReserve)
     {
-        unsigned rank, newReserve, oldReserve;
+   	  RTTR_Assert(ctrl_id >= 11 && ctrl_id < 21);
+   	  unsigned rank = 0, newReserve = 0, oldReserve = 0;
 
         // Minus-Button
         if(ctrl_id >= 11 && ctrl_id < 16)

--- a/libs/s25main/ingameWindows/iwMilitary.cpp
+++ b/libs/s25main/ingameWindows/iwMilitary.cpp
@@ -30,7 +30,7 @@
 #include "gameData/const_gui_ids.h"
 
 iwMilitary::iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
-    : TransmittingSettingsWindow(CGI_MILITARY, IngameWindow::posLastOrCenter, Extent(168, 330), _("Military"),
+    : TransmitSettingsIgwAdapter(CGI_MILITARY, IngameWindow::posLastOrCenter, Extent(168, 330), _("Military"),
                                  LOADER.GetImageN("io", 5)),
       gcFactory(gcFactory)
 {
@@ -65,7 +65,7 @@ iwMilitary::iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory
         GetCtrl<ctrlProgress>(2)->SetVisible(false);
     }
 
-    UpdateSettings();
+    iwMilitary::UpdateSettings();
 }
 
 /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden

--- a/libs/s25main/ingameWindows/iwMilitary.cpp
+++ b/libs/s25main/ingameWindows/iwMilitary.cpp
@@ -32,7 +32,7 @@
 iwMilitary::iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
     : IngameWindow(CGI_MILITARY, IngameWindow::posLastOrCenter, Extent(168, 330), _("Military"),
                    LOADER.GetImageN("io", 5)),
-      gwv(gwv), gcFactory(gcFactory), settings_changed(false)
+      gcFactory(gcFactory), settings_changed(false)
 {
     // Einzelne Balken
     const Extent progSize(132, 26);

--- a/libs/s25main/ingameWindows/iwMilitary.cpp
+++ b/libs/s25main/ingameWindows/iwMilitary.cpp
@@ -30,9 +30,9 @@
 #include "gameData/const_gui_ids.h"
 
 iwMilitary::iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
-    : IngameWindow(CGI_MILITARY, IngameWindow::posLastOrCenter, Extent(168, 330), _("Military"),
-                   LOADER.GetImageN("io", 5)),
-      gcFactory(gcFactory), settings_changed(false)
+    : TransmittingSettingsWindow(CGI_MILITARY, IngameWindow::posLastOrCenter, Extent(168, 330), _("Military"),
+                                 LOADER.GetImageN("io", 5)),
+      gcFactory(gcFactory)
 {
     // Einzelne Balken
     const Extent progSize(132, 26);
@@ -65,21 +65,7 @@ iwMilitary::iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory
         GetCtrl<ctrlProgress>(2)->SetVisible(false);
     }
 
-    // Absendetimer, in 2s-Abschnitten wird jeweils das ganze als Netzwerknachricht ggf. abgeschickt
-    using namespace std::chrono_literals;
-    AddTimer(22, 2s);
-    UpdateSettings(GAMECLIENT.visual_settings.military_settings);
-}
-
-iwMilitary::~iwMilitary()
-{
-    try
-    {
-        TransmitSettings();
-    } catch(...)
-    {
-        // Ignore
-    }
+    UpdateSettings();
 }
 
 /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
@@ -104,16 +90,6 @@ void iwMilitary::TransmitSettings()
     }
 }
 
-void iwMilitary::Msg_Timer(const unsigned /*ctrl_id*/)
-{
-    if(GAMECLIENT.IsReplayModeOn())
-        // Im Replay aktualisieren wir die Werte
-        UpdateSettings(GAMECLIENT.visual_settings.military_settings);
-    else
-        // Im normalen Spielmodus schicken wir den ganzen Spaß ab
-        TransmitSettings();
-}
-
 void iwMilitary::Msg_ProgressChange(const unsigned /*ctrl_id*/, const unsigned short /*position*/)
 {
     // Einstellungen wurden geändert
@@ -126,6 +102,11 @@ void iwMilitary::UpdateSettings(const MilitarySettings& military_settings)
         GAMECLIENT.ResetVisualSettings();
     for(unsigned i = 0; i < military_settings.size(); ++i)
         GetCtrl<ctrlProgress>(i)->SetPosition(military_settings[i]);
+}
+
+void iwMilitary::UpdateSettings()
+{
+    UpdateSettings(GAMECLIENT.visual_settings.military_settings);
 }
 
 void iwMilitary::Msg_ButtonClick(const unsigned ctrl_id)

--- a/libs/s25main/ingameWindows/iwMilitary.h
+++ b/libs/s25main/ingameWindows/iwMilitary.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "IngameWindow.h"
+#include "gameTypes/SettingsTypes.h"
 
 class GameCommandFactory;
 class GameWorldViewer;
@@ -35,8 +36,8 @@ public:
     ~iwMilitary() override;
 
 private:
-    /// Updatet die Steuerelemente mit den aktuellen Einstellungen aus dem Spiel
-    void UpdateSettings();
+    /// Updatet die Steuerelemente mit den übergebenen Einstellungen
+    void UpdateSettings(const MilitarySettings& military_settings);
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
     void TransmitSettings();
 

--- a/libs/s25main/ingameWindows/iwMilitary.h
+++ b/libs/s25main/ingameWindows/iwMilitary.h
@@ -17,14 +17,14 @@
 
 #pragma once
 
-#include "TransmittingSettingsWindow.h"
+#include "TransmitSettingsIgwAdapter.h"
 #include "gameTypes/SettingsTypes.h"
 
 class GameCommandFactory;
 class GameWorldViewer;
 
 /// Fenster mit den Militäreinstellungen.
-class iwMilitary : public TransmittingSettingsWindow
+class iwMilitary : public TransmitSettingsIgwAdapter
 {
     GameCommandFactory& gcFactory;
 

--- a/libs/s25main/ingameWindows/iwMilitary.h
+++ b/libs/s25main/ingameWindows/iwMilitary.h
@@ -26,7 +26,6 @@ class GameWorldViewer;
 /// Fenster mit den Militäreinstellungen.
 class iwMilitary : public IngameWindow
 {
-    const GameWorldViewer& gwv;
     GameCommandFactory& gcFactory;
     /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
     bool settings_changed;

--- a/libs/s25main/ingameWindows/iwMilitary.h
+++ b/libs/s25main/ingameWindows/iwMilitary.h
@@ -17,30 +17,27 @@
 
 #pragma once
 
-#include "IngameWindow.h"
+#include "TransmittingSettingsWindow.h"
 #include "gameTypes/SettingsTypes.h"
 
 class GameCommandFactory;
 class GameWorldViewer;
 
 /// Fenster mit den Militäreinstellungen.
-class iwMilitary : public IngameWindow
+class iwMilitary : public TransmittingSettingsWindow
 {
     GameCommandFactory& gcFactory;
-    /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
-    bool settings_changed;
 
 public:
     iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory);
-    ~iwMilitary() override;
 
 private:
     /// Updatet die Steuerelemente mit den übergebenen Einstellungen
     void UpdateSettings(const MilitarySettings& military_settings);
+    void UpdateSettings() override;
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
-    void TransmitSettings();
+    void TransmitSettings() override;
 
-    void Msg_Timer(unsigned ctrl_id) override;
     void Msg_ProgressChange(unsigned ctrl_id, unsigned short position) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
 };

--- a/libs/s25main/ingameWindows/iwPostWindow.cpp
+++ b/libs/s25main/ingameWindows/iwPostWindow.cpp
@@ -178,7 +178,13 @@ void iwPostWindow::Msg_ButtonClick(const unsigned ctrl_id)
         break;
 
         case ID_DELETE: // Delete
-        case ID_DENY:   // Cross (Deny)
+        {
+            if(!ValidateMessages() || !curMsg)
+                return;
+            postBox.DeleteMsg(curMsg);
+            break;
+        }
+        case ID_DENY: // Cross (Deny)
         {
             if(!ValidateMessages() || !curMsg)
                 return;
@@ -187,9 +193,9 @@ void iwPostWindow::Msg_ButtonClick(const unsigned ctrl_id)
             {
                 // If it is a question about a new contract, tell the other player we denied it
                 if(dcurMsg->IsAccept())
-                    GAMECLIENT.CancelPact(dcurMsg->GetPactType(), dcurMsg->GetPlayerId());
+                    if(GAMECLIENT.CancelPact(dcurMsg->GetPactType(), dcurMsg->GetPlayerId()))
+                        postBox.DeleteMsg(curMsg);
             }
-            postBox.DeleteMsg(curMsg);
         }
         break;
 
@@ -201,12 +207,15 @@ void iwPostWindow::Msg_ButtonClick(const unsigned ctrl_id)
             const auto* dcurMsg = dynamic_cast<const DiplomacyPostQuestion*>(GetMsg(curMsgId));
             if(dcurMsg)
             {
+                bool success = false;
                 // New contract?
                 if(dcurMsg->IsAccept())
-                    GAMECLIENT.AcceptPact(dcurMsg->GetPactId(), dcurMsg->GetPactType(), dcurMsg->GetPlayerId());
+                    success =
+                      GAMECLIENT.AcceptPact(dcurMsg->GetPactId(), dcurMsg->GetPactType(), dcurMsg->GetPlayerId());
                 else
-                    GAMECLIENT.CancelPact(dcurMsg->GetPactType(), dcurMsg->GetPlayerId());
-                postBox.DeleteMsg(dcurMsg);
+                    success = GAMECLIENT.CancelPact(dcurMsg->GetPactType(), dcurMsg->GetPlayerId());
+                if(success)
+                    postBox.DeleteMsg(dcurMsg);
             }
         }
         break;

--- a/libs/s25main/ingameWindows/iwShip.cpp
+++ b/libs/s25main/ingameWindows/iwShip.cpp
@@ -154,13 +154,16 @@ void iwShip::Msg_ButtonClick(const unsigned ctrl_id)
     // Expeditionskommando? (Schiff weiterfahren lassen, Kolonie gründen)
     if(ctrl_id >= 10 && ctrl_id <= 17)
     {
+        bool success = false;
         if(ctrl_id == 10)
-            gcFactory.FoundColony(ship_id);
+            success = gcFactory.FoundColony(ship_id);
         else if(ctrl_id == 11)
-            gcFactory.CancelExpedition(ship_id);
+            success = gcFactory.CancelExpedition(ship_id);
         else
-            gcFactory.TravelToNextSpot(ShipDirection(ctrl_id - 12), ship_id);
-        Close();
+            success = gcFactory.TravelToNextSpot(ShipDirection(ctrl_id - 12), ship_id);
+
+        if(success)
+            Close();
     }
 
     switch(ctrl_id)

--- a/libs/s25main/ingameWindows/iwSurrender.cpp
+++ b/libs/s25main/ingameWindows/iwSurrender.cpp
@@ -41,8 +41,8 @@ void iwSurrender::Msg_ButtonClick(const unsigned ctrl_id)
     {
         case 0: // OK
         {
-            GAMECLIENT.Surrender();
-            Close();
+            if(GAMECLIENT.Surrender())
+                Close();
         }
         break;
         case 1: // Abbrechen
@@ -52,8 +52,8 @@ void iwSurrender::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case 2: // OK + Alles abbrennen
         {
-            GAMECLIENT.DestroyAll();
-            Close();
+            if(GAMECLIENT.DestroyAll())
+                Close();
         }
         break;
     }

--- a/libs/s25main/ingameWindows/iwTools.cpp
+++ b/libs/s25main/ingameWindows/iwTools.cpp
@@ -79,7 +79,7 @@ iwTools::iwTools(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
                    TextureColor::Grey, LOADER.GetImageN("io", 191), _("Default"));
 
     // Einstellungen festlegen
-    UpdateSettings();
+    UpdateSettings(GAMECLIENT.visual_settings.tools_settings);
 
     // Netzwerk-Übertragungs-Timer
     using namespace std::chrono_literals;
@@ -204,14 +204,13 @@ void iwTools::Msg_ButtonClick(const unsigned ctrl_id)
                                              "The higher the value, the more likely this tool is to be produced.")));
                 break;
             case 13: // Standard
-                GAMECLIENT.visual_settings.tools_settings = GAMECLIENT.default_settings.tools_settings;
-                UpdateSettings();
+                UpdateSettings(GAMECLIENT.default_settings.tools_settings);
                 settings_changed = true;
                 break;
             case 15: // Zero all
-                std::fill(GAMECLIENT.visual_settings.tools_settings.begin(),
-                          GAMECLIENT.visual_settings.tools_settings.end(), 0);
-                UpdateSettings();
+                ToolSettings zero;
+                zero.fill(0);
+                UpdateSettings(zero);
                 settings_changed = true;
                 break;
         }
@@ -227,22 +226,16 @@ void iwTools::Msg_Timer(const unsigned /*ctrl_id*/)
 {
     if(isReplay)
         // Im Replay aktualisieren wir die Werte
-        UpdateSettings();
+        UpdateSettings(GAMECLIENT.visual_settings.tools_settings);
     else
         // Im normalen Spielmodus schicken wir den ganzen Spaß ab
         TransmitSettings();
 }
 
-void iwTools::UpdateSettings()
+void iwTools::UpdateSettings(const ToolSettings& tool_settings)
 {
     if(isReplay)
-    {
-        const GamePlayer& localPlayer = gwv.GetPlayer();
-        for(unsigned i = 0; i < NUM_TOOLS; ++i)
-            GetCtrl<ctrlProgress>(i)->SetPosition(localPlayer.GetToolPriority(i));
-    } else
-    {
-        for(unsigned i = 0; i < NUM_TOOLS; ++i)
-            GetCtrl<ctrlProgress>(i)->SetPosition(GAMECLIENT.visual_settings.tools_settings[i]);
-    }
+        GAMECLIENT.ResetVisualSettings();
+    for(unsigned i = 0; i < NUM_TOOLS; ++i)
+        GetCtrl<ctrlProgress>(i)->SetPosition(tool_settings[i]);
 }

--- a/libs/s25main/ingameWindows/iwTools.cpp
+++ b/libs/s25main/ingameWindows/iwTools.cpp
@@ -39,7 +39,7 @@
 #include "s25util/colors.h"
 
 iwTools::iwTools(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
-    : TransmittingSettingsWindow(
+    : TransmitSettingsIgwAdapter(
       CGI_TOOLS, IngameWindow::posLastOrCenter,
       Extent(166 + (gwv.GetWorld().GetGGS().isEnabled(AddonId::TOOL_ORDERING) ? 46 : 0), 432), _("Tools"),
       LOADER.GetImageN("io", 5)),

--- a/libs/s25main/ingameWindows/iwTools.h
+++ b/libs/s25main/ingameWindows/iwTools.h
@@ -20,6 +20,7 @@
 #include "IngameWindow.h"
 #include "notifications/Subscription.h"
 #include "gameTypes/GoodTypes.h"
+#include "gameTypes/SettingsTypes.h"
 #include <array>
 
 class GameCommandFactory;
@@ -44,8 +45,8 @@ private:
     Subscription toolSubscription;
 
     void AddToolSettingSlider(unsigned id, GoodType ware);
-    /// Updatet die Steuerelemente mit den aktuellen Einstellungen aus dem Spiel
-    void UpdateSettings();
+    /// Updatet die Steuerelemente mit den übergebenen Einstellungen
+    void UpdateSettings(const ToolSettings& tool_settings);
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
     void TransmitSettings();
 

--- a/libs/s25main/ingameWindows/iwTools.h
+++ b/libs/s25main/ingameWindows/iwTools.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "IngameWindow.h"
+#include "TransmittingSettingsWindow.h"
 #include "notifications/Subscription.h"
 #include "gameTypes/GoodTypes.h"
 #include "gameTypes/SettingsTypes.h"
@@ -26,12 +26,11 @@
 class GameCommandFactory;
 class GameWorldViewer;
 
-/// Fenster mit den Militäreinstellungen.
-class iwTools : public IngameWindow
+/// Tool settings window
+class iwTools : public TransmittingSettingsWindow
 {
 public:
     iwTools(const GameWorldViewer& gwv, GameCommandFactory& gcFactory);
-    ~iwTools() override;
 
 private:
     const GameWorldViewer& gwv;
@@ -39,7 +38,7 @@ private:
     /// How the order for each tool should be changed (pending actual transmission)
     std::array<int8_t, NUM_TOOLS> pendingOrderChanges;
     /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
-    bool settings_changed, ordersChanged;
+    bool ordersChanged;
     bool shouldUpdateTexts;
     bool isReplay;
     Subscription toolSubscription;
@@ -47,12 +46,12 @@ private:
     void AddToolSettingSlider(unsigned id, GoodType ware);
     /// Updatet die Steuerelemente mit den übergebenen Einstellungen
     void UpdateSettings(const ToolSettings& tool_settings);
+    void UpdateSettings() override;
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
-    void TransmitSettings();
+    void TransmitSettings() override;
 
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_ProgressChange(unsigned ctrl_id, unsigned short position) override;
-    void Msg_Timer(unsigned ctrl_id) override;
 
     void UpdateTexts();
     void Msg_PaintBefore() override;

--- a/libs/s25main/ingameWindows/iwTools.h
+++ b/libs/s25main/ingameWindows/iwTools.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "TransmittingSettingsWindow.h"
+#include "TransmitSettingsIgwAdapter.h"
 #include "notifications/Subscription.h"
 #include "gameTypes/GoodTypes.h"
 #include "gameTypes/SettingsTypes.h"
@@ -27,7 +27,7 @@ class GameCommandFactory;
 class GameWorldViewer;
 
 /// Tool settings window
-class iwTools : public TransmittingSettingsWindow
+class iwTools : public TransmitSettingsIgwAdapter
 {
 public:
     iwTools(const GameWorldViewer& gwv, GameCommandFactory& gcFactory);

--- a/libs/s25main/ingameWindows/iwTrade.cpp
+++ b/libs/s25main/ingameWindows/iwTrade.cpp
@@ -103,8 +103,8 @@ void iwTrade::Msg_ButtonClick(const unsigned /*ctrl_id*/)
     // Start trading
     if(!GetCtrl<ctrlComboBox>(4)->GetCtrl<ctrlList>(0)->IsVisible() && helpers::fromString(number_str, 0) > 0)
     {
-        gcFactory.TradeOverLand(wh.GetPos(), what, helpers::fromString(number_str, 0));
-        this->Close();
+        if(gcFactory.TradeOverLand(wh.GetPos(), what, helpers::fromString(number_str, 0)))
+            this->Close();
     }
 }
 

--- a/libs/s25main/ingameWindows/iwTransport.cpp
+++ b/libs/s25main/ingameWindows/iwTransport.cpp
@@ -29,7 +29,7 @@
 #include "gameData/const_gui_ids.h"
 
 iwTransport::iwTransport(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
-    : TransmittingSettingsWindow(CGI_TRANSPORT, IngameWindow::posLastOrCenter, Extent(166, 333), _("Transport"),
+    : TransmitSettingsIgwAdapter(CGI_TRANSPORT, IngameWindow::posLastOrCenter, Extent(166, 333), _("Transport"),
                                  LOADER.GetImageN("io", 5)),
       gwv(gwv), gcFactory(gcFactory)
 {

--- a/libs/s25main/ingameWindows/iwTransport.cpp
+++ b/libs/s25main/ingameWindows/iwTransport.cpp
@@ -82,12 +82,14 @@ iwTransport::iwTransport(const GameWorldViewer& gwv, GameCommandFactory& gcFacto
                                                            {20, 229},
                                                            {52, 246}}};
 
+    // Get current transport order
+    pendingOrder = GAMECLIENT.visual_settings.transport_order;
+
     // Einstellungen festlegen
     for(unsigned char i = 0; i < buttonData.size(); ++i)
     {
-        group->AddImageButton(i, BUTTON_POS[i], Extent(30, 30), TextureColor::Grey,
-                              buttonData[GAMECLIENT.visual_settings.transport_order[i]].sprite,
-                              _(buttonData[GAMECLIENT.visual_settings.transport_order[i]].tooltip));
+        group->AddImageButton(i, BUTTON_POS[i], Extent(30, 30), TextureColor::Grey, buttonData[pendingOrder[i]].sprite,
+                              _(buttonData[pendingOrder[i]].tooltip));
     }
     group->SetSelection(0);
 
@@ -108,9 +110,11 @@ void iwTransport::TransmitSettings()
     if(settings_changed)
     {
         // Daten übertragen
-        gcFactory.ChangeTransport(GAMECLIENT.visual_settings.transport_order);
-
-        settings_changed = false;
+        if(gcFactory.ChangeTransport(pendingOrder))
+        {
+            GAMECLIENT.visual_settings.transport_order = pendingOrder;
+            settings_changed = false;
+        }
     }
 }
 
@@ -132,7 +136,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
         {
             auto* group = GetCtrl<ctrlOptionGroup>(6);
 
-            GAMECLIENT.visual_settings.transport_order = GAMECLIENT.default_settings.transport_order;
+            pendingOrder = GAMECLIENT.default_settings.transport_order;
 
             for(unsigned char i = 0; i < buttonData.size(); ++i)
             {
@@ -151,8 +155,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             // Wenn wir schon ganz oben sind, gehts nicht weiter höher
             while(group->GetSelection() > 0)
             {
-                std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
-                          GAMECLIENT.visual_settings.transport_order[group->GetSelection() - 1]);
+                std::swap(pendingOrder[group->GetSelection()], pendingOrder[group->GetSelection() - 1]);
                 ctrlImageButton& btPrev = *group->GetCtrl<ctrlImageButton>(group->GetSelection() - 1);
                 ctrlImageButton& btNext = *group->GetCtrl<ctrlImageButton>(group->GetSelection());
                 btPrev.SwapImage(btNext);
@@ -170,8 +173,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             // Wenn wir schon ganz oben sind, gehts nicht weiter höher
             if(group->GetSelection() > 0)
             {
-                std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
-                          GAMECLIENT.visual_settings.transport_order[group->GetSelection() - 1]);
+                std::swap(pendingOrder[group->GetSelection()], pendingOrder[group->GetSelection() - 1]);
                 ctrlImageButton& btPrev = *group->GetCtrl<ctrlImageButton>(group->GetSelection() - 1);
                 ctrlImageButton& btNext = *group->GetCtrl<ctrlImageButton>(group->GetSelection());
                 btPrev.SwapImage(btNext);
@@ -189,8 +191,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             // Wenn wir schon ganz unten sind, gehts nicht weiter runter
             if(group->GetSelection() < 13)
             {
-                std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
-                          GAMECLIENT.visual_settings.transport_order[group->GetSelection() + 1]);
+                std::swap(pendingOrder[group->GetSelection()], pendingOrder[group->GetSelection() + 1]);
                 ctrlImageButton& btPrev = *group->GetCtrl<ctrlImageButton>(group->GetSelection());
                 ctrlImageButton& btNext = *group->GetCtrl<ctrlImageButton>(group->GetSelection() + 1);
                 btPrev.SwapImage(btNext);
@@ -208,8 +209,7 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
             // Wenn wir schon ganz unten sind, gehts nicht weiter runter
             while(group->GetSelection() < 13)
             {
-                std::swap(GAMECLIENT.visual_settings.transport_order[group->GetSelection()],
-                          GAMECLIENT.visual_settings.transport_order[group->GetSelection() + 1]);
+                std::swap(pendingOrder[group->GetSelection()], pendingOrder[group->GetSelection() + 1]);
                 ctrlImageButton& btPrev = *group->GetCtrl<ctrlImageButton>(group->GetSelection());
                 ctrlImageButton& btNext = *group->GetCtrl<ctrlImageButton>(group->GetSelection() + 1);
                 btPrev.SwapImage(btNext);
@@ -236,13 +236,16 @@ void iwTransport::Msg_Timer(const unsigned /*ctrl_id*/)
 void iwTransport::UpdateSettings()
 {
     if(GAMECLIENT.IsReplayModeOn())
+    {
         gwv.GetPlayer().FillVisualSettings(GAMECLIENT.visual_settings);
+        pendingOrder = GAMECLIENT.visual_settings.transport_order;
+    }
     auto* group = GetCtrl<ctrlOptionGroup>(6);
 
     // Einstellungen festlegen
     for(unsigned char i = 0; i < buttonData.size(); ++i)
     {
-        const auto& data = buttonData[GAMECLIENT.visual_settings.transport_order[i]];
+        const auto& data = buttonData[pendingOrder[i]];
         group->GetCtrl<ctrlImageButton>(i)->SetImage(data.sprite);
         group->GetCtrl<ctrlImageButton>(i)->SetTooltip(_(data.tooltip));
     }

--- a/libs/s25main/ingameWindows/iwTransport.cpp
+++ b/libs/s25main/ingameWindows/iwTransport.cpp
@@ -29,9 +29,9 @@
 #include "gameData/const_gui_ids.h"
 
 iwTransport::iwTransport(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
-    : IngameWindow(CGI_TRANSPORT, IngameWindow::posLastOrCenter, Extent(166, 333), _("Transport"),
-                   LOADER.GetImageN("io", 5)),
-      gwv(gwv), gcFactory(gcFactory), settings_changed(false)
+    : TransmittingSettingsWindow(CGI_TRANSPORT, IngameWindow::posLastOrCenter, Extent(166, 333), _("Transport"),
+                                 LOADER.GetImageN("io", 5)),
+      gwv(gwv), gcFactory(gcFactory)
 {
     AddImageButton(0, DrawPoint(18, 285), Extent(30, 30), TextureColor::Grey, LOADER.GetImageN("io", 225), _("Help"));
 
@@ -92,15 +92,6 @@ iwTransport::iwTransport(const GameWorldViewer& gwv, GameCommandFactory& gcFacto
                               _(buttonData[pendingOrder[i]].tooltip));
     }
     group->SetSelection(0);
-
-    // Netzwerk-Übertragungs-Timer
-    using namespace std::chrono_literals;
-    AddTimer(7, 2s);
-}
-
-iwTransport::~iwTransport()
-{
-    TransmitSettings();
 }
 
 void iwTransport::TransmitSettings()
@@ -221,16 +212,6 @@ void iwTransport::Msg_ButtonClick(const unsigned ctrl_id)
         }
         break;
     }
-}
-
-void iwTransport::Msg_Timer(const unsigned /*ctrl_id*/)
-{
-    if(GAMECLIENT.IsReplayModeOn())
-        // Im Replay aktualisieren wir die Werte
-        UpdateSettings();
-    else
-        // Im normalen Spielmodus schicken wir den ganzen Spaß ab
-        TransmitSettings();
 }
 
 void iwTransport::UpdateSettings()

--- a/libs/s25main/ingameWindows/iwTransport.h
+++ b/libs/s25main/ingameWindows/iwTransport.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "TransmittingSettingsWindow.h"
+#include "TransmitSettingsIgwAdapter.h"
 #include "gameTypes/SettingsTypes.h"
 #include <array>
 
@@ -25,7 +25,7 @@ class ITexture;
 class GameWorldViewer;
 class GameCommandFactory;
 
-class iwTransport : public TransmittingSettingsWindow
+class iwTransport : public TransmitSettingsIgwAdapter
 {
 private:
     struct ButtonData

--- a/libs/s25main/ingameWindows/iwTransport.h
+++ b/libs/s25main/ingameWindows/iwTransport.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "IngameWindow.h"
+#include "TransmittingSettingsWindow.h"
 #include "gameTypes/SettingsTypes.h"
 #include <array>
 
@@ -25,7 +25,7 @@ class ITexture;
 class GameWorldViewer;
 class GameCommandFactory;
 
-class iwTransport : public IngameWindow
+class iwTransport : public TransmittingSettingsWindow
 {
 private:
     struct ButtonData
@@ -41,19 +41,14 @@ private:
 
     TransportOrders pendingOrder;
 
-    /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
-    bool settings_changed;
-
 public:
     iwTransport(const GameWorldViewer& gwv, GameCommandFactory& gcFactory);
-    ~iwTransport() override;
 
 private:
     /// Updatet die Steuerelemente mit den übergebenen Einstellungen
-    void UpdateSettings();
+    void UpdateSettings() override;
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
-    void TransmitSettings();
+    void TransmitSettings() override;
 
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_Timer(unsigned ctrl_id) override;
 };

--- a/libs/s25main/ingameWindows/iwTransport.h
+++ b/libs/s25main/ingameWindows/iwTransport.h
@@ -39,6 +39,8 @@ private:
     static constexpr auto numButtons = std::tuple_size<TransportOrders>::value;
     std::array<ButtonData, numButtons> buttonData;
 
+    TransportOrders pendingOrder;
+
     /// Einstellungen nach dem letzten Netzwerk-Versenden nochmal verändert?
     bool settings_changed;
 
@@ -47,7 +49,7 @@ public:
     ~iwTransport() override;
 
 private:
-    /// Updatet die Steuerelemente mit den aktuellen Einstellungen aus dem Spiel
+    /// Updatet die Steuerelemente mit den übergebenen Einstellungen
     void UpdateSettings();
     /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
     void TransmitSettings();

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1660,7 +1660,7 @@ void GameClient::SetPause(bool pause)
     } else if(IsHost())
     {
         // Pause instantly
-        auto *msg = new GameMessage_Pause(pause);
+        auto* msg = new GameMessage_Pause(pause);
         if(pause)
             OnGameMessage(*msg);
         mainPlayer.sendMsgAsync(msg);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1660,7 +1660,7 @@ void GameClient::SetPause(bool pause)
     } else if(IsHost())
     {
         // Pause instantly
-        auto msg = new GameMessage_Pause(pause);
+        auto *msg = new GameMessage_Pause(pause);
         if(pause)
             OnGameMessage(*msg);
         mainPlayer.sendMsgAsync(msg);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1658,7 +1658,13 @@ void GameClient::SetPause(bool pause)
         framesinfo.isPaused = pause;
         framesinfo.frameTime = FramesInfo::milliseconds32_t::zero();
     } else if(IsHost())
-        mainPlayer.sendMsgAsync(new GameMessage_Pause(pause));
+    {
+        // Pause instantly
+   	 GameMessage_Pause* msg = new GameMessage_Pause(pause);
+        if(pause)
+            OnGameMessage(*msg);
+        mainPlayer.sendMsgAsync(msg);
+    }
 }
 
 void GameClient::ToggleReplayFOW()

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1660,7 +1660,7 @@ void GameClient::SetPause(bool pause)
     } else if(IsHost())
     {
         // Pause instantly
-        GameMessage_Pause* msg = new GameMessage_Pause(pause);
+        auto msg = new GameMessage_Pause(pause);
         if(pause)
             OnGameMessage(*msg);
         mainPlayer.sendMsgAsync(msg);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1660,7 +1660,7 @@ void GameClient::SetPause(bool pause)
     } else if(IsHost())
     {
         // Pause instantly
-   	 GameMessage_Pause* msg = new GameMessage_Pause(pause);
+        GameMessage_Pause* msg = new GameMessage_Pause(pause);
         if(pause)
             OnGameMessage(*msg);
         mainPlayer.sendMsgAsync(msg);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1658,12 +1658,7 @@ void GameClient::SetPause(bool pause)
         framesinfo.isPaused = pause;
         framesinfo.frameTime = FramesInfo::milliseconds32_t::zero();
     } else if(IsHost())
-    {
-        // Pause instantly
-        if(pause)
-            framesinfo.isPaused = true;
         mainPlayer.sendMsgAsync(new GameMessage_Pause(pause));
-    }
 }
 
 void GameClient::ToggleReplayFOW()


### PR DESCRIPTION
Hello there,

Pauses have some weird problems. Most notably when you are in the process of building a road when you pause the game then you can click to finish the road and this leaves an unremovable ghost road as seen below.

![pauseProblems](https://user-images.githubusercontent.com/711115/107875860-82142080-6ec2-11eb-8316-2daca846c06a.png)

Another problem is that for many ingame settings windows if you change something during a pause the changes very often are not registered, but still displayed. In the above picture this is visible for the military window, where the number of soldiers in barracks, even after the pause, does not reflect the choice made during the pause.

To address these issues I propose the changes in this pull request.

The guiding principles that I used are as follows (I tried to stay close to the ideas used already in the code and the things decided in some issues):

1. Most importantly at any time the displayed settings should reflect the actual settings or settings that will be changed in the next timer cycle.
2. Since adding game commands in a pause fails (and rightly so, as decided in #1229), any function that issues a game command potentially during a pause has to check whether it was successful and react accordingly.
3. Still a player can click through the windows in pause (to look at stats or see where a road could be built or whatever) and the windows don't have to be aware of the pause. Particularly, I think it's rude to just close the road building window for other players during a pause, so it stays open but they can't finish the road or any other road until the pause ends.
4. If control elements (progress bars and such) can be directly changed during a pause, then if the window is still open when the pause ends, the game commands for these changes will be issued after the pause ends. If the window is closed during a pause however, the noncommited changes made to control elements are discarded.

Especially because of 4 these changes reduce the importance of the visual settings in the game client. So this is related to #350.

During this I removed that for the host the pause starts immediately (as opposed to when the pause command is executed for all players) as it's potentially problematic (for example it's the direct reason for the ghost road problem mentioned at the beginning). If there was a particular reason for the immediate pause for the host we should discuss that.

I hope you find these changes helpful. I think they should make the behaviour during and after pauses much more predictable.

Best Regards
Jonathan