### PR TITLE
Fix and refactor RANDOM

### DIFF
--- a/libs/s25main/CatapultStone.cpp
+++ b/libs/s25main/CatapultStone.cpp
@@ -126,7 +126,7 @@ void CatapultStone::HandleEvent(const unsigned /*id*/)
             // Trifft nicht
             // ggf. Leiche hinlegen, falls da nix ist
             if(!gwg->GetSpecObj<noBase>(dest_map))
-                gwg->SetNO(dest_map, new noEnvObject(dest_map, 502 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2)));
+                gwg->SetNO(dest_map, new noEnvObject(dest_map, 502 + RANDOM_RAND(2)));
         }
     }
 }

--- a/libs/s25main/EconomyModeHandler.cpp
+++ b/libs/s25main/EconomyModeHandler.cpp
@@ -56,14 +56,14 @@ EconomyModeHandler::EconomyModeHandler(unsigned endFrame) : endFrame(endFrame), 
 
     while(goodsToCollect.size() < numGoodTypesToCollect - 1)
     {
-        GoodType nextGoodType = commonGoodPool[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), commonGoodPool.size())];
+        GoodType nextGoodType = RANDOM_ELEMENT(commonGoodPool);
         // No duplicates should be in goodsToCollect, so only add a good if it isn't one of the already found goods
         if(!helpers::contains(goodsToCollect, nextGoodType))
         {
             goodsToCollect.push_back(nextGoodType);
         }
     }
-    goodsToCollect.push_back(specialGoodPool[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), specialGoodPool.size())]);
+    goodsToCollect.push_back(RANDOM_ELEMENT(specialGoodPool));
 
     // Schedule end game event and trust the event manager to keep track of it
     if(!isInfinite())

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -1354,7 +1354,7 @@ void GamePlayer::RefreshDefenderList()
     for(unsigned i = 0; i < MILITARY_SETTINGS_SCALE[2]; ++i)
         shouldSendDefenderList.push_back(i < militarySettings_[2]);
     // und ordentlich schütteln
-    RANDOM_SHUFFLE(shouldSendDefenderList);
+    RANDOM_SHUFFLE2(shouldSendDefenderList, 0);
 }
 
 void GamePlayer::ChangeMilitarySettings(const MilitarySettings& military_settings)

--- a/libs/s25main/RoadSegment.cpp
+++ b/libs/s25main/RoadSegment.cpp
@@ -272,7 +272,7 @@ void RoadSegment::AddWareJob(const noRoadNode* rn)
     }
 
     // Zufällig Esel oder Träger zuerst fragen, ob er Zeit hat
-    unsigned char first = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2);
+    unsigned char first = RANDOM_RAND(2);
     for(unsigned char i = 0; i < 2; ++i)
     {
         if(carriers_[(i + first) % 2])

--- a/libs/s25main/buildings/BurnedWarehouse.cpp
+++ b/libs/s25main/buildings/BurnedWarehouse.cpp
@@ -67,7 +67,7 @@ void BurnedWarehouse::HandleEvent(const unsigned /*id*/)
 {
     RTTR_Assert(go_out_phase != GO_OUT_PHASES);
 
-    std::array<Direction, 6> possibleDirs;
+    std::array<Direction, helpers::NumEnumValues_v<Direction>> possibleDirs;
     unsigned possibleDirCt = 0;
 
     // Mögliche Richtungen zählen und speichern
@@ -104,7 +104,7 @@ void BurnedWarehouse::HandleEvent(const unsigned /*id*/)
 
         // In Alle Richtungen verteilen
         // Startrichtung zufällig bestimmen
-        unsigned start_dir = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 6);
+        unsigned start_dir = RANDOM_RAND(helpers::NumEnumValues_v<Direction>);
 
         for(unsigned j = 0; j < possibleDirCt; ++j)
         {

--- a/libs/s25main/buildings/nobBaseMilitary.cpp
+++ b/libs/s25main/buildings/nobBaseMilitary.cpp
@@ -88,7 +88,7 @@ void nobBaseMilitary::DestroyBuilding()
         {
             it->Abrogate();
             it->StartWandering();
-            it->StartWalking(RANDOM_ENUM(Direction, GetObjId()));
+            it->StartWalking(RANDOM_ENUM(Direction));
         }
     }
 
@@ -135,7 +135,7 @@ void nobBaseMilitary::AddLeavingEvent()
     // Wenn gerade keiner rausgeht, muss neues Event angemeldet werden
     if(!go_out)
     {
-        leaving_event = GetEvMgr().AddEvent(this, 20 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 10));
+        leaving_event = GetEvMgr().AddEvent(this, 20 + RANDOM_RAND(10));
         go_out = true;
     }
 }

--- a/libs/s25main/buildings/nobBaseWarehouse.cpp
+++ b/libs/s25main/buildings/nobBaseWarehouse.cpp
@@ -64,8 +64,7 @@ nobBaseWarehouse::nobBaseWarehouse(const BuildingType type, const MapPoint pos, 
     : nobBaseMilitary(type, pos, player, nation), fetch_double_protection(false), recruiting_event(nullptr),
       empty_event(nullptr), store_event(nullptr)
 {
-    producinghelpers_event = GetEvMgr().AddEvent(
-      this, PRODUCE_HELPERS_GF + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), PRODUCE_HELPERS_RANDOM_GF), 1);
+    producinghelpers_event = GetEvMgr().AddEvent(this, PRODUCE_HELPERS_GF + RANDOM_RAND(PRODUCE_HELPERS_RANDOM_GF), 1);
     // Reserve nullen
     reserve_soldiers_available.fill(0);
     reserve_soldiers_claimed_visual.fill(0);
@@ -403,7 +402,7 @@ void nobBaseWarehouse::HandleSendoutEvent()
         return;
 
     // Eine ID zufällig auswählen
-    const auto selectedId = possibleTypes[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), possibleTypes.size())];
+    const auto selectedId = RANDOM_ELEMENT(possibleTypes);
 
     if(holds_alternative<GoodType>(selectedId))
     {
@@ -476,8 +475,7 @@ void nobBaseWarehouse::HandleRecrutingEvent()
     unsigned real_recruits = max_recruits * recruiting_ratio / MILITARY_SETTINGS_SCALE[0];
     // Wurde abgerundet?
     unsigned remainingRecruits = real_recruits * recruiting_ratio % MILITARY_SETTINGS_SCALE[0];
-    if(remainingRecruits != 0
-       && unsigned(RANDOM.Rand(__FILE__, __LINE__, GetObjId(), MILITARY_SETTINGS_SCALE[0] - 1)) < remainingRecruits)
+    if(remainingRecruits != 0 && unsigned(RANDOM_RAND(MILITARY_SETTINGS_SCALE[0] - 1)) < remainingRecruits)
         ++real_recruits;
     else if(real_recruits == 0)
         return; // Nothing to do
@@ -537,8 +535,7 @@ void nobBaseWarehouse::HandleProduceHelperEvent()
         gwg->GetPlayer(player).DecreaseInventoryJob(Job::Helper, 1);
     }
 
-    producinghelpers_event = GetEvMgr().AddEvent(
-      this, PRODUCE_HELPERS_GF + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), PRODUCE_HELPERS_RANDOM_GF), 1);
+    producinghelpers_event = GetEvMgr().AddEvent(this, PRODUCE_HELPERS_GF + RANDOM_RAND(PRODUCE_HELPERS_RANDOM_GF), 1);
 
     // Evtl. genau der Gehilfe, der zum Rekrutieren notwendig ist
     TryRecruiting();
@@ -658,8 +655,7 @@ void nobBaseWarehouse::HandleLeaveEvent()
         go_out = false;
 
     if(go_out)
-        leaving_event =
-          GetEvMgr().AddEvent(this, LEAVE_INTERVAL + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), LEAVE_INTERVAL_RAND));
+        leaving_event = GetEvMgr().AddEvent(this, LEAVE_INTERVAL + RANDOM_RAND(LEAVE_INTERVAL_RAND));
 }
 
 /// Abgeleitete kann eine gerade erzeugte Ware ggf. sofort verwenden
@@ -1096,8 +1092,7 @@ void nobBaseWarehouse::TryRecruiting()
     if(!recruiting_event)
     {
         if(AreRecruitingConditionsComply())
-            recruiting_event = GetEvMgr().AddEvent(
-              this, RECRUITE_GF + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), RECRUITE_RANDOM_GF), 2);
+            recruiting_event = GetEvMgr().AddEvent(this, RECRUITE_GF + RANDOM_RAND(RECRUITE_RANDOM_GF), 2);
     }
 }
 

--- a/libs/s25main/buildings/nobHarborBuilding.cpp
+++ b/libs/s25main/buildings/nobHarborBuilding.cpp
@@ -138,7 +138,7 @@ void nobHarborBuilding::DestroyBuilding()
 
         figure->Abrogate();
         figure->StartWandering();
-        figure->StartWalking(RANDOM_ENUM(Direction, GetObjId()));
+        figure->StartWalking(RANDOM_ENUM(Direction));
     }
     figures_for_ships.clear();
 
@@ -152,7 +152,7 @@ void nobHarborBuilding::DestroyBuilding()
         RTTR_Assert(soldier->HasNoHome());
         RTTR_Assert(soldier->HasNoGoal());
         soldier->StartWandering();
-        soldier->StartWalking(RANDOM_ENUM(Direction, GetObjId()));
+        soldier->StartWalking(RANDOM_ENUM(Direction));
     }
     soldiers_for_ships.clear();
 

--- a/libs/s25main/buildings/nobMilitary.cpp
+++ b/libs/s25main/buildings/nobMilitary.cpp
@@ -236,7 +236,7 @@ void nobMilitary::HandleEvent(const unsigned id)
 
             // Wenn noch weitere drin sind, die müssen auch noch raus
             if(!leave_house.empty())
-                leaving_event = GetEvMgr().AddEvent(this, 30 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 10));
+                leaving_event = GetEvMgr().AddEvent(this, 30 + RANDOM_RAND(10));
             else
                 go_out = false;
 
@@ -1191,7 +1191,7 @@ void nobMilitary::SearchCoins()
             RTTR_Assert(helpers::contains(ordered_coins, ware));
 
             // Nach einer Weile nochmal nach evtl neuen Goldmünzen gucken
-            goldorder_event = GetEvMgr().AddEvent(this, 200 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 400), 1);
+            goldorder_event = GetEvMgr().AddEvent(this, 200 + RANDOM_RAND(400), 1);
         }
     }
 }
@@ -1224,8 +1224,7 @@ void nobMilitary::PrepareUpgrading()
         return;
 
     // Alles da --> Beförderungsevent anmelden
-    upgrade_event =
-      GetEvMgr().AddEvent(this, UPGRADE_TIME + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), UPGRADE_TIME_RANDOM), 2);
+    upgrade_event = GetEvMgr().AddEvent(this, UPGRADE_TIME + RANDOM_RAND(UPGRADE_TIME_RANDOM), 2);
 }
 
 void nobMilitary::HitOfCatapultStone()

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -1065,7 +1065,7 @@ void dskGameInterface::OnChatCommand(const std::string& cmd)
     else if(cmd == "surrender")
         GAMECLIENT.Surrender();
     else if(cmd == "async")
-        (void)RANDOM.Rand(__FILE__, __LINE__, 0, 255);
+        (void)RANDOM.Rand(RANDOM_CONTEXT2(0), 255);
     else if(cmd == "segfault")
     {
         char* x = nullptr;

--- a/libs/s25main/figures/noFigure.cpp
+++ b/libs/s25main/figures/noFigure.cpp
@@ -497,7 +497,7 @@ void noFigure::StartWandering(const unsigned burned_wh_id)
     this->burned_wh_id = burned_wh_id;
     // eine bestimmte Strecke rumirren und dann eine Flagge suchen
     // 3x rumirren und eine Flagge suchen, wenn dann keine gefunden wurde, stirbt die Figur
-    wander_way = WANDER_WAY_MIN + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), WANDER_WAY_MAX - WANDER_WAY_MIN);
+    wander_way = WANDER_WAY_MIN + RANDOM_RAND(WANDER_WAY_MAX - WANDER_WAY_MIN);
     // Soldaten sind härter im Nehmen
     wander_tryings = IsSoldier() ? WANDER_TRYINGS_SOLDIERS : WANDER_TRYINGS;
 
@@ -616,7 +616,7 @@ void noFigure::Wander()
         if(--wander_tryings > 0)
         {
             // von vorne beginnen wieder mit Rumirren
-            wander_way = WANDER_WAY_MIN + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), WANDER_WAY_MAX - WANDER_WAY_MIN);
+            wander_way = WANDER_WAY_MIN + RANDOM_RAND(WANDER_WAY_MAX - WANDER_WAY_MIN);
         } else
         {
             // Genug rumgeirrt, wir finden halt einfach nichts --> Sterben
@@ -640,11 +640,8 @@ bool noFigure::WalkInRandomDir()
 {
     PathConditionHuman pathChecker(*gwg);
     // Check all dirs starting with a random one and taking the first possible
-    unsigned dirOffset = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 6);
-    for(auto dir : helpers::EnumRange<Direction>{})
+    for(const Direction dir : helpers::enumRange(RANDOM_ENUM(Direction)))
     {
-        dir += dirOffset;
-
         if(pathChecker.IsNodeOk(gwg->GetNeighbour(pos, dir)) && pathChecker.IsEdgeOk(pos, dir))
         {
             StartWalking(dir);

--- a/libs/s25main/figures/nofAggressiveDefender.cpp
+++ b/libs/s25main/figures/nofAggressiveDefender.cpp
@@ -107,7 +107,7 @@ void nofAggressiveDefender::HomeDestroyedAtBegin()
 
     // Rumirren
     StartWandering();
-    StartWalking(RANDOM_ENUM(Direction, GetObjId()));
+    StartWalking(RANDOM_ENUM(Direction));
 }
 
 void nofAggressiveDefender::CancelAtAttackedBld()

--- a/libs/s25main/figures/nofAttacker.cpp
+++ b/libs/s25main/figures/nofAttacker.cpp
@@ -402,7 +402,7 @@ void nofAttacker::HomeDestroyedAtBegin()
 
     // Rumirren
     StartWandering();
-    StartWalking(RANDOM_ENUM(Direction, GetObjId()));
+    StartWalking(RANDOM_ENUM(Direction));
 }
 
 /// Wenn ein Kampf gewonnen wurde
@@ -679,7 +679,7 @@ void nofAttacker::TryToOrderAggressiveDefender()
         return;
 
     // 20%ige Chance, dass wirklich jemand angreift
-    if(RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 10) >= 2)
+    if(RANDOM_RAND(10) >= 2)
         return;
 
     OrderAggressiveDefender();

--- a/libs/s25main/figures/nofBuilder.cpp
+++ b/libs/s25main/figures/nofBuilder.cpp
@@ -255,7 +255,7 @@ void nofBuilder::StartFreewalk()
 
     RTTR_Assert(!possible_directions.empty());
     // Zufällige Richtung von diesen auswählen
-    FaceDir(possible_directions[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), possible_directions.size())]);
+    FaceDir(RANDOM_ELEMENT(possible_directions));
 
     // Und dort auch hinlaufen
     current_ev = GetEvMgr().AddEvent(this, (state == BuilderState::WaitingFreewalk) ? 24 : 17, 1);

--- a/libs/s25main/figures/nofCarrier.cpp
+++ b/libs/s25main/figures/nofCarrier.cpp
@@ -87,9 +87,9 @@ const helpers::EnumArray<Job, CarrierType> JOB_TYPES = {{Job::Helper, Job::PackD
 
 nofCarrier::nofCarrier(const CarrierType ct, const MapPoint pos, unsigned char player, RoadSegment* workplace,
                        noRoadNode* const goal)
-    : noFigure(JOB_TYPES[ct], pos, player, goal), ct(ct), state(CarrierState::FigureWork),
-      fat((RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2) != 0)), workplace(workplace), carried_ware(nullptr),
-      productivity_ev(nullptr), productivity(0), worked_gf(0), since_working_gf(0xFFFFFFFF), next_animation(0)
+    : noFigure(JOB_TYPES[ct], pos, player, goal), ct(ct), state(CarrierState::FigureWork), fat((RANDOM_RAND(2) != 0)),
+      workplace(workplace), carried_ware(nullptr), productivity_ev(nullptr), productivity(0), worked_gf(0),
+      since_working_gf(0xFFFFFFFF), next_animation(0)
 {}
 
 nofCarrier::nofCarrier(SerializedGameData& sgd, unsigned obj_id)

--- a/libs/s25main/figures/nofCatapultMan.cpp
+++ b/libs/s25main/figures/nofCatapultMan.cpp
@@ -156,7 +156,7 @@ void nofCatapultMan::HandleDerivedEvent(const unsigned /*id*/)
             workplace->ConsumeWares();
 
             // Eins zufällig auswählen
-            target = possibleTargets[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), possibleTargets.size())];
+            target = RANDOM_ELEMENT(possibleTargets);
 
             // Get distance and direction
             int distX;
@@ -229,7 +229,7 @@ void nofCatapultMan::HandleDerivedEvent(const unsigned /*id*/)
             // Stein in Bewegung setzen
 
             // Soll das Gebäude getroffen werden (70%)
-            bool hit = (RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 99) < 70);
+            bool hit = (RANDOM_RAND(99) < 70);
 
             // Radius fürs Treffen und Nicht-Treffen,  (in Pixeln), nur visuell
             const int RADIUS_HIT = 15; // nicht nach unten hin!
@@ -244,7 +244,7 @@ void nofCatapultMan::HandleDerivedEvent(const unsigned /*id*/)
             } else
             {
                 // Ansonsten zufälligen Punkt rundrum heraussuchen
-                destMap = gwg->GetNeighbour(target.pos, RANDOM_ENUM(Direction, GetObjId()));
+                destMap = gwg->GetNeighbour(target.pos, RANDOM_ENUM(Direction));
             }
 
             unsigned shooting_dir = (7 + wheel_steps) % 6;
@@ -272,10 +272,10 @@ void nofCatapultMan::HandleDerivedEvent(const unsigned /*id*/)
             // Bei getroffenen den Aufschlagspunkt am Gebäude ein bisschen variieren
             if(hit)
             {
-                dest.x += (RANDOM.Rand(__FILE__, __LINE__, GetObjId(), RADIUS_HIT * 2) - RADIUS_HIT);
+                dest.x += (RANDOM_RAND(RADIUS_HIT * 2) - RADIUS_HIT);
                 // hier nicht nach unten gehen, da die Tür (also Nullpunkt
                 // ja schon ziemlich weit unten ist!
-                dest.y -= RANDOM.Rand(__FILE__, __LINE__, GetObjId(), RADIUS_HIT);
+                dest.y -= RANDOM_RAND(RADIUS_HIT);
             }
 
             // Stein erzeugen

--- a/libs/s25main/figures/nofDefender.cpp
+++ b/libs/s25main/figures/nofDefender.cpp
@@ -147,7 +147,7 @@ void nofDefender::HomeDestroyedAtBegin()
 
     // Rumirren
     StartWandering();
-    StartWalking(RANDOM_ENUM(Direction, GetObjId()));
+    StartWalking(RANDOM_ENUM(Direction));
 }
 
 /// Wenn ein Kampf gewonnen wurde

--- a/libs/s25main/figures/nofFarmhand.cpp
+++ b/libs/s25main/figures/nofFarmhand.cpp
@@ -156,7 +156,7 @@ void nofFarmhand::HandleDerivedEvent(const unsigned /*id*/)
                 {
                     if(!available_point.empty())
                     {
-                        dest = available_point[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), available_point.size())];
+                        dest = RANDOM_ELEMENT(available_point);
                         break;
                     }
                 }

--- a/libs/s25main/figures/nofFisher.cpp
+++ b/libs/s25main/figures/nofFisher.cpp
@@ -105,11 +105,10 @@ unsigned short nofFisher::GetCarryID() const
 /// Abgeleitete Klasse informieren, wenn sie anfängt zu arbeiten (Vorbereitungen)
 void nofFisher::WorkStarted()
 {
-    unsigned char doffset = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 6);
     // Punkt mit Fisch suchen (mit zufälliger Richtung beginnen)
-    for(Direction dir : helpers::EnumRange<Direction>{})
+    for(Direction dir : helpers::enumRange(RANDOM_ENUM(Direction)))
     {
-        fishing_dir = dir + doffset;
+        fishing_dir = dir;
         Resource neighbourRes = gwg->GetNode(gwg->GetNeighbour(pos, fishing_dir)).resources;
         if(neighbourRes.has(ResourceType::Fish))
             break;
@@ -117,7 +116,7 @@ void nofFisher::WorkStarted()
 
     // Wahrscheinlichkeit, einen Fisch zu fangen sinkt mit abnehmendem Bestand
     unsigned short probability = 40 + (gwg->GetNode(gwg->GetNeighbour(pos, fishing_dir)).resources.getAmount()) * 10;
-    successful = (RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 100) < probability);
+    successful = (RANDOM_RAND(100) < probability);
 }
 
 /// Abgeleitete Klasse informieren, wenn fertig ist mit Arbeiten

--- a/libs/s25main/figures/nofForester.cpp
+++ b/libs/s25main/figures/nofForester.cpp
@@ -26,6 +26,7 @@
 #include "random/Random.h"
 #include "world/GameWorldGame.h"
 #include "nodeObjs/noTree.h"
+#include <boost/container/static_vector.hpp>
 
 nofForester::nofForester(const MapPoint pos, const unsigned char player, nobUsual* workplace)
     : nofFarmhand(Job::Forester, pos, player, workplace)
@@ -79,16 +80,12 @@ void nofForester::WorkFinished()
         gwg->DestroyNO(pos, false);
 
         // Je nach Landschaft andere Bäume pflanzbar!
-        const std::array<unsigned char, 3> NUM_AVAILABLE_TREES = {6, 3, 4};
-        const helpers::MultiArray<unsigned char, 3, 6> AVAILABLE_TREES = {
-          {{0, 1, 2, 6, 7, 8}, {0, 1, 7, 0xFF, 0xFF, 0xFF}, {0, 1, 6, 8, 0xFF, 0xFF}}};
-        uint8_t landscapeType = std::min<uint8_t>(gwg->GetLandscapeType().value, 2);
+        const std::array<boost::container::static_vector<unsigned char, 6>, 3> AVAILABLE_TREES = {
+          {{0, 1, 2, 6, 7, 8}, {0, 1, 7}, {0, 1, 6, 8}}};
+        uint8_t landscapeType = std::min<uint8_t>(gwg->GetLandscapeType().value, AVAILABLE_TREES.size() - 1);
 
         // jungen Baum einsetzen
-        gwg->SetNO(pos, new noTree(pos,
-                                   AVAILABLE_TREES[landscapeType][RANDOM.Rand(__FILE__, __LINE__, GetObjId(),
-                                                                              NUM_AVAILABLE_TREES[landscapeType])],
-                                   0));
+        gwg->SetNO(pos, new noTree(pos, RANDOM_ELEMENT(AVAILABLE_TREES[landscapeType]), 0));
 
         // BQ drumherum neu berechnen
         gwg->RecalcBQAroundPoint(pos);

--- a/libs/s25main/figures/nofGeologist.cpp
+++ b/libs/s25main/figures/nofGeologist.cpp
@@ -377,7 +377,7 @@ helpers::OptionalEnum<Direction> nofGeologist::GetNextNode()
         while(!available_nodes.empty())
         {
             // Dann einen Punkt zufällig auswählen
-            int randNode = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), available_nodes.size());
+            int randNode = RANDOM_RAND(available_nodes.size());
             node_goal = available_nodes[randNode];
             // und aus der Liste entfernen
             available_nodes.erase(available_nodes.begin() + randNode);

--- a/libs/s25main/figures/nofHunter.cpp
+++ b/libs/s25main/figures/nofHunter.cpp
@@ -180,7 +180,7 @@ void nofHunter::TryStartHunting()
     if(!available_animals.empty())
     {
         // Ein Tier zufällig heraussuchen
-        animal = available_animals[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), available_animals.size())];
+        animal = RANDOM_ELEMENT(available_animals);
 
         // Wir jagen es jetzt
         state = State::HunterChasing;
@@ -235,12 +235,11 @@ void nofHunter::HandleStateChasing()
 
         // Nun müssen wir drumherum einen Punkt suchen, von dem wir schießen, der natürlich direkt dem Standort
         // des Tieres gegenüberliegen muss (mit zufälliger Richtung beginnen)
-        unsigned doffset = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 6);
         shootingPos = MapPoint::Invalid();
-        for(const auto d : helpers::EnumRange<Direction>{})
+        for(const Direction d : helpers::enumRange(RANDOM_ENUM(Direction)))
         {
             Position delta;
-            switch((d + doffset))
+            switch(d)
             {
                 case Direction::West:
                     delta.x = -4;
@@ -274,7 +273,7 @@ void nofHunter::HandleStateChasing()
             {
                 shootingPos = curShootingPos;
                 // Richtung, in die geschossen wird, bestimmen (natürlich die entgegengesetzte nehmen)
-                shooting_dir = d + doffset + 3u;
+                shooting_dir = d + 3u;
                 break;
             }
         }

--- a/libs/s25main/figures/nofMetalworker.cpp
+++ b/libs/s25main/figures/nofMetalworker.cpp
@@ -177,7 +177,7 @@ helpers::OptionalEnum<GoodType> nofMetalworker::GetOrderedTool()
     if(random_array.empty())
         return boost::none;
 
-    unsigned toolIdx = random_array[RANDOM_RAND(GetObjId(), random_array.size())];
+    unsigned toolIdx = RANDOM_ELEMENT(random_array);
 
     owner.ToolOrderProcessed(toolIdx);
 
@@ -209,10 +209,10 @@ helpers::OptionalEnum<GoodType> nofMetalworker::GetRandomTool()
         if(gwg->GetGGS().getSelection(AddonId::METALWORKSBEHAVIORONZERO) == 1)
             return boost::none;
         else
-            return TOOLS[RANDOM_RAND(GetObjId(), TOOLS.size())];
+            return RANDOM_ELEMENT(TOOLS);
     }
 
-    return TOOLS[random_array[RANDOM_RAND(GetObjId(), random_array.size())]];
+    return TOOLS[RANDOM_ELEMENT(random_array)];
 }
 
 helpers::OptionalEnum<GoodType> nofMetalworker::ProduceWare()

--- a/libs/s25main/figures/nofPassiveSoldier.cpp
+++ b/libs/s25main/figures/nofPassiveSoldier.cpp
@@ -82,9 +82,8 @@ void nofPassiveSoldier::HandleDerivedEvent(const unsigned id)
 
                     // Sind wir immer noch nicht gesund? Dann neues Event anmelden!
                     if(hitpoints < HITPOINTS[GetRank()])
-                        healing_event = GetEvMgr().AddEvent(
-                          this, CONVALESCE_TIME + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), CONVALESCE_TIME_RANDOM),
-                          1);
+                        healing_event =
+                          GetEvMgr().AddEvent(this, CONVALESCE_TIME + RANDOM_RAND(CONVALESCE_TIME_RANDOM), 1);
                 }
             }
         }
@@ -105,8 +104,7 @@ void nofPassiveSoldier::Heal()
     // Ist er verletzt?
     // Dann muss er geheilt werden
     if(hitpoints < HITPOINTS[GetRank()])
-        healing_event = GetEvMgr().AddEvent(
-          this, CONVALESCE_TIME + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), CONVALESCE_TIME_RANDOM), 1);
+        healing_event = GetEvMgr().AddEvent(this, CONVALESCE_TIME + RANDOM_RAND(CONVALESCE_TIME_RANDOM), 1);
 }
 
 void nofPassiveSoldier::GoalReached()
@@ -124,7 +122,7 @@ void nofPassiveSoldier::InBuildingDestroyed()
     // Erstmal in zufällige Richtung rammeln
     StartWandering();
 
-    StartWalking(RANDOM_ENUM(Direction, GetObjId()));
+    StartWalking(RANDOM_ENUM(Direction));
 }
 
 void nofPassiveSoldier::LeaveBuilding()

--- a/libs/s25main/figures/nofPlaner.cpp
+++ b/libs/s25main/figures/nofPlaner.cpp
@@ -54,8 +54,7 @@ void nofPlaner::GoalReached()
     state = PlanerState::Walking;
 
     // Zufällig Uhrzeigersinn oder dagegen
-    pd =
-      (RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2) == 0) ? (PlaningDir::Clockwise) : (PlaningDir::Counterclockwise);
+    pd = (RANDOM_RAND(2) == 0) ? (PlaningDir::Clockwise) : (PlaningDir::Counterclockwise);
 
     // Je nachdem erst nach rechts oder links gehen
     StartWalking((pd == PlaningDir::Clockwise) ? Direction::SouthWest : Direction::East);

--- a/libs/s25main/figures/nofScout_Free.cpp
+++ b/libs/s25main/figures/nofScout_Free.cpp
@@ -51,7 +51,7 @@ void nofScout_Free::Draw(DrawPoint drawPt)
 void nofScout_Free::GoalReached()
 {
     /// Bestimmte Anzahl an Punkten abklappern, leicht variieren
-    rest_way = 80 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 20);
+    rest_way = 80 + RANDOM_RAND(20);
 
     state = State::ScoutScouting;
 

--- a/libs/s25main/figures/nofShipWright.cpp
+++ b/libs/s25main/figures/nofShipWright.cpp
@@ -108,8 +108,7 @@ void nofShipWright::HandleDerivedEvent(const unsigned /*id*/)
                 if(!available_points.empty())
                 {
                     // Einen Punkt zufällig auswählen und dorthin laufen
-                    curShipBuildPos =
-                      available_points[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), available_points.size())];
+                    curShipBuildPos = RANDOM_ELEMENT(available_points);
                     StartWalkingToShip();
                 } else
                 {

--- a/libs/s25main/figures/nofWarehouseWorker.cpp
+++ b/libs/s25main/figures/nofWarehouseWorker.cpp
@@ -28,7 +28,7 @@
 
 nofWarehouseWorker::nofWarehouseWorker(const MapPoint pos, const unsigned char player, Ware* ware, const bool task)
     : noFigure(Job::Helper, pos, player, gwg->GetSpecObj<noFlag>(gwg->GetNeighbour(pos, Direction::SouthEast))),
-      carried_ware(ware), shouldBringWareIn(task), fat((RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2)) != 0)
+      carried_ware(ware), shouldBringWareIn(task), fat((RANDOM_RAND(2)) != 0)
 {
     // Zur Inventur hinzufügen, sind ja sonst nicht registriert
     gwg->GetPlayer(player).IncreaseInventoryJob(Job::Helper, 1);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -50,6 +50,7 @@
 #include "ogl/glArchivItem_Map.h"
 #include "ogl/glFont.h"
 #include "random/Random.h"
+#include "random/randomIO.h"
 #include "world/GameWorld.h"
 #include "world/GameWorldView.h"
 #include "gameTypes/RoadBuildState.h"
@@ -832,7 +833,7 @@ bool GameClient::OnGameMessage(const GameMessage_Server_Async& msg)
     const bfs::path filePathSave = RTTRCONFIG.ExpandPath(s25::folders::save) / makePortableFileName(fileName + ".sav");
     const bfs::path filePathLog =
       RTTRCONFIG.ExpandPath(s25::folders::logs) / makePortableFileName(fileName + "Player.log");
-    RANDOM.SaveLog(filePathLog);
+    saveRandomLog(filePathLog, RANDOM.GetAsyncLog());
     SaveToFile(filePathSave);
     LOG.write(_("Async log saved at \"%s\",\ngame saved at \"%s\"\n")) % filePathLog % filePathSave;
     return true;

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -1536,7 +1536,7 @@ bfs::path GameServer::SaveAsyncLog()
             }
             const RandomEntry& curEntry = log.randEntries[i];
             if(curEntry.max != refEntry.max || curEntry.rngState != refEntry.rngState
-               || curEntry.obj_id != refEntry.obj_id)
+               || curEntry.objId != refEntry.objId)
             {
                 isIdentical = false;
                 break;

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -1535,7 +1535,7 @@ bfs::path GameServer::SaveAsyncLog()
                 break;
             }
             const RandomEntry& curEntry = log.randEntries[i];
-            if(curEntry.max != refEntry.max || curEntry.rngState != refEntry.rngState
+            if(curEntry.maxExcl != refEntry.maxExcl || curEntry.rngState != refEntry.rngState
                || curEntry.objId != refEntry.objId)
             {
                 isIdentical = false;

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -33,6 +33,7 @@
 #include "network/CreateServerInfo.h"
 #include "network/GameMessages.h"
 #include "ogl/glArchivItem_Map.h"
+#include "random/randomIO.h"
 #include "gameTypes/LanGameInfo.h"
 #include "gameTypes/TeamTypes.h"
 #include "gameData/GameConsts.h"

--- a/libs/s25main/nodeObjs/noAnimal.cpp
+++ b/libs/s25main/nodeObjs/noAnimal.cpp
@@ -32,8 +32,8 @@
 #include "s25util/colors.h"
 
 noAnimal::noAnimal(const Species species, const MapPoint pos)
-    : noMovable(NodalObjectType::Animal, pos), species(species), state(State::Walking),
-      pause_way(5 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 15)), hunter(nullptr), sound_moment(0)
+    : noMovable(NodalObjectType::Animal, pos), species(species), state(State::Walking), pause_way(5 + RANDOM_RAND(15)),
+      hunter(nullptr), sound_moment(0)
 {}
 
 void noAnimal::Serialize_noAnimal(SerializedGameData& sgd) const
@@ -228,8 +228,8 @@ void noAnimal::Walked()
             {
                 // dann stellt es sich hier hin und wartet erstmal eine Weile
                 state = State::Paused;
-                pause_way = 5 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 15);
-                current_ev = GetEvMgr().AddEvent(this, 50 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 50), 1);
+                pause_way = 5 + RANDOM_RAND(15);
+                current_ev = GetEvMgr().AddEvent(this, 50 + RANDOM_RAND(50), 1);
             } else
             {
                 StandardWalking();
@@ -252,12 +252,10 @@ void noAnimal::Walked()
 helpers::OptionalEnum<Direction> noAnimal::FindDir()
 {
     // mit zufälliger Richtung anfangen
-    unsigned doffset = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 6);
+    const Direction doffset = RANDOM_ENUM(Direction);
 
-    for(auto dir : helpers::EnumRange<Direction>{})
+    for(const auto dir : helpers::enumRange(doffset))
     {
-        dir += doffset;
-
         DescIdx<TerrainDesc> tLeft = gwg->GetLeftTerrain(pos, dir);
         DescIdx<TerrainDesc> tRight = gwg->GetRightTerrain(pos, dir);
 

--- a/libs/s25main/nodeObjs/noDisappearingEnvObject.cpp
+++ b/libs/s25main/nodeObjs/noDisappearingEnvObject.cpp
@@ -36,8 +36,7 @@ noDisappearingEnvObject::noDisappearingEnvObject(const MapPoint pos, const unsig
                                                  const unsigned add_var_living_time)
     : noCoordBase(NodalObjectType::Environment, pos), disappearing(false)
 {
-    dead_event =
-      GetEvMgr().AddEvent(this, living_time + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), add_var_living_time));
+    dead_event = GetEvMgr().AddEvent(this, living_time + RANDOM_RAND(add_var_living_time));
 }
 
 void noDisappearingEnvObject::Serialize(SerializedGameData& sgd) const

--- a/libs/s25main/nodeObjs/noFighting.cpp
+++ b/libs/s25main/nodeObjs/noFighting.cpp
@@ -210,7 +210,7 @@ void noFighting::HandleEvent(const unsigned id)
                 // Der Kampf hat gerade begonnen
 
                 // "Auslosen", wer als erstes dran ist mit Angreifen
-                turn = static_cast<unsigned char>(RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2));
+                turn = static_cast<unsigned char>(RANDOM_RAND(2));
                 // anfangen anzugreifen
                 StartAttack();
             }
@@ -302,12 +302,12 @@ void noFighting::StartAttack()
         switch(gwg->GetGGS().getSelection(AddonId::ADJUST_MILITARY_STRENGTH))
         {
             case 0: // Maximale Stärke
-                results[i] = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), soldiers[i]->GetRank() + 6);
+                results[i] = RANDOM_RAND(soldiers[i]->GetRank() + 6);
                 break;
             case 1: // Mittlere Stärke
-            default: results[i] = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), soldiers[i]->GetRank() + 10); break;
+            default: results[i] = RANDOM_RAND(soldiers[i]->GetRank() + 10); break;
             case 2: // Minimale Stärke
-                results[i] = RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 10);
+                results[i] = RANDOM_RAND(10);
                 break;
         }
     }
@@ -317,7 +317,7 @@ void noFighting::StartAttack()
         defending_animation = 3;
     else
         // Der Verteidiger hat diesen Zug gewonnen, zufällige Verteidigungsanimation
-        defending_animation = static_cast<unsigned char>(RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 3));
+        defending_animation = static_cast<unsigned char>(RANDOM_RAND(3));
 
     // Entsprechendes Event anmelden
     current_ev = GetEvMgr().AddEvent(this, 15);

--- a/libs/s25main/nodeObjs/noGrainfield.cpp
+++ b/libs/s25main/nodeObjs/noGrainfield.cpp
@@ -32,8 +32,7 @@ const unsigned GROWING_WAITING_LENGTH = 1100;
 const unsigned GROWING_LENGTH = 16;
 
 noGrainfield::noGrainfield(const MapPoint pos)
-    : noCoordBase(NodalObjectType::Grainfield, pos), type(RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2)),
-      state(State::GrowingWaiting), size(0)
+    : noCoordBase(NodalObjectType::Grainfield, pos), type(RANDOM_RAND(2)), state(State::GrowingWaiting), size(0)
 {
     event = GetEvMgr().AddEvent(this, GROWING_WAITING_LENGTH);
 }
@@ -122,7 +121,7 @@ void noGrainfield::HandleEvent(const unsigned /*id*/)
                 // bin nun ausgewachsen
                 state = State::Normal;
                 // nach langer Zeit verdorren
-                event = GetEvMgr().AddEvent(this, 3000 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 1000));
+                event = GetEvMgr().AddEvent(this, 3000 + RANDOM_RAND(1000));
             }
         }
         break;
@@ -155,5 +154,5 @@ void noGrainfield::BeginHarvesting()
 void noGrainfield::EndHarvesting()
 {
     // nach langer Zeit verdorren (von neuem)
-    event = GetEvMgr().AddEvent(this, 3000 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 1000));
+    event = GetEvMgr().AddEvent(this, 3000 + RANDOM_RAND(1000));
 }

--- a/libs/s25main/nodeObjs/noShip.cpp
+++ b/libs/s25main/nodeObjs/noShip.cpp
@@ -60,10 +60,8 @@ constexpr std::array<helpers::EnumArray<DrawPoint, Direction>, 2> SHIPS_FLAG_POS
 
 noShip::noShip(const MapPoint pos, const unsigned char player)
     : noMovable(NodalObjectType::Ship, pos), ownerId_(player), state(State::Idle), seaId_(0), goal_harborId(0),
-      goal_dir(0),
-      name(ship_names[gwg->GetPlayer(player).nation]
-                     [RANDOM.Rand(__FILE__, __LINE__, GetObjId(), ship_names[gwg->GetPlayer(player).nation].size())]),
-      curRouteIdx(0), lost(false), remaining_sea_attackers(0), home_harbor(0), covered_distance(0)
+      goal_dir(0), name(RANDOM_ELEMENT(ship_names[gwg->GetPlayer(player).nation])), curRouteIdx(0), lost(false),
+      remaining_sea_attackers(0), home_harbor(0), covered_distance(0)
 {
     // Meer ermitteln, auf dem dieses Schiff fährt
     for(const auto dir : helpers::EnumRange<Direction>{})
@@ -1220,7 +1218,7 @@ void noShip::ContinueExplorationExpedition()
         else
         {
             // Choose one randomly
-            goal_harborId = hps[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), hps.size())];
+            goal_harborId = RANDOM_ELEMENT(hps);
         }
     }
 

--- a/libs/s25main/nodeObjs/noSkeleton.cpp
+++ b/libs/s25main/nodeObjs/noSkeleton.cpp
@@ -25,7 +25,7 @@
 
 noSkeleton::noSkeleton(const MapPoint pos) : noCoordBase(NodalObjectType::Environment, pos), type(0)
 {
-    current_event = GetEvMgr().AddEvent(this, 15000 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 10000));
+    current_event = GetEvMgr().AddEvent(this, 15000 + RANDOM_RAND(10000));
 }
 
 noSkeleton::~noSkeleton() = default;
@@ -64,7 +64,7 @@ void noSkeleton::HandleEvent(const unsigned /*id*/)
     {
         // weiter verwesen, dann später sterben nach ner zufälligen Zeit
         type = 1;
-        current_event = GetEvMgr().AddEvent(this, 10000 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 10000));
+        current_event = GetEvMgr().AddEvent(this, 10000 + RANDOM_RAND(10000));
     } else
     {
         // ganz weg damit

--- a/libs/s25main/nodeObjs/noTree.cpp
+++ b/libs/s25main/nodeObjs/noTree.cpp
@@ -47,13 +47,12 @@ noTree::noTree(const MapPoint pos, const unsigned char type, const unsigned char
 
     // Every nth tree produces animals, but no palm and pineapple trees
     const std::array<unsigned, 6> TREESPERANIMALSPAWN = {20, 13, 10, 6, 4, 2};
-    produce_animals =
-      (type < 3 || type > 5)
-      && (RANDOM_RAND(GetObjId(), TREESPERANIMALSPAWN[gwg->GetGGS().getSelection(AddonId::MORE_ANIMALS)]) == 0);
+    produce_animals = (type < 3 || type > 5)
+                      && (RANDOM_RAND(TREESPERANIMALSPAWN[gwg->GetGGS().getSelection(AddonId::MORE_ANIMALS)]) == 0);
 
     // Falls das der Fall ist, dann wollen wir doch gleich mal eins produzieren
     if(produce_animals)
-        produce_animal_event = GetEvMgr().AddEvent(this, 6000 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2000), 3);
+        produce_animal_event = GetEvMgr().AddEvent(this, 6000 + RANDOM_RAND(2000), 3);
 }
 
 noTree::~noTree() = default;
@@ -151,7 +150,7 @@ void noTree::HandleEvent(const unsigned id)
         // Neues Tier erzeugen
         ProduceAnimal();
         // nächstes Event anmelden
-        produce_animal_event = GetEvMgr().AddEvent(this, 6000 + RANDOM.Rand(__FILE__, __LINE__, GetObjId(), 2000), 3);
+        produce_animal_event = GetEvMgr().AddEvent(this, 6000 + RANDOM_RAND(2000), 3);
 
         return;
     }
@@ -237,8 +236,7 @@ void noTree::ProduceAnimal()
     // neues Tier erzeugen, zufälliger Typ
     static const std::array<Species, 6> possibleSpecies = {
       {Species::RabbitWhite, Species::RabbitGrey, Species::Fox, Species::Stag, Species::Deer, Species::Sheep}};
-    auto* animal =
-      new noAnimal(possibleSpecies[RANDOM.Rand(__FILE__, __LINE__, GetObjId(), possibleSpecies.size())], pos);
+    auto* animal = new noAnimal(RANDOM_ELEMENT(possibleSpecies), pos);
     // In die Landschaft setzen
     gwg->AddFigure(pos, animal);
     // Und ihm die Pforten geben..

--- a/libs/s25main/random/Random.cpp
+++ b/libs/s25main/random/Random.cpp
@@ -48,9 +48,9 @@ void Random<T_PRNG>::ResetState(const PRNG& newState)
 }
 
 template<class T_PRNG>
-int Random<T_PRNG>::Rand(const char* const src_name, const unsigned src_line, const unsigned obj_id, const int max)
+int Random<T_PRNG>::Rand(const RandomContext& context, const int max)
 {
-    history_[numInvocations_ % history_.size()] = RandomEntry(numInvocations_, max, rng_, src_name, src_line, obj_id);
+    history_[numInvocations_ % history_.size()] = RandomEntry(numInvocations_, max, rng_, context);
     ++numInvocations_;
 
     return calcRandValue(rng_, max);
@@ -119,9 +119,9 @@ void Random<T_PRNG>::RandomEntry::Serialize(Serializer& ser) const
     // We save the type a) for double checking and b) for future extension
     ser.PushLongString(T_PRNG::getName());
     rngState.serialize(ser);
-    ser.PushLongString(src_name);
-    ser.PushUnsignedInt(src_line);
-    ser.PushUnsignedInt(obj_id);
+    ser.PushLongString(srcName);
+    ser.PushUnsignedInt(srcLine);
+    ser.PushUnsignedInt(objId);
 }
 
 template<class T_PRNG>
@@ -133,9 +133,9 @@ void Random<T_PRNG>::RandomEntry::Deserialize(Serializer& ser)
     if(name != T_PRNG::getName())
         throw std::runtime_error("Wrong random number generator");
     rngState.deserialize(ser);
-    src_name = ser.PopLongString();
-    src_line = ser.PopUnsignedInt();
-    obj_id = ser.PopUnsignedInt();
+    srcName = ser.PopLongString();
+    srcLine = ser.PopUnsignedInt();
+    objId = ser.PopUnsignedInt();
 }
 
 template<class T_PRNG>

--- a/libs/s25main/random/Random.cpp
+++ b/libs/s25main/random/Random.cpp
@@ -20,12 +20,12 @@
 #include <stdexcept>
 
 template<class T_PRNG>
-int calcRandValue(T_PRNG& rng, int max)
+int calcRandValue(T_PRNG& rng, int maxExcl)
 {
     // Special case: [0, 0) makes 0
-    if(max == 0)
+    if(maxExcl == 0)
         return 0;
-    return static_cast<int>(rng() % static_cast<unsigned>(max));
+    return static_cast<int>(rng() % static_cast<unsigned>(maxExcl));
 }
 
 template<class T_PRNG>
@@ -48,12 +48,12 @@ void Random<T_PRNG>::ResetState(const PRNG& newState)
 }
 
 template<class T_PRNG>
-int Random<T_PRNG>::Rand(const RandomContext& context, const int max)
+int Random<T_PRNG>::Rand(const RandomContext& context, const int maxExcl)
 {
-    history_[numInvocations_ % history_.size()] = RandomEntry(numInvocations_, max, rng_, context);
+    history_[numInvocations_ % history_.size()] = RandomEntry(numInvocations_, maxExcl, rng_, context);
     ++numInvocations_;
 
-    return calcRandValue(rng_, max);
+    return calcRandValue(rng_, maxExcl);
 }
 
 template<class T_PRNG>
@@ -115,7 +115,7 @@ template<class T_PRNG>
 void Random<T_PRNG>::RandomEntry::Serialize(Serializer& ser) const
 {
     ser.PushUnsignedInt(counter);
-    ser.PushSignedInt(max);
+    ser.PushSignedInt(maxExcl);
     // We save the type a) for double checking and b) for future extension
     ser.PushLongString(T_PRNG::getName());
     rngState.serialize(ser);
@@ -128,7 +128,7 @@ template<class T_PRNG>
 void Random<T_PRNG>::RandomEntry::Deserialize(Serializer& ser)
 {
     counter = ser.PopUnsignedInt();
-    max = ser.PopSignedInt();
+    maxExcl = ser.PopSignedInt();
     std::string name = ser.PopLongString();
     if(name != T_PRNG::getName())
         throw std::runtime_error("Wrong random number generator");
@@ -142,7 +142,7 @@ template<class T_PRNG>
 int Random<T_PRNG>::RandomEntry::GetValue() const
 {
     PRNG tmpRng(rngState);
-    return calcRandValue(tmpRng, max);
+    return calcRandValue(tmpRng, maxExcl);
 }
 
 // Instantiate the Random class with the used PRNG

--- a/libs/s25main/random/Random.cpp
+++ b/libs/s25main/random/Random.cpp
@@ -16,10 +16,7 @@
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
 #include "random/Random.h"
-#include "RttrConfig.h"
 #include "s25util/Serializer.h"
-#include <boost/nowide/fstream.hpp>
-#include <iomanip>
 #include <stdexcept>
 
 template<class T_PRNG>
@@ -112,16 +109,6 @@ std::vector<typename Random<T_PRNG>::RandomEntry> Random<T_PRNG>::GetAsyncLog()
     return ret;
 }
 
-template<class T_PRNG>
-void Random<T_PRNG>::SaveLog(const boost::filesystem::path& filepath)
-{
-    const std::vector<RandomEntry> log = GetAsyncLog();
-    boost::nowide::ofstream file(filepath);
-
-    for(const auto& curLog : log)
-        file << curLog << std::endl;
-}
-
 //////////////////////////////////////////////////////////////////////////
 
 template<class T_PRNG>
@@ -156,17 +143,6 @@ int Random<T_PRNG>::RandomEntry::GetValue() const
 {
     PRNG tmpRng(rngState);
     return calcRandValue(tmpRng, max);
-}
-
-template<class T_PRNG>
-std::ostream& Random<T_PRNG>::RandomEntry::print(std::ostream& os) const
-{
-    static const std::string rttrSrcBaseName = RttrConfig::GetSourceDir().generic_string() + "/";
-    std::string strippedSrcFile = boost::filesystem::path(src_name).generic_string();
-    if(strippedSrcFile.find(rttrSrcBaseName) == 0)
-        strippedSrcFile = strippedSrcFile.substr(rttrSrcBaseName.size());
-    return os << counter << ":R(" << max << ")=" << GetValue() << ",z=" << std::hex << std::setw(8) << rngState
-              << std::dec << std::setw(0) << "\t| " << strippedSrcFile << "#" << src_line << "\t| id=" << obj_id;
 }
 
 // Instantiate the Random class with the used PRNG

--- a/libs/s25main/random/Random.h
+++ b/libs/s25main/random/Random.h
@@ -111,7 +111,7 @@ using RandomEntry = UsedRandom::RandomEntry;
 #define RANDOM_RAND(objId, maxVal) RANDOM.Rand(__FILE__, __LINE__, objId, maxVal)
 /// Return a random enumerator of the given type. Requires the <helpers/MaxEnumValue.h> include
 #define RANDOM_ENUM(EnumType, objId) \
-    static_cast<EnumType>(RANDOM.Rand(__FILE__, __LINE__, objId, helpers::MaxEnumValue_v<EnumType>))
+    static_cast<EnumType>(RANDOM.Rand(__FILE__, __LINE__, objId, helpers::NumEnumValues_v<EnumType>))
 
 /// functor using RANDOM.Rand(...) e.g. for std::shuffle
 class RandomFunctor

--- a/libs/s25main/random/Random.h
+++ b/libs/s25main/random/Random.h
@@ -20,12 +20,9 @@
 #include "RTTR_Assert.h"
 #include "random/XorShift.h"
 #include "s25util/Singleton.h"
-#include <boost/filesystem/path.hpp>
 #include <array>
 #include <cstddef>
-#include <iosfwd>
 #include <limits>
-#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -61,9 +58,6 @@ public:
             : counter(counter), max(max), rngState(rngState), src_name(std::move(src_name)), src_line(src_line),
               obj_id(obj_id){};
 
-        friend std::ostream& operator<<(std::ostream& os, const RandomEntry& entry) { return entry.print(os); }
-        std::ostream& print(std::ostream& os) const;
-
         void Serialize(Serializer& ser) const;
         void Deserialize(Serializer& ser);
 
@@ -86,9 +80,6 @@ public:
     const PRNG& GetCurrentState() const;
 
     std::vector<RandomEntry> GetAsyncLog();
-
-    /// Save the log to a file
-    void SaveLog(const boost::filesystem::path& filepath);
 
 private:
     PRNG rng_; /// the PRNG
@@ -125,7 +116,7 @@ public:
     ptrdiff_t operator()(ptrdiff_t max) const
     {
         RTTR_Assert(max < std::numeric_limits<int>::max());
-        return RANDOM.Rand(file_, line_, 0, static_cast<int>(max));
+        return RANDOM.Rand(file_, line_, 0, static_cast<int>(max + 1));
     }
     template<class T>
     static void shuffleContainer(T& container, const char* file, unsigned line)
@@ -136,10 +127,10 @@ public:
         for(auto i = container.size() - 1; i > 0; --i)
         {
             using std::swap;
-            swap(container[i], container[getIdx(i + 1)]);
+            swap(container[i], container[getIdx(i)]);
         }
     }
 };
 
-/// Shortcut for creating an instance of RandomFunctor
+/// Shuffle the given container
 #define RANDOM_SHUFFLE(container) RandomFunctor::shuffleContainer(container, __FILE__, __LINE__)

--- a/libs/s25main/random/Random.h
+++ b/libs/s25main/random/Random.h
@@ -53,15 +53,15 @@ public:
     struct RandomEntry
     {
         unsigned counter;
-        int max;
+        int maxExcl;
         PRNG rngState;
         std::string srcName;
         unsigned srcLine;
         unsigned objId;
 
-        RandomEntry() : counter(0), max(0), srcLine(0), objId(0){};
-        RandomEntry(unsigned counter, int max, const PRNG& rngState, const RandomContext& ctx)
-            : counter(counter), max(max), rngState(rngState), srcName(ctx.srcName), srcLine(ctx.srcLine),
+        RandomEntry() : counter(0), maxExcl(0), srcLine(0), objId(0){};
+        RandomEntry(unsigned counter, int maxExcl, const PRNG& rngState, const RandomContext& ctx)
+            : counter(counter), maxExcl(maxExcl), rngState(rngState), srcName(ctx.srcName), srcLine(ctx.srcLine),
               objId(ctx.objId){};
 
         void Serialize(Serializer& ser) const;
@@ -75,8 +75,8 @@ public:
     void Init(const uint64_t& seed);
     /// Reset the Random class to start from a given state
     void ResetState(const PRNG& newState);
-    /// Return a random number in the range [0, max)
-    int Rand(const RandomContext& context, int max);
+    /// Return a random number in the range [0, maxExcl)
+    int Rand(const RandomContext& context, int maxExcl);
 
     /// Get a checksum of the RNG
     unsigned GetChecksum() const;
@@ -109,7 +109,7 @@ using RandomEntry = UsedRandom::RandomEntry;
     RandomContext { __FILE__, __LINE__, objId }
 /// Shortcut to get a new random value in range [0, maxVal) for a given object id
 /// Note: maxVal has to be small (at least <= 32768)
-#define RANDOM_RAND(maxVal) RANDOM.Rand(RANDOM_CONTEXT(), maxVal)
+#define RANDOM_RAND(maxValExcl) RANDOM.Rand(RANDOM_CONTEXT(), maxValExcl)
 /// Return a random element from the container. Must not be empty
 #define RANDOM_ELEMENT(container) detail::randomElement(container, RANDOM_CONTEXT())
 /// Return a random enumerator of the given type. Requires the <helpers/MaxEnumValue.h> include

--- a/libs/s25main/random/randomIO.cpp
+++ b/libs/s25main/random/randomIO.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "randomIO.h"
+#include "RttrConfig.h"
+#include <boost/nowide/fstream.hpp>
+#include <iomanip>
+
+std::ostream& operator<<(std::ostream& os, const RandomEntry& entry)
+{
+    static const std::string rttrSrcBaseName = RttrConfig::GetSourceDir().generic_string() + "/";
+    std::string strippedSrcFile = boost::filesystem::path(entry.src_name).generic_string();
+    if(strippedSrcFile.find(rttrSrcBaseName) == 0)
+        strippedSrcFile = strippedSrcFile.substr(rttrSrcBaseName.size());
+    return os << entry.counter << ":R(" << entry.max << ")=" << entry.GetValue() << ",z=" << std::hex << std::setw(8)
+              << entry.rngState << std::dec << std::setw(0) << "\t| " << strippedSrcFile << "#" << entry.src_line
+              << "\t| id=" << entry.obj_id;
+}
+
+void saveRandomLog(const boost::filesystem::path& filepath, const std::vector<RandomEntry>& log)
+{
+    boost::nowide::ofstream file(filepath);
+
+    for(const RandomEntry& curLog : log)
+        file << curLog << std::endl;
+}

--- a/libs/s25main/random/randomIO.cpp
+++ b/libs/s25main/random/randomIO.cpp
@@ -23,12 +23,12 @@
 std::ostream& operator<<(std::ostream& os, const RandomEntry& entry)
 {
     static const std::string rttrSrcBaseName = RttrConfig::GetSourceDir().generic_string() + "/";
-    std::string strippedSrcFile = boost::filesystem::path(entry.src_name).generic_string();
+    std::string strippedSrcFile = boost::filesystem::path(entry.srcName).generic_string();
     if(strippedSrcFile.find(rttrSrcBaseName) == 0)
         strippedSrcFile = strippedSrcFile.substr(rttrSrcBaseName.size());
     return os << entry.counter << ":R(" << entry.max << ")=" << entry.GetValue() << ",z=" << std::hex << std::setw(8)
-              << entry.rngState << std::dec << std::setw(0) << "\t| " << strippedSrcFile << "#" << entry.src_line
-              << "\t| id=" << entry.obj_id;
+              << entry.rngState << std::dec << std::setw(0) << "\t| " << strippedSrcFile << "#" << entry.srcLine
+              << "\t| id=" << entry.objId;
 }
 
 void saveRandomLog(const boost::filesystem::path& filepath, const std::vector<RandomEntry>& log)

--- a/libs/s25main/random/randomIO.cpp
+++ b/libs/s25main/random/randomIO.cpp
@@ -26,9 +26,9 @@ std::ostream& operator<<(std::ostream& os, const RandomEntry& entry)
     std::string strippedSrcFile = boost::filesystem::path(entry.srcName).generic_string();
     if(strippedSrcFile.find(rttrSrcBaseName) == 0)
         strippedSrcFile = strippedSrcFile.substr(rttrSrcBaseName.size());
-    return os << entry.counter << ":R(" << entry.max << ")=" << entry.GetValue() << ",z=" << std::hex << std::setw(8)
-              << entry.rngState << std::dec << std::setw(0) << "\t| " << strippedSrcFile << "#" << entry.srcLine
-              << "\t| id=" << entry.objId;
+    return os << entry.counter << ":R(" << entry.maxExcl << ")=" << entry.GetValue() << ",z=" << std::hex
+              << std::setw(8) << entry.rngState << std::dec << std::setw(0) << "\t| " << strippedSrcFile << "#"
+              << entry.srcLine << "\t| id=" << entry.objId;
 }
 
 void saveRandomLog(const boost::filesystem::path& filepath, const std::vector<RandomEntry>& log)

--- a/libs/s25main/random/randomIO.h
+++ b/libs/s25main/random/randomIO.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "Random.h"
+#include <boost/filesystem/path.hpp>
+#include <iosfwd>
+
+std::ostream& operator<<(std::ostream& os, const RandomEntry& entry);
+
+/// Save the log to a file
+void saveRandomLog(const boost::filesystem::path& filepath, const std::vector<RandomEntry>& log);

--- a/libs/s25main/world/MapLoader.cpp
+++ b/libs/s25main/world/MapLoader.cpp
@@ -361,7 +361,7 @@ void MapLoader::PlaceAnimals(const glArchivItem_Map& map)
         {
             // TODO: Which id is the polar bear?
             case 1:
-                species = (RANDOM.Rand(__FILE__, __LINE__, 0, 2) == 0) ? Species::RabbitWhite : Species::RabbitGrey;
+                species = (RANDOM.Rand(RANDOM_CONTEXT2(0), 2) == 0) ? Species::RabbitWhite : Species::RabbitGrey;
                 break; // Random rabbit
             case 2: species = Species::Fox; break;
             case 3: species = Species::Stag; break;
@@ -391,7 +391,7 @@ bool MapLoader::PlaceHQs(GameWorldBase& world, std::vector<MapPoint> hqPositions
     // random locations? -> randomize them :)
     if(randomStartPos)
     {
-        RANDOM_SHUFFLE(hqPositions);
+        RANDOM_SHUFFLE2(hqPositions, 0);
     }
 
     for(unsigned i = 0; i < world.GetNumPlayers(); ++i)

--- a/tests/s25Main/simple/testRandom.cpp
+++ b/tests/s25Main/simple/testRandom.cpp
@@ -42,6 +42,7 @@ BOOST_FIXTURE_TEST_SUITE(RNG_Tests, SeedFixture)
 
 BOOST_AUTO_TEST_CASE(RandomTest)
 {
+    const auto GetObjId = []() { return 0u; }; // Fake function for RANDOM_RAND
     for(unsigned seed : seeds)
     {
         RANDOM.Init(seed);
@@ -52,7 +53,7 @@ BOOST_AUTO_TEST_CASE(RandomTest)
             for(std::vector<unsigned>& result : results)
             {
                 // Using .at makes sure we don't exceed the maximum value
-                ++result.at(RANDOM_RAND(0, result.size()));
+                ++result.at(RANDOM_RAND(result.size()));
             }
         }
         // We want a uniform distribution. So all values should occur about the same number of times
@@ -72,13 +73,14 @@ BOOST_AUTO_TEST_CASE(RandomTest)
 
 BOOST_AUTO_TEST_CASE(RandomSameSeq)
 {
+    const auto GetObjId = []() { return 0u; }; // Fake function for RANDOM_RAND
     // The rng must return the same sequence of values for a given seed
     RANDOM.Init(0x1337);
     std::vector<int> results = {623, 453, 927, 305, 478, 933, 230, 491, 968, 623, 418};
     for(int result : results)
     {
-        // std::cout << RANDOM_RAND(0, 1024) << std::endl;
-        BOOST_TEST_REQUIRE(RANDOM_RAND(0, 1024) == result);
+        // std::cout << RANDOM_RAND(1024) << std::endl;
+        BOOST_TEST_REQUIRE(RANDOM_RAND(1024) == result);
     }
 }
 
@@ -125,13 +127,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ValueRangeValid, T_RNG, TestedRNGS)
 
 BOOST_AUTO_TEST_CASE(EmptyRange)
 {
+    const auto GetObjId = []() { return 0u; }; // Fake function for RANDOM_RAND
     for(unsigned seed : seeds)
     {
         RANDOM.Init(seed);
         for(int i = 0; i < 100; i++)
         {
             // Create a random number in [0, 0] is always 0
-            BOOST_TEST_REQUIRE(RANDOM_RAND(1337, 0) == 0);
+            BOOST_TEST_REQUIRE(RANDOM_RAND(0) == 0);
         }
     }
 }
@@ -241,16 +244,34 @@ constexpr auto maxEnumValue(TestEnum)
 
 BOOST_AUTO_TEST_CASE(RandomEnum)
 {
+    const auto GetObjId = []() { return 0u; }; // Fake function for RANDOM_ENUM
     helpers::EnumArray<bool, TestEnum> triggered{};
     for(unsigned seed : seeds)
     {
         RANDOM.Init(seed);
         triggered = {};
         for(int i = 0; i < 30; i++)
-            triggered[RANDOM_ENUM(TestEnum, 1337)] = true;
+            triggered[RANDOM_ENUM(TestEnum)] = true;
         BOOST_TEST(triggered[TestEnum::e1]);
         BOOST_TEST(triggered[TestEnum::e2]);
         BOOST_TEST(triggered[TestEnum::e3]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(RandomElement)
+{
+    const auto GetObjId = []() { return 0u; }; // Fake function for RANDOM_ENUM
+    std::array<bool, 3> triggered{};
+    const std::array<int, 3> indices{0, 1, 2};
+    for(unsigned seed : seeds)
+    {
+        RANDOM.Init(seed);
+        triggered = {};
+        for(int i = 0; i < 30; i++)
+            triggered[RANDOM_ELEMENT(indices)] = true;
+        BOOST_TEST(triggered[0]);
+        BOOST_TEST(triggered[1]);
+        BOOST_TEST(triggered[2]);
     }
 }
 

--- a/tests/s25Main/simple/testRandom.cpp
+++ b/tests/s25Main/simple/testRandom.cpp
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
 
+#include "helpers/EnumArray.h"
 #include "random/DefaultLCG.h"
 #include "random/Random.h"
 #include "random/XorShift.h"
@@ -78,19 +79,6 @@ BOOST_AUTO_TEST_CASE(RandomSameSeq)
     {
         // std::cout << RANDOM_RAND(0, 1024) << std::endl;
         BOOST_TEST_REQUIRE(RANDOM_RAND(0, 1024) == result);
-    }
-}
-
-BOOST_AUTO_TEST_CASE(RandomEmptySeq)
-{
-    for(unsigned seed : seeds)
-    {
-        RANDOM.Init(seed);
-        for(int i = 0; i < 100; i++)
-        {
-            // Create a random number in [0, 0) is always 0 (by definition)
-            BOOST_TEST_REQUIRE(RANDOM_RAND(0, 0) == 0);
-        }
     }
 }
 
@@ -235,6 +223,34 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Discard, T_RNG, TestedRNGS)
             rng();
         rng2.discard(skipCt);
         BOOST_TEST_REQUIRE(rng == rng2);
+    }
+}
+
+namespace {
+enum class TestEnum
+{
+    e1,
+    e2,
+    e3
+};
+constexpr auto maxEnumValue(TestEnum)
+{
+    return TestEnum::e3;
+}
+} // namespace
+
+BOOST_AUTO_TEST_CASE(RandomEnum)
+{
+    helpers::EnumArray<bool, TestEnum> triggered{};
+    for(unsigned seed : seeds)
+    {
+        RANDOM.Init(seed);
+        triggered = {};
+        for(int i = 0; i < 30; i++)
+            triggered[RANDOM_ENUM(TestEnum, 1337)] = true;
+        BOOST_TEST(triggered[TestEnum::e1]);
+        BOOST_TEST(triggered[TestEnum::e2]);
+        BOOST_TEST(triggered[TestEnum::e3]);
     }
 }
 


### PR DESCRIPTION
Found a bug where RANDOM_ENUM would not return the last enum value due to confusing argument name "max". I replaced that my maxExcl to avoid such issues in the future

After that I factored out the output functions to make including Random.h more lightweight.
Finally I used RANDOM_RAND everywhere where possible and refactored the usages a bit so all is consistent. Naturally a RANDOM_ELEMENT was added to simplify usage even more. This helps in detecting/avoiding bugs