### PR TITLE
Cluster mineable resources in random maps

### DIFF
--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -217,7 +217,7 @@ namespace rttr { namespace mapGenerator {
                 if(randomMRIindex < 0)
                     continue;
 
-                auto &mRI = mRIs[randomMRIindex];
+                auto& mRI = mRIs[randomMRIindex];
 
                 // Adjust and check the budget, if we are over we will not place the resource because we have already in
                 // the past.

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -217,7 +217,7 @@ namespace rttr { namespace mapGenerator {
                 if(total == 0)
                     continue;
 
-                // Pick a random resource, -1 indicates none.
+                // Pick a random resource
                 unsigned randomMRIindex = resourcePicker();
                 auto& mRI = mRIs[randomMRIindex];
 

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -188,10 +188,10 @@ namespace rttr { namespace mapGenerator {
             libsiedler2::Resource resource;
             MineableResourceInfo(int ratio, libsiedler2::Resource resource) : ratio(ratio), resource(resource) {}
         };
-        MineableResourceInfo mRIs[4] = {MineableResourceInfo(settings.ratioCoal, libsiedler2::R_Coal),
-                                        MineableResourceInfo(settings.ratioGold, libsiedler2::R_Gold),
-                                        MineableResourceInfo(settings.ratioIron, libsiedler2::R_Iron),
-                                        MineableResourceInfo(settings.ratioGranite, libsiedler2::R_Granite)};
+        auto mRIs = helpers::make_array(MineableResourceInfo(settings.ratioCoal, libsiedler2::R_Coal),
+                                                           MineableResourceInfo(settings.ratioGold, libsiedler2::R_Gold),
+                                                           MineableResourceInfo(settings.ratioIron, libsiedler2::R_Iron),
+                                                           MineableResourceInfo(settings.ratioGranite, libsiedler2::R_Granite));
         int total = settings.ratioCoal + settings.ratioGold + settings.ratioIron + settings.ratioGranite;
 
         // Helper to pick an index [0,4) into the mRIs array that identifies a randomly selected resource we should

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -239,7 +239,7 @@ namespace rttr { namespace mapGenerator {
                         const MapPoint pt_d = resources.MakeMapPoint(pt + Position(xd, yd));
                         // Only place it on mines that have no resource yet, adjust the budget for each placed
                         // resource.
-                        if(textures.All(pt_d, IsMinableMountain) && !resources[pt_d])
+                        if(!resources[pt_d] && textures.All(pt_d, IsMinableMountain))
                         {
                             --mRI.budget;
                             resources[pt_d] = mRI.resource + rnd.RandomValue(1, 8);

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -21,7 +21,6 @@
 #include "mapGenerator/Algorithms.h"
 #include "mapGenerator/Terrain.h"
 #include "mapGenerator/TextureHelper.h"
-#include "world/MapGeometry.h"
 
 namespace rttr { namespace mapGenerator {
 

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -192,7 +192,7 @@ namespace rttr { namespace mapGenerator {
                                                            MineableResourceInfo(settings.ratioGold, libsiedler2::R_Gold),
                                                            MineableResourceInfo(settings.ratioIron, libsiedler2::R_Iron),
                                                            MineableResourceInfo(settings.ratioGranite, libsiedler2::R_Granite));
-        int total = settings.ratioCoal + settings.ratioGold + settings.ratioIron + settings.ratioGranite;
+        const int total = settings.ratioCoal + settings.ratioGold + settings.ratioIron + settings.ratioGranite;
 
         // Helper to pick an index [0,4) into the mRIs array that identifies a randomly selected resource we should
         // place. Note that we do not perform budget adjustments and checks here.

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -199,7 +199,7 @@ namespace rttr { namespace mapGenerator {
         auto resourcePicker = [&]() {
             int ratio = 0;
             int randomNumber = rnd.RandomValue(1, std::max(1, total));
-            for(int i = 0; i < 4; ++i)
+            for(int i = 0; i < mRIs.size(); ++i)
             {
                 ratio += mRIs[i].ratio;
                 if(randomNumber < ratio)

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -177,7 +177,7 @@ namespace rttr { namespace mapGenerator {
     {
         const auto& textures = map.textureMap;
         auto& resources = map.resources;
-        struct mineableResourceInfo
+        struct MineableResourceInfo
         {
             // The current "budget", that is, how many many are we over, or under, compared to the desired distribution.
             int budget = 0;

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -236,7 +236,7 @@ namespace rttr { namespace mapGenerator {
                 {
                     for(int yd = -4; yd <= 4; ++yd)
                     {
-                        MapPoint pt_d = MakeMapPoint(Position(pt.x + xd, pt.y + yd), map.size);
+                        const MapPoint pt_d = resources.MakeMapPoint(pt + Position(xd, yd));
                         // Only place it on mines that have no resource yet, adjust the budget for each placed
                         // resource.
                         if(textures.All(pt_d, IsMinableMountain) && !resources[pt_d])

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -202,7 +202,7 @@ namespace rttr { namespace mapGenerator {
             for(int i = 0; i < mRIs.size(); ++i)
             {
                 ratio += mRIs[i].ratio;
-                if(randomNumber < ratio)
+                if(randomNumber <= ratio)
                     return i;
             }
             return -1;

--- a/libs/s25main/mapGenerator/Resources.cpp
+++ b/libs/s25main/mapGenerator/Resources.cpp
@@ -186,12 +186,12 @@ namespace rttr { namespace mapGenerator {
             int ratio;
             // The resource encoding
             libsiedler2::Resource resource;
-            mineableResourceInfo(int ratio, libsiedler2::Resource resource) : ratio(ratio), resource(resource) {}
+            MineableResourceInfo(int ratio, libsiedler2::Resource resource) : ratio(ratio), resource(resource) {}
         };
-        mineableResourceInfo mRIs[4] = {mineableResourceInfo(settings.ratioCoal, libsiedler2::R_Coal),
-                                        mineableResourceInfo(settings.ratioGold, libsiedler2::R_Gold),
-                                        mineableResourceInfo(settings.ratioIron, libsiedler2::R_Iron),
-                                        mineableResourceInfo(settings.ratioGranite, libsiedler2::R_Granite)};
+        MineableResourceInfo mRIs[4] = {MineableResourceInfo(settings.ratioCoal, libsiedler2::R_Coal),
+                                        MineableResourceInfo(settings.ratioGold, libsiedler2::R_Gold),
+                                        MineableResourceInfo(settings.ratioIron, libsiedler2::R_Iron),
+                                        MineableResourceInfo(settings.ratioGranite, libsiedler2::R_Granite)};
         int total = settings.ratioCoal + settings.ratioGold + settings.ratioIron + settings.ratioGranite;
 
         // Helper to pick an index [0,4) into the mRIs array that identifies a randomly selected resource we should
@@ -217,7 +217,7 @@ namespace rttr { namespace mapGenerator {
                 if(randomMRIindex < 0)
                     continue;
 
-                auto mRI = mRIs[randomMRIindex];
+                auto &mRI = mRIs[randomMRIindex];
 
                 // Adjust and check the budget, if we are over we will not place the resource because we have already in
                 // the past.


### PR DESCRIPTION
The random map generator placed resources purely random in a mountain. This is
not great. Manual maps always cluster resources and we should do so too.
However, having all resources in every mountain is also a good thing for
the balance of the game so we want to keep the clusters small. This is a
try to build small clusters while keeping the ratios the same.

With this patch, mountains (default distribution) look like this: 
![2021-02-28_22-02-1614572211](https://user-images.githubusercontent.com/6248191/109451498-32ca0600-7a13-11eb-8732-80bbaa39fa46.jpg)
