### PR TITLE
Improve pathfinding speed

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -94,6 +94,9 @@ IncludeCategories:
   - Regex:           '<(kaguya|turtle|glad|KHR)'
     Priority:        95
     SortPriority:    0
+  - Regex:           '<benchmark/'
+    Priority:        98
+    SortPriority:    0
   - Regex:           '<boost/'
     Priority:        99
     SortPriority:    0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   BOOST_VERSION: 1.69.0
+  ADDITIONAL_CMAKE_FLAGS: -DRTTR_ENABLE_BENCHMARKS=ON
 
 jobs:
   Linux:
@@ -34,7 +35,7 @@ jobs:
       - run: echo "DEPS_DIR=${{runner.temp}}/.cache" >> $GITHUB_ENV
       - run: echo "BOOST_VERSION=${{matrix.boostVersion}}" >> $GITHUB_ENV
         if: matrix.boostVersion
-      - run: echo "ADDITIONAL_CMAKE_FLAGS=-DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_SANITIZERS=ON" >> $GITHUB_ENV
+      - run: echo "ADDITIONAL_CMAKE_FLAGS=${ADDITIONAL_CMAKE_FLAGS} -DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_SANITIZERS=ON" >> $GITHUB_ENV
         if: matrix.externalSanitizer
 
       - uses: actions/checkout@v2
@@ -114,7 +115,7 @@ jobs:
 
       - name: Enable coverage collection
         if: matrix.coverage
-        run: echo "ADDITIONAL_CMAKE_FLAGS=${ADDITIONAL_CMAKE_FLAGS} -DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_COVERAGE=ON" >> $GITHUB_ENV
+        run: echo "ADDITIONAL_CMAKE_FLAGS=${ADDITIONAL_CMAKE_FLAGS} -DRTTR_ENABLE_COVERAGE=ON" >> $GITHUB_ENV
 
       - name: Setup environment
         run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ before_build:
   # Enable LTCG for release builds (speeds up linking as /GL compiled modules are used)
   - if %configuration% == Release (set "cmakeFlags=-DCMAKE_EXE_LINKER_FLAGS=/LTCG -DCMAKE_SHARED_LINKER_FLAGS=/LTCG")
   - echo "Configuring %GENERATOR% for %configuration% on %platform% with boost=%BOOST_ROOT%"
-  - cmake -G "%GENERATOR%" -A %platform% -DRTTR_ENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DRTTR_EXTERNAL_BUILD_TESTING=ON %cmakeFlags% ..
+  - cmake -G "%GENERATOR%" -A %platform% -DRTTR_ENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_BENCHMARKS=ON %cmakeFlags% ..
 
 build_script: cmake --build . --config %configuration% --parallel 4
 

--- a/libs/s25main/TerrainRenderer.cpp
+++ b/libs/s25main/TerrainRenderer.cpp
@@ -941,18 +941,19 @@ void TerrainRenderer::PrepareWaysPoint(PreparedRoads& sorted_roads, const GameWo
         // else Mountain left or right is a mountain terrain
         // else Upgraded for Donkey roads
         // else Normal
-        const TerrainDesc& lTerrain = desc.get(gwViewer.GetWorld().GetLeftTerrain(pt, targetDir));
         uint8_t gfxRoadType;
+        const auto terrain = gwViewer.GetWorld().GetTerrain(pt, targetDir);
+        const TerrainDesc& lTerrain = desc.get(terrain.left);
         if(type == PointRoad::Boat)
         {
             gfxRoadType = getFlatIndex(lTerrain.landscape, LandRoadType::Boat);
         } else
         {
-            if(lTerrain.kind == TerrainKind::Mountain)
+            if(desc.get(terrain.left).kind == TerrainKind::Mountain)
                 gfxRoadType = getFlatIndex(lTerrain.landscape, LandRoadType::Mountain);
             else
             {
-                const TerrainDesc& rTerrain = desc.get(gwViewer.GetWorld().GetRightTerrain(pt, targetDir));
+                const TerrainDesc& rTerrain = desc.get(terrain.right);
                 if(rTerrain.kind == TerrainKind::Mountain)
                     gfxRoadType = getFlatIndex(rTerrain.landscape, LandRoadType::Mountain);
                 else

--- a/libs/s25main/TerrainRenderer.cpp
+++ b/libs/s25main/TerrainRenderer.cpp
@@ -1056,23 +1056,23 @@ void TerrainRenderer::AltitudeChanged(const MapPoint pt, const GameWorldViewer& 
     UpdateVertexPos(pt, gwv);
     UpdateVertexColor(pt, gwv);
 
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        UpdateVertexColor(gwv.GetNeighbour(pt, dir), gwv);
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
+        UpdateVertexColor(nb, gwv);
 
     // und für die Ränder
     UpdateBorderVertex(pt);
 
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        UpdateBorderVertex(gwv.GetNeighbour(pt, dir));
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
+        UpdateBorderVertex(nb);
 
     // den selbst sowieso die Punkte darum updaten, da sich bei letzteren die Schattierung geändert haben könnte
     UpdateTrianglePos(pt, true);
     UpdateTriangleColor(pt, true);
 
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
     {
-        UpdateTrianglePos(gwv.GetNeighbour(pt, dir), true);
-        UpdateTriangleColor(gwv.GetNeighbour(pt, dir), true);
+        UpdateTrianglePos(nb, true);
+        UpdateTriangleColor(nb, true);
     }
 
     // Auch im zweiten Kreis drumherum die Dreiecke neu berechnen, da die durch die Schattenänderung der umliegenden
@@ -1084,10 +1084,10 @@ void TerrainRenderer::AltitudeChanged(const MapPoint pt, const GameWorldViewer& 
     UpdateBorderTrianglePos(pt, true);
     UpdateBorderTriangleColor(pt, true);
 
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
     {
-        UpdateBorderTrianglePos(gwv.GetNeighbour(pt, dir), true);
-        UpdateBorderTriangleColor(gwv.GetNeighbour(pt, dir), true);
+        UpdateBorderTrianglePos(nb, true);
+        UpdateBorderTriangleColor(nb, true);
     }
 
     for(unsigned i = 0; i < 12; ++i)
@@ -1101,23 +1101,23 @@ void TerrainRenderer::VisibilityChanged(const MapPoint pt, const GameWorldViewer
         return;
 
     UpdateVertexColor(pt, gwv);
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        UpdateVertexColor(gwv.GetNeighbour(pt, dir), gwv);
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
+        UpdateVertexColor(nb, gwv);
 
     // und für die Ränder
     UpdateBorderVertex(pt);
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        UpdateBorderVertex(gwv.GetNeighbour(pt, dir));
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
+        UpdateBorderVertex(nb);
 
     // den selbst sowieso die Punkte darum updaten, da sich bei letzteren die Schattierung geändert haben könnte
     UpdateTriangleColor(pt, true);
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        UpdateTriangleColor(gwv.GetNeighbour(pt, dir), true);
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
+        UpdateTriangleColor(nb, true);
 
     // und für die Ränder
     UpdateBorderTriangleColor(pt, true);
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        UpdateBorderTriangleColor(gwv.GetNeighbour(pt, dir), true);
+    for(const MapPoint nb : gwv.GetNeighbours(pt))
+        UpdateBorderTriangleColor(nb, true);
 }
 
 void TerrainRenderer::UpdateAllColors(const GameWorldViewer& gwv)

--- a/libs/s25main/ai/aijh/PositionSearch.cpp
+++ b/libs/s25main/ai/aijh/PositionSearch.cpp
@@ -59,9 +59,8 @@ AIJH::PositionSearchState AIJH::PositionSearch::execute(const AIPlayerJH& player
         }
 
         // now insert neighbouring nodes...
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const MapPoint neighbourPt : player.GetWorld().GetNeighbours(pt))
         {
-            MapPoint neighbourPt = player.GetWorld().GetNeighbour(pt, dir);
             unsigned nIdx = player.GetWorld().GetIdx(neighbourPt);
 
             // test if already tested or not in territory

--- a/libs/s25main/figures/nofActiveSoldier.cpp
+++ b/libs/s25main/figures/nofActiveSoldier.cpp
@@ -194,9 +194,9 @@ void nofActiveSoldier::ExpelEnemies()
     }
 
     // And around this point
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : gwg->GetNeighbours(pos))
     {
-        const std::list<noBase*>& fieldFigures = gwg->GetFigures(gwg->GetNeighbour(pos, dir));
+        const std::list<noBase*>& fieldFigures = gwg->GetFigures(nb);
         for(auto* fieldFigure : fieldFigures)
         {
             // Normal settler?

--- a/libs/s25main/figures/nofCharburner.cpp
+++ b/libs/s25main/figures/nofCharburner.cpp
@@ -160,16 +160,16 @@ nofFarmhand::PointQuality nofCharburner::GetPointQuality(const MapPoint pt) cons
     if(gwg->GetNode(pt).boundary_stones[BorderStonePos::OnPoint])
         return PointQuality::NotPossible;
 
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : gwg->GetNeighbours(pt))
     {
         // Don't set it next to buildings and other charburner piles and grain fields
-        BlockingManner bm = gwg->GetNO(gwg->GetNeighbour(pt, dir))->GetBM();
+        BlockingManner bm = gwg->GetNO(nb)->GetBM();
         if(bm != BlockingManner::None)
             return PointQuality::NotPossible;
         // darf außerdem nicht neben einer Straße liegen
         for(const auto dir2 : helpers::EnumRange<Direction>{})
         {
-            if(gwg->GetPointRoad(gwg->GetNeighbour(pt, dir), dir2) != PointRoad::None)
+            if(gwg->GetPointRoad(nb, dir2) != PointRoad::None)
                 return PointQuality::NotPossible;
         }
     }

--- a/libs/s25main/figures/nofDefender.h
+++ b/libs/s25main/figures/nofDefender.h
@@ -49,7 +49,7 @@ public:
         RTTR_Assert(!attacker);
         nofActiveSoldier::Destroy();
     }
-    void Serialize(SerializedGameData& sgd) const;
+    void Serialize(SerializedGameData& sgd) const override;
 
     GO_Type GetGOT() const final { return GO_Type::NofDefender; }
 

--- a/libs/s25main/figures/nofFarmer.cpp
+++ b/libs/s25main/figures/nofFarmer.cpp
@@ -153,10 +153,10 @@ nofFarmhand::PointQuality nofFarmer::GetPointQuality(const MapPoint pt) const
         if(noType != NodalObjectType::Environment && noType != NodalObjectType::Nothing)
             return PointQuality::NotPossible;
 
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const MapPoint nb : gwg->GetNeighbours(pt))
         {
             // Nicht direkt neben andere Getreidefelder und Gebäude setzen!
-            noType = gwg->GetNO(gwg->GetNeighbour(pt, dir))->GetType();
+            noType = gwg->GetNO(nb)->GetType();
             if(noType == NodalObjectType::Grainfield || noType == NodalObjectType::Building
                || noType == NodalObjectType::Buildingsite)
                 return PointQuality::NotPossible;

--- a/libs/s25main/figures/nofFisher.cpp
+++ b/libs/s25main/figures/nofFisher.cpp
@@ -140,9 +140,9 @@ nofFarmhand::PointQuality nofFisher::GetPointQuality(const MapPoint pt) const
         return PointQuality::NotPossible;
 
     // irgendwo drumherum muss es Fisch geben
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : gwg->GetNeighbours(pt))
     {
-        if(gwg->GetNode(gwg->GetNeighbour(pt, dir)).resources.has(ResourceType::Fish))
+        if(gwg->GetNode(nb).resources.has(ResourceType::Fish))
             return PointQuality::Class1;
     }
 

--- a/libs/s25main/figures/nofForester.cpp
+++ b/libs/s25main/figures/nofForester.cpp
@@ -117,9 +117,9 @@ nofFarmhand::PointQuality nofForester::GetPointQuality(const MapPoint pt) const
     }
 
     // es dürfen außerdem keine Gebäude rund um den Baum stehen
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : gwg->GetNeighbours(pt))
     {
-        if(gwg->GetNO(gwg->GetNeighbour(pt, dir))->GetType() == NodalObjectType::Building)
+        if(gwg->GetNO(nb)->GetType() == NodalObjectType::Building)
             return PointQuality::NotPossible;
     }
 

--- a/libs/s25main/gameTypes/GameTypesOutput.h
+++ b/libs/s25main/gameTypes/GameTypesOutput.h
@@ -102,7 +102,7 @@ RTTR_ENUM_OUTPUT(GO_Type)
 template<class T>
 std::ostream& operator<<(std::ostream& out, const DescIdx<T>& d)
 {
-    return out << d.value;
+    return out << static_cast<unsigned>(d.value);
 }
 
 inline std::ostream& operator<<(std::ostream& out, const Resource r)

--- a/libs/s25main/nodeObjs/noAnimal.cpp
+++ b/libs/s25main/nodeObjs/noAnimal.cpp
@@ -253,34 +253,33 @@ helpers::OptionalEnum<Direction> noAnimal::FindDir()
 {
     // mit zufälliger Richtung anfangen
     const Direction doffset = RANDOM_ENUM(Direction);
+    const WorldDescription& worldDesc = gwg->GetDescription();
 
     for(const auto dir : helpers::enumRange(doffset))
     {
-        DescIdx<TerrainDesc> tLeft = gwg->GetLeftTerrain(pos, dir);
-        DescIdx<TerrainDesc> tRight = gwg->GetRightTerrain(pos, dir);
+        const auto terrains = gwg->GetTerrain(pos, dir);
+        const DescIdx<TerrainDesc> tLeft = terrains.left;
+        const DescIdx<TerrainDesc> tRight = terrains.right;
 
         if(species == Species::Duck)
         {
             // Enten schwimmen nur auf dem Wasser --> muss daher Wasser sein
-            if(gwg->GetDescription().get(tLeft).kind == TerrainKind::Water
-               && gwg->GetDescription().get(tRight).kind == TerrainKind::Water)
+            if(worldDesc.get(tLeft).kind == TerrainKind::Water && worldDesc.get(tRight).kind == TerrainKind::Water)
                 return dir;
         } else if(species == Species::PolarBear)
         {
             // Polarbären laufen nur auf Schnee rum
-            if(gwg->GetDescription().get(tLeft).kind == TerrainKind::Snow
-               && gwg->GetDescription().get(tRight).kind == TerrainKind::Snow)
+            if(worldDesc.get(tLeft).kind == TerrainKind::Snow && worldDesc.get(tRight).kind == TerrainKind::Snow)
                 return dir;
         } else
         {
             // Die anderen Tiere dürfen nur auf Wiesen,Savannen usw. laufen, nicht auf Bergen oder in der Wüste!
-            if(!gwg->GetDescription().get(tLeft).IsUsableByAnimals()
-               || !gwg->GetDescription().get(tRight).IsUsableByAnimals())
+            if(!worldDesc.get(tLeft).IsUsableByAnimals() || !worldDesc.get(tRight).IsUsableByAnimals())
                 continue;
 
             // Außerdem dürfen keine Hindernisse im Weg sein
-            MapPoint dst = gwg->GetNeighbour(pos, dir);
-            noBase* no = gwg->GetNO(dst);
+            const MapPoint dst = gwg->GetNeighbour(pos, dir);
+            const noBase* no = gwg->GetNO(dst);
 
             if(no->GetType() != NodalObjectType::Nothing && no->GetType() != NodalObjectType::Environment
                && no->GetType() != NodalObjectType::Tree)

--- a/libs/s25main/pathfinding/FreePathFinder.cpp
+++ b/libs/s25main/pathfinding/FreePathFinder.cpp
@@ -49,7 +49,6 @@ void FreePathFinder::Init(const MapExtent& mapSize)
         nodes[idx].mapPt = pt;
         fpNodes[idx].lastVisited = 0;
         fpNodes[idx].mapPt = pt;
-        fpNodes[idx].idx = idx;
     }
 }
 

--- a/libs/s25main/pathfinding/FreePathFinderImpl.h
+++ b/libs/s25main/pathfinding/FreePathFinderImpl.h
@@ -35,7 +35,7 @@ struct NodePtrCmpGreater
         if(lhs->estimatedDistance == rhs->estimatedDistance)
         {
             // Enforce strictly monotonic increasing order
-            return (lhs->idx > rhs->idx);
+            return (lhs > rhs);
         }
 
         return (lhs->estimatedDistance > rhs->estimatedDistance);
@@ -117,10 +117,11 @@ bool FreePathFinder::FindPath(const MapPoint start, const MapPoint dest, bool ra
             continue;
 
         // Knoten in alle 6 Richtungen bilden
+        const auto neighbors = gwb_.GetNeighbours(best.mapPt);
         for(const Direction dir : helpers::enumRange(startDir))
         {
             // Koordinaten des entsprechenden umliegenden Punktes bilden
-            MapPoint neighbourPos = gwb_.GetNeighbour(best.mapPt, dir);
+            MapPoint neighbourPos = neighbors[dir];
 
             // ID des umliegenden Knotens bilden
             unsigned nbId = gwb_.GetIdx(neighbourPos);

--- a/libs/s25main/pathfinding/NewNode.h
+++ b/libs/s25main/pathfinding/NewNode.h
@@ -44,9 +44,8 @@ struct NewNode
     MapPoint mapPt = {};
 };
 
-struct FreePathNode
+struct FreePathNode : BinaryHeapPosMarker
 {
-    OpenListBinaryHeapBase<FreePathNode>::PosMarker posMarker;
     /// Indicator if node was visited (lastVisited == currentVisit)
     unsigned lastVisited;
     /// Previous node

--- a/libs/s25main/pathfinding/NewNode.h
+++ b/libs/s25main/pathfinding/NewNode.h
@@ -46,6 +46,7 @@ struct NewNode
 
 struct FreePathNode
 {
+    OpenListBinaryHeapBase<FreePathNode>::PosMarker posMarker;
     /// Indicator if node was visited (lastVisited == currentVisit)
     unsigned lastVisited;
     /// Previous node
@@ -56,11 +57,8 @@ struct FreePathNode
     unsigned targetDistance;
     /// Distance from start over thise node to target (== curDistance + targetDistance)
     unsigned estimatedDistance;
-    /// Index used to distinguish nodes with same estimate
-    unsigned idx;
-    /// Direction used to reach this node
-    Direction dir;
     /// Point on map which this node represents
     MapPoint mapPt;
-    OpenListBinaryHeapBase<FreePathNode>::PosMarker posMarker;
+    /// Direction used to reach this node
+    Direction dir;
 };

--- a/libs/s25main/pathfinding/OpenListBinaryHeap.h
+++ b/libs/s25main/pathfinding/OpenListBinaryHeap.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include "RTTR_Assert.h"
+#include <boost/container/small_vector.hpp>
 #include <limits>
-#include <vector>
 
 /// Just for occasional temporary debugging, all should be covered by tests and this is SLOW
 #define RTTR_SLOW_DEBUG_CHECKS 0
@@ -48,13 +48,12 @@ public:
         friend class OpenListBinaryHeapBase;
     };
 
-    OpenListBinaryHeapBase() { elements.reserve(128); }
     size_type size() const { return elements.size(); }
     bool empty() const { return elements.empty(); }
     void clear() { elements.clear(); }
 
 protected:
-    std::vector<Element> elements;
+    boost::container::small_vector<Element, 64> elements;
     static size_type& GetPos(PosMarker& posMarker) { return posMarker.pos; }
 };
 

--- a/libs/s25main/pathfinding/PathConditionHuman.h
+++ b/libs/s25main/pathfinding/PathConditionHuman.h
@@ -32,7 +32,8 @@ struct PathConditionHuman : PathConditionReachable
     BOOST_FORCEINLINE bool IsNodeOk(const MapPoint& pt) const
     {
         // Node blocked -> Can't go there
-        const BlockingManner bm = world.GetNO(pt)->GetBM();
+        const auto* no = world.GetNode(pt).obj;
+        const BlockingManner bm = no ? no->GetBM() : BlockingManner::None;
         if(bm != BlockingManner::None && bm != BlockingManner::Tree && bm != BlockingManner::Flag)
             return false;
         return PathConditionReachable::IsNodeOk(pt);
@@ -47,12 +48,13 @@ struct PathConditionHuman : PathConditionReachable
             return true;
 
         // Check terrain for node transition
-        const TerrainDesc& tLeft = world.GetDescription().get(world.GetLeftTerrain(fromPt, dir));
-        const TerrainDesc& tRight = world.GetDescription().get(world.GetRightTerrain(fromPt, dir));
+        const auto terrains = world.GetTerrain(fromPt, dir);
+        const TerrainDesc& tLeft = world.GetDescription().get(terrains.left);
+        const TerrainDesc& tRight = world.GetDescription().get(terrains.right);
         // Don't go next to danger terrain
         if(tLeft.Is(ETerrain::Unreachable) || tRight.Is(ETerrain::Unreachable))
             return false;
         // If either terrain is walkable, then we can use this transition
-        return (tLeft.Is(ETerrain::Walkable) || tRight.Is(ETerrain::Walkable));
+        return tLeft.Is(ETerrain::Walkable) || tRight.Is(ETerrain::Walkable);
     }
 };

--- a/libs/s25main/pathfinding/PathConditionReachable.h
+++ b/libs/s25main/pathfinding/PathConditionReachable.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "helpers/EnumRange.h"
 #include "world/World.h"
 
 struct PathConditionReachable
@@ -30,9 +29,9 @@ struct PathConditionReachable
     BOOST_FORCEINLINE bool IsNodeOk(const MapPoint& pt) const
     {
         bool goodTerrainFound = false;
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const DescIdx<TerrainDesc> tIdx : world.GetTerrainsAround(pt))
         {
-            const TerrainDesc& t = world.GetDescription().get(world.GetRightTerrain(pt, dir));
+            const TerrainDesc& t = world.GetDescription().get(tIdx);
             if(t.Is(ETerrain::Unreachable))
                 return false;
             else if(t.Is(ETerrain::Walkable))
@@ -44,8 +43,9 @@ struct PathConditionReachable
     BOOST_FORCEINLINE bool IsEdgeOk(const MapPoint& fromPt, const Direction dir) const
     {
         // Check terrain for node transition
-        const TerrainDesc& tLeft = world.GetDescription().get(world.GetLeftTerrain(fromPt, dir));
-        const TerrainDesc& tRight = world.GetDescription().get(world.GetRightTerrain(fromPt, dir));
+        const auto terrains = world.GetTerrain(fromPt, dir);
+        const TerrainDesc& tLeft = world.GetDescription().get(terrains.left);
+        const TerrainDesc& tRight = world.GetDescription().get(terrains.right);
         // Don't go next to danger terrain
         return !tLeft.Is(ETerrain::Unreachable) && !tRight.Is(ETerrain::Unreachable);
     }

--- a/libs/s25main/pathfinding/PathConditionShip.h
+++ b/libs/s25main/pathfinding/PathConditionShip.h
@@ -34,7 +34,9 @@ struct PathConditionShip
     BOOST_FORCEINLINE bool IsEdgeOk(const MapPoint& fromPt, const Direction dir) const
     {
         // We must have shippable water on both sides
-        return world.GetDescription().get(world.GetLeftTerrain(fromPt, dir)).Is(ETerrain::Shippable)
-               && world.GetDescription().get(world.GetRightTerrain(fromPt, dir)).Is(ETerrain::Shippable);
+        const auto terrains = world.GetTerrain(fromPt, dir);
+        const TerrainDesc& tLeft = world.GetDescription().get(terrains.left);
+        const TerrainDesc& tRight = world.GetDescription().get(terrains.right);
+        return tLeft.Is(ETerrain::Shippable) && tRight.Is(ETerrain::Shippable);
     }
 };

--- a/libs/s25main/world/BQCalculator.h
+++ b/libs/s25main/world/BQCalculator.h
@@ -86,9 +86,9 @@ BuildingQuality BQCalculator::operator()(const MapPoint pt, T_IsOnRoad isOnRoad,
         else
         {
             // Direct neighbours: Flag for altitude diff > 3
-            for(const auto dir : helpers::EnumRange<Direction>{})
+            for(const MapPoint nb : world.GetNeighbours(pt))
             {
-                otherAltitude = world.GetNeighbourNode(pt, dir).altitude;
+                otherAltitude = world.GetNode(nb).altitude;
                 if(safeDiff(curAltitude, otherAltitude) > 3)
                 {
                     curBQ = BuildingQuality::Flag;
@@ -123,8 +123,9 @@ BuildingQuality BQCalculator::operator()(const MapPoint pt, T_IsOnRoad isOnRoad,
 
     // Blocking manners of neighbours (cache for reuse)
     helpers::EnumArray<BlockingManner, Direction> neighbourBlocks;
+    const auto neighbours = world.GetNeighbours(pt);
     for(const auto dir : helpers::EnumRange<Direction>{})
-        neighbourBlocks[dir] = world.GetNO(world.GetNeighbour(pt, dir))->GetBM();
+        neighbourBlocks[dir] = world.GetNO(neighbours[dir])->GetBM();
 
     // Don't build anything around charburner piles
     for(const auto dir : helpers::EnumRange<Direction>{})
@@ -212,7 +213,7 @@ BuildingQuality BQCalculator::operator()(const MapPoint pt, T_IsOnRoad isOnRoad,
     {
         for(const Direction i : {Direction::West, Direction::NorthWest, Direction::NorthEast})
         {
-            if(isOnRoad(world.GetNeighbour(pt, i)))
+            if(isOnRoad(neighbours[i]))
             {
                 curBQ = BuildingQuality::House;
                 break;
@@ -248,7 +249,7 @@ BuildingQuality BQCalculator::operator()(const MapPoint pt, T_IsOnRoad isOnRoad,
         return curBQ;
 
     // If we can build the house flag -> OK
-    if((*this)(world.GetNeighbour(pt, Direction::SouthEast), isOnRoad, true) != BuildingQuality::Nothing)
+    if((*this)(neighbours[Direction::SouthEast], isOnRoad, true) != BuildingQuality::Nothing)
         return curBQ;
 
     // If not, we could still build a flag, unless there is another one around

--- a/libs/s25main/world/BQCalculator.h
+++ b/libs/s25main/world/BQCalculator.h
@@ -46,9 +46,9 @@ BuildingQuality BQCalculator::operator()(const MapPoint pt, T_IsOnRoad isOnRoad,
     unsigned flag_hits = 0;
 
     const WorldDescription& desc = world.GetDescription();
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const DescIdx<TerrainDesc> tIdx : world.GetTerrainsAround(pt))
     {
-        TerrainBQ bq = desc.get(world.GetRightTerrain(pt, dir)).GetBQ();
+        TerrainBQ bq = desc.get(tIdx).GetBQ();
         if(bq == TerrainBQ::Castle)
             ++building_hits;
         else if(bq == TerrainBQ::Mine)

--- a/libs/s25main/world/GameWorldBase.cpp
+++ b/libs/s25main/world/GameWorldBase.cpp
@@ -122,9 +122,9 @@ bool GameWorldBase::IsRoadAvailable(const bool boat_road, const MapPoint pt) con
     {
         bool flagPossible = false;
 
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const DescIdx<TerrainDesc> tIdx : GetTerrainsAround(pt))
         {
-            TerrainBQ bq = GetDescription().get(GetRightTerrain(pt, dir)).GetBQ();
+            const TerrainBQ bq = GetDescription().get(tIdx).GetBQ();
             if(bq == TerrainBQ::Danger)
                 return false;
             else if(bq != TerrainBQ::Nothing)

--- a/libs/s25main/world/GameWorldBase.cpp
+++ b/libs/s25main/world/GameWorldBase.cpp
@@ -174,9 +174,9 @@ bool GameWorldBase::IsOnRoad(const MapPoint& pt) const
 
 bool GameWorldBase::IsFlagAround(const MapPoint& pt) const
 {
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : GetNeighbours(pt))
     {
-        if(GetNO(GetNeighbour(pt, dir))->GetBM() == BlockingManner::Flag)
+        if(GetNO(nb)->GetBM() == BlockingManner::Flag)
             return true;
     }
     return false;
@@ -283,8 +283,8 @@ void GameWorldBase::AltitudeChanged(const MapPoint pt)
 void GameWorldBase::RecalcBQAroundPoint(const MapPoint pt)
 {
     RecalcBQ(pt);
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        RecalcBQ(GetNeighbour(pt, dir));
+    for(const MapPoint nb : GetNeighbours(pt))
+        RecalcBQ(nb);
 }
 
 void GameWorldBase::RecalcBQAroundPointBig(const MapPoint pt)

--- a/libs/s25main/world/GameWorldGame.cpp
+++ b/libs/s25main/world/GameWorldGame.cpp
@@ -327,9 +327,9 @@ void GameWorldGame::RecalcBorderStones(Position startPt, Extent areaSize)
 #ifdef PREVENT_BORDER_STONE_BLOCKING
             // Count number of border nodes with same owner
             int idx = pt.y * width + pt.x;
-            for(const auto dir : helpers::EnumRange<Direction>{})
+            for(const MapPoint nb : GetNeighbours(curMapPt))
             {
-                if(GetNeighbourNode(curMapPt, dir).boundary_stones[0] == owner)
+                if(GetNode(nb).boundary_stones[0] == owner)
                     ++neighbors[idx];
             }
 #endif
@@ -422,9 +422,8 @@ void GameWorldGame::RecalcTerritory(const noBaseBuilding& building, TerritoryCha
         // Do not destroy the triggering building or its flag
         // TODO: What about this point?
         const uint8_t owner = GetNode(curMapPt).owner;
-        for(Direction dir : helpers::EnumRange<Direction>{})
+        for(const MapPoint neighbourPt : GetNeighbours(curMapPt))
         {
-            MapPoint neighbourPt = GetNeighbour(curMapPt, dir);
             if(ptsHandled.insert(neighbourPt).second)
                 DestroyPlayerRests(neighbourPt, owner, &building);
         }
@@ -523,9 +522,9 @@ bool GameWorldGame::DoesDestructionChangeTerritory(const noBaseBuilding& buildin
         if(GetDescription().get(node.t1).Is(ETerrain::Walkable) && GetDescription().get(node.t2).Is(ETerrain::Walkable))
             return true;
         // also check neighboring nodes since border will still count as player territory but not allow any buildings!
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const MapPoint neighbourPt : GetNeighbours(curMapPt))
         {
-            const MapNode& nNode = GetNeighbourNode(curMapPt, dir);
+            const MapNode& nNode = GetNode(neighbourPt);
             if(GetDescription().get(nNode.t1).Is(ETerrain::Walkable)
                || GetDescription().get(nNode.t2).Is(ETerrain::Walkable))
                 return true;
@@ -701,14 +700,11 @@ void GameWorldGame::DestroyPlayerRests(const MapPoint pt, unsigned char newOwner
 void GameWorldGame::RoadNodeAvailable(const MapPoint pt)
 {
     // Figuren direkt daneben
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : GetNeighbours(pt))
     {
         // Nochmal prüfen, ob er nun wirklich verfügbar ist (evtl blocken noch mehr usw.)
         if(!IsRoadNodeForFigures(pt))
             continue;
-
-        // Koordinaten um den Punkt herum
-        MapPoint nb = GetNeighbour(pt, dir);
 
         // Figuren Bescheid sagen
         for(noBase* object : GetFigures(nb))
@@ -932,9 +928,9 @@ void GameWorldGame::StopOnRoads(const MapPoint pt, const helpers::OptionalEnum<D
             figures.push_back(static_cast<noFigure*>(fieldFigure));
 
     // Und natürlich in unmittelbarer Umgebung suchen
-    for(Direction dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : GetNeighbours(pt))
     {
-        const std::list<noBase*>& fieldFigures = GetFigures(GetNeighbour(pt, dir));
+        const std::list<noBase*>& fieldFigures = GetFigures(nb);
         for(auto* fieldFigure : fieldFigures)
             if(fieldFigure->GetType() == NodalObjectType::Figure)
                 figures.push_back(static_cast<noFigure*>(fieldFigure));

--- a/libs/s25main/world/GameWorldGame.cpp
+++ b/libs/s25main/world/GameWorldGame.cpp
@@ -1367,10 +1367,9 @@ void GameWorldGame::PlaceAndFixWater()
         }
 
         uint8_t minHumidity = 100;
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const DescIdx<TerrainDesc> tIdx : GetTerrainsAround(pt))
         {
-            DescIdx<TerrainDesc> t = GetRightTerrain(pt, dir);
-            uint8_t curHumidity = GetDescription().get(t).humidity;
+            const uint8_t curHumidity = GetDescription().get(tIdx).humidity;
             if(curHumidity < minHumidity)
             {
                 minHumidity = curHumidity;

--- a/libs/s25main/world/GameWorldViewer.cpp
+++ b/libs/s25main/world/GameWorldViewer.cpp
@@ -238,6 +238,11 @@ void GameWorldViewer::ChangePlayer(unsigned player, bool updateVisualData /* = t
     }
 }
 
+helpers::EnumArray<MapPoint, Direction> GameWorldViewer::GetNeighbours(const MapPoint pt) const
+{
+    return GetWorld().GetNeighbours(pt);
+}
+
 void GameWorldViewer::VisibilityChanged(const MapPoint& pt, unsigned player)
 {
     // If visibility changed for us, or our team mate if shared view is on -> Update renderer

--- a/libs/s25main/world/GameWorldViewer.h
+++ b/libs/s25main/world/GameWorldViewer.h
@@ -100,6 +100,8 @@ public:
     /// Makes this a viewer for another player
     void ChangePlayer(unsigned player, bool updateVisualData = true);
 
+    helpers::EnumArray<MapPoint, Direction> GetNeighbours(MapPoint pt) const;
+
 private:
     /// Visual node status (might be different than world if GameCommand is just sent) to hide network latency
     struct VisualMapNode

--- a/libs/s25main/world/MapBase.cpp
+++ b/libs/s25main/world/MapBase.cpp
@@ -100,7 +100,7 @@ MapPoint MapBase::GetNeighbour2(const MapPoint pt, unsigned dir) const
     return MakeMapPoint(::GetNeighbour2(Position(pt), dir));
 }
 
-std::array<MapPoint, 6> MapBase::GetNeighbours(const MapPoint& pt) const
+helpers::EnumArray<MapPoint, Direction> MapBase::GetNeighbours(const MapPoint& pt) const
 {
     unsigned yplus1 = pt.y == size_.y - 1 ? 0 : pt.y + 1;
     unsigned yminus1 = (pt.y == 0 ? size_.y : pt.y) - 1;

--- a/libs/s25main/world/MapBase.cpp
+++ b/libs/s25main/world/MapBase.cpp
@@ -100,19 +100,20 @@ MapPoint MapBase::GetNeighbour2(const MapPoint pt, unsigned dir) const
     return MakeMapPoint(::GetNeighbour2(Position(pt), dir));
 }
 
-helpers::EnumArray<MapPoint, Direction> MapBase::GetNeighbours(const MapPoint& pt) const
+helpers::EnumArray<MapPoint, Direction> MapBase::GetNeighbours(const MapPoint pt) const
 {
-    unsigned yplus1 = pt.y == size_.y - 1 ? 0 : pt.y + 1;
-    unsigned yminus1 = (pt.y == 0 ? size_.y : pt.y) - 1;
-    unsigned xplus1 = pt.x == size_.x - 1 ? 0 : pt.x + 1;
-    unsigned xminus1 = (pt.x == 0 ? size_.x : pt.x) - 1;
+    const MapCoord yplus1 = pt.y == size_.y - 1 ? 0 : pt.y + 1;
+    const MapCoord yminus1 = (pt.y == 0 ? size_.y : pt.y) - 1;
+    const MapCoord xplus1 = pt.x == size_.x - 1 ? 0 : pt.x + 1;
+    const MapCoord xminus1 = (pt.x == 0 ? size_.x : pt.x) - 1;
+    const bool isEvenRow = (pt.y & 1) == 0;
 
     return {MapPoint(xminus1, pt.y),
-            MapPoint((pt.y & 1) ? pt.x : xminus1, yminus1),
-            MapPoint((!(pt.y & 1)) ? pt.x : xplus1, yminus1),
+            MapPoint(!isEvenRow ? pt.x : xminus1, yminus1),
+            MapPoint(isEvenRow ? pt.x : xplus1, yminus1),
             MapPoint(xplus1, pt.y),
-            MapPoint((!(pt.y & 1)) ? pt.x : xplus1, yplus1),
-            MapPoint((pt.y & 1) ? pt.x : xminus1, yplus1)};
+            MapPoint(isEvenRow ? pt.x : xplus1, yplus1),
+            MapPoint(!isEvenRow ? pt.x : xminus1, yplus1)};
 }
 
 unsigned MapBase::CalcDistance(const Position& p1, const Position& p2) const

--- a/libs/s25main/world/MapBase.h
+++ b/libs/s25main/world/MapBase.h
@@ -72,7 +72,7 @@ public:
     // Convenience functions for the above function
     MapCoord GetXA(MapPoint pt, Direction dir) const;
     // Gets all neighbors (in all directions) for given position
-    helpers::EnumArray<MapPoint, Direction> GetNeighbours(const MapPoint& pt) const;
+    helpers::EnumArray<MapPoint, Direction> GetNeighbours(MapPoint pt) const;
 
     /// Return all points in a radius around pt (excluding pt) that satisfy a given condition.
     /// Points can be transformed (e.g. to flags at those points) by the functor taking a map point and a radius
@@ -114,7 +114,6 @@ public:
 // Implementation
 //////////////////////////////////////////////////////////////////////////
 
-// Convenience functions
 inline MapCoord MapBase::GetXA(const MapPoint pt, Direction dir) const
 {
     return GetNeighbour(pt, dir).x;

--- a/libs/s25main/world/MapBase.h
+++ b/libs/s25main/world/MapBase.h
@@ -164,7 +164,7 @@ detail::GetPointsResult_t<T_TransformPt> MapBase::GetPointsInRadius(const MapPoi
                 if(isValid(el))
                 {
                     result.push_back(el);
-                    if(T_maxResults > 0 && static_cast<int>(result.size()) > T_maxResults)
+                    if(T_maxResults > 0 && static_cast<int>(result.size()) >= T_maxResults)
                         return result;
                 }
                 curPt = GetNeighbour(curPt, dir);

--- a/libs/s25main/world/MapBase.h
+++ b/libs/s25main/world/MapBase.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "RTTR_Assert.h"
+#include "helpers/EnumArray.h"
 #include "helpers/EnumRange.h"
 #include "gameTypes/Direction.h"
 #include "gameTypes/MapCoordinates.h"
@@ -71,7 +72,7 @@ public:
     // Convenience functions for the above function
     MapCoord GetXA(MapPoint pt, Direction dir) const;
     // Gets all neighbors (in all directions) for given position
-    std::array<MapPoint, 6> GetNeighbours(const MapPoint& pt) const;
+    helpers::EnumArray<MapPoint, Direction> GetNeighbours(const MapPoint& pt) const;
 
     /// Return all points in a radius around pt (excluding pt) that satisfy a given condition.
     /// Points can be transformed (e.g. to flags at those points) by the functor taking a map point and a radius

--- a/libs/s25main/world/MapGeometry.cpp
+++ b/libs/s25main/world/MapGeometry.cpp
@@ -50,7 +50,7 @@ Position GetNeighbour(const Position& p, const Direction dir)
         case Direction::SouthWest: return Position(p.x - !(p.y & 1), p.y + 1);
     }
     RTTR_Assert(false);
-    BOOST_UNREACHABLE_RETURN({});
+    BOOST_UNREACHABLE_RETURN({})
 }
 
 Position GetNeighbour2(Position pt, unsigned dir)

--- a/libs/s25main/world/MapLoader.cpp
+++ b/libs/s25main/world/MapLoader.cpp
@@ -683,9 +683,8 @@ unsigned MapLoader::MeasureSea(World& world, const MapPoint start, unsigned shor
         RTTR_Assert(visited[world.GetIdx(p)]);
         world.GetNodeInt(p).seaId = seaId;
 
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const MapPoint neighbourPt : world.GetNeighbours(p))
         {
-            MapPoint neighbourPt = world.GetNeighbour(p, dir);
             if(visited[world.GetIdx(neighbourPt)])
                 continue;
             visited[world.GetIdx(neighbourPt)] = true;

--- a/libs/s25main/world/World.cpp
+++ b/libs/s25main/world/World.cpp
@@ -274,10 +274,20 @@ DescIdx<TerrainDesc> World::GetRightTerrain(const MapPoint pt, Direction dir) co
     throw std::logic_error("Invalid direction");
 }
 
-DescIdx<TerrainDesc> World::GetLeftTerrain(const MapPoint pt, Direction dir) const
+WalkTerrain World::GetTerrain(MapPoint pt, Direction dir) const
 {
-    // We can find the left terrain by going a bit more left/counter-clockwise and take the right terrain
-    return GetRightTerrain(pt, dir - 1u);
+    return {GetRightTerrain(pt, dir - 1u), GetRightTerrain(pt, dir)};
+}
+
+helpers::EnumArray<DescIdx<TerrainDesc>, Direction> World::GetTerrainsAround(MapPoint pt) const
+{
+    const MapNode& nwNode = GetNeighbourNode(pt, Direction::NorthWest);
+    const MapNode& neNode = GetNeighbourNode(pt, Direction::NorthEast);
+    const MapNode& curNode = GetNode(pt);
+    const MapNode& wNode = GetNeighbourNode(pt, Direction::West);
+    helpers::EnumArray<DescIdx<TerrainDesc>, Direction> result{nwNode.t1,  nwNode.t2,  neNode.t1,
+                                                               curNode.t2, curNode.t1, wNode.t2};
+    return result;
 }
 
 void World::SaveFOWNode(const MapPoint pt, const unsigned player, unsigned curTime)

--- a/libs/s25main/world/World.cpp
+++ b/libs/s25main/world/World.cpp
@@ -116,11 +116,8 @@ void World::AddFigure(const MapPoint pt, noBase* fig)
     figures.push_back(fig);
 
 #if RTTR_ENABLE_ASSERTS
-    for(const auto dir : helpers::EnumRange<Direction>{})
-    {
-        MapPoint nb = GetNeighbour(pt, dir);
+    for(const MapPoint nb : GetNeighbours(pt))
         RTTR_Assert(!helpers::contains(GetNode(nb).figures, fig)); // Added figure that is in surrounding?
-    }
 #endif
 }
 
@@ -213,8 +210,8 @@ void World::ChangeAltitude(const MapPoint pt, const unsigned char altitude)
 
     // Schattierung neu berechnen von diesem Punkt und den Punkten drumherum
     RecalcShadow(pt);
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        RecalcShadow(GetNeighbour(pt, dir));
+    for(const MapPoint nb : GetNeighbours(pt))
+        RecalcShadow(nb);
 
     // Abgeleiteter Klasse Bescheid sagen
     AltitudeChanged(pt);
@@ -228,9 +225,9 @@ bool World::IsPlayerTerritory(const MapPoint pt, const unsigned char owner) cons
         return false;
 
     // Neighbour nodes must belong to this player
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : GetNeighbours(pt))
     {
-        if(GetNeighbourNode(pt, dir).owner != ptOwner)
+        if(GetNode(nb).owner != ptOwner)
             return false;
     }
 
@@ -473,9 +470,9 @@ unsigned short World::GetSeaFromCoastalPoint(const MapPoint pt) const
         return 0;
 
     // Surrounding must be valid sea
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint nb : GetNeighbours(pt))
     {
-        unsigned short seaId = GetNeighbourNode(pt, dir).seaId;
+        unsigned short seaId = GetNode(nb).seaId;
         if(seaId)
         {
             // Check size (TODO: Others checks like harbor spots?)

--- a/libs/s25main/world/World.cpp
+++ b/libs/s25main/world/World.cpp
@@ -257,20 +257,6 @@ BuildingQuality World::AdjustBQ(const MapPoint pt, unsigned char player, Buildin
         return nodeBQ;
 }
 
-DescIdx<TerrainDesc> World::GetRightTerrain(const MapPoint pt, Direction dir) const
-{
-    switch(dir)
-    {
-        case Direction::West: return GetNeighbourNode(pt, Direction::NorthWest).t1;
-        case Direction::NorthWest: return GetNeighbourNode(pt, Direction::NorthWest).t2;
-        case Direction::NorthEast: return GetNeighbourNode(pt, Direction::NorthEast).t1;
-        case Direction::East: return GetNode(pt).t2;
-        case Direction::SouthEast: return GetNode(pt).t1;
-        case Direction::SouthWest: return GetNeighbourNode(pt, Direction::West).t2;
-    }
-    throw std::logic_error("Invalid direction");
-}
-
 WalkTerrain World::GetTerrain(MapPoint pt, Direction dir) const
 {
     // Manually inlined code from GetNeighbors. Measured to greatly improve performance

--- a/libs/s25main/world/World.h
+++ b/libs/s25main/world/World.h
@@ -155,11 +155,9 @@ public:
         return dynamic_cast<const T*>(GetNode(pt).obj);
     }
 
-    /// Return the terrain to the right when walking from the point in the given direction
-    /// 0 = left upper triangle, 1 = triangle above, ..., 4 = triangle below
-    DescIdx<TerrainDesc> GetRightTerrain(MapPoint pt, Direction dir) const;
     /// Get left and right terrain from the point in the given direction
     WalkTerrain GetTerrain(MapPoint pt, Direction dir) const;
+    /// Return all terrains around the given point. The per-direction entry is the terrain to the right
     helpers::EnumArray<DescIdx<TerrainDesc>, Direction> GetTerrainsAround(MapPoint pt) const;
 
     /// Create the FOW-objects, -streets, etc for a point and player

--- a/tests/s25Main/CMakeLists.txt
+++ b/tests/s25Main/CMakeLists.txt
@@ -42,6 +42,11 @@ add_subdirectory(resources)
 add_subdirectory(simple)
 add_subdirectory(UI)
 
+option(RTTR_ENABLE_BENCHMARKS "Build the benchmarks" OFF)
+if(RTTR_ENABLE_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()
+
 if(WIN32)
     include(GatherDll)
     gather_dll_copy(testWorldFixtures)

--- a/tests/s25Main/benchmarks/CMakeLists.txt
+++ b/tests/s25Main/benchmarks/CMakeLists.txt
@@ -1,0 +1,26 @@
+option(RTTR_USE_SYSTEM_BENCHMARK "Use system installed google benchmark. Fails if not found!" "${RTTR_USE_SYSTEM_LIBS}")
+if(RTTR_USE_SYSTEM_BENCHMARK)
+  find_package(benchmark REQUIRED)
+else()
+    include(FetchContent)
+    FetchContent_Declare(
+        GoogleBenchmark
+        GIT_REPOSITORY https://github.com/google/benchmark.git
+        GIT_TAG v1.5.2
+    )
+    set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
+    set(BENCHMARK_ENABLE_INSTALL  OFF CACHE BOOL "")
+    FetchContent_MakeAvailable(GoogleBenchmark)
+endif()
+
+file(GLOB sources *.cpp)
+set(benchmarksCommands "")
+foreach(src IN LISTS sources)
+  get_filename_component(name ${src} NAME_WE)
+  set(name BM_${name})
+  add_executable(${name} ${src})
+  target_link_libraries(${name} PRIVATE s25Main testHelpers testConfig benchmark::benchmark benchmark::benchmark_main)
+  list(APPEND benchmarksCommands COMMAND ${name})
+endforeach()
+
+add_custom_target(RUN_BENCHMARKS ${benchmarksCommands})

--- a/tests/s25Main/benchmarks/RealWorldPathfinding.cpp
+++ b/tests/s25Main/benchmarks/RealWorldPathfinding.cpp
@@ -50,7 +50,7 @@ static void BM_World(benchmark::State& state)
     if(!loader.Load(rttr::test::rttrBaseDir / "data/RTTR/MAPS/NEW/AM_FANGDERZEIT.SWD"))
         state.SkipWithError("Map failed to load");
 
-    const auto& curValues = routes[state.range()];
+    const auto& curValues = routes[static_cast<size_t>(state.range())];
     state.SetLabel(std::get<0>(curValues));
     const MapPoint start = std::get<1>(curValues);
     const MapPoint goal = std::get<2>(curValues);

--- a/tests/s25Main/benchmarks/RealWorldPathfinding.cpp
+++ b/tests/s25Main/benchmarks/RealWorldPathfinding.cpp
@@ -19,13 +19,13 @@
 #include "PlayerInfo.h"
 #include "network/GameClient.h"
 #include "ogl/glAllocator.h"
+#include "world/MapLoader.h"
 #include "libsiedler2/libsiedler2.h"
 #include <rttr/test/Fixture.hpp>
 #include <benchmark/benchmark.h>
 #include <array>
 #include <test/testConfig.h>
 #include <utility>
-#include "world/MapLoader.h"
 
 constexpr std::array<std::tuple<const char*, MapPoint, MapPoint>, 7> routes = {{{"Simple 1", {85, 147}, {87, 150}},
                                                                                 {"Simple 2", {85, 147}, {85, 152}},

--- a/tests/s25Main/benchmarks/RealWorldPathfinding.cpp
+++ b/tests/s25Main/benchmarks/RealWorldPathfinding.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "Game.h"
+#include "PlayerInfo.h"
+#include "network/GameClient.h"
+#include "ogl/glAllocator.h"
+#include "libsiedler2/libsiedler2.h"
+#include <rttr/test/Fixture.hpp>
+#include <benchmark/benchmark.h>
+#include <array>
+#include <test/testConfig.h>
+#include <utility>
+#include "world/MapLoader.h"
+
+constexpr std::array<std::tuple<const char*, MapPoint, MapPoint>, 7> routes = {{{"Simple 1", {85, 147}, {87, 150}},
+                                                                                {"Simple 2", {85, 147}, {85, 152}},
+                                                                                {"Simple 3", {85, 147}, {79, 149}},
+                                                                                {"Medium 1", {85, 147}, {77, 163}},
+                                                                                {"Medium 2", {85, 147}, {79, 127}},
+                                                                                {"Hard", {21, 200}, {42, 188}},
+                                                                                {"Water", {152, 66}, {198, 34}}}};
+
+static void BM_World(benchmark::State& state)
+{
+    rttr::test::Fixture f;
+    libsiedler2::setAllocator(new GlAllocator);
+
+    std::vector<PlayerInfo> players(2);
+    for(auto& player : players)
+        player.ps = PlayerState::Occupied;
+    GlobalGameSettings ggs;
+    auto game = std::make_shared<Game>(ggs, 0, players);
+    GameWorldGame& world = game->world_;
+    MapLoader loader(world);
+    if(!loader.Load(rttr::test::rttrBaseDir / "data/RTTR/MAPS/NEW/AM_FANGDERZEIT.SWD"))
+        state.SkipWithError("Map failed to load");
+
+    const auto& curValues = routes[state.range()];
+    state.SetLabel(std::get<0>(curValues));
+    const MapPoint start = std::get<1>(curValues);
+    const MapPoint goal = std::get<2>(curValues);
+
+    for(auto _ : state)
+    {
+        const bool result = state.range() < 6 ? world.FindHumanPath(start, goal).has_value() :
+                                                world.FindShipPath(start, goal, 600, nullptr, nullptr);
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK(BM_World)->DenseRange(0, routes.size() - 1);

--- a/tests/s25Main/benchmarks/openlist.cpp
+++ b/tests/s25Main/benchmarks/openlist.cpp
@@ -20,6 +20,7 @@
 #include "network/GameClient.h"
 #include "pathfinding/OpenListBinaryHeap.h"
 #include "rttr/test/random.hpp"
+#include "s25util/warningSuppression.h"
 #include <benchmark/benchmark.h>
 #include <test/testConfig.h>
 
@@ -74,7 +75,10 @@ static void BM_PopElements(benchmark::State& state)
         benchmark::DoNotOptimize(list);
         state.ResumeTiming();
         for(auto& node : nodes)
+        {
             list.pop();
+            RTTR_UNUSED(node);
+        }
         benchmark::DoNotOptimize(list);
     }
     state.SetItemsProcessed(state.iterations() * state.range(0));

--- a/tests/s25Main/benchmarks/openlist.cpp
+++ b/tests/s25Main/benchmarks/openlist.cpp
@@ -24,11 +24,10 @@
 #include <test/testConfig.h>
 
 namespace {
-struct DummyNode
+struct DummyNode : BinaryHeapPosMarker
 {
     unsigned dummy[8]; // Roughly the size of FreePathNode
     unsigned key;
-    OpenListBinaryHeapBase<DummyNode>::PosMarker posMarker;
 };
 struct NodeGetKey
 {

--- a/tests/s25Main/benchmarks/openlist.cpp
+++ b/tests/s25Main/benchmarks/openlist.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "Game.h"
+#include "PlayerInfo.h"
+#include "network/GameClient.h"
+#include "pathfinding/OpenListBinaryHeap.h"
+#include "rttr/test/random.hpp"
+#include <benchmark/benchmark.h>
+#include <test/testConfig.h>
+
+namespace {
+struct DummyNode
+{
+    unsigned dummy[8]; // Roughly the size of FreePathNode
+    unsigned key;
+    OpenListBinaryHeapBase<DummyNode>::PosMarker posMarker;
+};
+struct NodeGetKey
+{
+    constexpr auto operator()(const DummyNode& el) const { return el.key; }
+};
+using OpenList = OpenListBinaryHeap<DummyNode, NodeGetKey>;
+
+auto getRandomNodes(size_t numElements, unsigned maxValue = 512)
+{
+    std::vector<DummyNode> nodes(numElements);
+    for(auto& node : nodes)
+        node.key = rttr::test::randomValue(0u, maxValue);
+    return nodes;
+}
+} // namespace
+
+static void BM_PushElements(benchmark::State& state)
+{
+    const auto numElements = static_cast<size_t>(state.range(0));
+    for(auto _ : state)
+    {
+        state.PauseTiming();
+        auto nodes = getRandomNodes(numElements);
+        OpenList list;
+        state.ResumeTiming();
+        for(auto& node : nodes)
+            list.push(&node);
+        benchmark::DoNotOptimize(list);
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+BENCHMARK(BM_PushElements)->Arg(3)->Arg(5)->Arg(7)->Arg(10)->Arg(20)->Arg(30)->Arg(40);
+
+static void BM_PopElements(benchmark::State& state)
+{
+    const auto numElements = static_cast<size_t>(state.range(0));
+    for(auto _ : state)
+    {
+        state.PauseTiming();
+        auto nodes = getRandomNodes(numElements);
+        OpenList list;
+        for(auto& node : nodes)
+            list.push(&node);
+        benchmark::DoNotOptimize(list);
+        state.ResumeTiming();
+        for(auto& node : nodes)
+            list.pop();
+        benchmark::DoNotOptimize(list);
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+BENCHMARK(BM_PopElements)->Arg(3)->Arg(5)->Arg(7)->Arg(10)->Arg(20)->Arg(30)->Arg(40);
+
+static void BM_PushPopElements(benchmark::State& state)
+{
+    const auto numElements = static_cast<size_t>(state.range(0));
+    const auto numOperations = static_cast<size_t>(state.range(1));
+    for(auto _ : state)
+    {
+        state.PauseTiming();
+        auto nodes = getRandomNodes(numElements, numElements / 3u); // Force duplicates
+        OpenList list;
+        for(auto& node : nodes)
+            list.push(&node);
+        benchmark::DoNotOptimize(list);
+        state.ResumeTiming();
+        for(unsigned i = 0; i < numOperations; i++)
+        {
+            auto* el = list.pop();
+            // Modify sligthly and readd
+            el->key =
+              static_cast<unsigned>(static_cast<int>(el->key) + rttr::test::randomValue(-std::min<int>(2, el->key), 2));
+            list.push(el);
+        }
+        benchmark::DoNotOptimize(list);
+    }
+    state.SetItemsProcessed(state.iterations() * numOperations * 2);
+}
+BENCHMARK(BM_PushPopElements)->ArgsProduct({{3, 5, 7, 10, 20, 30, 40, 70}, {5, 7, 15, 20, 50, 200, 600}});

--- a/tests/s25Main/integration/testBoundaryStones.cpp
+++ b/tests/s25Main/integration/testBoundaryStones.cpp
@@ -69,7 +69,7 @@ BOOST_FIXTURE_TEST_CASE(BorderStones, WorldFixtureEmpty0P)
                       0u);
         }
         // Get the minimum possible region where border stones would be placed
-        const auto radius1Pts = helpers::toEnumArray<Direction>(world.GetNeighbours(middlePt));
+        const auto radius1Pts = world.GetNeighbours(middlePt);
         // Set only the middle pt and recalc
         world.SetOwner(middlePt, 1);
         // Only middle pt has a single boundary stone

--- a/tests/s25Main/integration/testGameCommands.cpp
+++ b/tests/s25Main/integration/testGameCommands.cpp
@@ -101,9 +101,8 @@ BOOST_FIXTURE_TEST_CASE(PlaceFlagTest, WorldWithGCExecution2P)
     BOOST_TEST_REQUIRE(world.GetSpecObj<noRoadNode>(flagPt) == flag);
 
     // Place flag at neighbour
-    for(const auto dir : helpers::EnumRange<Direction>{})
+    for(const MapPoint curPt : world.GetNeighbours(flagPt))
     {
-        MapPoint curPt = world.GetNeighbour(flagPt, dir);
         this->SetFlag(curPt);
         // Should not work
         BOOST_TEST_REQUIRE(!world.GetSpecObj<noRoadNode>(curPt));
@@ -116,8 +115,8 @@ BOOST_FIXTURE_TEST_CASE(PlaceFlagTest, WorldWithGCExecution2P)
     // Removed from game
     BOOST_TEST_REQUIRE(GameObject::GetNumObjs() == objCt - 1);
     // And everything clear now
-    for(const auto dir : helpers::EnumRange<Direction>{})
-        BOOST_TEST_REQUIRE(world.GetNeighbourNode(flagPt, dir).bq == BuildingQuality::Castle);
+    for(const MapPoint nb : world.GetNeighbours(flagPt))
+        BOOST_TEST_REQUIRE(world.GetNode(nb).bq == BuildingQuality::Castle);
 }
 
 BOOST_FIXTURE_TEST_CASE(BuildRoadTest, WorldWithGCExecution2P)

--- a/tests/s25Main/integration/testWorld.cpp
+++ b/tests/s25Main/integration/testWorld.cpp
@@ -290,26 +290,34 @@ BOOST_AUTO_TEST_CASE(GetTerrainReturnsCorrectValues)
     {
         const MapPoint testPt(1, 1);
         // t1 (idx) is the triangle directly below, t2 (idx+1) on right lower
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::SouthEast) == calcT1(testPt));
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::East) == calcT2(testPt));
+        auto terrain = world.GetTerrain(testPt, Direction::SouthEast);
+        BOOST_TEST(terrain.left == calcT2(testPt));
+        BOOST_TEST(terrain.right == calcT1(testPt));
+
+        terrain = world.GetTerrain(testPt, Direction::West);
         // right lower from previous point
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::SouthWest) == calcT2(MapPoint(0, 1)));
+        BOOST_TEST(terrain.left == calcT2(MapPoint(0, 1)));
         // below and right lower from upper point
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::West) == calcT1(MapPoint(1, 0)));
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::NorthWest) == calcT2(MapPoint(1, 0)));
+        BOOST_TEST(terrain.right == calcT1(MapPoint(1, 0)));
+
+        terrain = world.GetTerrain(testPt, Direction::NorthEast);
+        BOOST_TEST(terrain.left == calcT2(MapPoint(1, 0)));
         // below of the point next to it
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::NorthEast) == calcT1(MapPoint(2, 0)));
+        BOOST_TEST(terrain.right == calcT1(MapPoint(2, 0)));
     }
     {
         const MapPoint testPt(5, 3); // Last point -> check borders
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::SouthEast) == calcT1(testPt));
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::East) == calcT2(testPt));
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::SouthWest) == calcT2(MapPoint(4, 3)));
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::West) == calcT1(MapPoint(5, 2)));
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::NorthWest) == calcT2(MapPoint(5, 2)));
-        BOOST_TEST(world.GetRightTerrain(testPt, Direction::NorthEast) == calcT1(MapPoint(0, 2)));
+        auto terrain = world.GetTerrain(testPt, Direction::SouthEast);
+        BOOST_TEST(terrain.left == calcT2(testPt));
+        BOOST_TEST(terrain.right == calcT1(testPt));
+        terrain = world.GetTerrain(testPt, Direction::West);
+        BOOST_TEST(terrain.left == calcT2(MapPoint(4, 3)));
+        BOOST_TEST(terrain.right == calcT1(MapPoint(5, 2)));
+        terrain = world.GetTerrain(testPt, Direction::NorthEast);
+        BOOST_TEST(terrain.left == calcT2(MapPoint(5, 2)));
+        BOOST_TEST(terrain.right == calcT1(MapPoint(0, 2)));
     }
-    // Now assume GetRightTerrain works and only check for consistency:
+    // Now assume GetTerrain works and only check for consistency:
     RTTR_FOREACH_PT(MapPoint, world.GetSize())
     {
         BOOST_TEST_CONTEXT(pt)
@@ -317,7 +325,6 @@ BOOST_AUTO_TEST_CASE(GetTerrainReturnsCorrectValues)
             const auto terrains = world.GetTerrainsAround(pt);
             for(const auto dir : helpers::enumRange<Direction>())
             {
-                BOOST_TEST(terrains[dir] == world.GetRightTerrain(pt, dir));
                 const auto terrain = world.GetTerrain(pt, dir);
                 BOOST_TEST(terrain.left == terrains[dir - 1u]);
                 BOOST_TEST(terrain.right == terrains[dir]);

--- a/tests/s25Main/mapGenerator/testHarbors.cpp
+++ b/tests/s25Main/mapGenerator/testHarbors.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(PlaceHarborPosition_flattens_ground_around_harbor_position)
 
     for(unsigned i = 0; i < neighbors.size(); i++)
     {
-        map.z[neighbors[i]] = minHeight + i;
+        map.z[neighbors[Direction(i)]] = minHeight + i;
     }
 
     // run actual test

--- a/tests/s25Main/simple/testMapBase.cpp
+++ b/tests/s25Main/simple/testMapBase.cpp
@@ -127,6 +127,10 @@ BOOST_AUTO_TEST_CASE(GetMatchingPointsInRadius)
         BOOST_TEST(pt.x % 2 == 1);
     for(const MapPoint pt : evenPts)
         BOOST_TEST(pt.x % 2 == 0);
+    const std::vector<MapPoint> firstEvenPt =
+      world.GetMatchingPointsInRadius<1>(center, 5, [](const MapPoint pt) { return pt.x % 2 == 0; });
+    BOOST_TEST_REQUIRE(firstEvenPt.size() == 1u);
+    BOOST_TEST(firstEvenPt.front() == evenPts.front());
 }
 
 BOOST_AUTO_TEST_CASE(GetIdx)

--- a/tests/s25Main/simple/testOpenLists.cpp
+++ b/tests/s25Main/simple/testOpenLists.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2021 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "pathfinding/OpenListBinaryHeap.h"
+#include <rttr/test/random.hpp>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <iterator>
+#include <set>
+#include <vector>
+
+namespace {
+struct ListEl
+{
+    unsigned key;
+    OpenListBinaryHeapBase<ListEl>::PosMarker posMarker;
+};
+
+struct ListGetKey
+{
+    constexpr auto operator()(const ListEl& el) const { return el.key; }
+};
+
+class OpenList : public OpenListBinaryHeap<ListEl, ListGetKey>
+{
+public:
+    using Parent = OpenListBinaryHeap<ListEl, ListGetKey>;
+    using Parent::arePositionsValid;
+    using Parent::isHeap;
+};
+auto getSortedVector(unsigned ct, bool ascending)
+{
+    std::vector<ListEl> elements;
+    std::generate_n(std::back_inserter(elements), ct, [i = 0u]() mutable { return ListEl{i++, {}}; });
+    if(!ascending)
+        std::reverse(elements.begin(), elements.end());
+    return elements;
+}
+auto getRandomVector(unsigned ct, unsigned maxVal = 100000)
+{
+    std::vector<ListEl> elements;
+    std::uniform_int_distribution<unsigned> distr(0, maxVal);
+    std::generate_n(std::back_inserter(elements), ct, [&]() { return ListEl{distr(rttr::test::getRandState()), {}}; });
+    return elements;
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(OpenLists)
+
+BOOST_AUTO_TEST_CASE(PushTopWorks)
+{
+    OpenList list;
+    BOOST_TEST_REQUIRE(list.isHeap());
+    BOOST_TEST_REQUIRE(list.arePositionsValid());
+    BOOST_TEST_REQUIRE(list.size() == 0u);
+    BOOST_TEST_REQUIRE(list.empty());
+
+    std::vector<ListEl> elements = getSortedVector(rttr::test::randomValue(5u, 30u), true);
+    for(unsigned i = 0; i < elements.size(); ++i)
+    {
+        // After pushing an element the list must still be a heap and the first (lowest) element at the top
+        list.push(&elements[i]);
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+        BOOST_TEST(list.size() == i + 1u);
+        BOOST_TEST(list.top() == &elements.front());
+    }
+
+    list.clear();
+    BOOST_TEST_REQUIRE(list.empty());
+
+    // Now the same but in reverse
+    elements = getSortedVector(rttr::test::randomValue(5u, 30u), false);
+    for(unsigned i = 0; i < elements.size(); ++i)
+    {
+        // After pushing an element the list must still be a heap and the last (lowest) element at the top
+        list.push(&elements[i]);
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+        BOOST_TEST(list.size() == i + 1u);
+        BOOST_TEST(list.top() == &elements[i]);
+    }
+
+    list.clear();
+    BOOST_TEST_REQUIRE(list.empty());
+
+    // And random
+    elements = getRandomVector(rttr::test::randomValue(5u, 50u));
+    for(unsigned i = 0; i < elements.size(); ++i)
+    {
+        // After pushing an element the list must still be a heap and the lowest element at the top
+        list.push(&elements[i]);
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+        BOOST_TEST(list.size() == i + 1u);
+        const auto minVal =
+          std::min_element(elements.begin(), elements.begin() + i + 1, [](const auto& lhs, const auto& rhs) {
+              return lhs.key < rhs.key;
+          })->key;
+        BOOST_TEST(list.top()->key == minVal);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PopRemovesLowestElement)
+{
+    OpenList list;
+
+    // Random vector with some duplicate elements
+    auto elements = getRandomVector(rttr::test::randomValue(30u, 70u), 20);
+    std::multiset<unsigned> keys;
+    for(unsigned i = 0; i < elements.size(); ++i)
+    {
+        list.push(&elements[i]);
+        keys.insert(elements[i].key);
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+        BOOST_TEST(list.size() == i + 1u);
+    }
+    // Pop all elements should return lowest elements first (hence the set for comparison)
+    for(unsigned i = 0; i < elements.size(); ++i)
+    {
+        BOOST_TEST_REQUIRE(!list.empty());
+        const auto* el = list.top();
+        BOOST_TEST(el->key == *keys.begin());
+        const auto* elPop = list.pop();
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+        BOOST_TEST(elPop->key == *keys.begin());
+        BOOST_TEST(elPop == el);
+        keys.erase(keys.begin());
+    }
+    BOOST_TEST(list.empty());
+}
+
+BOOST_AUTO_TEST_CASE(RearrangeMakesTheHeapValidAgain)
+{
+    OpenList list;
+
+    // Random vector with some duplicate elements
+    auto elements = getRandomVector(rttr::test::randomValue(30u, 70u), 20);
+    std::multiset<unsigned> keys;
+    for(unsigned i = 0; i < elements.size(); ++i)
+    {
+        list.push(&elements[i]);
+        // Just to be sure, actually already tested
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+    }
+    // Change each element once
+    for(auto& el : elements)
+    {
+        list.rearrange(&el); // No-op
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+        // Make a lower value
+        if(el.key > 0u)
+            el.key = rttr::test::randomValue(0u, el.key - 1u);
+        keys.insert(el.key);
+        list.rearrange(&el);
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+    }
+
+    // Pop all elements in right order
+    for(unsigned i = 0; i < elements.size(); ++i)
+    {
+        BOOST_TEST_REQUIRE(!list.empty());
+        const auto* el = list.top();
+        const auto* elPop = list.pop();
+        BOOST_TEST_REQUIRE(list.isHeap());
+        BOOST_TEST_REQUIRE(list.arePositionsValid());
+        BOOST_TEST(elPop == el);
+        BOOST_TEST(elPop->key == *keys.begin());
+        keys.erase(keys.begin());
+    }
+    BOOST_TEST(list.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/simple/testOpenLists.cpp
+++ b/tests/s25Main/simple/testOpenLists.cpp
@@ -24,10 +24,10 @@
 #include <vector>
 
 namespace {
-struct ListEl
+struct ListEl : BinaryHeapPosMarker
 {
     unsigned key;
-    OpenListBinaryHeapBase<ListEl>::PosMarker posMarker;
+    ListEl(unsigned key) : key(key) {}
 };
 
 struct ListGetKey
@@ -35,17 +35,19 @@ struct ListGetKey
     constexpr auto operator()(const ListEl& el) const { return el.key; }
 };
 
-class OpenList : public OpenListBinaryHeap<ListEl, ListGetKey>
+using OpenListBase = OpenListBinaryHeap<ListEl, ListGetKey>;
+
+class OpenList : public OpenListBase
 {
 public:
-    using Parent = OpenListBinaryHeap<ListEl, ListGetKey>;
+    using Parent = OpenListBase;
     using Parent::arePositionsValid;
     using Parent::isHeap;
 };
 auto getSortedVector(unsigned ct, bool ascending)
 {
     std::vector<ListEl> elements;
-    std::generate_n(std::back_inserter(elements), ct, [i = 0u]() mutable { return ListEl{i++, {}}; });
+    std::generate_n(std::back_inserter(elements), ct, [i = 0u]() mutable { return ListEl(i++); });
     if(!ascending)
         std::reverse(elements.begin(), elements.end());
     return elements;
@@ -54,7 +56,7 @@ auto getRandomVector(unsigned ct, unsigned maxVal = 100000)
 {
     std::vector<ListEl> elements;
     std::uniform_int_distribution<unsigned> distr(0, maxVal);
-    std::generate_n(std::back_inserter(elements), ct, [&]() { return ListEl{distr(rttr::test::getRandState()), {}}; });
+    std::generate_n(std::back_inserter(elements), ct, [&]() { return ListEl(distr(rttr::test::getRandState())); });
     return elements;
 }
 } // namespace

--- a/tests/s25Main/simple/testOpenLists.cpp
+++ b/tests/s25Main/simple/testOpenLists.cpp
@@ -27,7 +27,7 @@ namespace {
 struct ListEl : BinaryHeapPosMarker
 {
     unsigned key;
-    ListEl(unsigned key) : key(key) {}
+    ListEl(unsigned key) : BinaryHeapPosMarker(), key(key) {}
 };
 
 struct ListGetKey
@@ -155,9 +155,9 @@ BOOST_AUTO_TEST_CASE(RearrangeMakesTheHeapValidAgain)
     // Random vector with some duplicate elements
     auto elements = getRandomVector(rttr::test::randomValue(30u, 70u), 20);
     std::multiset<unsigned> keys;
-    for(unsigned i = 0; i < elements.size(); ++i)
+    for(auto& el : elements)
     {
-        list.push(&elements[i]);
+        list.push(&el);
         // Just to be sure, actually already tested
         BOOST_TEST_REQUIRE(list.isHeap());
         BOOST_TEST_REQUIRE(list.arePositionsValid());

--- a/tests/s25Main/worldFixtures/CreateSeaWorld.cpp
+++ b/tests/s25Main/worldFixtures/CreateSeaWorld.cpp
@@ -38,16 +38,14 @@ bool PlaceHarbor(MapPoint pt, GameWorldBase& world, std::vector<MapPoint>& harbo
         if(world.GetNode(curPt).bq != BuildingQuality::Castle)
             continue;
         // We must have a coast around
-        for(const auto dir : helpers::EnumRange<Direction>{})
+        for(const MapPoint posCoastPt : world.GetNeighbours(curPt))
         {
-            MapPoint posCoastPt = world.GetNeighbour(curPt, dir);
             // Coast must not be water
             if(world.IsWaterPoint(posCoastPt))
                 continue; // LCOV_EXCL_LINE
             // But somewhere around must be a sea
-            for(const auto j : helpers::EnumRange<Direction>{})
+            for(const MapPoint posSeaPt : world.GetNeighbours(posCoastPt))
             {
-                MapPoint posSeaPt = world.GetNeighbour(posCoastPt, j);
                 if(world.IsSeaPoint(posSeaPt))
                 {
                     harbors.push_back(curPt);

--- a/tests/s25Main/worldFixtures/WorldFixture.h
+++ b/tests/s25Main/worldFixtures/WorldFixture.h
@@ -128,3 +128,15 @@ struct WorldFixture
         return result;
     }
 };
+
+class TestWorld : public World
+{
+public:
+    TestWorld() = default;
+    TestWorld(const MapExtent size, DescIdx<LandscapeDesc> lt = DescIdx<LandscapeDesc>{1}) { Init(size, lt); }
+    using World::GetNodeInt;
+
+protected:
+    void AltitudeChanged(MapPoint) override {}
+    void VisibilityChanged(MapPoint, unsigned, Visibility, Visibility) override {}
+};

--- a/tests/s25Main/worldFixtures/WorldFixture.h
+++ b/tests/s25Main/worldFixtures/WorldFixture.h
@@ -137,6 +137,8 @@ public:
     using World::GetNodeInt;
 
 protected:
+    // LCOV_EXCL_START
     void AltitudeChanged(MapPoint) override {}
     void VisibilityChanged(MapPoint, unsigned, Visibility, Visibility) override {}
+    // LCOV_EXCL_STOP
 };


### PR DESCRIPTION
Improve the speed for freepathfinding by over 100% (more than twice as fast)
Replay speed in total has decreased by 10%

Adds a new option RTTR_ENABLE_BENCHMARKS which adds benchmarks for the pathfinding using Google Benchmark.

- [x] Based on #1382

More measurements at various stages:

```
First benchmarks. Replays: 29.6s, 31.5s -- 520.6s, 603.1s
BM_World/0       1087 ns         1088 ns       746667 Simple 1
BM_World/1       3206 ns         3209 ns       224000 Simple 2
BM_World/2       4375 ns         4395 ns       160000 Simple 3
BM_World/3      25026 ns        25112 ns        28000 Medium 1
BM_World/4      13205 ns        13393 ns        56000 Medium 2
BM_World/5     188842 ns       188354 ns         3733 Hard
BM_World/6     492699 ns       500000 ns         1000 Water

Small vector
BM_World/0       1030 ns         1025 ns       746667 Simple 1
BM_World/1       3178 ns         3223 ns       213333 Simple 2
BM_World/2       4360 ns         4395 ns       160000 Simple 3
BM_World/3      25319 ns        25495 ns        26353 Medium 1
BM_World/4      13283 ns        13497 ns        49778 Medium 2
BM_World/5     189965 ns       192540 ns         3733 Hard
BM_World/6     497743 ns       488281 ns         1120 Water

GetNeighbors
BM_World/0        901 ns          900 ns       746667 Simple 1
BM_World/1       2646 ns         2623 ns       280000 Simple 2
BM_World/2       3605 ns         3610 ns       194783 Simple 3
BM_World/3      20448 ns        20403 ns        34462 Medium 1
BM_World/4      11108 ns        11230 ns        64000 Medium 2
BM_World/5     156301 ns       156948 ns         4480 Hard
BM_World/6     413698 ns       414406 ns         1659 Water

Combined GetTerrain
BM_World/0        673 ns          663 ns       896000 Simple 1
BM_World/1       1960 ns         1995 ns       344615 Simple 2
BM_World/2       2635 ns         2668 ns       263529 Simple 3
BM_World/3      15003 ns        15067 ns        49778 Medium 1
BM_World/4       8072 ns         8022 ns        89600 Medium 2
BM_World/5     118022 ns       117188 ns         6400 Hard
BM_World/6     320906 ns       322316 ns         2133 Water

Inline GetRightTerrain into GetTerrainsAround
BM_World/0        641 ns          642 ns      1120000 Simple 1
BM_World/1       1825 ns         1842 ns       407273 Simple 2
BM_World/2       2518 ns         2511 ns       280000 Simple 3
BM_World/3      14081 ns        14125 ns        49778 Medium 1
BM_World/4       7874 ns         7847 ns        89600 Medium 2
BM_World/5     112609 ns       112305 ns         6400 Hard
BM_World/6     309510 ns       306920 ns         2240 Water

Don't use GetNeighborNode in GetTerrainsAround
BM_World/0        447 ns          445 ns      1544828 Simple 1
BM_World/1       1310 ns         1318 ns       497778 Simple 2
BM_World/2       1887 ns         1925 ns       373333 Simple 3
BM_World/3      10534 ns        10498 ns        64000 Medium 1
BM_World/4       5720 ns         5720 ns       112000 Medium 2
BM_World/5      91619 ns        92072 ns         7467 Hard
BM_World/6     259750 ns       256696 ns         2800 Water

Inline functions into GetTerrain. Replays: 27.4s, 28.4s -- 502.7s, 583.5s
BM_World/0        379 ns          381 ns      1723077 Simple 1
BM_World/1       1073 ns         1074 ns       640000 Simple 2
BM_World/2       1457 ns         1444 ns       497778 Simple 3
BM_World/3       8528 ns         8545 ns        89600 Medium 1
BM_World/4       4306 ns         4332 ns       165926 Medium 2
BM_World/5      80995 ns        80218 ns         8960 Hard
BM_World/6     226126 ns       224933 ns         2987 Water
```