### PR TITLE
Explicitely set the clang-format version to EXACT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON CACHE BOOL "Inline symbol visibility")
 # ClangFormat
 ################################################################################
 
-find_package(ClangFormat 10)
+find_package(ClangFormat 10 EXACT)
 
 ################################################################################
 # Set paths.


### PR DESCRIPTION
This avoids a misleading message about why later versions are incompatible, e.g.: 'found suitable version "11.1.0", minimum required is "10"'

Fixes #1400