### PR TITLE
Fix AI AdjustSettings to create correct tools

### DIFF
--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -2362,20 +2362,21 @@ void AIPlayerJH::AdjustSettings()
     ToolSettings toolsettings;
     const Inventory& inventory = aii.GetInventory();
     // Saw
-    toolsettings[2] = (inventory.goods[GoodType::Saw] + inventory.people[Job::Carpenter] < 2) ?
+    toolsettings[3] = (inventory.goods[GoodType::Saw] + inventory.people[Job::Carpenter] < 2) ?
                         4 :
                         inventory.goods[GoodType::Saw] < 1 ? 1 : 0;
+
     // Pickaxe
-    toolsettings[3] = (inventory.goods[GoodType::PickAxe] < 1) ? 1 : 0;
+    toolsettings[4] = (inventory.goods[GoodType::PickAxe] < 1) ? 1 : 0;
     // Hammer
-    toolsettings[4] = (inventory.goods[GoodType::Hammer] < 1) ? 1 : 0;
+    toolsettings[1] = (inventory.goods[GoodType::Hammer] < 1) ? 1 : 0;
     // Crucible
     toolsettings[6] = (inventory.goods[GoodType::Crucible] + inventory.people[Job::IronFounder]
                        < bldPlanner->GetNumBuildings(BuildingType::Ironsmelter) + 1) ?
                         1 :
                         0;
     // Scythe
-    toolsettings[8] = (toolsettings[4] < 1 && toolsettings[3] < 1 && toolsettings[6] < 1 && toolsettings[2] < 1
+    toolsettings[8] = (toolsettings[4] < 1 && toolsettings[3] < 1 && toolsettings[6] < 1 && toolsettings[1] < 1
                        && (inventory.goods[GoodType::Scythe] < 1)) ?
                         1 :
                         0;
@@ -2385,12 +2386,12 @@ void AIPlayerJH::AdjustSettings()
                          1 :
                          0;
     // Shovel
-    toolsettings[5] = (toolsettings[4] < 1 && toolsettings[3] < 1 && toolsettings[6] < 1 && toolsettings[2] < 1
+    toolsettings[5] = (toolsettings[4] < 1 && toolsettings[3] < 1 && toolsettings[6] < 1 && toolsettings[1] < 1
                        && (inventory.goods[GoodType::Shovel] < 1)) ?
                         1 :
                         0;
     // Axe
-    toolsettings[1] = (toolsettings[4] < 1 && toolsettings[3] < 1 && toolsettings[6] < 1 && toolsettings[2] < 1
+    toolsettings[2] = (toolsettings[4] < 1 && toolsettings[3] < 1 && toolsettings[6] < 1 && toolsettings[1] < 1
                        && (inventory.goods[GoodType::Axe] + inventory.people[Job::Woodcutter] < 12)
                        && inventory.goods[GoodType::Axe] < 1) ?
                         1 :


### PR DESCRIPTION
### Disclaimer: This is the first time I ever touched C++ code. I'm a python hobbyist with no professional background. I hope I can make a humble contribution to this great project.

As mentioned on the forums and in an issue (fixes #1084), AI tended to build wrong tools. To investigate, I privately added logging corresponding to the commented tools in `AIPlayerJH.cpp` `AdjustSettings`:

https://github.com/Return-To-The-Roots/s25client/blob/85a6b994185edbe1479462efc640abcc9a048fb9/libs/s25main/ai/aijh/AIPlayerJH.cpp#L2364-L2368

Running a game observing this logging, then saving the game and returning as one of the AIs, I saw they set up their tools wrong.

I found the order in `ToolConsts.h` matched the order of the ingame interface, but the indexes used in `AIPlayerJH.cpp` did not match this - as you can see, `GoodType::Saw` would be index 3 here, while above `toolsettings[2]` is commented as `Saw`.

https://github.com/Return-To-The-Roots/s25client/blob/85a6b994185edbe1479462efc640abcc9a048fb9/libs/s25main/gameData/ToolConsts.h#L24-L37

After matching the indexes in `AIPlayerJH.cpp` to `ToolConsts.h`, which is what this PR does, local testing shows AI producing expected tools again.

In case direct contact would be required, I joined the discord server as `Spezus`.