### PR TITLE
Custom nations are lowercase -> Fix loading code

### DIFF
--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -357,7 +357,7 @@ NationResourcesSource getNationResourcesSource(const Nation nation, bool isWinte
     if(isWinter)
         buildingsFilename.insert(buildingsFilename.begin(), 'W');
     bfs::path nationFolder;
-    // The original ("native") nations ise uppercase file names while we use lowercase names for the new ones
+    // The original ("native") nations use uppercase file names while we use lowercase names for the new ones
     // Especially relevant for case sensitive file systems
     if(rttr::enum_cast(nation) < NUM_NATIVE_NATIONS)
     {

--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -357,6 +357,8 @@ NationResourcesSource getNationResourcesSource(const Nation nation, bool isWinte
     if(isWinter)
         buildingsFilename.insert(buildingsFilename.begin(), 'W');
     bfs::path nationFolder;
+    // The original ("native") nations ise uppercase file names while we use lowercase names for the new ones
+    // Especially relevant for case sensitive file systems
     if(rttr::enum_cast(nation) < NUM_NATIVE_NATIONS)
     {
         nationFolder = config.ExpandPath(s25::folders::mbob);

--- a/tests/s25Main/benchmarks/CMakeLists.txt
+++ b/tests/s25Main/benchmarks/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
     FetchContent_Declare(
         GoogleBenchmark
         GIT_REPOSITORY https://github.com/google/benchmark.git
-        GIT_TAG v1.5.2
+        GIT_TAG v1.5.3
     )
     set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
     set(BENCHMARK_ENABLE_INSTALL  OFF CACHE BOOL "")


### PR DESCRIPTION
Fixes #1420

Instead of renaming our new files to UPPERCASE I created code to detect the lower case filenames which IMO is nicer as e.g. our resource IDs are lowercase and most other resources are too.

Factored out into a new function for clarity