### PR TITLE
Introduce separate constant for build date 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT RTTR_VERSION)
     string(TIMESTAMP RTTR_VERSION "%Y%m%d")
 endif()
 
-project(s25client VERSION ${RTTR_VERSION})
+project(RTTR VERSION ${RTTR_VERSION})
 
 message(STATUS "Using CMake ${CMAKE_VERSION}")
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Then just run (tests or application) as usual.
     - Enter boost installation path for "Value"
     - Press ok
   - Press generate
-- Open and use build/s25client.sln
+- Open and use build/RTTR.sln
 
 --
 

--- a/libs/rttrConfig/CMakeLists.txt
+++ b/libs/rttrConfig/CMakeLists.txt
@@ -22,6 +22,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/build_paths.h.cmake build_paths.h @ON
 if(NOT RTTR_REVISION OR NOT RTTR_VERSION)
     message(FATAL_ERROR "Internal error: RTTR_REVISION or RTTR_VERSION not set")
 endif()
+string(TIMESTAMP RTTR_BUILD_DATE "%Y%m%d")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/build_version_defines.h.cmake build_version_defines.h @ONLY)
 
 target_include_directories(rttrConfig PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/libs/rttrConfig/build_version_defines.h.cmake
+++ b/libs/rttrConfig/build_version_defines.h.cmake
@@ -4,5 +4,9 @@
 
 #pragma once
 
-#define WINDOW_VERSION "@RTTR_VERSION@"
-#define WINDOW_REVISION "@RTTR_REVISION@"
+namespace rttr
+{
+	constexpr const char* BUILD_DATE = "@RTTR_BUILD_DATE@";
+	constexpr const char* VERSION = "@RTTR_VERSION@";
+	constexpr const char* REVISION = "@RTTR_REVISION@";
+}

--- a/libs/rttrConfig/src/RTTR_Version.cpp
+++ b/libs/rttrConfig/src/RTTR_Version.cpp
@@ -5,33 +5,20 @@
 #include "RTTR_Version.h"
 #include "build_version_defines.h"
 
-std::string RTTR_Version::GetTitle()
-{
-    return "Return To The Roots";
-}
+namespace rttr { namespace version {
 
-std::string RTTR_Version::GetVersionDate()
-{
-    return WINDOW_VERSION;
-}
+    std::string GetTitle() { return "Return To The Roots"; }
 
-std::string RTTR_Version::GetRevision()
-{
-    return WINDOW_REVISION;
-}
+    std::string GetVersion() { return rttr::VERSION; }
 
-std::string RTTR_Version::GetShortRevision()
-{
-    return std::string(WINDOW_REVISION).substr(0, 7);
-}
+    std::string GetBuildDate() { return rttr::BUILD_DATE; }
 
-std::string RTTR_Version::GetYear()
-{
-    // nasty but works, if versioning principle changes, we should make it use date function
-    return std::string(WINDOW_VERSION).substr(0, 4);
-}
+    std::string GetRevision() { return rttr::REVISION; }
 
-std::string RTTR_Version::GetReadableVersion()
-{
-    return "v" + GetVersionDate() + " - " + GetShortRevision();
-}
+    std::string GetShortRevision() { return GetRevision().substr(0, 7); }
+
+    std::string GetYear() { return GetBuildDate().substr(0, 4); }
+
+    std::string GetReadableVersion() { return "v" + GetVersion() + " - " + GetShortRevision(); }
+
+}} // namespace rttr::version

--- a/libs/rttrConfig/src/RTTR_Version.h
+++ b/libs/rttrConfig/src/RTTR_Version.h
@@ -6,13 +6,12 @@
 
 #include <string>
 
-class RTTR_Version
-{
-public:
-    static std::string GetTitle();
-    static std::string GetVersionDate();
-    static std::string GetRevision();
-    static std::string GetShortRevision();
-    static std::string GetYear();
-    static std::string GetReadableVersion();
-};
+namespace rttr { namespace version {
+    std::string GetTitle();
+    std::string GetVersion();
+    std::string GetBuildDate();
+    std::string GetRevision();
+    std::string GetShortRevision();
+    std::string GetYear();
+    std::string GetReadableVersion();
+}} // namespace rttr::version

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -94,8 +94,7 @@ void WaitForEnter()
 std::string GetProgramDescription()
 {
     std::stringstream s;
-    s << RTTR_Version::GetTitle() << " v" << RTTR_Version::GetVersionDate() << "-" << RTTR_Version::GetRevision()
-      << "\n"
+    s << rttr::version::GetTitle() << " v" << rttr::version::GetVersion() << "-" << rttr::version::GetRevision() << "\n"
       << "Compiled with " << System::getCompilerName() << " for " << System::getOSName();
     return s.str();
 }

--- a/libs/s25main/Debug.cpp
+++ b/libs/s25main/Debug.cpp
@@ -166,8 +166,8 @@ DebugInfo::DebugInfo()
     // Bits
     SendUnsigned(sizeof(void*) * 8u);
 
-    SendString(RTTR_Version::GetVersionDate());
-    SendString(RTTR_Version::GetRevision());
+    SendString(rttr::version::GetVersion());
+    SendString(rttr::version::GetRevision());
 
     SendUnsigned(GAMECLIENT.GetGFNumber());
 }

--- a/libs/s25main/SavedFile.cpp
+++ b/libs/s25main/SavedFile.cpp
@@ -15,7 +15,7 @@
 
 SavedFile::SavedFile() : saveTime_(0)
 {
-    const std::string rev = RTTR_Version::GetRevision();
+    const std::string rev = rttr::version::GetRevision();
     std::copy(rev.begin(), rev.begin() + revision.size(), revision.begin());
 }
 

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -176,7 +176,7 @@ void Settings::Load()
         // global
         // {
         // stimmt die Spielrevision überein?
-        if(iniGlobal->getValue("gameversion") != RTTR_Version::GetRevision())
+        if(iniGlobal->getValue("gameversion") != rttr::version::GetRevision())
             s25util::warning("Your application version has changed - please recheck your settings!\n");
 
         global.submit_debug_data = iniGlobal->getValueI("submit_debug_data");
@@ -321,7 +321,7 @@ void Settings::Save()
     // global
     // {
     iniGlobal->setValue("version", VERSION);
-    iniGlobal->setValue("gameversion", RTTR_Version::GetRevision());
+    iniGlobal->setValue("gameversion", rttr::version::GetRevision());
     iniGlobal->setValue("submit_debug_data", global.submit_debug_data);
     iniGlobal->setValue("use_upnp", global.use_upnp);
     iniGlobal->setValue("smartCursor", global.smartCursor ? 1 : 0);

--- a/libs/s25main/desktops/dskLAN.cpp
+++ b/libs/s25main/desktops/dskLAN.cpp
@@ -153,7 +153,7 @@ bool dskLAN::ConnectToSelectedGame()
         return false;
 
     const GameInfo& game = openGames[selectedId];
-    if(game.info.revision == RTTR_Version::GetRevision())
+    if(game.info.revision == rttr::version::GetRevision())
     {
         auto connect = std::make_unique<iwDirectIPConnect>(ServerType::LAN);
         connect->Connect(game.ip, game.info.port, game.info.isIPv6, game.info.hasPwd);

--- a/libs/s25main/desktops/dskLobby.cpp
+++ b/libs/s25main/desktops/dskLobby.cpp
@@ -218,7 +218,7 @@ bool dskLobby::ConnectToSelectedGame()
         std::string serverRevision = itServer->getVersion();
         if(!serverRevision.empty() && serverRevision[0] == 'v')
             serverRevision = serverRevision.substr(std::string("v20001011 - ").size());
-        if(serverRevision == RTTR_Version::GetShortRevision())
+        if(serverRevision == rttr::version::GetShortRevision())
         {
             auto connect = std::make_unique<iwDirectIPConnect>(ServerType::Lobby);
             connect->Connect(itServer->getHost(), itServer->getPort(), false, itServer->hasPassword());

--- a/libs/s25main/desktops/dskMenuBase.cpp
+++ b/libs/s25main/desktops/dskMenuBase.cpp
@@ -22,12 +22,12 @@ void dskMenuBase::AddBottomTexts()
 {
     AddFormattedText(ID_txtVersion, DrawPoint(0, 600), "Return To The Roots - %1%", COLOR_YELLOW,
                      FontStyle::LEFT | FontStyle::BOTTOM, NormalFont)
-      % RTTR_Version::GetReadableVersion();
+      % rttr::version::GetReadableVersion();
     AddText(ID_txtURL, DrawPoint(400, 600), "http://www.siedler25.org", COLOR_GREEN,
             FontStyle::CENTER | FontStyle::BOTTOM, NormalFont);
     AddFormattedText(ID_txtCopyright, DrawPoint(800, 600),
                      "\xC2\xA9"
                      " 2005 - %s Settlers Freaks",
                      COLOR_YELLOW, FontStyle::RIGHT | FontStyle::BOTTOM, NormalFont)
-      % RTTR_Version::GetYear();
+      % rttr::version::GetYear();
 }

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -100,7 +100,7 @@ bool VideoDriverWrapper::CreateScreen(const VideoMode size, const bool fullscree
         return false;
     }
 
-    if(!videodriver->CreateScreen(RTTR_Version::GetTitle(), size, fullscreen))
+    if(!videodriver->CreateScreen(rttr::version::GetTitle(), size, fullscreen))
     {
         s25util::fatal_error("Could not create window!\n");
         return false;

--- a/libs/s25main/ingameWindows/iwLobbyConnect.cpp
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.cpp
@@ -80,7 +80,7 @@ iwLobbyConnect::iwLobbyConnect()
     AddTextButton(ID_btConnect, DrawPoint(20, 190), btSize, TextureColor::Red1, _("Connect"), NormalFont);
     AddTextButton(ID_btRegister, DrawPoint(260, 190), btSize, TextureColor::Green2, _("Register"), NormalFont);
 
-    LOBBYCLIENT.SetProgramVersion(RTTR_Version::GetReadableVersion());
+    LOBBYCLIENT.SetProgramVersion(rttr::version::GetReadableVersion());
     LOBBYCLIENT.AddListener(this);
 }
 

--- a/libs/s25main/ingameWindows/iwOptionsWindow.cpp
+++ b/libs/s25main/ingameWindows/iwOptionsWindow.cpp
@@ -54,13 +54,13 @@ iwOptionsWindow::iwOptionsWindow(SoundManager& soundManager)
     AddImage(ID_imgSoldier, DrawPoint(150, 36), LOADER.GetImageN("io", 30));
 
     AddText(ID_txtRttr, DrawPoint(150, 60), "Return To The Roots", COLOR_YELLOW, FontStyle::CENTER, NormalFont);
-    AddText(ID_txtVersion, DrawPoint(150, 77), RTTR_Version::GetReadableVersion(), COLOR_YELLOW, FontStyle::CENTER,
+    AddText(ID_txtVersion, DrawPoint(150, 77), rttr::version::GetReadableVersion(), COLOR_YELLOW, FontStyle::CENTER,
             NormalFont);
     AddFormattedText(ID_txtCopyright, DrawPoint(150, 94),
                      "\xC2\xA9"
                      "2005 - %s Settlers Freaks",
                      COLOR_YELLOW, FontStyle::CENTER, NormalFont)
-      % RTTR_Version::GetYear();
+      % rttr::version::GetYear();
 
     AddImageButton(ID_btKeyboardLayout, DrawPoint(35, 120), Extent(35, 35), TextureColor::Green2,
                    LOADER.GetImageN("io", 79));

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -388,7 +388,7 @@ bool GameClient::OnGameMessage(const GameMessage_Player_Id& msg)
     mainPlayer.playerId = msg.player;
 
     // Server-Typ senden
-    mainPlayer.sendMsgAsync(new GameMessage_Server_Type(clientconfig.servertyp, RTTR_Version::GetRevision()));
+    mainPlayer.sendMsgAsync(new GameMessage_Server_Type(clientconfig.servertyp, rttr::version::GetRevision()));
     return true;
 }
 

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -240,8 +240,8 @@ void GameServer::AnnounceStatusChange()
         info.maxNumPlayers = playerInfos.size();
         info.port = config.port;
         info.isIPv6 = config.ipv6;
-        info.version = RTTR_Version::GetReadableVersion();
-        info.revision = RTTR_Version::GetRevision();
+        info.version = rttr::version::GetReadableVersion();
+        info.revision = rttr::version::GetRevision();
         Serializer ser;
         info.Serialize(ser);
         lanAnnouncer.SetPayload(ser.GetData(), ser.GetLength());
@@ -915,7 +915,7 @@ bool GameServer::OnGameMessage(const GameMessage_Server_Type& msg)
     int typeok = 0;
     if(msg.type != config.servertype)
         typeok = 1;
-    else if(msg.revision != RTTR_Version::GetRevision())
+    else if(msg.revision != rttr::version::GetRevision())
         typeok = 2;
 
     player->sendMsgAsync(new GameMessage_Server_TypeOK(typeok));

--- a/tests/rttrConfig/testRttrConfig.cpp
+++ b/tests/rttrConfig/testRttrConfig.cpp
@@ -4,11 +4,13 @@
 
 #define BOOST_TEST_MODULE RTTR_Config
 
+#include "RTTR_Version.h"
 #include "RttrConfig.h"
 #include "s25util/System.h"
 #include <rttr/test/BaseFixture.hpp>
 #include <rttr/test/LogAccessor.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/nowide/args.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -55,4 +57,24 @@ BOOST_FIXTURE_TEST_CASE(PrefixPath, rttr::test::BaseFixture)
         BOOST_TEST_REQUIRE(RTTRCONFIG.Init());
         BOOST_TEST(prefixPath == fs::current_path());
     }
+}
+
+BOOST_AUTO_TEST_CASE(YearIsValid)
+{
+    const std::string year = rttr::version::GetYear();
+    BOOST_TEST(year.length() == 4u);
+    int iYear;
+    BOOST_TEST_REQUIRE(boost::conversion::try_lexical_convert(year, iYear));
+    BOOST_TEST(iYear >= 2000);
+    BOOST_TEST(iYear < 3000);
+}
+
+BOOST_AUTO_TEST_CASE(BuildDateIsValid)
+{
+    const std::string date = rttr::version::GetBuildDate();
+    BOOST_TEST(date.length() == 8u);
+    int iDate;
+    BOOST_TEST_REQUIRE(boost::conversion::try_lexical_convert(date, iDate));
+    BOOST_TEST(iDate >= 20000000);
+    BOOST_TEST(iDate < 30000000);
 }


### PR DESCRIPTION
For stable the version is an actual version and does not contain the date, hence the need for a new constant

Using `constexpr const char*` now instead of defines

