### PR TITLE
Fix build with Boost 1.77 (missing <algorithm> include)

### DIFF
--- a/libs/s25main/convertSounds.cpp
+++ b/libs/s25main/convertSounds.cpp
@@ -8,6 +8,7 @@
 #include <libsiedler2/ArchivItem_Sound_Wave.h>
 #include <libsiedler2/loadMapping.h>
 #include <s25util/StringConversion.h>
+#include <algorithm>
 #include <cmath>
 #include <samplerate.hpp>
 #include <sstream>


### PR DESCRIPTION
Fix build with Boost 1.77 (missing <algorithm> include)

Needed for std::transform which is defined within <algorithm>. The
build fails with newer versions	of Boost, presumably because of
a missing indirect include.

Closes: https://bugs.gentoo.org/808767