### PR TITLE
Fix test broken by change in libsamplerate 0.2.0

### DIFF
--- a/libs/libsamplerate/include/samplerate.hpp
+++ b/libs/libsamplerate/include/samplerate.hpp
@@ -152,6 +152,8 @@ class State : public detail::StateBase
 {
     static SRC_STATE* createOrThrow(Converter converter, int channels)
     {
+        if (channels <= 0)
+            throw std::runtime_error("Channel count must be >= 1.");
         int error;
         auto* state = src_new(static_cast<int>(converter), channels, &error);
         if(!state)
@@ -174,6 +176,8 @@ class StateCallback : public detail::StateBase
 {
     static SRC_STATE* createOrThrow(Converter converter, int channels, src_callback_t func, void* data)
     {
+        if (channels <= 0)
+            throw std::runtime_error("Channel count must be >= 1.");
         int error;
         auto* state = src_callback_new(func, static_cast<int>(converter), channels, &error, data);
         if(!state)


### PR DESCRIPTION
Since libsndfile/libsamplerate@26d92c369394bcd0b0cea488890edce1a0d757d5, initialising libsamplerate with 0 channels or less causes a SIGABRT.