### PR TITLE
Fix corrupted data on attack

### DIFF
--- a/libs/s25main/Savegame.cpp
+++ b/libs/s25main/Savegame.cpp
@@ -5,6 +5,8 @@
 #include "Savegame.h"
 #include "gameTypes/CompressedData.h"
 #include "s25util/BinaryFile.h"
+#include <boost/filesystem/operations.hpp>
+#include <boost/nowide/fstream.hpp>
 
 std::string Savegame::GetSignature() const
 {
@@ -112,6 +114,12 @@ bool Savegame::ReadGameData(BinaryFile& file)
         data.resize(compressedLength);
         file.ReadRawData(data.data(), data.size());
         data = CompressedData::decompress(data, uncompressedLength);
+#ifndef NDEBUG
+        // In debug builds write uncompressed game data to temporary file
+        const auto gameDataPath = boost::filesystem::temp_directory_path() / "rttrGameData.raw";
+        boost::nowide::ofstream f(gameDataPath, std::ios::binary);
+        f.write(data.data(), data.size());
+#endif
     } else
     { // Old savegames have a size here which is always bigger than 1
         RTTR_Assert(compressedFlagOrSize > 1u);

--- a/libs/s25main/buildings/nobMilitary.cpp
+++ b/libs/s25main/buildings/nobMilitary.cpp
@@ -921,6 +921,7 @@ void nobMilitary::Capture(const unsigned char new_owner)
 
     troops_on_mission.clear();
     aggressive_defenders.clear();
+    far_away_capturers.clear();
 
     // Alten Besitzer merken
     unsigned char old_player = player;

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -259,8 +259,6 @@ void dskGameInterface::ShowPersistentWindowsAfterSwitch()
         WINDOWMANAGER.ShowAfterSwitch(std::make_unique<iwMerchandiseStatistics>(gwv.GetViewer().GetPlayer()));
 }
 
-void dskGameInterface::SettingsChanged() {}
-
 void dskGameInterface::Resize(const Extent& newSize)
 {
     Window::Resize(newSize);

--- a/libs/s25main/desktops/dskGameInterface.h
+++ b/libs/s25main/desktops/dskGameInterface.h
@@ -47,8 +47,6 @@ public:
 
     void LC_Status_ConnectionLost() override;
     void LC_Status_Error(const std::string& error) override;
-    /// Called whenever Settings are changed ingame
-    void SettingsChanged();
 
     RoadBuildMode GetRoadMode() const { return road.mode; }
 

--- a/libs/s25main/resources/ArchiveLocator.cpp
+++ b/libs/s25main/resources/ArchiveLocator.cpp
@@ -104,8 +104,11 @@ ResolvedFile ArchiveLocator::resolve(const boost::filesystem::path& filepath) co
                 logger_.write(_("Skipping removed file %1% when checking for files to load for %2%\n")) % fullFilePath
                   % resId;
             else if(helpers::contains(result, fullFilePath))
-                logger_.write(_("Skipping duplicate override file %1% for %2%\n")) % fullFilePath % resId;
-            else
+            {
+                // Don't log a message if we directly load an "override" file. E.g. for the Babylonians
+                if(fullFilePath != filepath)
+                    logger_.write(_("Skipping duplicate override file %1% for %2%\n")) % fullFilePath % resId;
+            } else
                 result.push_back(fullFilePath);
         }
     }

--- a/libs/s25main/resources/ResourceId.cpp
+++ b/libs/s25main/resources/ResourceId.cpp
@@ -28,5 +28,5 @@ ResourceId ResourceId::make(const boost::filesystem::path& filepath)
 
 std::ostream& operator<<(std::ostream& os, const ResourceId& resId)
 {
-    return os << resId.name_;
+    return os.write(resId.name_, resId.length_);
 }


### PR DESCRIPTION
When a Military building is captured and recaptured before all capturers arrived they are told about that but not removed from the list in the building leading to dangling pointers

Fixes #1452

Also fixes some output issues mentioned in the forum post on this bug report.