### PR TITLE
Fix saving of settings when pressing ESC

### DIFF
--- a/libs/s25main/WindowManager.h
+++ b/libs/s25main/WindowManager.h
@@ -79,10 +79,10 @@ public:
     }
     /// Registers a window to be shown after a desktop switch
     IngameWindow* ShowAfterSwitch(std::unique_ptr<IngameWindow> window);
-    /// schliesst ein IngameWindow und entfernt es aus der Fensterliste.
-    void Close(const IngameWindow* window);
     /// Sucht ein Fenster mit der entsprechenden Fenster-ID und schließt es (falls es so eins gibt)
     void Close(unsigned id);
+    /// Close the window right away and free it.
+    void CloseNow(IngameWindow* window);
     /// merkt einen Desktop zum Wechsel vor.
     Desktop* Switch(std::unique_ptr<Desktop> desktop);
     /// Verarbeitung des Drückens der Linken Maustaste.
@@ -111,7 +111,7 @@ public:
     void Msg_ScreenResize(const Extent& newSize);
 
     /// Return the window currently on the top (probably active)
-    const IngameWindow* GetTopMostWindow() const;
+    IngameWindow* GetTopMostWindow() const;
     IngameWindow* FindWindowAtPos(const Position& pos) const;
     IngameWindow* FindNonModalWindow(unsigned id) const;
 
@@ -133,6 +133,8 @@ private:
     void DoDesktopSwitch();
     /// Actually close all ingame windows marked for closing
     void CloseMarkedIngameWnds();
+    /// Close the window and remove it from the window list
+    void DoClose(IngameWindow* window);
 
     Cursor cursor_;
     std::unique_ptr<Desktop> curDesktop;  /// aktueller Desktop

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -658,7 +658,8 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
 
         // Bisheriges Actionfenster schließen, falls es eins gab
         // aktuelle Mausposition merken, da diese durch das Schließen verändert werden kann
-        WINDOWMANAGER.Close(actionwindow);
+        if(actionwindow)
+            actionwindow->Close();
         VIDEODRIVER.SetMousePos(mc.GetPos());
 
         ShowActionWindow(action_tabs, cSel, mc.GetPos(), enable_military_buildings);
@@ -1153,7 +1154,7 @@ void dskGameInterface::GI_FlagDestroyed(const MapPoint pt)
     if(actionwindow)
     {
         if(actionwindow->GetSelectedPt() == pt)
-            WINDOWMANAGER.Close(actionwindow);
+            actionwindow->Close();
     }
 }
 

--- a/libs/s25main/desktops/dskLobby.cpp
+++ b/libs/s25main/desktops/dskLobby.cpp
@@ -154,13 +154,8 @@ void dskLobby::Msg_TableRightButton(const unsigned ctrl_id, const boost::optiona
 
             if(boost::lexical_cast<unsigned>(item.c_str()) != 0)
             {
-                if(serverInfoWnd)
-                {
-                    if(serverInfoWnd->GetServerId() == boost::lexical_cast<unsigned>(item))
-                        return; // raus
-
-                    WINDOWMANAGER.Close(serverInfoWnd);
-                }
+                if(serverInfoWnd && serverInfoWnd->GetServerId() == boost::lexical_cast<unsigned>(item))
+                    return; // Already open -> Nothing to do
 
                 serverInfoWnd = &WINDOWMANAGER.ReplaceWindow(
                   std::make_unique<iwLobbyServerInfo>(boost::lexical_cast<unsigned>(item)));

--- a/libs/s25main/ingameWindows/iwAction.cpp
+++ b/libs/s25main/ingameWindows/iwAction.cpp
@@ -376,7 +376,7 @@ void iwAction::AddAttackControls(ctrlGroup* group, const unsigned attackers_coun
     }
 }
 
-iwAction::~iwAction()
+void iwAction::Close()
 {
     if(mousePosAtOpen_.isValid())
         VIDEODRIVER.SetMousePos(mousePosAtOpen_);

--- a/libs/s25main/ingameWindows/iwAction.h
+++ b/libs/s25main/ingameWindows/iwAction.h
@@ -72,7 +72,8 @@ private:
 public:
     iwAction(GameInterface& gi, GameWorldView& gwv, const Tabs& tabs, MapPoint selectedPt, const DrawPoint& mousePos,
              Params params, bool military_buildings);
-    ~iwAction() override;
+
+    void Close() override;
 
     /// Gibt zurück, auf welchen Punkt es sich bezieht
     const MapPoint& GetSelectedPt() const { return selectedPt; }

--- a/tests/s25Main/UI/testFont.cpp
+++ b/tests/s25Main/UI/testFont.cpp
@@ -5,6 +5,7 @@
 #include "Loader.h"
 #include "ogl/glFont.h"
 #include "uiHelper/uiHelpers.hpp"
+#include "rttr/test/LogAccessor.hpp"
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(Font)
@@ -12,7 +13,11 @@ BOOST_AUTO_TEST_SUITE(Font)
 BOOST_FIXTURE_TEST_CASE(WrapInfoVaryingLen, uiHelper::Fixture)
 {
     LOADER.initResourceFolders();
-    BOOST_TEST(LOADER.LoadFonts());
+    {
+        rttr::test::LogAccessor logAcc;
+        BOOST_TEST(LOADER.LoadFonts());
+        logAcc.clearLog();
+    }
     const auto& font = *SmallFont;
     std::string input = "a\naa\naaa\naaaa\naaaaa\naa";
     auto output = std::vector<std::string>{"a", "aa", "aaa", "aaaa", "aaaa", "a", "aa"};

--- a/tests/s25Main/UI/testVideoDriver.cpp
+++ b/tests/s25Main/UI/testVideoDriver.cpp
@@ -6,6 +6,7 @@
 #include "helpers/containerUtils.h"
 #include "mockupDrivers/MockupVideoDriver.h"
 #include "uiHelper/uiHelpers.hpp"
+#include "rttr/test/LogAccessor.hpp"
 #include <rttr/test/stubFunction.hpp>
 #include <s25util/warningSuppression.h>
 #include <glad/glad.h>
@@ -62,8 +63,12 @@ RTTR_POP_DIAGNOSTIC
 BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
 {
     // Fresh start
-    VIDEODRIVER.DestroyScreen();
-    VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+    {
+        rttr::test::LogAccessor logAcc;
+        VIDEODRIVER.DestroyScreen();
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        logAcc.clearLog();
+    }
 
     RTTR_STUB_FUNCTION(glGenTextures, rttrOglMock2::glGenTextures);
     RTTR_STUB_FUNCTION(glDeleteTextures, rttrOglMock2::glDeleteTextures);
@@ -71,12 +76,20 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
     for(unsigned i = 1u; i <= 5u; ++i)
         BOOST_TEST(VIDEODRIVER.GenerateTexture() == i);
     BOOST_TEST_REQUIRE(rttrOglMock2::activeTextures.size() == 5u);
-    VIDEODRIVER.DestroyScreen();
+    {
+        rttr::test::LogAccessor logAcc;
+        VIDEODRIVER.DestroyScreen();
+        logAcc.clearLog();
+    }
     BOOST_TEST_REQUIRE(rttrOglMock2::activeTextures.empty());
     // Next cleanup call is a no-op (validated inside glDeleteTextures)
     VIDEODRIVER.CleanUp();
 
-    VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+    {
+        rttr::test::LogAccessor logAcc;
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        logAcc.clearLog();
+    }
     glGenTextures = rttrOglMock2::glGenTextures;
     glDeleteTextures = rttrOglMock2::glDeleteTextures;
     for(unsigned i = 1u; i <= 5u; ++i)

--- a/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
+++ b/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
@@ -51,4 +51,14 @@ MockupVideoDriver* GetVideoDriver()
     return video;
 }
 
+Fixture::~Fixture()
+{
+    if(!dynamic_cast<DummyDesktop*>(WINDOWMANAGER.GetCurrentDesktop()) || WINDOWMANAGER.GetTopMostWindow())
+    {
+        // Switch back to new, empty desktop to clean up active windows
+        WINDOWMANAGER.Switch(std::make_unique<DummyDesktop>());
+        WINDOWMANAGER.Draw();
+    }
+}
+
 } // namespace uiHelper

--- a/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.hpp
+++ b/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.hpp
@@ -14,6 +14,7 @@ void initGUITests();
 struct Fixture
 {
     Fixture() { initGUITests(); }
+    ~Fixture();
 };
 
 /// Return the video driver. Initializes the GUI tests if required

--- a/tests/s25Main/lua/testLuaGUI.cpp
+++ b/tests/s25Main/lua/testLuaGUI.cpp
@@ -14,12 +14,13 @@
 #include "ogl/glFont.h"
 #include "uiHelper/uiHelpers.hpp"
 
-BOOST_FIXTURE_TEST_SUITE(LuaGUITestSuite, LuaTestsFixture)
+struct LuaGuiFixture : LuaTestsFixture, uiHelper::Fixture
+{};
+
+BOOST_FIXTURE_TEST_SUITE(LuaGUITestSuite, LuaGuiFixture)
 
 BOOST_AUTO_TEST_CASE(MissionStatement)
 {
-    uiHelper::initGUITests();
-
     // Set player
     MOCK_EXPECT(localGameState.GetPlayerId).returns(1);
 
@@ -35,60 +36,59 @@ BOOST_AUTO_TEST_CASE(MissionStatement)
 
     // Show it to us
     executeLua("rttr:MissionStatement(1, 'Title', 'Text')");
-    const auto* wnd = dynamic_cast<const iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
+    const auto* wnd = dynamic_cast<iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");
 
     // double windows stack
     executeLua("rttr:MissionStatement(1, 'Title2', 'Text')");
-    const auto* wnd2 = dynamic_cast<const iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
+    const auto* wnd2 = dynamic_cast<iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd2);
     // Other window still on top
     BOOST_TEST_REQUIRE(wnd2 == wnd);
     // Close first wnd
-    WINDOWMANAGER.Close(wnd);
+    WINDOWMANAGER.CloseNow(const_cast<iwMissionStatement*>(wnd));
     // 2nd shows
-    wnd2 = dynamic_cast<const iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
+    wnd2 = dynamic_cast<iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd2);
     BOOST_TEST_REQUIRE(wnd2 != wnd);
     BOOST_TEST_REQUIRE(wnd2->GetTitle() == "Title2");
     // Close wnd
-    WINDOWMANAGER.Close(wnd2);
+    WINDOWMANAGER.CloseNow(const_cast<iwMissionStatement*>(wnd2));
     BOOST_TEST_REQUIRE(!WINDOWMANAGER.GetTopMostWindow());
 
     // No image
     executeLua("rttr:MissionStatement(1, 'Title', 'Text', IM_NONE)");
-    wnd = dynamic_cast<const iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
+    wnd = dynamic_cast<iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");
     BOOST_TEST_REQUIRE(wnd->GetCtrls<ctrlImage>().empty());
-    WINDOWMANAGER.Close(wnd);
+    WINDOWMANAGER.CloseNow(const_cast<iwMissionStatement*>(wnd));
     // Non-default image
     executeLua("rttr:MissionStatement(1, 'Title', 'Text', IM_AVATAR10)");
-    wnd = dynamic_cast<const iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
+    wnd = dynamic_cast<iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");
     BOOST_TEST_REQUIRE(!wnd->GetCtrls<ctrlImage>().empty());
-    WINDOWMANAGER.Close(wnd);
+    WINDOWMANAGER.CloseNow(const_cast<iwMissionStatement*>(wnd));
     // Invalid image
     executeLua("rttr:MissionStatement(1, 'Title', 'Text', 999999)");
-    wnd = dynamic_cast<const iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
+    wnd = dynamic_cast<iwMissionStatement*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");
     BOOST_TEST_REQUIRE(wnd->GetCtrls<ctrlImage>().empty());
-    WINDOWMANAGER.Close(wnd);
+    WINDOWMANAGER.CloseNow(const_cast<iwMissionStatement*>(wnd));
 }
 
 BOOST_AUTO_TEST_CASE(MessageBoxTest)
 {
-    uiHelper::initGUITests();
     // Default Info
     executeLua("rttr:MsgBox('Title', string.rep('Text\\n', 15))");
-    const auto* wnd = dynamic_cast<const iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
+    const auto* wnd = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");
@@ -100,29 +100,29 @@ BOOST_AUTO_TEST_CASE(MessageBoxTest)
     BOOST_TEST_REQUIRE(wnd->GetCtrls<ctrlButton>().front()->GetPos().y > 15 * NormalFont->getHeight());
     // And window higher than button
     BOOST_TEST_REQUIRE(static_cast<int>(wnd->GetIwSize().y) > wnd->GetCtrls<ctrlButton>().front()->GetPos().y);
-    WINDOWMANAGER.Close(wnd);
+    WINDOWMANAGER.CloseNow(const_cast<iwMsgbox*>(wnd));
     // Error
     executeLua("rttr:MsgBox('Title', 'Text', true)");
-    wnd = dynamic_cast<const iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
+    wnd = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");
     BOOST_TEST_REQUIRE(!wnd->GetCtrls<ctrlImage>().empty());
     BOOST_TEST_REQUIRE(wnd->GetCtrls<ctrlImage>().front()->GetImage()
                        == LOADER.GetImageN("io", rttr::enum_cast(MsgboxIcon::ExclamationRed)));
-    WINDOWMANAGER.Close(wnd);
+    WINDOWMANAGER.CloseNow(const_cast<iwMsgbox*>(wnd));
     // MsgBoxEx
     executeLua("rttr:MsgBoxEx('Title', 'Text', 'io', 100)");
-    wnd = dynamic_cast<const iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
+    wnd = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");
     BOOST_TEST_REQUIRE(!wnd->GetCtrls<ctrlImage>().empty());
     BOOST_TEST_REQUIRE(wnd->GetCtrls<ctrlImage>().front()->GetImage() == LOADER.GetImageN("io", 100));
-    WINDOWMANAGER.Close(wnd);
+    WINDOWMANAGER.CloseNow(const_cast<iwMsgbox*>(wnd));
     // MsgBoxEx with position
     executeLua("rttr:MsgBoxEx('Title', 'Text', 'io', 101, 500, 200)");
-    wnd = dynamic_cast<const iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
+    wnd = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(wnd);
     BOOST_TEST_REQUIRE(wnd->IsActive());
     BOOST_TEST_REQUIRE(wnd->GetTitle() == "Title");


### PR DESCRIPTION
When pressing ESC the window was directly deleted instead of first calling Close which triggers a settings update for e.g. the tools window.

Refactor this so deleting a window is purely done by the WindowManager and before deleting Close is always called.
Add tests which catch this.

Also some changes to tests to avoid log spam and fix possibly missed mock-verify calls.

Fixes #1455