### PR TITLE
Fix missing forester productivity

### DIFF
--- a/libs/common/include/helpers/mathFuncs.h
+++ b/libs/common/include/helpers/mathFuncs.h
@@ -13,10 +13,11 @@ namespace helpers {
 int gcd(int a, int b) noexcept;
 /// Returns the result of "dividend / divisor" rounded to the nearest integer value
 unsigned roundedDiv(unsigned dividend, unsigned divisor) noexcept;
+/// Return ceil(dividend / divisor)
 constexpr unsigned divCeil(unsigned dividend, unsigned divisor) noexcept
 {
-    return (dividend + divisor - 1)
-           / divisor; // Standard trick using truncating division for smalish values (no overflow)
+    // Standard trick using truncating division for smallish values (no overflow)
+    return (dividend + divisor - 1) / divisor;
 }
 /// Clamp the value into [min, max]
 template<typename T>

--- a/libs/s25main/BuildingRegister.cpp
+++ b/libs/s25main/BuildingRegister.cpp
@@ -152,10 +152,11 @@ unsigned BuildingRegister::CalcAverageProductivity(BuildingType bldType) const
     if(!BLD_WORK_DESC[bldType].producedWare)
         return 0;
     unsigned productivity = 0;
-    unsigned numBlds = GetBuildings(bldType).size();
+    const auto& buildings = GetBuildings(bldType);
+    const unsigned numBlds = buildings.size();
     if(numBlds > 0)
     {
-        for(const nobUsual* bld : GetBuildings(bldType))
+        for(const nobUsual* bld : buildings)
             productivity += bld->GetProductivity();
         productivity /= numBlds;
     }
@@ -171,10 +172,10 @@ unsigned short BuildingRegister::CalcAverageProductivity() const
         if(!BLD_WORK_DESC[bldType].producedWare)
             continue;
 
-        for(const nobUsual* bld : GetBuildings(bldType))
+        const auto& buildings = GetBuildings(bldType);
+        numBlds += buildings.size();
+        for(const nobUsual* bld : buildings)
             totalProductivity += bld->GetProductivity();
-
-        numBlds += GetBuildings(bldType).size();
     }
     if(numBlds == 0)
         return 0;

--- a/libs/s25main/GameInterface.h
+++ b/libs/s25main/GameInterface.h
@@ -30,8 +30,6 @@ public:
     virtual void GI_Winner(unsigned playerId) = 0;
     virtual void GI_TeamWinner(unsigned playerId) = 0;
 
-    /// An important window was closed (currently iwAction, iwRoad)
-    virtual void GI_WindowClosed(Window* wnd) = 0;
     /// Changes into road building mode
     virtual void GI_StartRoadBuilding(MapPoint startPt, bool waterRoad) = 0;
     /// Cancels the road building mode

--- a/libs/s25main/buildings/nobUsual.h
+++ b/libs/s25main/buildings/nobUsual.h
@@ -25,23 +25,23 @@ class nobUsual : public noBuilding
     /// Produktivität
     unsigned short productivity;
     /// Produktion eingestellt? (letzteres nur visuell, um Netzwerk-Latenzen zu verstecken)
-    bool disable_production, disable_production_virtual;
+    bool disableProduction, disableProductionVirtual;
     /// Warentyp, den er zuletzt bestellt hatte (bei >1 Waren)
-    unsigned char last_ordered_ware;
+    unsigned char lastOrderedWare;
     /// Rohstoffe, die zur Produktion benötigt werden
     std::array<uint8_t, 3> numWares;
     /// Bestellte Waren
-    std::vector<std::list<Ware*>> ordered_wares;
+    std::vector<std::list<Ware*>> orderedWares;
     /// Bestell-Ware-Event
     const GameEvent* orderware_ev;
     /// Rechne-Produktivität-aus-Event
     const GameEvent* productivity_ev;
     /// Letzte Produktivitäten (Durchschnitt = Gesamt produktivität), vorne das neuste !
-    std::array<uint16_t, 6> last_productivities;
+    std::array<uint16_t, 6> lastProductivities;
     /// How many GFs he did not work since the last productivity calculation
     unsigned short numGfNotWorking;
     /// Since which GF he did not work (0xFFFFFFFF = currently working)
-    unsigned since_not_working;
+    unsigned sinceNotWorking;
     /// Did we notify the player that we are out of resources?
     bool outOfRessourcesMsgSent;
 
@@ -99,13 +99,7 @@ public:
     void TakeWare(Ware* ware) override;
 
     /// Bestellte Waren
-    bool AreThereAnyOrderedWares() const
-    {
-        for(const auto& ordered_ware : ordered_wares)
-            if(!ordered_ware.empty())
-                return true;
-        return false;
-    }
+    bool AreThereAnyOrderedWares() const;
 
     /// Gibt Pointer auf Produktivität zurück
     const unsigned short* GetProductivityPointer() const { return &productivity; }
@@ -113,13 +107,13 @@ public:
     const nofBuildingWorker* GetWorker() const { return worker; }
 
     /// Stoppt/Erlaubt Produktion (visuell)
-    void ToggleProductionVirtual() { disable_production_virtual = !disable_production_virtual; }
+    void ToggleProductionVirtual() { disableProductionVirtual = !disableProductionVirtual; }
     /// Stoppt/Erlaubt Produktion (real)
     void SetProductionEnabled(bool enabled);
     /// Fragt ab, ob Produktion ausgeschaltet ist (visuell)
-    bool IsProductionDisabledVirtual() const { return disable_production_virtual; }
+    bool IsProductionDisabledVirtual() const { return disableProductionVirtual; }
     /// Fragt ab, ob Produktion ausgeschaltet ist (real)
-    bool IsProductionDisabled() const { return disable_production; }
+    bool IsProductionDisabled() const { return disableProduction; }
     /// Called when there are no more resources
     void OnOutOfResources();
     /// Fängt an NICHT zu arbeiten (wird gemessen fürs Ausrechnen der Produktivität)
@@ -129,5 +123,5 @@ public:
 
 private:
     /// Calculates the productivity and resets the counter
-    unsigned short CalcProductivity();
+    unsigned short CalcCurrentProductivity();
 };

--- a/libs/s25main/buildings/nobUsual.h
+++ b/libs/s25main/buildings/nobUsual.h
@@ -20,6 +20,7 @@ class GameEvent;
 // Gewöhnliches Gebäude mit einem Arbeiter und Waren
 class nobUsual : public noBuilding
 {
+protected:
     /// Der Typ, der hier arbeitet
     nofBuildingWorker* worker;
     /// Produktivität
@@ -45,11 +46,12 @@ class nobUsual : public noBuilding
     /// Did we notify the player that we are out of resources?
     bool outOfRessourcesMsgSent;
 
-protected:
     friend class SerializedGameData;
     friend class BuildingFactory;
     nobUsual(BuildingType type, MapPoint pos, unsigned char player, Nation nation);
     nobUsual(SerializedGameData& sgd, unsigned obj_id);
+
+    void DestroyBuilding() override;
 
 public:
     /// Wird gerade gearbeitet oder nicht?
@@ -57,10 +59,6 @@ public:
 
     ~nobUsual() override;
 
-protected:
-    void DestroyBuilding() override;
-
-public:
     void Serialize(SerializedGameData& sgd) const override;
 
     GO_Type GetGOT() const override { return GO_Type::NobUsual; }

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -1134,11 +1134,11 @@ void dskGameInterface::GI_BuildRoad()
     }
 }
 
-void dskGameInterface::GI_WindowClosed(Window* wnd)
+void dskGameInterface::Msg_WindowClosed(IngameWindow& wnd)
 {
-    if(actionwindow == wnd)
+    if(actionwindow == &wnd)
         actionwindow = nullptr;
-    else if(roadwindow == wnd)
+    else if(roadwindow == &wnd)
         roadwindow = nullptr;
 }
 

--- a/libs/s25main/desktops/dskGameInterface.h
+++ b/libs/s25main/desktops/dskGameInterface.h
@@ -81,7 +81,6 @@ public:
     void GI_CancelRoadBuilding() override;
     /// Baut die gewünschte bis jetzt noch visuelle Straße (schickt Anfrage an Server)
     void GI_BuildRoad() override;
-    void GI_WindowClosed(Window* wnd) override;
 
     // Sucht einen Weg von road_point_x/y zu cselx/y und baut ihn ( nur visuell )
     // Bei Wasserwegen kann die Reichweite nicht bis zum gewünschten
@@ -104,7 +103,7 @@ public:
 
     void OnChatCommand(const std::string& cmd) override;
 
-private:
+protected:
     /// Initializes player specific stuff after start or player swap
     void InitPlayer();
 
@@ -127,6 +126,8 @@ private:
     bool Msg_WheelUp(const MouseCoords& mc) override;
     bool Msg_WheelDown(const MouseCoords& mc) override;
     void WheelZoom(float step);
+
+    void Msg_WindowClosed(IngameWindow& wnd) override;
 
     void OnBuildingNote(const BuildingNote& note);
 

--- a/libs/s25main/gameData/BuildingConsts.h
+++ b/libs/s25main/gameData/BuildingConsts.h
@@ -52,7 +52,7 @@ const helpers::EnumArray<BldWorkDescription, BuildingType> SUPPRESS_UNUSED BLD_W
   {Job::Woodcutter, GoodType::Wood},
   {Job::Fisher, GoodType::Fish},
   {Job::Stonemason, GoodType::Stones},
-  {Job::Forester}, // Produces trees
+  {Job::Forester, GoodType::Nothing}, // Produces trees
   {Job::Butcher, GoodType::Meat, WaresNeeded(GoodType::Ham)},
   {Job::Hunter, GoodType::Meat},
   {Job::Brewer, GoodType::Beer, WaresNeeded(GoodType::Grain, GoodType::Water)},

--- a/libs/s25main/ingameWindows/iwAction.cpp
+++ b/libs/s25main/ingameWindows/iwAction.cpp
@@ -383,7 +383,6 @@ void iwAction::Close()
     IngameWindow::Close();
     if(mousePosAtOpen_.isValid())
         VIDEODRIVER.SetMousePos(mousePosAtOpen_);
-    gi.GI_WindowClosed(this);
 }
 
 void iwAction::Msg_Group_ButtonClick(const unsigned /*group_id*/, const unsigned ctrl_id)

--- a/libs/s25main/ingameWindows/iwBuildingProductivities.cpp
+++ b/libs/s25main/ingameWindows/iwBuildingProductivities.cpp
@@ -11,7 +11,7 @@
 #include "s25util/colors.h"
 
 /// Reihenfolge der Gebäude
-const std::array<BuildingType, 24> bts = {
+const std::array<BuildingType, 24> iwBuildingProductivities::icons = {
   BuildingType::GraniteMine,    BuildingType::CoalMine,    BuildingType::IronMine,      BuildingType::GoldMine,
   BuildingType::Woodcutter,     BuildingType::Fishery,     BuildingType::Quarry,        BuildingType::Forester,
   BuildingType::Slaughterhouse, BuildingType::Hunter,      BuildingType::Brewery,       BuildingType::Armory,
@@ -36,30 +36,30 @@ const Extent percentSize(100, 18);
 iwBuildingProductivities::iwBuildingProductivities(const GamePlayer& player)
     : IngameWindow(CGI_BUILDINGSPRODUCTIVITY, IngameWindow::posLastOrCenter,
                    Extent(2 * percentSize.x + 2 * image_percent_x + percent_image_x + right_x,
-                          (bts.size() / 2 + 1) * (distance_y + 1))
+                          (icons.size() / 2 + 1) * (distance_y + 1))
                      + bldProdContentOffset,
                    _("Productivity"), LOADER.GetImageN("resource", 41)),
       player(player), percents()
 {
     const Nation playerNation = player.nation;
-    for(unsigned y = 0; y < bts.size() / 2 + bts.size() % 2; ++y)
+    for(unsigned y = 0; y < icons.size() / 2 + icons.size() % 2; ++y)
     {
         for(unsigned x = 0; x < 2; ++x)
         {
-            if(y * 2 + x >= bts.size()) //-V547
+            if(y * 2 + x >= icons.size()) //-V547
                 break;
             unsigned imgId = (y * 2 + x) * 2;
             DrawPoint imgPos(x * (percent_image_x + percentSize.x + image_percent_x),
                              distance_y * y + percentSize.y / 2);
             imgPos = imgPos + bldProdContentOffset;
-            if(player.IsBuildingEnabled(bts[y * 2 + x]))
+            if(player.IsBuildingEnabled(icons[y * 2 + x]))
             {
-                AddImage(imgId, imgPos, LOADER.GetNationIcon(playerNation, bts[y * 2 + x]),
-                         _(BUILDING_NAMES[bts[y * 2 + x]]));
+                AddImage(imgId, imgPos, LOADER.GetNationIcon(playerNation, icons[y * 2 + x]),
+                         _(BUILDING_NAMES[icons[y * 2 + x]]));
                 DrawPoint percentPos(image_percent_x + x * (percent_image_x + percentSize.x + image_percent_x),
                                      distance_y * y);
                 AddPercent(imgId + 1, percentPos + bldProdContentOffset, percentSize, TextureColor::Grey, COLOR_YELLOW,
-                           SmallFont, &percents[bts[y * 2 + x]]);
+                           SmallFont, &percents[icons[y * 2 + x]]);
             } else
                 AddImage(imgId, imgPos, LOADER.GetImageN("io", 188));
         }
@@ -74,13 +74,11 @@ iwBuildingProductivities::iwBuildingProductivities(const GamePlayer& player)
     // _("Help"));
 }
 
-/// Aktualisieren der Prozente
 void iwBuildingProductivities::UpdatePercents()
 {
     percents = player.GetBuildingRegister().CalcProductivities();
 }
 
-/// Produktivitäts-percentbars aktualisieren
 void iwBuildingProductivities::Msg_PaintAfter()
 {
     IngameWindow::Msg_PaintAfter();

--- a/libs/s25main/ingameWindows/iwBuildingProductivities.cpp
+++ b/libs/s25main/ingameWindows/iwBuildingProductivities.cpp
@@ -6,60 +6,66 @@
 #include "GamePlayer.h"
 #include "Loader.h"
 #include "files.h"
+#include "helpers/mathFuncs.h"
 #include "gameData/BuildingConsts.h"
 #include "gameData/const_gui_ids.h"
 #include "s25util/colors.h"
 
-/// Reihenfolge der Gebäude
 const std::array<BuildingType, 24> iwBuildingProductivities::icons = {
-  BuildingType::GraniteMine,    BuildingType::CoalMine,    BuildingType::IronMine,      BuildingType::GoldMine,
-  BuildingType::Woodcutter,     BuildingType::Fishery,     BuildingType::Quarry,        BuildingType::Forester,
-  BuildingType::Slaughterhouse, BuildingType::Hunter,      BuildingType::Brewery,       BuildingType::Armory,
-  BuildingType::Metalworks,     BuildingType::Ironsmelter, BuildingType::PigFarm,       BuildingType::Mill,
-  BuildingType::Bakery,         BuildingType::Sawmill,     BuildingType::Mint,          BuildingType::Well,
-  BuildingType::Shipyard,       BuildingType::Farm,        BuildingType::DonkeyBreeder, BuildingType::Charburner};
+  // clang-format off
+  BuildingType::Woodcutter,    BuildingType::Slaughterhouse,
+  BuildingType::Forester,      BuildingType::Metalworks,
+  BuildingType::Quarry,        BuildingType::Armory,
+  BuildingType::Fishery,       BuildingType::Ironsmelter,
+  BuildingType::Hunter,        BuildingType::Mint,
+  BuildingType::Sawmill,       BuildingType::Brewery,
+  BuildingType::Mill,          BuildingType::Shipyard,
+  BuildingType::Bakery,        BuildingType::GoldMine,
+  BuildingType::Well,          BuildingType::IronMine,
+  BuildingType::Farm,          BuildingType::CoalMine,
+  BuildingType::PigFarm,       BuildingType::GraniteMine,
+  BuildingType::DonkeyBreeder, BuildingType::Charburner,
+  // clang-format on
+};
 
 /// Abstand vom linken, oberen Fensterrand
-const Extent bldProdContentOffset(50, 30);
-/// Abstand vom rechten Fensterrand
-const unsigned short right_x = 40;
+constexpr Extent bldProdContentOffset(50, 30);
 /// Horizontaler Abstand zwischen Bild und Prozentbar
-const unsigned short image_percent_x = 35;
+constexpr unsigned short image_percent_x = 35;
 /// Horizontaler Abstand zwischen Prozentbar und nächstem Bild
-const unsigned short percent_image_x = 40;
+constexpr unsigned short percent_image_x = 40;
 /// Vertikaler Abstand zwischen 2 nacheinanderfolgenden "Zeilen"
-const unsigned short distance_y = 35;
-
+constexpr unsigned short distance_y = 35;
 /// Größe der Prozentbalken
-const Extent percentSize(100, 18);
+constexpr Extent percentSize(100, 18);
+
+constexpr unsigned numRows = helpers::divCeil(iwBuildingProductivities::icons.size(), 2);
+constexpr Extent cellSize(percent_image_x + percentSize.x + image_percent_x, distance_y);
 
 iwBuildingProductivities::iwBuildingProductivities(const GamePlayer& player)
     : IngameWindow(CGI_BUILDINGSPRODUCTIVITY, IngameWindow::posLastOrCenter,
-                   Extent(2 * percentSize.x + 2 * image_percent_x + percent_image_x + right_x,
-                          (icons.size() / 2 + 1) * (distance_y + 1))
-                     + bldProdContentOffset,
-                   _("Productivity"), LOADER.GetImageN("resource", 41)),
+                   cellSize * Extent(2, numRows + 1) + bldProdContentOffset, _("Productivity"),
+                   LOADER.GetImageN("resource", 41)),
       player(player), percents()
 {
     const Nation playerNation = player.nation;
-    for(unsigned y = 0; y < icons.size() / 2 + icons.size() % 2; ++y)
+    unsigned curIdx = 0;
+    for(unsigned y = 0; y < numRows; ++y)
     {
-        for(unsigned x = 0; x < 2; ++x)
+        for(unsigned x = 0; x < 2; ++x, ++curIdx)
         {
-            if(y * 2 + x >= icons.size()) //-V547
+            if(curIdx >= icons.size()) //-V547
                 break;
-            unsigned imgId = (y * 2 + x) * 2;
-            DrawPoint imgPos(x * (percent_image_x + percentSize.x + image_percent_x),
-                             distance_y * y + percentSize.y / 2);
-            imgPos = imgPos + bldProdContentOffset;
-            if(player.IsBuildingEnabled(icons[y * 2 + x]))
+            const DrawPoint curPos = cellSize * DrawPoint(x, y) + bldProdContentOffset;
+            const DrawPoint imgPos = curPos + DrawPoint(0, percentSize.y / 2);
+            const unsigned imgId = curIdx * 2;
+            if(player.IsBuildingEnabled(icons[curIdx]))
             {
-                AddImage(imgId, imgPos, LOADER.GetNationIcon(playerNation, icons[y * 2 + x]),
-                         _(BUILDING_NAMES[icons[y * 2 + x]]));
-                DrawPoint percentPos(image_percent_x + x * (percent_image_x + percentSize.x + image_percent_x),
-                                     distance_y * y);
-                AddPercent(imgId + 1, percentPos + bldProdContentOffset, percentSize, TextureColor::Grey, COLOR_YELLOW,
-                           SmallFont, &percents[icons[y * 2 + x]]);
+                AddImage(imgId, imgPos, LOADER.GetNationIcon(playerNation, icons[curIdx]),
+                         _(BUILDING_NAMES[icons[curIdx]]));
+                DrawPoint percentPos = curPos + DrawPoint(image_percent_x, 0);
+                AddPercent(imgId + 1, percentPos, percentSize, TextureColor::Grey, COLOR_YELLOW, SmallFont,
+                           &percents[icons[curIdx]]);
             } else
                 AddImage(imgId, imgPos, LOADER.GetImageN("io", 188));
         }

--- a/libs/s25main/ingameWindows/iwBuildingProductivities.h
+++ b/libs/s25main/ingameWindows/iwBuildingProductivities.h
@@ -17,7 +17,7 @@ class iwBuildingProductivities : public IngameWindow
     helpers::EnumArray<uint16_t, BuildingType> percents;
 
 public:
-    // Icons shown (in this order)
+    /// Icons shown (in this order)
     static const std::array<BuildingType, 24> icons;
 
     iwBuildingProductivities(const GamePlayer& player);

--- a/libs/s25main/ingameWindows/iwBuildingProductivities.h
+++ b/libs/s25main/ingameWindows/iwBuildingProductivities.h
@@ -7,23 +7,22 @@
 #include "IngameWindow.h"
 #include "helpers/EnumArray.h"
 #include "gameTypes/BuildingType.h"
+#include <array>
 
 class GamePlayer;
 
-/// Fenster, welches die Anzahl aller Gebäude und der Baustellen auflistet
 class iwBuildingProductivities : public IngameWindow
 {
     const GamePlayer& player;
-    /// Prozentzahlen der einzelnen Gebäude
     helpers::EnumArray<uint16_t, BuildingType> percents;
 
 public:
+    // Icons shown (in this order)
+    static const std::array<BuildingType, 24> icons;
+
     iwBuildingProductivities(const GamePlayer& player);
 
 private:
-    /// Aktualisieren der Prozente
     void UpdatePercents();
-
-    /// Produktivitäts-Progressbars aktualisieren
     void Msg_PaintAfter() override;
 };

--- a/libs/s25main/ingameWindows/iwRoadWindow.cpp
+++ b/libs/s25main/ingameWindows/iwRoadWindow.cpp
@@ -32,11 +32,6 @@ iwRoadWindow::iwRoadWindow(GameInterface& gi, bool flagpossible, const Position&
     VIDEODRIVER.SetMousePos(defaultBt->GetDrawPos() + DrawPoint(defaultBt->GetSize()) / 2);
 }
 
-iwRoadWindow::~iwRoadWindow()
-{
-    gi.GI_WindowClosed(this);
-}
-
 void iwRoadWindow::Msg_ButtonClick(const unsigned ctrl_id)
 {
     switch(ctrl_id)

--- a/libs/s25main/ingameWindows/iwRoadWindow.h
+++ b/libs/s25main/ingameWindows/iwRoadWindow.h
@@ -16,7 +16,6 @@ private:
 
 public:
     iwRoadWindow(GameInterface& gi, bool flagpossible, const Position& mousePos);
-    ~iwRoadWindow() override;
 
 private:
     void Msg_ButtonClick(unsigned ctrl_id) override;

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -12,9 +12,8 @@
 #include "rttr/test/random.hpp"
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(IngameWnd)
+BOOST_FIXTURE_TEST_CASE(IngameWnd, uiHelper::Fixture)
 {
-    uiHelper::initGUITests();
     iwHelp wnd("Foo barFoo barFoo barFoo bar\n\n\n\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\n");
     const Extent oldSize = wnd.GetSize();
     BOOST_TEST_REQUIRE(oldSize.x > 50u);
@@ -35,7 +34,7 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::MountainDistance)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::IslandAmount)
 // LCOV_EXCL_STOP
 
-BOOST_AUTO_TEST_CASE(IwMapGenerator)
+BOOST_FIXTURE_TEST_CASE(IwMapGenerator, uiHelper::Fixture)
 {
     const auto expectedNumPlayers = rttr::test::randomValue(2u, 7u);
     const auto expectedMapType = rttr::test::randomValue<uint8_t>(0, 2);
@@ -47,7 +46,6 @@ BOOST_AUTO_TEST_CASE(IwMapGenerator)
     const auto expectedTrees = rttr::test::randomValue<unsigned short>(0, 100);
     const auto expectedStonePiles = rttr::test::randomValue<unsigned short>(0, 100);
 
-    uiHelper::initGUITests();
     rttr::mapGenerator::MapSettings settings;
     iwMapGenerator wnd(settings);
     wnd.GetCtrl<ctrlComboBox>(iwMapGenerator::CTRL_PLAYER_NUMBER)->SetSelection(expectedNumPlayers - 2);

--- a/tests/s25Main/integration/testDskGameInterface.cpp
+++ b/tests/s25Main/integration/testDskGameInterface.cpp
@@ -34,15 +34,16 @@ struct dskGameInterfaceMock : public dskGameInterface
     {}
     void Msg_PaintBefore() override {}
     void Msg_PaintAfter() override {}
+    using dskGameInterface::actionwindow;
 };
 struct GameInterfaceFixture : uiHelper::Fixture
 {
     WorldFixture<CreateEmptyWorld, 1> worldFixture;
-    dskGameInterface* gameDesktop;
+    dskGameInterfaceMock* gameDesktop;
     const GameWorldView* view;
     GameInterfaceFixture()
     {
-        gameDesktop = static_cast<dskGameInterface*>(
+        gameDesktop = static_cast<dskGameInterfaceMock*>(
           WINDOWMANAGER.Switch(std::make_unique<dskGameInterfaceMock>(worldFixture.game)));
         WINDOWMANAGER.Draw();
         view = &gameDesktop->GetView();
@@ -185,6 +186,18 @@ BOOST_FIXTURE_TEST_CASE(ScrollingWithCtrl, GameInterfaceFixture)
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetCursor() == Cursor::Hand);
     BOOST_TEST_REQUIRE(view->GetOffset() == pos);
     checkNotScrolling(*view);
+}
+
+BOOST_FIXTURE_TEST_CASE(IwActionClose, GameInterfaceFixture)
+{
+    gameDesktop->ShowActionWindow(iwAction::Tabs{}, MapPoint(0, 1), DrawPoint(42, 37), false);
+    WINDOWMANAGER.Draw();
+    BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow());
+    BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == gameDesktop->actionwindow);
+    WINDOWMANAGER.GetTopMostWindow()->Close();
+    WINDOWMANAGER.Draw();
+    BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == nullptr);
+    BOOST_TEST_REQUIRE(gameDesktop->actionwindow == nullptr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/integration/testGamePlayer.cpp
+++ b/tests/s25Main/integration/testGamePlayer.cpp
@@ -5,11 +5,17 @@
 #include "GamePlayer.h"
 #include "buildings/nobBaseWarehouse.h"
 #include "buildings/nobMilitary.h"
+#include "buildings/nobUsual.h"
 #include "factories/BuildingFactory.h"
 #include "figures/nofPassiveSoldier.h"
+#include "ingameWindows/iwBuildingProductivities.h"
 #include "worldFixtures/CreateEmptyWorld.h"
 #include "worldFixtures/WorldFixture.h"
+#include "gameData/BuildingProperties.h"
+#include "rttr/test/random.hpp"
+#include "s25util/warningSuppression.h"
 #include <boost/test/unit_test.hpp>
+#include <numeric>
 
 using WorldFixtureEmpty2P = WorldFixture<CreateEmptyWorld, 2>;
 
@@ -33,4 +39,75 @@ BOOST_FIXTURE_TEST_CASE(Defeat, WorldFixtureEmpty2P)
     // Destroy this -> defeated
     world.DestroyNO(milBldPos);
     BOOST_TEST_REQUIRE(world.GetPlayer(0).IsDefeated());
+}
+
+namespace {
+// Hack to access protected member for testing
+struct SetProductivity : nobUsual
+{
+    using nobUsual::productivity;
+};
+RTTR_ATTRIBUTE_NO_UBSAN(vptr) void setProductivity(nobUsual* bld, unsigned short newProd)
+{
+    static_cast<SetProductivity*>(bld)->productivity = newProd;
+}
+} // namespace
+
+using WorldFixtureEmpty1P = WorldFixture<CreateEmptyWorld, 1, 2 * helpers::MaxEnumValue_v<BuildingType>, 4>;
+BOOST_FIXTURE_TEST_CASE(ProductivityStats, WorldFixtureEmpty1P)
+{
+    using boost::test_tools::per_element;
+    const auto& buildingRegister = world.GetPlayer(0).GetBuildingRegister();
+    helpers::EnumArray<unsigned short, BuildingType> expectedProductivity{};
+    BOOST_TEST(buildingRegister.CalcProductivities() == expectedProductivity, per_element());
+    BOOST_TEST(buildingRegister.CalcAverageProductivity() == 0u);
+
+    MapPoint curPos(0, 0);
+    for(const auto bldType : helpers::EnumRange<BuildingType>{})
+    {
+        if(!BuildingProperties::IsValid(bldType))
+            continue;
+
+        noBuilding* bld;
+        if(bldType == BuildingType::Headquarters)
+            bld = world.GetPlayer(0).GetFirstWH();
+        else
+        {
+            // Size checks (in x) only for safety. Should never fail due to construction of map size
+            while(world.GetNode(curPos).bq != BuildingQuality::Castle)
+                BOOST_TEST_REQUIRE((++curPos.x) < world.GetSize().x);
+            bld = BuildingFactory::CreateBuilding(world, bldType, curPos, 0, Nation::Babylonians);
+            BOOST_TEST_REQUIRE((curPos.x += 2) < world.GetSize().x);
+        }
+        // Test productivity calculation for all buildings shown in the productivity window
+        if(helpers::contains(iwBuildingProductivities::icons, bldType))
+        {
+            auto* productionBld = dynamic_cast<nobUsual*>(bld);
+            BOOST_TEST_REQUIRE(productionBld);
+            const auto productivity = rttr::test::randomValue(1, 100);
+            setProductivity(productionBld, productivity);
+            expectedProductivity[bldType] = productivity;
+        }
+    }
+    BOOST_TEST(buildingRegister.CalcProductivities() == expectedProductivity, per_element());
+    unsigned avgProd = std::accumulate(expectedProductivity.begin(), expectedProductivity.end(), 0u)
+                       / iwBuildingProductivities::icons.size();
+    BOOST_TEST(buildingRegister.CalcAverageProductivity() == avgProd);
+
+    // Average productivity over multiple buildings of same type
+    avgProd = 0;
+    for(const BuildingType bldType : iwBuildingProductivities::icons)
+    {
+        auto* bld =
+          static_cast<nobUsual*>(BuildingFactory::CreateBuilding(world, bldType, curPos, 0, Nation::Babylonians));
+        if((curPos.x += 2) >= world.GetSize().x)
+            curPos = MapPoint(0, curPos.y + 2);
+        const auto productivity = rttr::test::randomValue(1, 100);
+        setProductivity(bld, productivity);
+        avgProd += productivity + expectedProductivity[bldType];
+        expectedProductivity[bldType] = (productivity + expectedProductivity[bldType]) / 2;
+    }
+    avgProd /= iwBuildingProductivities::icons.size() * 2;
+    BOOST_TEST(buildingRegister.CalcProductivities() == expectedProductivity, per_element());
+    BOOST_TEST(buildingRegister.CalcAverageProductivity() == avgProd);
 }

--- a/tests/s25Main/simple/testGameData.cpp
+++ b/tests/s25Main/simple/testGameData.cpp
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "helpers/EnumRange.h"
 #include "gameTypes/GameTypesOutput.h"
+#include "gameData/BuildingConsts.h"
+#include "gameData/BuildingProperties.h"
 #include "gameData/JobConsts.h"
 #include "gameData/ToolConsts.h"
 #include <boost/preprocessor/seq/for_each.hpp>
@@ -46,6 +49,21 @@ BOOST_AUTO_TEST_CASE(NationSpecificJobBobs)
                != JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Africans));
     BOOST_TEST(JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Vikings)
                < JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Babylonians));
+}
+
+BOOST_AUTO_TEST_CASE(ProductionBuildingsAreNobUsual)
+{
+    for(const auto bld : helpers::enumRange<BuildingType>())
+    {
+        if(!BuildingProperties::IsValid(bld))
+            continue;
+        // Only nobUsuals can produce wares (though not all do)
+        if(BLD_WORK_DESC[bld].producedWare)
+        {
+            BOOST_TEST_INFO("bld: " << bld);
+            BOOST_TEST(BuildingProperties::IsUsual(bld));
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/simple/testGameData.cpp
+++ b/tests/s25Main/simple/testGameData.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "gameTypes/GameTypesOutput.h"
+#include "gameData/JobConsts.h"
+#include "gameData/ToolConsts.h"
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
+#include <boost/test/unit_test.hpp>
+
+/// Tests of static game data, i.e. the constants defined in the source files
+BOOST_AUTO_TEST_SUITE(StaticGameDataTests)
+
+BOOST_AUTO_TEST_CASE(ToolMappingMatches)
+{
+#define TEST_TOOLMAP_SINGLE(s, _, Enumerator)                             \
+    static_assert(TOOL_TO_GOOD[Tool::Enumerator] == GoodType::Enumerator, \
+                  "Mismatch for " BOOST_PP_STRINGIZE(Enumerator));
+    // Generate a static assert for each enumerator
+#define TEST_TOOLMAP(...) BOOST_PP_SEQ_FOR_EACH(TEST_TOOLMAP_SINGLE, 0, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
+    TEST_TOOLMAP(Tongs, Hammer, Axe, Saw, PickAxe, Shovel, Crucible, RodAndLine, Scythe, Cleaver, Rollingpin, Bow);
+    BOOST_TEST(true);
+
+#undef TEST_TOOLMAP_SINGLE
+#undef TEST_TOOLMAP
+}
+
+BOOST_AUTO_TEST_CASE(NationSpecificJobBobs)
+{
+    // Helper is not nation specific
+    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Vikings)
+               == JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Africans));
+    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Vikings)
+               == JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Babylonians));
+    // Soldiers are
+    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Vikings)
+               != JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Africans));
+    // Non native nations come after native ones
+    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Vikings)
+               < JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Babylonians));
+    // Same for scouts
+    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Vikings)
+               != JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Africans));
+    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Vikings)
+               < JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Babylonians));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/simple/testGameTypes.cpp
+++ b/tests/s25Main/simple/testGameTypes.cpp
@@ -6,29 +6,12 @@
 #include "helpers/EnumRange.h"
 #include "gameTypes/GameTypesOutput.h"
 #include "gameTypes/Resource.h"
-#include "gameData/JobConsts.h"
-#include "gameData/ToolConsts.h"
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/preprocessor/variadic/to_seq.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(GameTypes)
-
-BOOST_AUTO_TEST_CASE(ToolMappingMatches)
-{
-#define TEST_TOOLMAP_SINGLE(s, _, Enumerator)                             \
-    static_assert(TOOL_TO_GOOD[Tool::Enumerator] == GoodType::Enumerator, \
-                  "Mismatch for " BOOST_PP_STRINGIZE(Enumerator));
-    // Generate a static assert for each enumerator
-#define TEST_TOOLMAP(...) BOOST_PP_SEQ_FOR_EACH(TEST_TOOLMAP_SINGLE, 0, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
-
-    TEST_TOOLMAP(Tongs, Hammer, Axe, Saw, PickAxe, Shovel, Crucible, RodAndLine, Scythe, Cleaver, Rollingpin, Bow);
-    BOOST_TEST(true);
-
-#undef TEST_TOOLMAP_SINGLE
-#undef TEST_TOOLMAP
-}
 
 BOOST_AUTO_TEST_CASE(ResourceValues)
 {
@@ -108,26 +91,6 @@ BOOST_AUTO_TEST_CASE(ResourceConvertToFromUInt8)
     const Resource res(0xFF);
     BOOST_TEST(res.getType() == ResourceType::Nothing);
     BOOST_TEST(res.getAmount() == 0u);
-}
-
-BOOST_AUTO_TEST_CASE(NationSpecificJobBobs)
-{
-    // Helper is not nation specific
-    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Vikings)
-               == JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Africans));
-    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Vikings)
-               == JOB_SPRITE_CONSTS[Job::Helper].getBobId(Nation::Babylonians));
-    // Soldiers are
-    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Vikings)
-               != JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Africans));
-    // Non native nations come after native ones
-    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Vikings)
-               < JOB_SPRITE_CONSTS[Job::Private].getBobId(Nation::Babylonians));
-    // Same for scouts
-    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Vikings)
-               != JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Africans));
-    BOOST_TEST(JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Vikings)
-               < JOB_SPRITE_CONSTS[Job::Scout].getBobId(Nation::Babylonians));
 }
 
 BOOST_AUTO_TEST_CASE(AIResourcesMatchValues)


### PR DESCRIPTION
Some refactoring related to the productivity handling, added tests to reproduce the issue and ensure related things (e.g. that buildings producing something are "Usual" buildings)

Also reorder the buildings according to the original with 4 buildings added:
- Forester below woodcutter
- Iron smelter below armoury
- Donkey-breeder below pig farm
- Charburner below mines

Fixes #1454

Result (old RttR, S2, new RttR): 
![Unbenannt](https://user-images.githubusercontent.com/309017/150386441-f0fe8b3a-3179-46a7-8211-e8ad11ce4146.png)

CC @Spikeone 