### PR TITLE
Update Ingame-Readmes and display user-data folder

### DIFF
--- a/data/RTTR/texte/de/keyboardlayout.txt
+++ b/data/RTTR/texte/de/keyboardlayout.txt
@@ -1,4 +1,4 @@
-                  SIEDLER II.5 - RETURN TO THE ROOTS
+                          RETURN TO THE ROOTS
 ------------------------------------------------------------------------
 Globale Tastaturbelegung im Spiel:
 
@@ -47,6 +47,6 @@ P:.................... Pause/Fortsetzen (Auch nach GF Sprung)
 1-7:.................. Spielerwechsel
 
 ------------------------------------------------------------------------
-http://www.siedler25.org    Copyright (C) 2005-2022 Settlers Freaks
+https://www.siedler25.org        Copyright (C) 2005-2022 Settlers Freaks
 ------------------------------------------------------------------------
 

--- a/data/RTTR/texte/de/keyboardlayout.txt
+++ b/data/RTTR/texte/de/keyboardlayout.txt
@@ -1,4 +1,4 @@
-2016.06.03        SIEDLER II.5 - RETURN TO THE ROOTS           0.8.1-dev
+                  SIEDLER II.5 - RETURN TO THE ROOTS
 ------------------------------------------------------------------------
 Globale Tastaturbelegung im Spiel:
 
@@ -47,6 +47,6 @@ P:.................... Pause/Fortsetzen (Auch nach GF Sprung)
 1-7:.................. Spielerwechsel
 
 ------------------------------------------------------------------------
-http://www.siedler25.org    Copyright (C) 2005-2016 Settlers Freaks
+http://www.siedler25.org    Copyright (C) 2005-2022 Settlers Freaks
 ------------------------------------------------------------------------
 

--- a/data/RTTR/texte/de/readme.txt
+++ b/data/RTTR/texte/de/readme.txt
@@ -1,4 +1,4 @@
-2017                          RETURN TO THE ROOTS                          0.8.2
+                              RETURN TO THE ROOTS
 --------------------------------------------------------------------------------
 
 A. Allgemeine Hinweise
@@ -248,12 +248,23 @@ D. Abstürze und Fehler
 
 E. Übersicht: Updates und Änderungen
 
-  * 0.8.3 - TBD
+  * 0.9.4 - 06.01.2022
+  ------------------------------------------------------------------------------
+  - Verschiedene Fixes für Bugs, die nicht-ladbare Savegames und Crashes verursachten
+  - Fix für bisuelle glitches bei hohem Terrain
+  - Drücken von ESC speichert die Einstellungen vor dem Schließen des Fensters
+  - Fix für das nicht-schließbar Action-Window
+  - Bei Spielstart werden die zuletzt geöffneten Fesnter wieder geöffnet und deren Position wiederhergestellt
+  - Fix fehlerhafte Behandlung der Versionen (behebt Anzeigefehler und Fehler bei Beitritt zu anderen Spielern)
+
+  * 0.9.1 - 24.07.2021
   ------------------------------------------------------------------------------
   - Vollbild Modus für alle Treiber und Betriebssystem
   - Random map generator
   - Sonderzeichen im Benutzernamen werden unterstüzt
-  - Einige Fehler und Abstürze behoben
+  - Einige Fehler, Abstürze und Asyncs behoben
+  - Map editor
+  - Performanceverbesserungen
 
   * 0.8.2 - 22.08.2017
   ------------------------------------------------------------------------------
@@ -382,5 +393,5 @@ E. Übersicht: Updates und Änderungen
   - alles ;-)
 
 --------------------------------------------------------------------------------
-http://www.siedler25.org                 Copyright (C) 2005-2017 Settlers Freaks
+http://www.siedler25.org                 Copyright (C) 2005-2022 Settlers Freaks
 --------------------------------------------------------------------------------

--- a/data/RTTR/texte/de/readme.txt
+++ b/data/RTTR/texte/de/readme.txt
@@ -393,5 +393,5 @@ E. Übersicht: Updates und Änderungen
   - alles ;-)
 
 --------------------------------------------------------------------------------
-http://www.siedler25.org                 Copyright (C) 2005-2022 Settlers Freaks
+https://www.siedler25.org                Copyright (C) 2005-2022 Settlers Freaks
 --------------------------------------------------------------------------------

--- a/data/RTTR/texte/keyboardlayout.txt
+++ b/data/RTTR/texte/keyboardlayout.txt
@@ -1,4 +1,4 @@
-                  SIEDLER II.5 - RETURN TO THE ROOTS
+                          RETURN TO THE ROOTS
 ------------------------------------------------------------------------
 Global keyboard layout in game:
 
@@ -46,5 +46,5 @@ J:.................... Go to specific GF
 P:.................... Pause/Resume (also after GF jump)
 1-7:.................. Change to other player
 ------------------------------------------------------------------------
-http://www.siedler25.org    Copyright (C) 2005-2022 Settlers Freaks
+https://www.siedler25.org        Copyright (C) 2005-2022 Settlers Freaks
 ------------------------------------------------------------------------

--- a/data/RTTR/texte/keyboardlayout.txt
+++ b/data/RTTR/texte/keyboardlayout.txt
@@ -1,4 +1,4 @@
-2016.06.03        SIEDLER II.5 - RETURN TO THE ROOTS           0.8.1-dev
+                  SIEDLER II.5 - RETURN TO THE ROOTS
 ------------------------------------------------------------------------
 Global keyboard layout in game:
 
@@ -46,5 +46,5 @@ J:.................... Go to specific GF
 P:.................... Pause/Resume (also after GF jump)
 1-7:.................. Change to other player
 ------------------------------------------------------------------------
-http://www.siedler25.org    Copyright (C) 2005-2016 Settlers Freaks
+http://www.siedler25.org    Copyright (C) 2005-2022 Settlers Freaks
 ------------------------------------------------------------------------

--- a/data/RTTR/texte/readme.txt
+++ b/data/RTTR/texte/readme.txt
@@ -379,5 +379,5 @@ E. Summary: Updates and changelog
   - Everything! ;-)
 
 --------------------------------------------------------------------------------
-http://www.siedler25.org                 Copyright (C) 2005-2022 Settlers Freaks
+https://www.siedler25.org                Copyright (C) 2005-2022 Settlers Freaks
 --------------------------------------------------------------------------------

--- a/data/RTTR/texte/readme.txt
+++ b/data/RTTR/texte/readme.txt
@@ -1,4 +1,4 @@
-2017                          RETURN TO THE ROOTS                          0.8.2
+                              RETURN TO THE ROOTS
 --------------------------------------------------------------------------------
 
 A. Reference Note
@@ -225,9 +225,9 @@ D. Crash and bugs
   communication between you and us, e.g. when we need more information
   from you.
 
-  Alternatively you can post the bug in the forum or visit us on IRC
-  channel: irc.freenode.net:6667/#siedler2.5
-  You can also join the irc-channel by visiting our homepage.
+  Alternatively you can post the bug in the forum or visit us on Discord:
+  https://discord.gg/kyTQsSx
+  You can also join the IRC-channel and Discord by visiting our homepage.
 
   Thanks a lot
 
@@ -238,12 +238,23 @@ D. Crash and bugs
 
 E. Summary: Updates and changelog
 
-  * 0.8.3 - TBD
+  * 0.9.4 - 06.01.2022
+  ------------------------------------------------------------------------------
+  - Various fixes for bugs leading to unloadable savegames and crashes
+  - Fix drawing issues related to high terrain
+  - Pressing ESC now does no longer discard pending changes of setting windows
+  - Fix uncloseable action window
+  - On game start reopen windows opened in last game and restorr their positions
+  - Fix faulty version handling (visual issues and unable to join other players)
+
+  * 0.9.1 - 24.07.2021
   ------------------------------------------------------------------------------
   - Fullscreen mode on all drivers and OSs
   - Random map generator
   - Allow special chars in user name
-  - Fix some bugs and crashes
+  - Fix some bugs, crashes and asyncs
+  - Map editor included
+  - Improved performance
 
   * 0.8.2 - 22.08.2017
   ------------------------------------------------------------------------------
@@ -368,5 +379,5 @@ E. Summary: Updates and changelog
   - Everything! ;-)
 
 --------------------------------------------------------------------------------
-http://www.siedler25.org                 Copyright (C) 2005-2017 Settlers Freaks
+http://www.siedler25.org                 Copyright (C) 2005-2022 Settlers Freaks
 --------------------------------------------------------------------------------

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -390,7 +390,7 @@ bool VideoSDL2::MessageLoop()
                 // Handle only 1st mouse move
                 if(!mouseMoved)
                 {
-                    mouse_xy.pos = Position(ev.button.x, ev.button.y);
+                    mouse_xy.pos = Position(ev.motion.x, ev.motion.y);
 
                     CallBack->Msg_MouseMove(mouse_xy);
                     mouseMoved = true;

--- a/libs/common/include/Rect.h
+++ b/libs/common/include/Rect.h
@@ -39,6 +39,12 @@ struct RectBase
     void setSize(const extent_type& newSize);
     void move(const position_type& offset);
     static RectBase move(RectBase rect, const position_type& offset);
+
+    constexpr bool operator==(const RectBase& rhs) const
+    {
+        return left == rhs.left && top == rhs.top && right == rhs.right && bottom == rhs.bottom;
+    }
+    constexpr bool operator!=(const RectBase& rhs) const { return !(*this == rhs); }
 };
 
 using Rect = RectBase<int>;

--- a/libs/common/include/RectOutput.h
+++ b/libs/common/include/RectOutput.h
@@ -1,0 +1,15 @@
+// Copyright (C) 2005 - 2022 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "PointOutput.h"
+#include "Rect.h"
+#include <iostream>
+
+template<typename T>
+std::ostream& operator<<(std::ostream& out, const RectBase<T>& rect)
+{
+    return out << "[Origin: " << rect.getOrigin() << " Size:" << rect.getSize() << "]"; // *1 to convert chars to int
+}

--- a/libs/rttrConfig/src/RttrConfig.cpp
+++ b/libs/rttrConfig/src/RttrConfig.cpp
@@ -17,13 +17,16 @@ namespace bfs = boost::filesystem;
 #    error "At least one of the RTTR_*DIR is undefined!"
 #endif
 
-#ifndef RTTR_SETTINGSDIR
+// Folder for user data, formerly "SETTINGSDIR" or "CONFIG"
+#ifdef RTTR_SETTINGSDIR
+#    define RTTR_USERDATADIR RTTR_SETTINGSDIR
+#elif !defined(RTTR_USERDATADIR)
 #    if defined(_WIN32)
-#        define RTTR_SETTINGSDIR "~/Return To The Roots"
+#        define RTTR_USERDATADIR "~/Return To The Roots"
 #    elif defined(__APPLE__)
-#        define RTTR_SETTINGSDIR "~/Library/Application Support/Return To The Roots"
+#        define RTTR_USERDATADIR "~/Library/Application Support/Return To The Roots"
 #    else
-#        define RTTR_SETTINGSDIR "~/.s25rttr"
+#        define RTTR_USERDATADIR "~/.s25rttr"
 #    endif
 #endif // !RTTR_SETTINGSDIR
 
@@ -127,7 +130,6 @@ bool RttrConfig::Init()
     pathMappings["LIB"] = RTTR_LIBDIR;
     pathMappings["DRIVER"] = RTTR_DRIVERDIR;
     pathMappings["RTTR"] = RTTR_DATADIR "/RTTR";
-    pathMappings["CONFIG"] = RTTR_SETTINGSDIR;
-    pathMappings["USERDATA"] = RTTR_SETTINGSDIR;
+    pathMappings["USERDATA"] = RTTR_USERDATADIR;
     return true;
 }

--- a/libs/rttrConfig/src/files.h
+++ b/libs/rttrConfig/src/files.h
@@ -18,7 +18,7 @@ namespace folders {
     constexpr auto assetsNations = "<RTTR_RTTR>/assets/nations";     // Addon specific assets
     constexpr auto assetsOverrides = "<RTTR_RTTR>/assets/overrides"; // Assets overriding S2 files
     constexpr auto assetsUserOverrides = "<RTTR_USERDATA>/LSTS";     // User overrides for assets
-    constexpr auto config = "<RTTR_CONFIG>";
+    constexpr auto config = "<RTTR_USERDATA>";
     constexpr auto data = "<RTTR_GAME>/DATA"; // S2 game data
     constexpr auto driver = "<RTTR_DRIVER>";
     constexpr auto gamedata = "<RTTR_RTTR>/gamedata";   // Path to the gamedata
@@ -55,8 +55,8 @@ namespace resources {
     constexpr auto boat = "<RTTR_GAME>/DATA/BOBS/BOAT.LST";
     constexpr auto boot_z = "<RTTR_GAME>/DATA/BOOT_Z.LST";
     constexpr auto carrier = "<RTTR_GAME>/DATA/BOBS/CARRIER.BOB";
-    constexpr auto config = "<RTTR_CONFIG>/CONFIG.INI"; // main config file
-    constexpr auto ingameOptions = "<RTTR_CONFIG>/IngameOptions.ini";
+    constexpr auto config = "<RTTR_USERDATA>/CONFIG.INI"; // main config file
+    constexpr auto ingameOptions = "<RTTR_USERDATA>/IngameOptions.ini";
     constexpr auto io = "<RTTR_GAME>/DATA/IO/IO.DAT";
     constexpr auto jobs = "<RTTR_GAME>/DATA/BOBS/JOBS.BOB";
     constexpr auto mis0bobs = "<RTTR_GAME>/DATA/MIS0BOBS.LST";

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -395,6 +395,9 @@ bool InitDirectories()
             return false;
         }
     }
+    LOG.write("Directory for user data (config etc.): %1%\n", LogTarget::Stdout)
+      % RTTRCONFIG.ExpandPath(s25::folders::config);
+
     // Write this to file too, after folders are created
     LOG.setLogFilepath(RTTRCONFIG.ExpandPath(s25::folders::logs));
     try

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -365,15 +365,15 @@ bool InitDirectories()
 {
     // Note: Do not use logger yet. Filepath may not exist
     const auto curPath = bfs::current_path();
-    LOG.write("Starting in %s\n", LogTarget::Stdout) % curPath;
-
-    // diverse dirs anlegen
-    const std::array<std::string, 10> dirs = {
-      {s25::folders::config, s25::folders::mapsOwn, s25::folders::logs, s25::folders::mapsPlayed, s25::folders::replays,
-       s25::folders::save, s25::folders::assetsUserOverrides, s25::folders::screenshots, s25::folders::playlists}};
+    LOG.write("Starting in %1%\n", LogTarget::Stdout) % curPath;
 
     if(!MigrateFilesAndDirectories())
         return false;
+
+    // Create all required/useful folders
+    const std::array<std::string, 10> dirs = {
+      {s25::folders::config, s25::folders::logs, s25::folders::mapsOwn, s25::folders::mapsPlayed, s25::folders::replays,
+       s25::folders::save, s25::folders::assetsUserOverrides, s25::folders::screenshots, s25::folders::playlists}};
 
     for(const std::string& rawDir : dirs)
     {
@@ -404,7 +404,7 @@ bool InitDirectories()
     {
         LOG.open();
         LOG.write("%1%\n\n", LogTarget::File) % GetProgramDescription();
-        LOG.write("Starting in %s\n", LogTarget::File) % curPath;
+        LOG.write("Starting in %1%\n", LogTarget::File) % curPath;
     } catch(const std::exception& e)
     {
         LOG.write("Error initializing log: %1%\nSystem reports: %2%\n", LogTarget::Stderr) % e.what()

--- a/libs/s25main/controls/ctrlText.cpp
+++ b/libs/s25main/controls/ctrlText.cpp
@@ -23,7 +23,8 @@ void ctrlBaseText::SetFont(glFont* font)
 
 ctrlText::ctrlText(Window* parent, unsigned id, const DrawPoint& pos, const std::string& text, unsigned color,
                    FontStyle format, const glFont* font)
-    : Window(parent, id, pos), ctrlBaseText(text, color, font), format(format)
+    : Window(parent, id, pos), ctrlBaseText(text, color, font), format_(format),
+      maxWidth_(static_cast<unsigned short>(-1))
 {}
 
 Rect ctrlText::GetBoundaryRect() const
@@ -31,14 +32,16 @@ Rect ctrlText::GetBoundaryRect() const
     if(text.empty())
         return Rect(GetDrawPos(), 0, 0);
     else
-        return font->getBounds(GetDrawPos(), text, format);
+    {
+        Rect bounds = font->getBounds(GetDrawPos(), text, format_);
+        if(bounds.getSize().x > maxWidth_)
+            bounds.setSize(Extent(maxWidth_, bounds.getSize().y));
+        return bounds;
+    }
 }
 
-/**
- *  zeichnet das Fenster.
- */
 void ctrlText::Draw_()
 {
     if(!text.empty())
-        font->Draw(GetDrawPos(), text, format, color_);
+        font->Draw(GetDrawPos(), text, format_, color_, maxWidth_);
 }

--- a/libs/s25main/controls/ctrlText.h
+++ b/libs/s25main/controls/ctrlText.h
@@ -17,9 +17,11 @@ public:
              FontStyle format, const glFont* font);
 
     Rect GetBoundaryRect() const override;
+    void setMaxWidth(unsigned short maxWidth) { maxWidth_ = maxWidth; }
 
 protected:
     void Draw_() override;
 
-    FontStyle format;
+    FontStyle format_;
+    unsigned short maxWidth_;
 };

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -12,6 +12,7 @@
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlEdit.h"
 #include "controls/ctrlTable.h"
+#include "controls/ctrlText.h"
 #include "desktops/dskLobby.h"
 #include "files.h"
 #include "helpers/make_array.h"
@@ -182,6 +183,9 @@ iwLoad::iwLoad(CreateServerInfo csi) : iwSaveLoad(0, _("Load game!")), csi(std::
 {
     AddEdit(1, DrawPoint(20, 350), Extent(510, 22), TextureColor::Green2, NormalFont);
     AddImageButton(2, DrawPoint(540, 346), Extent(40, 40), TextureColor::Green2, LOADER.GetImageN("io", 48));
+    auto* text = AddText(3, DrawPoint(20, 375), RTTRCONFIG.ExpandPath(s25::folders::save).string(), COLOR_YELLOW,
+                         FontStyle::TOP, SmallFont);
+    text->setMaxWidth(510);
     // Tabelle ausfüllen beim Start
     RefreshTable();
 }

--- a/libs/s25main/ogl/glFont.cpp
+++ b/libs/s25main/ogl/glFont.cpp
@@ -166,10 +166,9 @@ inline void glFont::DrawChar(char32_t curChar, VertexArrays& vertices, DrawPoint
  *                      @p FontStyle::TOP     - Text oben ( standard )
  *                      @p FontStyle::VCENTER - Text vertikal zentriert
  *                      @p FontStyle::BOTTOM  - Text unten
- *  @param[in] color  Farbe des Textes
- *  @param[in] length Länge des Textes
- *  @param[in] max    maximale Länge
- *  @param     end    Suffix for displaying a truncation of the text (...)
+ *  @param[in] color    Farbe des Textes
+ *  @param[in] maxWidth maximale Länge
+ *  @param     end      Suffix for displaying a truncation of the text (...)
  */
 void glFont::Draw(DrawPoint pos, const std::string& text, FontStyle format, unsigned color, unsigned short maxWidth,
                   const std::string& end) const

--- a/libs/s25main/ogl/glFont.h
+++ b/libs/s25main/ogl/glFont.h
@@ -26,7 +26,6 @@ public:
     glFont(const libsiedler2::ArchivItem_Font&);
 
     /// Draw the the text at the given position with format (alignment) and color.
-    /// If length is given, only that many chars (not glyphs!) will be used
     /// If maxWidth is given then the text length will be at most maxWidth. If the text is shortened then end is
     /// appended (included in maxWidth)
     void Draw(DrawPoint pos, const std::string& text, FontStyle format, unsigned color = COLOR_WHITE,


### PR DESCRIPTION
- Remove version and year from header avoiding the need to update them
- Add release notes for 0.9.x
- Update copyright year to 2022

- Show user data folder in the console window and the savegame folder in the load game window:
![2022-01-21_12-01-13](https://user-images.githubusercontent.com/309017/150517086-9df36df2-835e-4b67-9778-df2dd3514bf0.png)


Additionally I removed the redundant `RTTR_CONFIG` (same as `RTTR_USERDATA`) and added an option to the text-control to have a max-length to avoid overlong user names etc. from breaking the window. Not really great yet, but does its job.