### PR TITLE
Include tag annotation in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,21 @@ jobs:
             tar -czf ${{steps.filenames.outputs.devTools}} "$NAME/external/dev-tools"
             rm -r "$NAME/external/dev-tools"/*
             tar -czf ${{steps.filenames.outputs.src}} "$NAME"
+      - name: Get tag message
+        run: |
+          tagName=${{steps.get_tag.outputs.tag}}
+          tagType=$(git cat-file -t $tagName)
+          if [[ "$tagType" == "tag" ]]; then
+            tagMsg="$(git tag -l --format='%(contents)' $tagName)"
+            # Make sure to keep newlines and add an empty line before and after the message for better formatting
+            echo "TAG_MSG<<EOF" >> $GITHUB_ENV
+            echo "" >> $GITHUB_ENV
+            echo "$tagMsg" >> $GITHUB_ENV
+            echo "" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "TAG_MSG=" >> $GITHUB_ENV
+          fi
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -53,7 +68,7 @@ jobs:
           release_name: Release ${{ github.ref }}
           body: |
             Return To The Roots (Settlers II(R) Clone)
-
+            ${{ env.TAG_MSG }}
             - ${{steps.filenames.outputs.src}} contains all source files including the submodules
             - ${{steps.filenames.outputs.devTools}} contains optional binaries for development. Extract over the source folder if required
           draft: false


### PR DESCRIPTION
See https://trstringer.com/github-actions-multiline-strings/ for the multiline string workaround.

Test:
```
$ tagName=v0.9.0
$ tagType=$(git cat-file -t $tagName)
$ if [[ "$tagType" == "tag" ]]; then echo "Ok"; fi
Ok
$ tagMsg="$(git tag -l --format='%(contents)' $tagName)"
$          echo "TAG_MSG<<EOF" >> $GITHUB_ENV
$          echo "$tagMsg" >> $GITHUB_ENV
$          echo "" >> $GITHUB_ENV
$          echo "EOF" >> $GITHUB_ENV
$ cat $GITHUB_ENV
TAG_MSG<<EOF

- bugfixes
- better performance
- improved networking code
- LUA script support
- updated to SDL2
- included map editor
- builtin random map generator

EOF
```

Closes #1427

This should work. Of course we can only see that in the next release