### PR TITLE
Fix meaning of playlist repeats and make playlists infinite

### DIFF
--- a/data/RTTR/MUSIC/S2_Standard.pll
+++ b/data/RTTR/MUSIC/S2_Standard.pll
@@ -1,4 +1,4 @@
-3 in_order
+0 in_order
 s01
 s02
 s03

--- a/libs/s25main/Playlist.h
+++ b/libs/s25main/Playlist.h
@@ -12,29 +12,32 @@
 
 class Log;
 
-/// Speichert die Daten über eine Playlist und verwaltet diese
+/// List of songs with meta data.
+/// Also controls which song is played (next)
+/// After all songs have been played the playlist is restarted (reshuffled if needed)
 class Playlist
 {
 public:
     Playlist() = default;
     Playlist(std::vector<std::string> songs, unsigned numRepeats, bool random);
 
-    /// liefert den Dateinamen des aktuellen Songs
-    std::string getCurrentSong() const;
+    /// Get the currently played song, or an empty string if none
+    const std::string& getCurrentSong() const { return currentSong_; };
 
-    /// schaltet einen Song weiter und liefert den Dateinamen des aktuellen Songs
-    std::string getNextSong();
+    /// Switches to the next song and returns its name
+    const std::string& getNextSong();
 
-    /// Playlist in Datei speichern
+    /// Save playlist to file
     bool SaveAs(const boost::filesystem::path& filepath) const;
-    /// Playlist laden
+    /// Load playlist from file
     bool Load(Log& logger, const boost::filesystem::path& filepath);
 
     const auto& getSongs() const { return songs_; }
     unsigned getNumRepeats() const { return numRepeats_; }
     bool isRandomized() const { return random_; }
 
-    /// Wählt den Start-Song aus
+    /// Moves the song with the given index (in the songs_ array) to the front of the list of songs to be played
+    /// Has no effect if the song is not in the queue (anymore), e.g. if it was already played
     void SetStartSong(unsigned id);
 
 private:
@@ -42,7 +45,7 @@ private:
     void Prepare();
 
     std::vector<std::string> songs_; /// Filenames of titles to play
-    unsigned numRepeats_ = 1;        /// How often to repeat all songs
+    unsigned numRepeats_ = 1;        /// How often to repeat each song
     bool random_ = false;            /// True for random order, else in-order
     std::vector<unsigned> order_;    /// Actual order of the songs, indices into songs
     std::string currentSong_;

--- a/libs/s25main/ingameWindows/iwMusicPlayer.h
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.h
@@ -31,7 +31,7 @@ class iwMusicPlayer final : public IngameWindow
 
 public:
     iwMusicPlayer();
-    ~iwMusicPlayer() override;
+    void Close() override;
 
 private:
     /// Get the full path to a playlist by its name

--- a/tests/s25Main/audio/testPlaylist.cpp
+++ b/tests/s25Main/audio/testPlaylist.cpp
@@ -22,59 +22,81 @@ BOOST_AUTO_TEST_CASE(DefaultConstructedPlaylistIsEmpty)
     BOOST_TEST(pl.getNextSong().empty());
 }
 
+BOOST_AUTO_TEST_CASE(EmptySongsCauseException)
+{
+    const auto songs0 = std::vector<std::string>{"", "s02", "s03"};
+    const auto songs1 = std::vector<std::string>{"s01", "", "s03"};
+    const auto songs2 = std::vector<std::string>{"s01", "s02", ""};
+    BOOST_REQUIRE_THROW(Playlist _(songs0, 0, false), std::invalid_argument);
+    BOOST_REQUIRE_THROW(Playlist _(songs1, 0, false), std::invalid_argument);
+    BOOST_REQUIRE_THROW(Playlist _(songs2, 0, false), std::invalid_argument);
+    // However no songs are allowed and simply do nothing
+    Playlist pl(std::vector<std::string>{}, rttr::test::randomValue(0u, 10u), rttr::test::randomBool());
+    BOOST_TEST(pl.getSongs().empty());
+    BOOST_TEST(pl.getCurrentSong().empty());
+    BOOST_TEST(pl.getNextSong().empty());
+    // Even when called multiple times
+    BOOST_TEST(pl.getNextSong().empty());
+    BOOST_TEST(pl.getNextSong().empty());
+}
+
 BOOST_AUTO_TEST_CASE(PlaylistPlaysInOrder)
 {
     const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
-    Playlist pl(songs, 1, false);
+    Playlist pl(songs, 0, false);
     BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
-    for(const auto& song : songs)
-    {
-        BOOST_TEST(pl.getNextSong() == song);
-        BOOST_TEST(pl.getCurrentSong() == song);
-    }
-    // End of playlist
-    BOOST_TEST(pl.getNextSong().empty());
-    BOOST_TEST(pl.getCurrentSong().empty());
-}
-
-BOOST_AUTO_TEST_CASE(RepeatedPlaylistPlaysInOrder)
-{
-    const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
-    const auto numRepeats = rttr::test::randomValue(2u, 5u);
-    Playlist pl(songs, numRepeats, false);
-    BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
-    for(unsigned i = 0; i < numRepeats; i++)
+    for(int numPlaylistRepeats = rttr::test::randomValue(1, 5); numPlaylistRepeats > 0; --numPlaylistRepeats)
     {
         for(const auto& song : songs)
         {
             BOOST_TEST(pl.getNextSong() == song);
             BOOST_TEST(pl.getCurrentSong() == song);
         }
+        // End of playlist, the next loop will repeat the same songs
     }
-    // End of playlist
-    BOOST_TEST(pl.getNextSong().empty());
-    BOOST_TEST(pl.getCurrentSong().empty());
 }
 
-BOOST_AUTO_TEST_CASE(RandomPlaylistPlaysEachSongOnce)
+BOOST_AUTO_TEST_CASE(RepeatedPlaylistPlaysInOrder)
 {
     const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
-    Playlist pl(songs, 1, true);
+    const auto numRepeats = rttr::test::randomValue(1u, 3u);
+    Playlist pl(songs, numRepeats, false);
     BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
-    std::vector<std::string> playedSongs;
-    for(unsigned i = 0; i < songs.size(); i++)
+    for(int numPlaylistRepeats = rttr::test::randomValue(1, 5); numPlaylistRepeats > 0; --numPlaylistRepeats)
     {
-        const auto song = pl.getNextSong();
-        BOOST_TEST(!song.empty());
-        BOOST_TEST(pl.getCurrentSong() == song);
-        playedSongs.push_back(song);
+        for(const auto& song : songs)
+        {
+            // Note the `<=`: Repeats is the amount of repeats, i.e. 0==play once, no repeats
+            for(unsigned i = 0; i <= numRepeats; i++)
+            {
+                BOOST_TEST(pl.getNextSong() == song);
+                BOOST_TEST(pl.getCurrentSong() == song);
+            }
+        }
+        // End of playlist, the next loop will repeat the same songs
     }
-    // End of playlist
-    BOOST_TEST(pl.getNextSong().empty());
-    BOOST_TEST(pl.getCurrentSong().empty());
-    for(const auto& song : songs)
+}
+
+BOOST_AUTO_TEST_CASE(RandomPlaylistPlaysEachSongOncePerPlaylistRepeat)
+{
+    const auto songs = std::vector<std::string>{"s01", "s02", "s03"};
+    Playlist pl(songs, 0, true);
+    BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
+    for(int numPlaylistRepeats = rttr::test::randomValue(1, 5); numPlaylistRepeats > 0; --numPlaylistRepeats)
     {
-        BOOST_TEST(helpers::contains(playedSongs, song));
+        std::vector<std::string> playedSongs;
+        for(unsigned i = 0; i < songs.size(); i++)
+        {
+            const auto& song = pl.getNextSong();
+            BOOST_TEST(!song.empty());
+            BOOST_TEST(pl.getCurrentSong() == song);
+            playedSongs.push_back(song);
+        }
+        // End of playlist
+        for(const auto& song : songs)
+        {
+            BOOST_TEST(helpers::contains(playedSongs, song));
+        }
     }
 }
 
@@ -84,27 +106,28 @@ BOOST_AUTO_TEST_CASE(RandomPlaylistPlaysEachSongNumRepeatsTimes)
     const auto numRepeats = rttr::test::randomValue(2u, 5u);
     Playlist pl(songs, numRepeats, true);
     BOOST_TEST(pl.getCurrentSong().empty()); // Nothing yet
-    std::vector<std::string> playedSongs;
-    for(unsigned i = 0; i < songs.size() * numRepeats; i++)
+    for(int numPlaylistRepeats = rttr::test::randomValue(1, 5); numPlaylistRepeats > 0; --numPlaylistRepeats)
     {
-        const auto song = pl.getNextSong();
-        BOOST_TEST(!song.empty());
-        BOOST_TEST(pl.getCurrentSong() == song);
-        playedSongs.push_back(song);
-    }
-    // End of playlist
-    BOOST_TEST(pl.getNextSong().empty());
-    BOOST_TEST(pl.getCurrentSong().empty());
-    for(const auto& song : songs)
-    {
-        const unsigned numPlayed = helpers::count(playedSongs, song);
-        BOOST_TEST(numPlayed == numRepeats);
+        std::vector<std::string> playedSongs;
+        for(unsigned i = 0; i < songs.size() * (numRepeats + 1u); i++)
+        {
+            const auto& song = pl.getNextSong();
+            BOOST_TEST(!song.empty());
+            BOOST_TEST(pl.getCurrentSong() == song);
+            playedSongs.push_back(song);
+        }
+        // End of playlist
+        for(const auto& song : songs)
+        {
+            const unsigned numPlayed = helpers::count(playedSongs, song);
+            BOOST_TEST(numPlayed == numRepeats + 1u);
+        }
     }
 }
 
 BOOST_AUTO_TEST_CASE(SaveLoadResultsInSamePlaylist)
 {
-    const auto songs = std::vector<std::string>{"folder/s01.ogg", "s02 with space", "winfolder\\s03.mp3"};
+    const auto songs = std::vector<std::string>{"folder/song.ogg", "song with space.ogg", "windows_folder\\song.mp3"};
     const auto numRepeats = rttr::test::randomValue(2u, 5u);
     const bool isRandom = rttr::test::randomValue(0u, 1u) == 1u;
     Playlist pl(songs, numRepeats, isRandom);
@@ -116,8 +139,10 @@ BOOST_AUTO_TEST_CASE(SaveLoadResultsInSamePlaylist)
     BOOST_TEST(pl.getSongs() == pl2.getSongs(), boost::test_tools::per_element());
     BOOST_TEST(pl.getNumRepeats() == pl2.getNumRepeats());
     BOOST_TEST(pl.isRandomized() == pl2.isRandomized());
-    // Playlist is prepared
-    BOOST_TEST(!pl.getNextSong().empty());
+    // Playlist can be played
+    const auto& firstSong = pl.getNextSong();
+    BOOST_TEST_REQUIRE(!firstSong.empty());
+    BOOST_TEST(helpers::contains(songs, firstSong));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The repeats now actually mean repeats, i.e. a value of 1 repeats the song once, playing it twice.
On ordered playlists this will play each song N+1 times before starting the next.
For random playlists it doesn't matter much, but a higher value basically increases the chance of playing the same song again, up to N+1 times (in total).
After all songs of the playlist have been player N+1 times the whole playlist is reshuffled (if set) and restarted.

Fixes #1480

Basically uses "Option 5" which should please everyone.