### PR TITLE
Fix drawing glitch on start

### DIFF
--- a/libs/s25main/TerrainRenderer.cpp
+++ b/libs/s25main/TerrainRenderer.cpp
@@ -291,12 +291,6 @@ void TerrainRenderer::GenerateOpenGL(const GameWorldViewer& gwv)
     const GameWorldBase& world = gwv.GetWorld();
     Init(world.GetSize());
 
-    maxNodeAltitude_ = 0;
-    RTTR_FOREACH_PT(MapPoint, size_)
-    {
-        maxNodeAltitude_ = std::max(maxNodeAltitude_, world.GetNode(pt).altitude);
-    }
-
     GenerateVertices(gwv);
     const WorldDescription& desc = world.GetDescription();
     LoadTextures(desc);
@@ -1044,7 +1038,6 @@ void TerrainRenderer::DrawWays(const PreparedRoads& sorted_roads) const
 
 void TerrainRenderer::AltitudeChanged(const MapPoint pt, const GameWorldViewer& gwv)
 {
-    maxNodeAltitude_ = std::max(maxNodeAltitude_, gwv.GetWorld().GetNode(pt).altitude);
     // den selbst sowieso die Punkte darum updaten, da sich bei letzteren die Schattierung geändert haben könnte
     UpdateVertexPos(pt, gwv);
     UpdateVertexColor(pt, gwv);

--- a/libs/s25main/TerrainRenderer.h
+++ b/libs/s25main/TerrainRenderer.h
@@ -57,8 +57,6 @@ public:
     /// Recalculates all colors on the map
     void UpdateAllColors(const GameWorldViewer& gwv);
 
-    uint8_t getMaxNodeAltitude() const { return maxNodeAltitude_; }
-
 private:
     struct MapTile
     {
@@ -125,8 +123,6 @@ private:
 
     /// Size of the map
     MapExtent size_;
-    /// Max height of any node
-    uint8_t maxNodeAltitude_;
     /// Map sized array of vertex related data
     std::vector<Vertex> vertices;
     /// Map sized array with terrain indices/textures (bottom, bottom right of node)

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -688,7 +688,7 @@ bool dskGameInterface::Msg_MouseMove(const MouseCoords& mc)
     if(SETTINGS.interface.revert_mouse)
         acceleration = -acceleration;
 
-    gwv.MoveTo((mc.GetPos() - startScrollPt) * acceleration);
+    gwv.MoveBy((mc.GetPos() - startScrollPt) * acceleration);
     VIDEODRIVER.SetMousePos(startScrollPt);
 
     if(!SETTINGS.global.smartCursor)
@@ -726,16 +726,16 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
             return true;
 
         case KeyType::Left: // Nach Links Scrollen
-            gwv.MoveToX(-30);
+            gwv.MoveBy({-30, 0});
             return true;
         case KeyType::Right: // Nach Rechts Scrollen
-            gwv.MoveToX(30);
+            gwv.MoveBy({30, 0});
             return true;
         case KeyType::Up: // Nach Oben Scrollen
-            gwv.MoveToY(-30);
+            gwv.MoveBy({0, -30});
             return true;
         case KeyType::Down: // Nach Unten Scrollen
-            gwv.MoveToY(30);
+            gwv.MoveBy({0, 30});
             return true;
 
         case KeyType::F2: // Spiel speichern

--- a/libs/s25main/ingameWindows/iwObservate.cpp
+++ b/libs/s25main/ingameWindows/iwObservate.cpp
@@ -218,7 +218,7 @@ bool iwObservate::MoveToFollowedObj(const MapPoint ptToCheck)
             if(followMovable.IsMoving())
                 drawPt += followMovable.CalcWalkingRelative();
 
-            view->MoveTo(drawPt - view->GetSize() / 2u, true);
+            view->MoveTo(drawPt - view->GetSize() / 2u);
             return true;
         }
     }
@@ -234,7 +234,7 @@ bool iwObservate::Msg_MouseMove(const MouseCoords& mc)
         if(SETTINGS.interface.revert_mouse)
             acceleration = -acceleration;
 
-        view->MoveTo((mc.GetPos() - scrollOrigin) * acceleration);
+        view->MoveBy((mc.GetPos() - scrollOrigin) * acceleration);
         VIDEODRIVER.SetMousePos(scrollOrigin);
     }
 

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -617,7 +617,7 @@ void GameWorldView::CalcFxLx()
     firstPt.x = offset.x / TR_W - 1;
     firstPt.y = offset.y / TR_H - 1;
     lastPt.x = (offset.x + size_.x) / TR_W + 1;
-    const auto maxAltitude = gwv.GetTerrainRenderer().getMaxNodeAltitude();
+    const auto maxAltitude = gwv.getMaxNodeAltitude();
     lastPt.y = (offset.y + size_.y + maxAltitude * HEIGHT_FACTOR) / TR_H + 1;
 
     if(zoomFactor_ != 1.f) //-V550

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -39,7 +39,7 @@ GameWorldView::GameWorldView(const GameWorldViewer& gwv, const Position& pos, co
       show_productivity(SETTINGS.ingame.showProductivity), offset(0, 0), lastOffset(0, 0), gwv(gwv), origin_(pos),
       size_(size), zoomFactor_(1.f), targetZoomFactor_(1.f), zoomSpeed_(0.f)
 {
-    MoveTo(0, 0);
+    MoveBy({0, 0});
 }
 
 const GameWorldBase& GameWorldView::GetWorld() const
@@ -555,21 +555,14 @@ void GameWorldView::ToggleShowNamesAndProductivity()
     SaveIngameSettingsValues();
 }
 
-/**
- *  verschiebt das Bild zu einer bestimmten Stelle.
- */
-void GameWorldView::MoveTo(int x, int y, bool absolute)
+void GameWorldView::MoveBy(const DrawPoint& numPixels)
 {
-    MoveTo(DrawPoint(x, y), absolute);
+    MoveTo(offset + numPixels);
 }
 
-void GameWorldView::MoveTo(const DrawPoint& newPos, bool absolute)
+void GameWorldView::MoveTo(const DrawPoint& newPos)
 {
-    if(absolute)
-        offset = newPos;
-    else
-        offset += newPos;
-
+    offset = newPos;
     DrawPoint size(GetWorld().GetWidth() * TR_W, GetWorld().GetHeight() * TR_H);
     if(size.x && size.y)
     {
@@ -593,15 +586,14 @@ void GameWorldView::MoveToMapPt(const MapPoint pt)
     lastOffset = offset;
     Position nodePos = GetWorld().GetNodePos(pt);
 
-    MoveTo(nodePos - GetSize() / 2u, true);
+    MoveTo(nodePos - GetSize() / 2u);
 }
 
-/// Springt zur letzten Position, bevor man "weggesprungen" ist
 void GameWorldView::MoveToLastPosition()
 {
     Position newLastOffset = offset;
 
-    MoveTo(lastOffset.x, lastOffset.y, true);
+    MoveTo(lastOffset);
 
     lastOffset = newLastOffset;
 }

--- a/libs/s25main/world/GameWorldView.h
+++ b/libs/s25main/world/GameWorldView.h
@@ -103,16 +103,15 @@ public:
 
     void Draw(const RoadBuildState& rb, MapPoint selected, bool drawMouse, unsigned* water = nullptr);
 
-    /// Bewegt sich zu einer bestimmten Position in Pixeln auf der Karte
-    void MoveTo(int x, int y, bool absolute = false);
-    void MoveTo(const DrawPoint& newPos, bool absolute = false);
+    /// Moves the map view by the given offset in pixels
+    void MoveBy(const DrawPoint& numPixels);
+    /// Moves a position on the map in pixels
+    void MoveTo(const DrawPoint& newPos);
     /// Zentriert den Bildschirm auf ein bestimmtes Map-Object
     void MoveToMapPt(MapPoint pt);
     /// Springt zur letzten Position, bevor man "weggesprungen" ist
     void MoveToLastPosition();
 
-    void MoveToX(int x, bool absolute = false) { MoveTo((absolute ? 0 : offset.x) + x, offset.y, true); }
-    void MoveToY(int y, bool absolute = false) { MoveTo(offset.x, (absolute ? 0 : offset.y) + y, true); }
     DrawPoint GetOffset() const { return offset; }
 
     /// Add a debug node printer

--- a/libs/s25main/world/GameWorldViewer.h
+++ b/libs/s25main/world/GameWorldViewer.h
@@ -36,6 +36,7 @@ public:
     /// Return non-const world (TODO: Remove, this is a view only!)
     GameWorldBase& GetWorldNonConst() { return gwb; }
     const TerrainRenderer& GetTerrainRenderer() const { return tr; }
+    auto getMaxNodeAltitude() const { return maxNodeAltitude_; }
     SoundManager& GetSoundMgr();
     /// Get the player instance for this view
     const GamePlayer& GetPlayer() const;
@@ -104,6 +105,8 @@ private:
     TerrainRenderer tr;
     Subscription evVisibilityChanged, evAltitudeChanged, evRoadConstruction, evBQChanged;
     NodeMapBase<VisualMapNode> visualNodes;
+    /// Max height of any node
+    uint8_t maxNodeAltitude_ = 0;
 
     void InitVisualData();
     inline void VisibilityChanged(const MapPoint& pt, unsigned player);

--- a/tests/s25Main/UI/testControls.cpp
+++ b/tests/s25Main/UI/testControls.cpp
@@ -240,9 +240,9 @@ BOOST_AUTO_TEST_CASE(AdjustWidthForMaxChars_SetsCorrectSize)
 BOOST_AUTO_TEST_CASE(TextControlWorks)
 {
     auto font = createMockFont({'?', 'a', 'z'});
-    const auto parentPos = rttr::test::randomPoint<DrawPoint>();
+    const auto parentPos = rttr::test::randomPoint<DrawPoint>(-1000, 1000);
     Window parent(nullptr, 0, parentPos);
-    const auto pos = rttr::test::randomPoint<DrawPoint>();
+    const auto pos = rttr::test::randomPoint<DrawPoint>(-1000, 1000);
     const auto* testText = "a?z?a?z?a?z?a?z?a?z?";
     ctrlText text(&parent, 0, pos, testText, COLOR_YELLOW, FontStyle{}, font.get());
 

--- a/tests/s25Main/integration/testGameWorldView.cpp
+++ b/tests/s25Main/integration/testGameWorldView.cpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2005 - 2022 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "PointOutput.h"
+#include "worldFixtures/CreateEmptyWorld.h"
+#include "worldFixtures/WorldFixture.h"
+#include "world/GameWorldView.h"
+#include "world/GameWorldViewer.h"
+#include "gameData/MapConsts.h"
+#include "rttr/test/random.hpp"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(GameWorldViewTests)
+
+namespace {
+using EmptyWorldFixture1P = WorldFixture<CreateEmptyWorld, 1>;
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(HasCorrectDrawCoords, EmptyWorldFixture1P)
+{
+    GameWorldViewer gwv(0, world);
+    const auto viewSize = rttr::test::randomPoint<Extent>(100, 1000);
+    GameWorldView view(gwv, Position(0, 0), viewSize);
+    BOOST_TEST(view.GetPos() == Position(0, 0));
+    BOOST_TEST(view.GetSize() == viewSize);
+    BOOST_TEST(view.GetFirstPt() == Position(-1, -1));
+    BOOST_TEST(view.GetLastPt().x > static_cast<int>(viewSize.x / TR_W));
+    BOOST_TEST(view.GetLastPt().y > static_cast<int>(viewSize.y / TR_H));
+
+    const auto origFirstPt = view.GetFirstPt();
+    const auto origLastPt = view.GetLastPt();
+    auto newOffset = rttr::test::randomPoint<DrawPoint>(100, 200);
+    BOOST_TEST_REQUIRE(view.GetOffset() == DrawPoint(0, 0));
+    view.MoveTo(newOffset);
+    BOOST_TEST_REQUIRE(view.GetOffset() == newOffset);
+    const auto offsetFirstPt = view.GetFirstPt();
+    const auto offsetLastPt = view.GetLastPt();
+    BOOST_TEST(offsetFirstPt.x > origFirstPt.x);
+    BOOST_TEST(offsetFirstPt.y > origFirstPt.y);
+    BOOST_TEST(offsetLastPt.x > origLastPt.x);
+    BOOST_TEST(offsetLastPt.y > origLastPt.y);
+    // Relative move
+    {
+        const auto offset = rttr::test::randomPoint<Position>(-100, 100);
+        view.MoveBy(offset);
+        BOOST_TEST_REQUIRE(view.GetOffset() == newOffset + offset);
+    }
+
+    // Don't move if moved by multiples of total size
+    {
+        const DrawPoint drawSize(world.GetSize() * DrawPoint(TR_W, TR_H));
+        // Absolute
+        view.MoveTo(newOffset + drawSize);
+        BOOST_TEST_REQUIRE(view.GetOffset() == newOffset);
+        // Relative +-
+        view.MoveBy(drawSize);
+        BOOST_TEST_REQUIRE(view.GetOffset() == newOffset);
+        view.MoveBy(drawSize);
+        BOOST_TEST_REQUIRE(view.GetOffset() == newOffset);
+        // Absolute by multiples of the size
+        const auto offset = rttr::test::randomPoint<Position>(1, 10);
+        view.MoveTo(newOffset + (drawSize * rttr::test::randomPoint<Position>(2, 5)) + offset);
+        BOOST_TEST_REQUIRE(view.GetOffset() == newOffset + offset);
+    }
+
+    // Move back to start restores first/last points
+    view.MoveTo({0, 0});
+    BOOST_TEST_REQUIRE(view.GetOffset() == DrawPoint(0, 0));
+    BOOST_TEST(view.GetFirstPt() == origFirstPt);
+    BOOST_TEST(view.GetLastPt() == origLastPt);
+    // Relative move also updates first/last point
+    view.MoveBy(newOffset);
+    BOOST_TEST_REQUIRE(view.GetOffset() == newOffset);
+    BOOST_TEST(view.GetFirstPt() == offsetFirstPt);
+    BOOST_TEST(view.GetLastPt() == offsetLastPt);
+}
+
+BOOST_FIXTURE_TEST_CASE(GetsCorrectMaxHeight, EmptyWorldFixture1P)
+{
+    GameWorldViewer gwv(0, world);
+    const auto viewSize = rttr::test::randomPoint<Extent>(100, 1000);
+    GameWorldView view(gwv, Position(0, 0), viewSize);
+    BOOST_TEST(gwv.getMaxNodeAltitude() == world.GetNode(MapPoint(0, 0)).altitude); // All same height
+
+    {
+        EmptyWorldFixture1P world2;
+        const auto newMaxHeight = world2.world.GetNodeWriteable(MapPoint(0, 0)).altitude *= 2;
+        GameWorldViewer gwv2(0, world2.world);
+        BOOST_TEST(gwv2.getMaxNodeAltitude() == newMaxHeight);
+        GameWorldView view2(gwv2, Position(0, 0), viewSize);
+        BOOST_TEST(view2.GetFirstPt() == view.GetFirstPt());
+        BOOST_TEST(view2.GetLastPt().x == view.GetLastPt().x);
+        BOOST_TEST(view2.GetLastPt().y > view.GetLastPt().y); // Should have increased due to higher altitude
+
+        // React on height changes, at least after moves
+        world.ChangeAltitude(MapPoint(0, 0), newMaxHeight);
+        view.MoveBy(DrawPoint(0, 0)); // no-op move
+        BOOST_TEST(gwv.getMaxNodeAltitude() == newMaxHeight);
+        BOOST_TEST(view.GetFirstPt() == view2.GetFirstPt());
+        BOOST_TEST(view.GetLastPt() == view2.GetLastPt());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Move maxNodeAltitude from TerrainRenderer to GameWorldViewer

This field was initialized to late: In GenerateOpenGL
It is used by the GameWorldView constructor: Through the `Move` function which recalculates the first and last map points to draw based on the max height.
This moves makes the value available very early.

Also adds tests and a little refactoring of the `MoveTo` function (move the relative move into new `MoveBy`)

Fixes #1456