### PR TITLE
Fix connection issues

### DIFF
--- a/libs/s25main/controls/ctrlEdit.cpp
+++ b/libs/s25main/controls/ctrlEdit.cpp
@@ -60,6 +60,14 @@ void ctrlEdit::SetFocus(bool focus)
     {
         focus_ = focus;
         txtCtrl->SetTextColor(focus_ ? 0xFFFFA000 : COLOR_YELLOW);
+        if(focus && GetParent())
+        {
+            for(auto* edit : GetParent()->GetCtrls<ctrlEdit>())
+            {
+                if(edit != this)
+                    edit->SetFocus(false);
+            }
+        }
     }
 }
 

--- a/libs/s25main/desktops/dskLobby.h
+++ b/libs/s25main/desktops/dskLobby.h
@@ -12,6 +12,9 @@ class iwDirectIPCreate;
 class LobbyServerList;
 class LobbyPlayerList;
 
+/// Check if we can connect to this server, i.e. the version is valid
+bool isServerVersionValid(const LobbyServerInfo& serverInfo);
+
 class dskLobby final : public dskMenuBase, public LobbyInterface
 {
 private:

--- a/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
@@ -113,7 +113,7 @@ void iwDirectIPConnect::Msg_ButtonClick(const unsigned ctrl_id)
                 SetStatus(_("Connection failed!"), COLOR_RED);
             } else
             {
-                SetStatus(_("Connecting with Host..."), COLOR_RED);
+                SetStatus(_("Connecting with Host..."), COLOR_YELLOW);
                 GetCtrl<ctrlButton>(ID_btConnect)->SetEnabled(false);
                 std::unique_ptr<ILobbyClient> lobbyClient;
                 if(serverType_ == ServerType::Lobby)

--- a/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
@@ -79,17 +79,9 @@ void iwDirectIPConnect::Msg_EditEnter(const unsigned ctrl_id)
 {
     switch(ctrl_id)
     {
-        case ID_edtIp:
-            GetCtrl<ctrlEdit>(ID_edtIp)->SetFocus(false);
-            GetCtrl<ctrlEdit>(ID_edtPort)->SetFocus(true);
-            GetCtrl<ctrlEdit>(ID_edtPw)->SetFocus(false);
-            break;
-        case ID_edtPort:
-            GetCtrl<ctrlEdit>(ID_edtIp)->SetFocus(false);
-            GetCtrl<ctrlEdit>(ID_edtPort)->SetFocus(false);
-            GetCtrl<ctrlEdit>(ID_edtPw)->SetFocus(true);
-            break;
-        case ID_edtPw: Msg_ButtonClick(ID_btConnect); break;
+        case ID_edtIp: GetCtrl<ctrlEdit>(ID_edtPort)->SetFocus(true); break;
+        case ID_edtPort: GetCtrl<ctrlEdit>(ID_edtPw)->SetFocus(true); break;
+        case ID_edtPw: GetCtrl<ctrlEdit>(ID_btConnect)->SetFocus(true); break;
     }
 }
 

--- a/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
@@ -51,7 +51,7 @@ iwDirectIPConnect::iwDirectIPConnect(ServerType serverType)
                              (serverType != ServerType::Direct), true);
 
     AddText(ID_txtPw, DrawPoint(20, 130), _("Password (if needed):"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    AddEdit(ID_edtIp, DrawPoint(20, 145), Extent(260, 22), TextureColor::Green2, NormalFont, 0, false, false, true);
+    AddEdit(ID_edtPw, DrawPoint(20, 145), Extent(260, 22), TextureColor::Green2, NormalFont, 0, false, false, true);
 
     AddText(ID_txtIpv6, DrawPoint(20, 185), _("Use IPv6:"), COLOR_YELLOW, FontStyle{}, NormalFont);
 
@@ -144,30 +144,16 @@ void iwDirectIPConnect::SetStatus(const std::string& text, unsigned color)
     txtStatus->SetText(text);
 }
 
-/**
- *  Setzt den Hostnamen im Editfeld.
- */
-void iwDirectIPConnect::SetHost(const std::string& hostIp)
-{
-    GetCtrl<ctrlEdit>(ID_edtIp)->SetText(hostIp);
-}
-
 void iwDirectIPConnect::Connect(const std::string& hostOrIp, const unsigned short port, const bool isIPv6,
                                 const bool hasPwd)
 {
-    SetHost(hostOrIp);
-    SetPort(port);
+    GetCtrl<ctrlEdit>(ID_edtIp)->SetText(hostOrIp);
+    GetCtrl<ctrlEdit>(ID_edtPort)->SetText(s25util::toStringClassic(port));
     GetCtrl<ctrlOptionGroup>(ID_grpIpv6)->SetSelection(isIPv6 ? 1 : 0, true);
     auto* btConnect = GetCtrl<ctrlButton>(ID_btConnect);
     VIDEODRIVER.SetMousePos(btConnect->GetDrawPos() + DrawPoint(btConnect->GetSize()) / 2);
-    if(!hasPwd)
+    if(hasPwd)
+        GetCtrl<ctrlEdit>(ID_edtPw)->SetFocus(true);
+    else
         Msg_ButtonClick(ID_btConnect);
-}
-
-/**
- *  Setzt den Port im Editfeld.
- */
-void iwDirectIPConnect::SetPort(unsigned short port)
-{
-    GetCtrl<ctrlEdit>(ID_edtPort)->SetText(s25util::toStringClassic(port));
 }

--- a/libs/s25main/ingameWindows/iwDirectIPConnect.h
+++ b/libs/s25main/ingameWindows/iwDirectIPConnect.h
@@ -16,8 +16,6 @@ private:
 
 public:
     iwDirectIPConnect(ServerType serverType);
-    void SetHost(const std::string& hostIp);
-    void SetPort(unsigned short port);
     /// Connects to the given server or fills in the info if it has a password
     void Connect(const std::string& hostOrIp, unsigned short port, bool isIPv6, bool hasPwd);
 

--- a/tests/s25Main/integration/testGameWorldView.cpp
+++ b/tests/s25Main/integration/testGameWorldView.cpp
@@ -42,7 +42,7 @@ BOOST_FIXTURE_TEST_CASE(HasCorrectDrawCoords, EmptyWorldFixture1P)
     BOOST_TEST(offsetLastPt.y > origLastPt.y);
     // Relative move
     {
-        const auto offset = rttr::test::randomPoint<Position>(-100, 100);
+        const auto offset = rttr::test::randomPoint<Position>(-100, 70); // Smallish max offset to not exceed map size
         view.MoveBy(offset);
         BOOST_TEST_REQUIRE(view.GetOffset() == newOffset + offset);
     }


### PR DESCRIPTION
This solves 2 issues:
- Being unable to connect to games with the tagged (stable) versions because the extraction of the server revision only works for the data-as-version format
- A crash when connecting with the nightly due to a C&P mistake which removed the password-edit from the connect dialog

Fixes #1492

Also a bit cleanup:
- Setting focus on one edit removes it from the others of the same parent
- Remove the SetHost/SetPort functions that were only used once (left-over from the refactoring the introduced the connect function)