### PR TITLE
Add support for Clang 13 and fix ordering of tools by AI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,11 +33,11 @@ jobs:
           - { compiler: gcc-11,   os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
           - { compiler: gcc-11,   os: ubuntu-20.04, buildType: Release }
           # Latest Clang with externals
-          - { compiler: clang-12, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }
-          - { compiler: clang-12, os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
-          - { compiler: clang-12, os: ubuntu-20.04, buildType: Release }
+          - { compiler: clang-13, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }
+          - { compiler: clang-13, os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
+          - { compiler: clang-13, os: ubuntu-20.04, buildType: Release }
           # Latest Clang with latest boost
-          - { compiler: clang-12, os: ubuntu-20.04, buildType: Debug, boostVersion: 1.77.0, externalSanitizer: true }
+          - { compiler: clang-13, os: ubuntu-20.04, buildType: Debug, boostVersion: 1.78.0, externalSanitizer: true }
 
     runs-on: ${{matrix.os}}
 
@@ -65,6 +65,12 @@ jobs:
           path: ${{env.DEPS_DIR}}
           key: ${{matrix.os}}-${{env.BOOST_VERSION}}
 
+      - name: Add LLVM repo
+        if: matrix.compiler == 'clang-13' && matrix.os == 'ubuntu-20.04'
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+          sudo apt update
       - name: Install Compiler
         if: "!startsWith(runner.os, 'macos')"
         run: |

--- a/libs/common/include/Point.h
+++ b/libs/common/include/Point.h
@@ -24,10 +24,11 @@ struct Point //-V690
     T x, y;
     constexpr Point() noexcept : x(getInvalidValue()), y(getInvalidValue()) {}
     constexpr Point(const T x, const T y) noexcept : x(x), y(y) {}
-    constexpr Point(const Point&) = default;
     template<typename U>
     constexpr explicit Point(const Point<U>& pt) noexcept : x(static_cast<T>(pt.x)), y(static_cast<T>(pt.y))
     {}
+    constexpr Point(const Point&) = default;
+    constexpr Point& operator=(const Point&) = default;
 
     static constexpr Point Invalid() noexcept { return Point(); }
     /// Create a new point with all coordinates set to value

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -2371,7 +2371,7 @@ void AIPlayerJH::AdjustSettings()
                     const unsigned requiredTools = numBuildingsRequiringWorker - inventory[job];
                     // When we are missing tools produce some.
                     // Slightly higher priority if we don't have any tool at all.
-                    if(requiredTools > inventory[good])
+                    if(requiredTools > numToolsAvailable)
                         return (inventory[good] == 0) ? 4 : 2;
                     numToolsAvailable -= requiredTools;
                 }

--- a/tests/s25Main/benchmarks/CMakeLists.txt
+++ b/tests/s25Main/benchmarks/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
     FetchContent_Declare(
         GoogleBenchmark
         GIT_REPOSITORY https://github.com/google/benchmark.git
-        GIT_TAG v1.5.3
+        GIT_TAG v1.6.1
     )
     set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
     set(BENCHMARK_ENABLE_INSTALL  OFF CACHE BOOL "")


### PR DESCRIPTION
As LLVM APT repos for clang-13 on Ubuntu 20.02 are now available we can test this on CI.

This requires fixing a more pedantic behavior: Giving a custom (even defaulted) copy ctor requires now also a custom copy assignment operator if that is wanted.

Another warning found an actual bug in the AI code, although the effect should be minor in practice.

See the individual commits for details.

Closes #1430