### PR TITLE
Use a 3-state enum for the window close behavior

### DIFF
--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -137,7 +137,7 @@ void WindowManager::RelayKeyboardMessage(KeyboardMsgHandler msg, const KeyEvent&
         // Find one which isn't yet marked for closing so multiple ESC in between draw calls can close multiple windows
         const auto itActiveWnd =
           std::find_if(windows.rbegin(), windows.rend(), [](const auto& wnd) { return !wnd->ShouldBeClosed(); });
-        if(itActiveWnd != windows.rend() && (*itActiveWnd)->isUserClosable())
+        if(itActiveWnd != windows.rend() && (*itActiveWnd)->getCloseBehavior() != CloseBehavior::Custom)
             (*itActiveWnd)->Close();
     } else if(!CALL_MEMBER_FN(*windows.back(), msg)(ke)) // send to active window
     {
@@ -404,7 +404,7 @@ void WindowManager::Msg_RightDown(const MouseCoords& mc)
     if(!curDesktop)
         return;
 
-    // Sind Fenster vorhanden && ist das aktive Fenster ok
+    // Right-click closes (most) windows, so check that
     if(!windows.empty())
     {
         IngameWindow* foundWindow = FindWindowAtPos(mc.GetPos());
@@ -419,7 +419,7 @@ void WindowManager::Msg_RightDown(const MouseCoords& mc)
         if(foundWindow)
         {
             // Close it if requested
-            if(foundWindow->isUserClosable())
+            if(foundWindow->getCloseBehavior() == CloseBehavior::Regular)
                 foundWindow->Close();
             else
             {

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -14,6 +14,16 @@ class MouseCoords;
 template<typename T>
 struct Point;
 
+enum CloseBehavior
+{
+    /// Closeable via right-click, button, keyboard (ESC, ALT+W)
+    Regular,
+    /// Close behavior is managed by window, e.g. explicit button
+    Custom,
+    /// Same as Regular, but doesn't (auto-)close on right-click
+    NoRightClick,
+};
+
 class IngameWindow : public Window
 {
 public:
@@ -27,8 +37,8 @@ public:
     static const Extent borderSize;
 
     IngameWindow(unsigned id, const DrawPoint& pos, const Extent& size, std::string title,
-                 glArchivItem_Bitmap* background, bool modal = false, bool isUserClosable = true,
-                 Window* parent = nullptr);
+                 glArchivItem_Bitmap* background, bool modal = false,
+                 CloseBehavior closeBehavior = CloseBehavior::Regular, Window* parent = nullptr);
 
     /// setzt den Hintergrund.
     void SetBackground(glArchivItem_Bitmap* background) { this->background = background; }
@@ -61,11 +71,9 @@ public:
     /// ist das Fenster minimiert?
     bool IsMinimized() const { return isMinimized_; }
 
-    /// Can the user close the window (e.g. right-click, ESC)
-    /// If this is false the close button at the title bar will be hidden
-    bool isUserClosable() const { return isUserClosable_; }
+    CloseBehavior getCloseBehavior() const { return closeBehavior_; }
 
-    /// Modal windows cannot be minimized and stay on top of non-modal ones
+    /// Modal windows cannot be minimized, are always active and stay on top of non-modal ones
     bool IsModal() const { return isModal_; }
 
     void MouseLeftDown(const MouseCoords& mc);
@@ -93,20 +101,22 @@ protected:
     DrawPoint lastMousePos;
     bool last_down;
     bool last_down2;
-    std::array<ButtonState, 2> button_state;
+    std::array<ButtonState, 2> buttonState;
 
     /// Offset from left and top to actual content
     Extent contentOffset;
     /// Offset from content to right and bottom boundary
     Extent contentOffsetEnd;
 
-    Rect GetLeftButtonRect() const;
-    Rect GetRightButtonRect() const;
+    /// Get bounds of close button (left)
+    Rect GetCloseButtonBounds() const;
+    /// Get bounds of minimize button (right)
+    Rect GetMinimizeButtonBounds() const;
 
 private:
     bool isModal_;
     bool closeme;
     bool isMinimized_;
     bool isMoving;
-    bool isUserClosable_;
+    CloseBehavior closeBehavior_;
 };

--- a/libs/s25main/ingameWindows/TransmitSettingsIgwAdapter.cpp
+++ b/libs/s25main/ingameWindows/TransmitSettingsIgwAdapter.cpp
@@ -13,8 +13,8 @@ constexpr unsigned TransmitSettingsIgwAdapter::firstCtrlID;
 
 TransmitSettingsIgwAdapter::TransmitSettingsIgwAdapter(unsigned id, const DrawPoint& pos, const Extent& size,
                                                        const std::string& title, glArchivItem_Bitmap* background,
-                                                       bool modal, bool isUserClosable, Window* parent)
-    : IngameWindow(id, pos, size, title, background, modal, isUserClosable, parent), settings_changed(false)
+                                                       bool modal)
+    : IngameWindow(id, pos, size, title, background, modal), settings_changed(false)
 {
     // Timer for transmitting changes every 2 seconds
     using namespace std::chrono_literals;

--- a/libs/s25main/ingameWindows/TransmitSettingsIgwAdapter.h
+++ b/libs/s25main/ingameWindows/TransmitSettingsIgwAdapter.h
@@ -16,8 +16,7 @@ protected:
 
 public:
     TransmitSettingsIgwAdapter(unsigned id, const DrawPoint& pos, const Extent& size, const std::string& title,
-                               glArchivItem_Bitmap* background, bool modal = false, bool isUserClosable = true,
-                               Window* parent = nullptr);
+                               glArchivItem_Bitmap* background, bool modal = false);
 
     /// Updates the control elements with values from visual settings
     virtual void UpdateSettings() = 0;

--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -33,7 +33,7 @@ constexpr unsigned AddonGuiLineHeight = 30;
 iwAddons::iwAddons(GlobalGameSettings& ggs, Window* parent, AddonChangeAllowed policy,
                    std::vector<AddonId> whitelistedAddons)
     : IngameWindow(CGI_ADDONS, IngameWindow::posLastOrCenter, Extent(700, 500), _("Addon Settings"),
-                   LOADER.GetImageN("resource", 41), true, false, parent),
+                   LOADER.GetImageN("resource", 41), true, CloseBehavior::Custom, parent),
       ggs(ggs), policy_(policy), whitelistedAddons_(std::move(whitelistedAddons))
 {
     AddText(ID_txtAddFeatures, DrawPoint(20, 30), _("Additional features:"), COLOR_YELLOW, FontStyle{}, NormalFont);

--- a/libs/s25main/ingameWindows/iwChat.cpp
+++ b/libs/s25main/ingameWindows/iwChat.cpp
@@ -16,7 +16,7 @@ ChatDestination lastChatDestination = ChatDestination::All;
 
 iwChat::iwChat(Window* parent)
     : IngameWindow(CGI_CHAT, IngameWindow::posLastOrCenter, Extent(300, 150), _("Chat Window"),
-                   LOADER.GetImageN("resource", 41), false, true, parent)
+                   LOADER.GetImageN("resource", 41), false, CloseBehavior::Regular, parent)
 {
     // Eingabefeld für Chattext
     AddEdit(0, DrawPoint(20, 30), Extent(260, 22), TextureColor::Grey, NormalFont);

--- a/libs/s25main/ingameWindows/iwConnecting.cpp
+++ b/libs/s25main/ingameWindows/iwConnecting.cpp
@@ -25,7 +25,7 @@ enum
 
 iwConnecting::iwConnecting(ServerType serverType, std::unique_ptr<ILobbyClient> lobbyClient)
     : IngameWindow(CGI_CONNECTING, IngameWindow::posCenter, Extent(300, 120), _("Connecting"),
-                   LOADER.GetImageN("resource", 41), true, false),
+                   LOADER.GetImageN("resource", 41), true, CloseBehavior::Custom),
       serverType_(serverType), lobbyClient_(std::move(lobbyClient))
 {
     WINDOWMANAGER.SetCursor(Cursor::Moon);

--- a/libs/s25main/ingameWindows/iwDirectIPCreate.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPCreate.cpp
@@ -17,7 +17,7 @@
 
 iwDirectIPCreate::iwDirectIPCreate(ServerType server_type)
     : IngameWindow(CGI_DIRECTIPCREATE, IngameWindow::posLastOrCenter, Extent(300, 285), _("Create Game"),
-                   LOADER.GetImageN("resource", 41), true, true),
+                   LOADER.GetImageN("resource", 41), true, CloseBehavior::Custom),
       server_type(server_type)
 {
     ctrlEdit *name, *port;

--- a/libs/s25main/ingameWindows/iwMissionStatement.cpp
+++ b/libs/s25main/ingameWindows/iwMissionStatement.cpp
@@ -12,7 +12,7 @@
 iwMissionStatement::iwMissionStatement(const std::string& title, const std::string& content, bool pauseGame,
                                        HelpImage image)
     : IngameWindow(CGI_MISSION_STATEMENT, IngameWindow::posLastOrCenter, Extent(640, 480), title,
-                   LOADER.GetImageN("io", 5), true, false),
+                   LOADER.GetImageN("io", 5), true, CloseBehavior::Custom),
       pauseGame_(pauseGame)
 {
     glArchivItem_Bitmap* img = (image == IM_NONE) ? nullptr : LOADER.GetImageN("io", image);

--- a/libs/s25main/ingameWindows/iwMsgbox.cpp
+++ b/libs/s25main/ingameWindows/iwMsgbox.cpp
@@ -28,17 +28,13 @@ const unsigned short maxTextHeight = 200;
 
 iwMsgbox::iwMsgbox(const std::string& title, const std::string& text, Window* msgHandler, MsgboxButton button,
                    MsgboxIcon icon, unsigned msgboxid)
-    : IngameWindow(CGI_MSGBOX, IngameWindow::posLastOrCenter, Extent(420, 140), title, LOADER.GetImageN("resource", 41),
-                   true, false),
-      button(button), msgboxid(msgboxid), msgHandler_(msgHandler)
-{
-    Init(text, "io", rttr::enum_cast(icon));
-}
+    : iwMsgbox(title, text, msgHandler, button, "io", rttr::enum_cast(icon), msgboxid)
+{}
 
 iwMsgbox::iwMsgbox(const std::string& title, const std::string& text, Window* msgHandler, MsgboxButton button,
                    const ResourceId& iconFile, unsigned iconIdx, unsigned msgboxid /* = 0 */)
     : IngameWindow(CGI_MSGBOX, IngameWindow::posLastOrCenter, Extent(420, 140), title, LOADER.GetImageN("resource", 41),
-                   true, false),
+                   true, CloseBehavior::Custom),
       button(button), msgboxid(msgboxid), msgHandler_(msgHandler)
 {
     Init(text, iconFile, iconIdx);

--- a/libs/s25main/ingameWindows/iwObservate.cpp
+++ b/libs/s25main/ingameWindows/iwObservate.cpp
@@ -25,7 +25,7 @@ const Extent BigWndSize(340, 310);
 
 iwObservate::iwObservate(GameWorldView& gwv, const MapPoint selectedPt)
     : IngameWindow(CGI_OBSERVATION, IngameWindow::posAtMouse, SmallWndSize, _("Observation window"), nullptr, false,
-                   false),
+                   CloseBehavior::NoRightClick),
       parentView(gwv),
       view(new GameWorldView(gwv.GetViewer(), Position(GetDrawPos() * DrawPoint(10, 15)), GetSize() - Extent::all(20))),
       selectedPt(selectedPt), lastWindowPos(Point<unsigned short>::Invalid()), isScrolling(false), zoomLvl(0),

--- a/libs/s25main/ingameWindows/iwPleaseWait.cpp
+++ b/libs/s25main/ingameWindows/iwPleaseWait.cpp
@@ -16,7 +16,7 @@
  */
 iwPleaseWait::iwPleaseWait()
     : IngameWindow(CGI_PLEASEWAIT, IngameWindow::posLastOrCenter, Extent(300, 60), _("Please wait..."),
-                   LOADER.GetImageN("resource", 41), true, false)
+                   LOADER.GetImageN("resource", 41), true, CloseBehavior::Custom)
 {
     WINDOWMANAGER.SetCursor(Cursor::Moon);
     AddText(0, GetSize() / 2, _("Please wait..."), COLOR_YELLOW, FontStyle::CENTER | FontStyle::VCENTER, NormalFont);

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(ConnectingWindow)
         boost::signals2::scoped_connection _ = wnd.onError.connect(onError);
         // Modal and doesn't react on right-click
         BOOST_TEST(wnd.IsModal());
-        BOOST_TEST(!wnd.isUserClosable());
+        BOOST_TEST(wnd.getCloseBehavior() == CloseBehavior::Custom);
         ctrlPercent& progressBar = *wnd.GetCtrls<ctrlPercent>().at(0);
         BOOST_TEST(!progressBar.IsVisible()); // Initially hidden
         for(auto st :

--- a/tests/s25Main/UI/testWindowManager.cpp
+++ b/tests/s25Main/UI/testWindowManager.cpp
@@ -137,8 +137,8 @@ BOOST_FIXTURE_TEST_CASE(DblClick, WMFixture)
 namespace {
 MOCK_BASE_CLASS(TestIngameWnd, IngameWindow)
 {
-    explicit TestIngameWnd(unsigned id, bool isModal = false, bool isUserClosable = true)
-        : IngameWindow(id, DrawPoint(0, 0), Extent(100, 100), "", nullptr, isModal, isUserClosable)
+    explicit TestIngameWnd(unsigned id, bool isModal = false, CloseBehavior closeBehavior = CloseBehavior::Regular)
+        : IngameWindow(id, DrawPoint(0, 0), Extent(100, 100), "", nullptr, isModal, closeBehavior)
     {
         closed.erase(std::remove(closed.begin(), closed.end(), this), closed.end());
     }
@@ -393,7 +393,7 @@ BOOST_FIXTURE_TEST_CASE(EscClosesWindow, uiHelper::Fixture)
     REQUIRE_WINDOW_DESTROYED(wnd1);
 
     // ESC does not close non-user-closable windows
-    wnd1 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, false, false));
+    wnd1 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, false, CloseBehavior::Custom));
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
     WINDOWMANAGER.Msg_KeyDown(evEsc);
     REQUIRE_WINDOW_ALIVE(wnd1);
@@ -401,7 +401,7 @@ BOOST_FIXTURE_TEST_CASE(EscClosesWindow, uiHelper::Fixture)
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
 
-    wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, true, false));
+    wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, true, CloseBehavior::Custom));
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd2);
     WINDOWMANAGER.Msg_KeyDown(evEsc);
     REQUIRE_WINDOW_ALIVE(wnd1);
@@ -450,14 +450,14 @@ BOOST_FIXTURE_TEST_CASE(RightclickClosesWindow, uiHelper::Fixture)
     REQUIRE_WINDOW_DESTROYED(wnd3);
 
     // Don't close non-user-closable windows
-    wnd1 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, false, false));
+    wnd1 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, false, CloseBehavior::Custom));
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
     WINDOWMANAGER.Msg_RightDown(evRDown);
     MOCK_EXPECT(wnd1->Draw_).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
 
-    wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, true, false));
+    wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, true, CloseBehavior::NoRightClick));
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd2);
     WINDOWMANAGER.Msg_RightDown(evRDown);
     MOCK_EXPECT(wnd1->Draw_).once();


### PR DESCRIPTION
Additionally to regular close behavior (close on right click, ESC, ...) and full custom behavior we need a mode that only ignores right click, e.g. for the observation window.
Hence introduce an enum instead of the bool which additionally makes the window constructors much more readable.

Also a bit refactoring in the draw code: Translated comments, renamed snake_case variables and related functions for easier understanding of the code and this change. Additionally updated the turtle submodule which now uses less of the preprocessor