### PR TITLE
Update nix shell to current repository eco system.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,11 @@
-# Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+# Copyright (C) 2005 - 2022 Settlers Freaks <sf-team at siedler25.org>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 { pkgs ? import <nixpkgs> {} }:
 
 with pkgs;
-stdenv.mkDerivation {
+mkShell {
   name = "s25client";
   buildInputs = [
     boost
@@ -17,5 +17,6 @@ stdenv.mkDerivation {
     miniupnpc
     SDL2
     SDL2_mixer
+    libsamplerate
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,15 @@
 with pkgs;
 mkShell {
   name = "s25client";
+
+  # Set SOURCE_DATE_EPOCH to the newest file in the directory.
+  # RTTR_BUILD_DATE is calculated by that epoch value.
+  shellHook = ''
+    updateSourceDateEpoch .
+  '';
+
   buildInputs = [
+    stdenv
     boost
     bzip2
     cmake

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,18 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { overlays = [
+    # This is a workaround for https://github.com/NixOS/nixpkgs/issues/146759
+    # NixOS does currently ship an incomple SDL2 installation when withStatic=false.
+    # See https://nixpk.gs/pr-tracker.html?pr=149601 as state for a PR on NixOS side.
+    (final: prev: {
+      SDL2 = prev.SDL2.override {
+        withStatic = true;
+      };
+    })];
+  }
+}:
 
 with pkgs;
 mkShell {


### PR DESCRIPTION
The shell.nix file which was added to the project is a quite bit outdated and does not result in a runtime which is capable of compiling the game.
As i am currently running nixos (which is a distro build around the package manager nix, which at the end, the shell.nix can possibly be used in), i gave it a try to update it to the current state of the nix eco system.

The old version was mostly broken due to not having a SDL2 which includes a `libSDL2Main.a`, thus the cmake modules do not find the needed version information. 

edit:
sorry for force pushing again. but after cleaning old devShells i noticed that it also requires libsamplerate which was because of some reason on the shell before by something else.