### PR TITLE
Plugin fixes

### DIFF
--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -1051,8 +1051,8 @@ void addDefaultResourceFolders(const RttrConfig& config, ArchiveLocator& locator
     locator.addOverrideFolder(config.ExpandPath(s25::folders::assetsOverrides));
     for(AddonId addonId : enabledAddons)
     {
-        const auto overrideFolder =
-          config.ExpandPath(s25::folders::assetsAddons) / s25util::toStringClassic(static_cast<uint32_t>(addonId), true);
+        const auto overrideFolder = config.ExpandPath(s25::folders::assetsAddons)
+                                    / s25util::toStringClassic(static_cast<uint32_t>(addonId), true);
         if(bfs::exists(overrideFolder))
             locator.addOverrideFolder(overrideFolder);
     }

--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -1052,7 +1052,7 @@ void addDefaultResourceFolders(const RttrConfig& config, ArchiveLocator& locator
     for(AddonId addonId : enabledAddons)
     {
         const auto overrideFolder =
-          config.ExpandPath(s25::folders::assetsAddons) / s25util::toStringClassic(static_cast<uint32_t>(addonId));
+          config.ExpandPath(s25::folders::assetsAddons) / s25util::toStringClassic(static_cast<uint32_t>(addonId), true);
         if(bfs::exists(overrideFolder))
             locator.addOverrideFolder(overrideFolder);
     }

--- a/libs/s25main/addons/AddonCatapultGraphics.h
+++ b/libs/s25main/addons/AddonCatapultGraphics.h
@@ -17,6 +17,6 @@ class AddonCatapultGraphics : public AddonBool
 public:
     AddonCatapultGraphics()
         : AddonBool(AddonId::CATAPULT_GRAPHICS, AddonGroup::GamePlay, _("Nation-specific catapult graphics"),
-                    _("Adds new race-specific graphics for catapults to the game."))
+                    _("Adds new nation-specific graphics for catapults to the game."))
     {}
 };

--- a/libs/s25main/addons/AddonCatapultGraphics.h
+++ b/libs/s25main/addons/AddonCatapultGraphics.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2022 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -8,7 +8,7 @@
 #include "mygettext/mygettext.h"
 
 /**
- *  Addon for new race specific catapult graphics.
+ *  Addon for new nation-specific catapult graphics.
  *
  *  Those graphics were made by Parasit.
  */
@@ -16,7 +16,7 @@ class AddonCatapultGraphics : public AddonBool
 {
 public:
     AddonCatapultGraphics()
-        : AddonBool(AddonId::CATAPULT_GRAPHICS, AddonGroup::GamePlay, _("Race specific catapult graphics"),
+        : AddonBool(AddonId::CATAPULT_GRAPHICS, AddonGroup::GamePlay, _("Nation-specific catapult graphics"),
                     _("Adds new race-specific graphics for catapults to the game."))
     {}
 };

--- a/libs/s25main/addons/AddonMilitaryAid.h
+++ b/libs/s25main/addons/AddonMilitaryAid.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "AddonBool.h"
+#include "AddonList.h"
 #include "mygettext/mygettext.h"
 
 /**
@@ -12,11 +12,17 @@
  *
  *  Gfx by SpikeOne.
  */
-class AddonMilitaryAid : public AddonBool
+class AddonMilitaryAid : public AddonList
 {
 public:
     AddonMilitaryAid()
-        : AddonBool(AddonId::MILITARY_AID, AddonGroup::GamePlay | AddonGroup::Military, _("Military Aid"),
-                    _("Adds military building indicators in construction aid mode."))
+        : AddonList(AddonId::MILITARY_AID, AddonGroup::GamePlay | AddonGroup::Military, _("Military Aid"),
+                    _("Adds indicators for constructing or attacking military buildings."),
+                    {
+                        _("Off"),
+                        _("Construction aid only"),
+                        _("Construction and attack aid")
+                    },
+                    0)
     {}
 };

--- a/libs/s25main/addons/AddonMilitaryAid.h
+++ b/libs/s25main/addons/AddonMilitaryAid.h
@@ -18,11 +18,6 @@ public:
     AddonMilitaryAid()
         : AddonList(AddonId::MILITARY_AID, AddonGroup::GamePlay | AddonGroup::Military, _("Military Aid"),
                     _("Adds indicators for constructing or attacking military buildings."),
-                    {
-                        _("Off"),
-                        _("Construction aid only"),
-                        _("Construction and attack aid")
-                    },
-                    0)
+                    {_("Off"), _("Construction aid only"), _("Construction and attack aid")}, 0)
     {}
 };

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -353,9 +353,10 @@ void GameWorldView::DrawNameProductivityOverlay(const TerrainRenderer& terrainRe
             // Is object not belonging to local player?
             if(no->GetPlayer() != gwv.GetPlayerId())
             {
-                auto* attackAidImage = LOADER.GetImageN("map_new", 20000);
                 if(GetWorld().GetGGS().getSelection(AddonId::MILITARY_AID) == 2 && gwv.GetNumSoldiersForAttack(pt) > 0)
-                    attackAidImage->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
+                {
+                    LOADER.GetImageN("map_new", 20000)->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
+                }
                 continue;
             }
 

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -347,12 +347,18 @@ void GameWorldView::DrawNameProductivityOverlay(const TerrainRenderer& terrainRe
             if(!no)
                 continue;
 
-            // Is object not belonging to local player?
-            if(no->GetPlayer() != gwv.GetPlayerId())
-                continue;
-
             Position curPos = GetWorld().GetNodePos(pt) - offset + curOffset;
             curPos.y -= 22;
+
+            // Is object not belonging to local player?
+            if(no->GetPlayer() != gwv.GetPlayerId())
+            {
+                auto *attackAidImage = LOADER.GetImageN("map_new", 20000);
+                if(GetWorld().GetGGS().isEnabled(AddonId::MILITARY_AID))
+                    if(gwv.GetNumSoldiersForAttack(pt) > 0) // soldiers available for attack?
+                        attackAidImage->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
+                continue;
+            }
 
             // Draw object name
             if(show_names)
@@ -501,13 +507,6 @@ void GameWorldView::DrawObject(const MapPoint& pt, const DrawPoint& curPos)
         return;
 
     obj->Draw(curPos);
-
-    return;
-    // TODO: military aid - display icon overlay of attack possibility
-    RTTR_IGNORE_UNREACHABLE_CODE
-    if(gwv.GetNumSoldiersForAttack(pt) > 0) // soldiers available for attack?
-        LOADER.GetImageN("map_new", 20000)->DrawFull(curPos + DrawPoint(1, -5));
-    RTTR_POP_DIAGNOSTIC
 }
 
 void GameWorldView::DrawBoundaryStone(const MapPoint& pt, const DrawPoint pos, Visibility vis)

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -355,7 +355,8 @@ void GameWorldView::DrawNameProductivityOverlay(const TerrainRenderer& terrainRe
             {
                 if(GetWorld().GetGGS().getSelection(AddonId::MILITARY_AID) == 2 && gwv.GetNumSoldiersForAttack(pt) > 0)
                 {
-                    LOADER.GetImageN("map_new", 20000)->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
+                    auto* attackAidImage = LOADER.GetImageN("map_new", 20000);
+                    attackAidImage->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
                 }
                 continue;
             }

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -354,7 +354,7 @@ void GameWorldView::DrawNameProductivityOverlay(const TerrainRenderer& terrainRe
             if(no->GetPlayer() != gwv.GetPlayerId())
             {
                 auto *attackAidImage = LOADER.GetImageN("map_new", 20000);
-                if(GetWorld().GetGGS().isEnabled(AddonId::MILITARY_AID))
+                if(GetWorld().GetGGS().getSelection(AddonId::MILITARY_AID) == 2)
                     if(gwv.GetNumSoldiersForAttack(pt) > 0) // soldiers available for attack?
                         attackAidImage->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
                 continue;
@@ -490,7 +490,7 @@ void GameWorldView::DrawConstructionAid(const MapPoint& pt, const DrawPoint& cur
         // Draw building quality icon
         bm->DrawFull(curPos);
         // Show ability to construct military buildings
-        if(GetWorld().GetGGS().isEnabled(AddonId::MILITARY_AID))
+        if(GetWorld().GetGGS().getSelection(AddonId::MILITARY_AID) > 0)
         {
             if(!GetWorld().IsMilitaryBuildingNearNode(pt, gwv.GetPlayerId())
                && (bq == BuildingQuality::Hut || bq == BuildingQuality::House || bq == BuildingQuality::Castle

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -353,10 +353,9 @@ void GameWorldView::DrawNameProductivityOverlay(const TerrainRenderer& terrainRe
             // Is object not belonging to local player?
             if(no->GetPlayer() != gwv.GetPlayerId())
             {
-                auto *attackAidImage = LOADER.GetImageN("map_new", 20000);
-                if(GetWorld().GetGGS().getSelection(AddonId::MILITARY_AID) == 2)
-                    if(gwv.GetNumSoldiersForAttack(pt) > 0) // soldiers available for attack?
-                        attackAidImage->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
+                auto* attackAidImage = LOADER.GetImageN("map_new", 20000);
+                if(GetWorld().GetGGS().getSelection(AddonId::MILITARY_AID) == 2 && gwv.GetNumSoldiersForAttack(pt) > 0)
+                    attackAidImage->DrawFull(curPos - DrawPoint(0, attackAidImage->getHeight()));
                 continue;
             }
 
@@ -490,7 +489,7 @@ void GameWorldView::DrawConstructionAid(const MapPoint& pt, const DrawPoint& cur
         // Draw building quality icon
         bm->DrawFull(curPos);
         // Show ability to construct military buildings
-        if(GetWorld().GetGGS().getSelection(AddonId::MILITARY_AID) > 0)
+        if(GetWorld().GetGGS().isEnabled(AddonId::MILITARY_AID))
         {
             if(!GetWorld().IsMilitaryBuildingNearNode(pt, gwv.GetPlayerId())
                && (bq == BuildingQuality::Hut || bq == BuildingQuality::House || bq == BuildingQuality::Castle
@@ -500,7 +499,7 @@ void GameWorldView::DrawConstructionAid(const MapPoint& pt, const DrawPoint& cur
     }
 }
 
-void GameWorldView::DrawObject(const MapPoint& pt, const DrawPoint& curPos)
+void GameWorldView::DrawObject(const MapPoint& pt, const DrawPoint& curPos) const
 {
     noBase* obj = GetWorld().GetNode(pt).obj;
     if(!obj)

--- a/libs/s25main/world/GameWorldView.h
+++ b/libs/s25main/world/GameWorldView.h
@@ -131,7 +131,7 @@ public:
 private:
     void CalcFxLx();
     void DrawBoundaryStone(const MapPoint& pt, DrawPoint pos, Visibility vis);
-    void DrawObject(const MapPoint& pt, const DrawPoint& curPos);
+    void DrawObject(const MapPoint& pt, const DrawPoint& curPos) const;
     void DrawConstructionAid(const MapPoint& pt, const DrawPoint& curPos);
     void DrawFigures(const MapPoint& pt, const DrawPoint& curPos, std::vector<ObjectBetweenLines>& between_lines) const;
     void DrawMovingFiguresFromBelow(const TerrainRenderer& terrainRenderer, const DrawPoint& curPos,


### PR DESCRIPTION
Fixes #1521 

![obraz](https://user-images.githubusercontent.com/16180344/185753220-4f0ecf55-9d96-44df-9195-489deee5e68c.png)

Also brings back Military Aid to its full functionality (note the icon which indicates that enemy guardhouse can be attacked):

![obraz](https://user-images.githubusercontent.com/16180344/185680861-379c5a0a-4037-4036-ad72-642049f7ea77.png)

Submodule which needs to be merged prior to this one so that I can update submodule refs: https://github.com/Return-To-The-Roots/languages/pull/20