### PR TITLE
CI: Update markdown-lint action to 1.5

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,10 +37,9 @@ jobs:
                  -prune -false -o \( -name '*.hpp' -or -name '*.h' \) \
                  -print0 | xargs -0 -n1 tools/ci/checkIncludeGuards.sh
       - name: Lint markdown files
-        uses: avto-dev/markdown-lint@v1.3.0
+        uses: avto-dev/markdown-lint@v1.5.0
         with:
-          args: --ignore data/RTTR/MAPS .
-          ignore: external
+          ignore: external data/RTTR/MAPS .
       - name: Check licensing
         run:
           pip install --user reuse


### PR DESCRIPTION
This allows to remove the ignore-files workaround and hopefully fixes the recent false-positives such as

> `doc/lua/constants.md:12:3 MD051/link-fragments Link fragments should be valid [Context: "[Wares / Goods](#Wares-/-Goods)"]`