### PR TITLE
Fix mouse panning issues in SDL2 video driver

### DIFF
--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -251,8 +251,6 @@ bool VideoSDL2::SwapBuffers()
 
 bool VideoSDL2::MessageLoop()
 {
-    static bool mouseMoved = false;
-
     SDL_Event ev;
     while(SDL_PollEvent(&ev))
     {
@@ -387,19 +385,12 @@ bool VideoSDL2::MessageLoop()
             }
             break;
             case SDL_MOUSEMOTION:
-                // Handle only 1st mouse move
-                if(!mouseMoved)
-                {
-                    mouse_xy.pos = Position(ev.motion.x, ev.motion.y);
-
-                    CallBack->Msg_MouseMove(mouse_xy);
-                    mouseMoved = true;
-                }
+                mouse_xy.pos = Position(ev.motion.x, ev.motion.y);
+                CallBack->Msg_MouseMove(mouse_xy);
                 break;
         }
     }
 
-    mouseMoved = false;
     return true;
 }
 


### PR DESCRIPTION
This should fix #1526 and #1500.
The SDL2 video driver got stuck on the logic regarding `mouseMoved`. I didn't see any reason why to catch the first mouse move only. The problem is, that the Msg_MouseMove is only sent on the first time -> no mouse pan working. So this PR removes the logic around `mouseMoved` and basically sends every mouse motion event.
