### PR TITLE
Allow to offer a new pact after a pact duration has expired

### DIFF
--- a/libs/libGamedata/lua/CampaignDataLoader.h
+++ b/libs/libGamedata/lua/CampaignDataLoader.h
@@ -18,8 +18,6 @@ public:
     CampaignDataLoader(CampaignDescription& campaignDesc, const boost::filesystem::path& basePath);
     ~CampaignDataLoader() override;
 
-    bool CheckScriptVersion();
-
     /// Return version of the interface. Changes here reflect breaking changes
     static unsigned GetVersion();
 
@@ -30,4 +28,6 @@ public:
 private:
     CampaignDescription& campaignDesc_;
     boost::filesystem::path basePath_;
+
+    bool CheckScriptVersion();
 };

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -1545,7 +1545,6 @@ void GamePlayer::SuggestPact(const unsigned char targetPlayerId, const PactType 
 
     if(!pacts[targetPlayerId][pt].accepted && duration > 0)
     {
-        pacts[targetPlayerId][pt].accepted = false;
         pacts[targetPlayerId][pt].duration = duration;
         pacts[targetPlayerId][pt].start = world.GetEvMgr().GetCurrentGF();
         GamePlayer targetPlayer = world.GetPlayer(targetPlayerId);
@@ -2063,9 +2062,12 @@ void GamePlayer::TestPacts()
             {
                 // Pact was running but is expired -> Cancel for both players
                 pacts[i][pact].duration = 0;
+                pacts[i][pact].accepted = false;
                 GamePlayer& otherPlayer = world.GetPlayer(i);
                 RTTR_Assert(otherPlayer.pacts[GetPlayerId()][pact].duration);
+                RTTR_Assert(otherPlayer.pacts[GetPlayerId()][pact].accepted);
                 otherPlayer.pacts[GetPlayerId()][pact].duration = 0;
+                otherPlayer.pacts[GetPlayerId()][pact].accepted = false;
                 // And notify
                 PactChanged(pact);
                 otherPlayer.PactChanged(pact);

--- a/tests/common/testContainerUtils.cpp
+++ b/tests/common/testContainerUtils.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(MakeUniqueStable)
     vec = {5, 6, 5, 5, 2, 6, 1, 5, 7, 7, 3, -1, 3};
     std::vector<int> expectedVec = {5, 6, 2, 1, 7, 3, -1};
     helpers::makeUniqueStable(vec);
-    BOOST_TEST_REQUIRE(vec == expectedVec, per_element);
+    BOOST_TEST(vec == expectedVec, per_element);
 }
 
 BOOST_AUTO_TEST_CASE(MakeUnique)
@@ -61,44 +61,44 @@ BOOST_AUTO_TEST_CASE(MakeUnique)
     vec.push_back(-1);
     helpers::makeUnique(vec);
     BOOST_TEST_REQUIRE(vec.size() == 2u);
-    BOOST_TEST_REQUIRE(vec[0] == -1);
-    BOOST_TEST_REQUIRE(vec[1] == 1);
+    BOOST_TEST(vec[0] == -1);
+    BOOST_TEST(vec[1] == 1);
     // More mixed elements
     vec = {5, 6, 5, 5, 2, 6, 1, 5, 7, 7, 3, -1, 3};
     std::vector<int> expectedVec = {-1, 1, 2, 3, 5, 6, 7};
     helpers::makeUnique(vec);
-    BOOST_TEST_REQUIRE(vec == expectedVec, per_element);
+    BOOST_TEST(vec == expectedVec, per_element);
 }
 
 BOOST_AUTO_TEST_CASE(IndexOf)
 {
     std::vector<int> vec;
     // Empty vector
-    BOOST_TEST_REQUIRE(helpers::indexOf(vec, 1) == -1);
+    BOOST_TEST(helpers::indexOf(vec, 1) == -1);
     // 1 el
     vec.push_back(1);
-    BOOST_TEST_REQUIRE(helpers::indexOf(vec, 1) == 0);
-    BOOST_TEST_REQUIRE(helpers::indexOf(vec, 2) == -1);
+    BOOST_TEST(helpers::indexOf(vec, 1) == 0);
+    BOOST_TEST(helpers::indexOf(vec, 2) == -1);
     // 2 els
     vec.push_back(0);
-    BOOST_TEST_REQUIRE(helpers::indexOf(vec, 1) == 0);
-    BOOST_TEST_REQUIRE(helpers::indexOf(vec, 0) == 1);
-    BOOST_TEST_REQUIRE(helpers::indexOf(vec, 2) == -1);
+    BOOST_TEST(helpers::indexOf(vec, 1) == 0);
+    BOOST_TEST(helpers::indexOf(vec, 0) == 1);
+    BOOST_TEST(helpers::indexOf(vec, 2) == -1);
 
     // Pointer vector
     std::vector<int*> ptrVec;
-    BOOST_TEST_REQUIRE(helpers::indexOf(ptrVec, (int*)1337) == -1);       //-V566
-    BOOST_TEST_REQUIRE(helpers::indexOf(ptrVec, (const int*)1337) == -1); //-V566
-    ptrVec.push_back((int*)1336);                                         //-V566
-    ptrVec.push_back((int*)1337);                                         //-V566
-    ptrVec.push_back((int*)1338);                                         //-V566
-    BOOST_TEST_REQUIRE(helpers::indexOf(ptrVec, (int*)1337) == 1);        //-V566
-    BOOST_TEST_REQUIRE(helpers::indexOf(ptrVec, (const int*)1337) == 1);  //-V566
+    BOOST_TEST(helpers::indexOf(ptrVec, (int*)1337) == -1);       //-V566
+    BOOST_TEST(helpers::indexOf(ptrVec, (const int*)1337) == -1); //-V566
+    ptrVec.push_back((int*)1336);                                 //-V566
+    ptrVec.push_back((int*)1337);                                 //-V566
+    ptrVec.push_back((int*)1338);                                 //-V566
+    BOOST_TEST(helpers::indexOf(ptrVec, (int*)1337) == 1);        //-V566
+    BOOST_TEST(helpers::indexOf(ptrVec, (const int*)1337) == 1);  //-V566
 
     vec = {1, 3, 5, 6};
-    BOOST_TEST_REQUIRE(helpers::indexOf_if(vec, [](int el) { return el % 2 == 0; }) == 3);
-    BOOST_TEST_REQUIRE(helpers::indexOf_if(vec, [](int el) { return el > 2; }) == 1);
-    BOOST_TEST_REQUIRE(helpers::indexOf_if(vec, [](int el) { return el > 6; }) == -1);
+    BOOST_TEST(helpers::indexOf_if(vec, [](int el) { return el % 2 == 0; }) == 3);
+    BOOST_TEST(helpers::indexOf_if(vec, [](int el) { return el > 2; }) == 1);
+    BOOST_TEST(helpers::indexOf_if(vec, [](int el) { return el > 6; }) == -1);
 }
 
 BOOST_AUTO_TEST_CASE(Reverse)

--- a/tests/common/testMultiArray.cpp
+++ b/tests/common/testMultiArray.cpp
@@ -40,8 +40,8 @@ BOOST_AUTO_TEST_CASE(Test2DArray)
         BOOST_TEST_REQUIRE(sma32[i].size() == 2u);
         for(int j = 0; j < 2; j++)
         {
-            BOOST_TEST_REQUIRE(sma32[i][j] == i * 10 + j);
-            BOOST_TEST_REQUIRE(sma32(i, j) == i * 10 + j);
+            BOOST_TEST(sma32[i][j] == i * 10 + j);
+            BOOST_TEST(sma32(i, j) == i * 10 + j);
         }
     }
 
@@ -79,8 +79,8 @@ BOOST_AUTO_TEST_CASE(Test3DArray)
             BOOST_TEST_REQUIRE(sma432[i][j].size() == 2u);
             for(int k = 0; k < 2; k++)
             {
-                BOOST_TEST_REQUIRE(sma432[i][j][k] == i * 100 + j * 10 + k);
-                BOOST_TEST_REQUIRE(sma432(i, j, k) == i * 100 + j * 10 + k);
+                BOOST_TEST(sma432[i][j][k] == i * 100 + j * 10 + k);
+                BOOST_TEST(sma432(i, j, k) == i * 100 + j * 10 + k);
             }
         }
     }
@@ -101,8 +101,8 @@ BOOST_AUTO_TEST_CASE(Test4DArray)
                 BOOST_TEST_REQUIRE(sma3432[i][j][k].size() == 2u);
                 for(int l = 0; l < 2; l++)
                 {
-                    BOOST_TEST_REQUIRE(sma3432[i][j][k][l] == i * 1000 + j * 100 + k * 10 + l);
-                    BOOST_TEST_REQUIRE(sma3432(i, j, k, l) == i * 1000 + j * 100 + k * 10 + l);
+                    BOOST_TEST(sma3432[i][j][k][l] == i * 1000 + j * 100 + k * 10 + l);
+                    BOOST_TEST(sma3432(i, j, k, l) == i * 1000 + j * 100 + k * 10 + l);
                 }
             }
         }

--- a/tests/common/testRect.cpp
+++ b/tests/common/testRect.cpp
@@ -12,16 +12,16 @@ BOOST_AUTO_TEST_CASE(RectCtor)
     const Extent size(5, 7);
     // Compound ctor
     Rect rect1(origin, size);
-    BOOST_TEST_REQUIRE(rect1.getOrigin() == origin);
-    BOOST_TEST_REQUIRE(rect1.getSize() == size);
+    BOOST_TEST(rect1.getOrigin() == origin);
+    BOOST_TEST(rect1.getSize() == size);
     // Semi-Individual ctor
     Rect rect2(origin, size.x, size.y);
-    BOOST_TEST_REQUIRE(rect2.getOrigin() == origin);
-    BOOST_TEST_REQUIRE(rect2.getSize() == size);
+    BOOST_TEST(rect2.getOrigin() == origin);
+    BOOST_TEST(rect2.getSize() == size);
     // Individual ctor
     Rect rect3(origin.x, origin.y, size.x, size.y);
-    BOOST_TEST_REQUIRE(rect3.getOrigin() == origin);
-    BOOST_TEST_REQUIRE(rect3.getSize() == size);
+    BOOST_TEST(rect3.getOrigin() == origin);
+    BOOST_TEST(rect3.getSize() == size);
 }
 
 BOOST_AUTO_TEST_CASE(Rectmove)

--- a/tests/libGameData/testGameData.cpp
+++ b/tests/libGameData/testGameData.cpp
@@ -36,8 +36,8 @@ BOOST_AUTO_TEST_CASE(LoadGameData)
 {
     WorldDescription worldDesc;
     loadGameData(worldDesc);
-    BOOST_TEST_REQUIRE(worldDesc.edges.size() == 3u * 5u - 1u);
-    BOOST_TEST_REQUIRE(worldDesc.terrain.size() >= 3u * NUM_TTS);
+    BOOST_TEST(worldDesc.edges.size() == 3u * 5u - 1u);
+    BOOST_TEST(worldDesc.terrain.size() >= 3u * NUM_TTS);
     for(unsigned l = 0; l < NUM_LTS; l++)
     {
         auto lt = Landscape(l);
@@ -57,24 +57,23 @@ BOOST_AUTO_TEST_CASE(LoadGameData)
         {
             auto t = TerrainType(i);
             const TerrainDesc& desc = worldDesc.terrain.get(worldDesc.terrain.getIndex(tNames[i]));
-            BOOST_TEST_REQUIRE(desc.s2Id == TerrainData::GetTextureIdentifier(t));
+            BOOST_TEST(desc.s2Id == TerrainData::GetTextureIdentifier(t));
             EdgeType newEdge =
               !desc.edgeType ? ET_NONE : EdgeType((helpers::indexOf(eNames, worldDesc.get(desc.edgeType).name) + 1));
-            BOOST_TEST_REQUIRE(newEdge == TerrainData::GetEdgeType(lt, t));
-            BOOST_TEST_REQUIRE(desc.GetBQ() == TerrainData::GetBuildingQuality(t));
+            BOOST_TEST(newEdge == TerrainData::GetEdgeType(lt, t));
+            BOOST_TEST(desc.GetBQ() == TerrainData::GetBuildingQuality(t));
             BOOST_TEST(!desc.Is(ETerrain::Walkable)
                        == (TerrainData::GetBuildingQuality(t) == TerrainBQ::Nothing
                            || TerrainData::GetBuildingQuality(t) == TerrainBQ::Danger));
-            BOOST_TEST_REQUIRE(desc.Is(ETerrain::Mineable) == (TerrainData::GetBuildingQuality(t) == TerrainBQ::Mine));
-            BOOST_TEST_REQUIRE(desc.Is(ETerrain::Buildable)
-                               == (TerrainData::GetBuildingQuality(t) == TerrainBQ::Castle));
-            BOOST_TEST_REQUIRE(desc.Is(ETerrain::Shippable) == TerrainData::IsUsableByShip(t));
-            BOOST_TEST_REQUIRE((desc.kind == TerrainKind::Snow) == TerrainData::IsSnow(lt, t));
+            BOOST_TEST(desc.Is(ETerrain::Mineable) == (TerrainData::GetBuildingQuality(t) == TerrainBQ::Mine));
+            BOOST_TEST(desc.Is(ETerrain::Buildable) == (TerrainData::GetBuildingQuality(t) == TerrainBQ::Castle));
+            BOOST_TEST(desc.Is(ETerrain::Shippable) == TerrainData::IsUsableByShip(t));
+            BOOST_TEST((desc.kind == TerrainKind::Snow) == TerrainData::IsSnow(lt, t));
 
-            BOOST_TEST_REQUIRE((desc.IsUsableByAnimals() || desc.kind == TerrainKind::Snow)
-                               == (TerrainData::IsUsableByAnimals(t) || TerrainData::IsSnow(lt, t)));
-            BOOST_TEST_REQUIRE(desc.IsVital() == TerrainData::IsVital(t));
-            BOOST_TEST_REQUIRE(desc.minimapColor == TerrainData::GetColor(lt, t));
+            BOOST_TEST((desc.IsUsableByAnimals() || desc.kind == TerrainKind::Snow)
+                       == (TerrainData::IsUsableByAnimals(t) || TerrainData::IsSnow(lt, t)));
+            BOOST_TEST(desc.IsVital() == TerrainData::IsVital(t));
+            BOOST_TEST(desc.minimapColor == TerrainData::GetColor(lt, t));
         }
     }
     // TerrainData::PrintEdgePrios();
@@ -84,13 +83,13 @@ BOOST_AUTO_TEST_CASE(DetectRecursion)
 {
     rttr::test::TmpFolder tmp;
     {
-        bnw::ofstream file(tmp.get() / "default.lua");
+        bnw::ofstream file(tmp / "default.lua");
         file << "include(\"foo.lua\")\n";
-        bnw::ofstream file2(tmp.get() / "foo.lua");
+        bnw::ofstream file2(tmp / "foo.lua");
         file2 << "include(\"default.lua\")\n";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get());
+    GameDataLoader loader(desc, tmp);
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("Maximum include depth", false);
@@ -100,11 +99,11 @@ BOOST_AUTO_TEST_CASE(DetectInvalidFilenames)
 {
     rttr::test::TmpFolder tmp;
     {
-        bnw::ofstream file(tmp.get() / "default.lua");
+        bnw::ofstream file(tmp / "default.lua");
         file << "include(\"foo(=.lua\")\n";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get());
+    GameDataLoader loader(desc, tmp);
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("disallowed chars", false);
@@ -114,11 +113,11 @@ BOOST_AUTO_TEST_CASE(DetectNonexistingFile)
 {
     rttr::test::TmpFolder tmp;
     {
-        bnw::ofstream file(tmp.get() / "default.lua");
+        bnw::ofstream file(tmp / "default.lua");
         file << "include(\"foo.lua\")\n";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get());
+    GameDataLoader loader(desc, tmp);
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("File not found", false);
@@ -128,12 +127,12 @@ BOOST_AUTO_TEST_CASE(DetectWrongExtension)
 {
     rttr::test::TmpFolder tmp;
     {
-        bnw::ofstream file(tmp.get() / "default.lua");
+        bnw::ofstream file(tmp / "default.lua");
         file << "include(\"foo.txt\")\n";
-        bnw::ofstream file2(tmp.get() / "foo.txt");
+        bnw::ofstream file2(tmp / "foo.txt");
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get());
+    GameDataLoader loader(desc, tmp);
     rttr::test::LogAccessor logAcc;
     BOOST_TEST(!loader.Load());
     RTTR_REQUIRE_LOG_CONTAINS("File must have .lua as the extension", false);
@@ -142,12 +141,12 @@ BOOST_AUTO_TEST_CASE(DetectWrongExtension)
 BOOST_AUTO_TEST_CASE(DetectFolderEscape)
 {
     rttr::test::TmpFolder tmp;
-    bfs::path basePath(tmp.get() / "gameData");
+    bfs::path basePath(tmp / "gameData");
     create_directories(basePath);
     {
         bnw::ofstream file(basePath / "default.lua");
         file << "include(\"../foo.lua\")\n";
-        bnw::ofstream file2(tmp.get() / "foo.lua");
+        bnw::ofstream file2(tmp / "foo.lua");
     }
     WorldDescription desc;
     GameDataLoader loader(desc, basePath);
@@ -160,7 +159,7 @@ BOOST_AUTO_TEST_CASE(DetectFolderEscape)
 BOOST_AUTO_TEST_CASE(DetectAbsolute)
 {
     rttr::test::TmpFolder tmp;
-    bfs::path basePath(tmp.get() / "gameData");
+    bfs::path basePath(tmp / "gameData");
     create_directories(basePath);
     {
         bnw::ofstream file(basePath / "default.lua");
@@ -178,7 +177,7 @@ BOOST_AUTO_TEST_CASE(TextureCoords)
 {
     rttr::test::TmpFolder tmp;
     {
-        bnw::ofstream file(tmp.get() / "default.lua");
+        bnw::ofstream file(tmp / "default.lua");
         file << "rttr:AddLandscape{\
             name = \"testland\",\
             mapGfx = \"<RTTR_GAME>/DATA/MAP_0_Z.LST\",\
@@ -203,38 +202,38 @@ BOOST_AUTO_TEST_CASE(TextureCoords)
             pos = { 10, 20, 32, 31 }, texType = \"rotated\" }";
     }
     WorldDescription desc;
-    GameDataLoader loader(desc, tmp.get());
+    GameDataLoader loader(desc, tmp);
     BOOST_TEST_REQUIRE(loader.Load());
     // Border points are inset by half a pixel for OpenGL (sample middle of pixel!)
     // Overlapped uses the full rectangle
     const TerrainDesc::Triangle rsuO = desc.terrain.tryGet("terrain1")->GetRSUTriangle();
-    BOOST_TEST_REQUIRE(rsuO.tip == PointF(10 + 32 / 2.f, 20 + 0.5f));
-    BOOST_TEST_REQUIRE(rsuO.left == PointF(10 + 0.5f, 20 + 31 - 0.5f));
-    BOOST_TEST_REQUIRE(rsuO.right == PointF(10 + 32 - 0.5f, 20 + 31 - 0.5f));
+    BOOST_TEST(rsuO.tip == PointF(10 + 32 / 2.f, 20 + 0.5f));
+    BOOST_TEST(rsuO.left == PointF(10 + 0.5f, 20 + 31 - 0.5f));
+    BOOST_TEST(rsuO.right == PointF(10 + 32 - 0.5f, 20 + 31 - 0.5f));
     const TerrainDesc::Triangle usdO = desc.terrain.tryGet("terrain1")->GetUSDTriangle();
-    BOOST_TEST_REQUIRE(usdO.tip == PointF(10 + 32 / 2.f, 20 + 31 - 0.5f));
-    BOOST_TEST_REQUIRE(usdO.left == PointF(10 + 0.5f, 20 + 0.5f));
-    BOOST_TEST_REQUIRE(usdO.right == PointF(10 + 32 - 0.5f, 20 + 0.5f));
+    BOOST_TEST(usdO.tip == PointF(10 + 32 / 2.f, 20 + 31 - 0.5f));
+    BOOST_TEST(usdO.left == PointF(10 + 0.5f, 20 + 0.5f));
+    BOOST_TEST(usdO.right == PointF(10 + 32 - 0.5f, 20 + 0.5f));
 
     // Stacked has RSU over USD
     const TerrainDesc::Triangle rsuS = desc.terrain.tryGet("terrain2")->GetRSUTriangle();
-    BOOST_TEST_REQUIRE(rsuS.tip == rsuO.tip);
-    BOOST_TEST_REQUIRE(rsuS.left == PointF(10 + 0.5f, 20 + 31 / 2.f));
-    BOOST_TEST_REQUIRE(rsuS.right == PointF(10 + 32 - 0.5f, 20 + 31 / 2.f));
+    BOOST_TEST(rsuS.tip == rsuO.tip);
+    BOOST_TEST(rsuS.left == PointF(10 + 0.5f, 20 + 31 / 2.f));
+    BOOST_TEST(rsuS.right == PointF(10 + 32 - 0.5f, 20 + 31 / 2.f));
     const TerrainDesc::Triangle usdS = desc.terrain.tryGet("terrain2")->GetUSDTriangle();
-    BOOST_TEST_REQUIRE(usdS.tip == usdO.tip);
-    BOOST_TEST_REQUIRE(usdS.left == PointF(10 + 0.5f, 20 + 31 / 2.f));
-    BOOST_TEST_REQUIRE(usdS.right == PointF(10 + 32 - 0.5f, 20 + 31 / 2.f));
+    BOOST_TEST(usdS.tip == usdO.tip);
+    BOOST_TEST(usdS.left == PointF(10 + 0.5f, 20 + 31 / 2.f));
+    BOOST_TEST(usdS.right == PointF(10 + 32 - 0.5f, 20 + 31 / 2.f));
 
     // Rotated is stacked sideways (note that order stays the same)
     const TerrainDesc::Triangle rsuR = desc.terrain.tryGet("terrain3")->GetRSUTriangle();
-    BOOST_TEST_REQUIRE(rsuR.tip == rsuS.left);
-    BOOST_TEST_REQUIRE(rsuR.left == rsuS.right);
-    BOOST_TEST_REQUIRE(rsuR.right == rsuS.tip);
+    BOOST_TEST(rsuR.tip == rsuS.left);
+    BOOST_TEST(rsuR.left == rsuS.right);
+    BOOST_TEST(rsuR.right == rsuS.tip);
     const TerrainDesc::Triangle usdR = desc.terrain.tryGet("terrain3")->GetUSDTriangle();
-    BOOST_TEST_REQUIRE(usdR.tip == usdS.right);
-    BOOST_TEST_REQUIRE(usdR.left == usdS.tip);
-    BOOST_TEST_REQUIRE(usdR.right == usdS.left);
+    BOOST_TEST(usdR.tip == usdS.right);
+    BOOST_TEST(usdR.left == usdS.tip);
+    BOOST_TEST(usdR.right == usdS.left);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/UI/testMapSelection.cpp
+++ b/tests/s25Main/UI/testMapSelection.cpp
@@ -90,11 +90,11 @@ SelectionMapInputData createInputForSelectionMap(rttr::test::TmpFolder const& tm
     uint32_t const green = 0xff00ff00;
     uint32_t const blue = 0xff0000ff;
 
-    auto backgroundPath = tmp.get() / "background.bmp";
-    auto mapPath = tmp.get() / "map.bmp";
-    auto missionmapmaskPath = tmp.get() / "missionmapmask.bmp";
-    auto markerPath = tmp.get() / "marker.bmp";
-    auto conqueredPath = tmp.get() / "conquered.bmp";
+    auto backgroundPath = tmp / "background.bmp";
+    auto mapPath = tmp / "map.bmp";
+    auto missionmapmaskPath = tmp / "missionmapmask.bmp";
+    auto markerPath = tmp / "marker.bmp";
+    auto conqueredPath = tmp / "conquered.bmp";
 
     storeBitmap(backgroundPath, createBitmapWithOneColor(backgroundSize, red));
     storeBitmap(mapPath, createBitmapFromBuffer(createMapTestData(mapSize)));

--- a/tests/s25Main/audio/testSounds.cpp
+++ b/tests/s25Main/audio/testSounds.cpp
@@ -31,8 +31,8 @@ BOOST_AUTO_TEST_CASE(DefaultConstructedSoundHandleIsInvalid)
 {
     SoundHandle handle;
     BOOST_TEST_REQUIRE(!handle);
-    BOOST_REQUIRE_THROW(handle.getRawHandle(), std::runtime_error);
-    BOOST_REQUIRE_THROW(handle.getType(), std::runtime_error);
+    BOOST_CHECK_THROW(handle.getRawHandle(), std::runtime_error);
+    BOOST_CHECK_THROW(handle.getType(), std::runtime_error);
 }
 
 BOOST_FIXTURE_TEST_CASE(SoundHandleGetUnloadedWhenLastGoesOutOfScope, LoadMockupAudio)
@@ -43,12 +43,12 @@ BOOST_FIXTURE_TEST_CASE(SoundHandleGetUnloadedWhenLastGoesOutOfScope, LoadMockup
         SoundHandle handle = AUDIODRIVER.LoadEffect("Foo.wav");
         BOOST_TEST_REQUIRE(MockupSoundData::numAlive == 1);
         BOOST_TEST_REQUIRE(handle);
-        BOOST_TEST_REQUIRE(handle.getType() == SoundType::Effect);
+        BOOST_TEST(handle.getType() == SoundType::Effect);
         MOCK_EXPECT(audioDriverMock->LoadMusic).once().with("Foo2.wav").calls(makeDoLoad(SoundType::Music));
         SoundHandle handle2 = AUDIODRIVER.LoadMusic("Foo2.wav");
         BOOST_TEST_REQUIRE(MockupSoundData::numAlive == 2);
         BOOST_TEST_REQUIRE(handle2);
-        BOOST_TEST_REQUIRE(handle2.getType() == SoundType::Music);
+        BOOST_TEST(handle2.getType() == SoundType::Music);
 
         {
             // Copy handle
@@ -83,7 +83,7 @@ BOOST_FIXTURE_TEST_CASE(SoundHandlesCanBeUnloadedByDriver, LoadMockupAudio)
         SoundHandle handle = AUDIODRIVER.LoadEffect("Foo.wav");
         BOOST_TEST_REQUIRE(MockupSoundData::numAlive == 1);
         BOOST_TEST_REQUIRE(handle);
-        BOOST_TEST_REQUIRE(handle.getType() == SoundType::Effect);
+        BOOST_TEST(handle.getType() == SoundType::Effect);
 
         // Release driver
         MOCK_EXPECT(audioDriverMock->doUnloadSound)
@@ -119,9 +119,9 @@ BOOST_FIXTURE_TEST_CASE(PlayFromFile, LoadMockupAudio)
         MOCK_EXPECT(audioDriverMock->doPlayEffect).in(s).once().with(mock::affirm, 50, false).returns(channel);
         EffectPlayId id = effect->Play(50, false); //-V522
         BOOST_TEST_REQUIRE(MockupSoundData::numAlive == 1);
-        BOOST_TEST_REQUIRE(effect->getLoadedType() == SoundType::Effect);
-        BOOST_TEST_REQUIRE(id != EffectPlayId::Invalid);
-        BOOST_TEST_REQUIRE(audioDriverMock->GetEffectChannel(id) == channel);
+        BOOST_TEST(effect->getLoadedType() == SoundType::Effect);
+        BOOST_TEST(id != EffectPlayId::Invalid);
+        BOOST_TEST(audioDriverMock->GetEffectChannel(id) == channel);
         MOCK_EXPECT(audioDriverMock->IsEffectPlaying).in(s).once().with(id).returns(true);
         BOOST_TEST_REQUIRE(AUDIODRIVER.IsEffectPlaying(id));
 
@@ -132,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(PlayFromFile, LoadMockupAudio)
         AUDIODRIVER.StopEffect(id);
         BOOST_TEST(id == EffectPlayId::Invalid);
         BOOST_TEST_REQUIRE(audioDriverMock->GetEffectChannel(idCopy) == -1);
-        BOOST_TEST_REQUIRE(!AUDIODRIVER.IsEffectPlaying(idCopy));
+        BOOST_TEST(!AUDIODRIVER.IsEffectPlaying(idCopy));
 
         // Unload when effect goes out of scope
         MOCK_EXPECT(audioDriverMock->doUnloadSound).in(s).once().calls(makeUnloadHandle(SoundType::Effect));
@@ -161,7 +161,7 @@ BOOST_FIXTURE_TEST_CASE(PlayFromFile, LoadMockupAudio)
         MOCK_EXPECT(audioDriverMock->PlayMusic).in(s).once().with(mock::any, 0);
         music->Play();
         BOOST_TEST_REQUIRE(MockupSoundData::numAlive == 1);
-        BOOST_TEST_REQUIRE(music->getLoadedType() == SoundType::Music);
+        BOOST_TEST(music->getLoadedType() == SoundType::Music);
 
         MOCK_EXPECT(audioDriverMock->StopMusic).in(s).once();
         AUDIODRIVER.StopMusic();

--- a/tests/s25Main/integration/testAI.cpp
+++ b/tests/s25Main/integration/testAI.cpp
@@ -127,7 +127,7 @@ BOOST_FIXTURE_TEST_CASE(KeepBQUpdated, BiggerWorldWithGCExecution)
         RTTR_FOREACH_PT(MapPoint, world.GetSize())
         {
             BOOST_TEST_INFO(pt);
-            BOOST_TEST_REQUIRE(this->world.GetBQ(pt, curPlayer) == aijh.GetAINode(pt).bq);
+            BOOST_TEST(this->world.GetBQ(pt, curPlayer) == aijh.GetAINode(pt).bq);
         }
     };
     const auto assertBqEqualAround = [this, &aijh](const unsigned lineNr, MapPoint pt, unsigned radius) {
@@ -136,7 +136,7 @@ BOOST_FIXTURE_TEST_CASE(KeepBQUpdated, BiggerWorldWithGCExecution)
           pt, radius,
           [&](const MapPoint curPt, unsigned) {
               BOOST_TEST_INFO(curPt);
-              BOOST_TEST_REQUIRE(this->world.GetBQ(curPt, curPlayer) == aijh.GetAINode(curPt).bq);
+              BOOST_TEST(this->world.GetBQ(curPt, curPlayer) == aijh.GetAINode(curPt).bq);
               return false;
           },
           true);
@@ -293,9 +293,9 @@ BOOST_FIXTURE_TEST_CASE(BuildWoodIndustry, WorldWithGCExecution<1>)
            && playerHasBld(player, BuildingType::Forester))
             break;
     }
-    BOOST_TEST_REQUIRE(playerHasBld(player, BuildingType::Sawmill));
-    BOOST_TEST_REQUIRE(playerHasBld(player, BuildingType::Woodcutter));
-    BOOST_TEST_REQUIRE(playerHasBld(player, BuildingType::Forester));
+    BOOST_TEST(playerHasBld(player, BuildingType::Sawmill));
+    BOOST_TEST(playerHasBld(player, BuildingType::Woodcutter));
+    BOOST_TEST(playerHasBld(player, BuildingType::Forester));
 }
 
 BOOST_FIXTURE_TEST_CASE(ExpandWhenNoSpace, BiggerWorldWithGCExecution)

--- a/tests/s25Main/integration/testBaseWarehouse.cpp
+++ b/tests/s25Main/integration/testBaseWarehouse.cpp
@@ -36,24 +36,26 @@ struct AddGoodsFixture : public WorldFixture<CreateEmptyWorld, 1>, public rttr::
     {
         nobBaseWarehouse& hq = *world.GetSpecObj<nobBaseWarehouse>(world.GetPlayer(0).GetHQPos());
         for(const auto i : helpers::enumRange<Job>())
-        {
-            BOOST_TEST_REQUIRE(hq.GetNumVisualFigures(i) == numPeople[i]);
-            BOOST_TEST_REQUIRE(hq.GetNumRealFigures(i) == numPeople[i]);
-        }
+            BOOST_TEST_CONTEXT("Job: " << rttr::enum_cast(i))
+            {
+                BOOST_TEST(hq.GetNumVisualFigures(i) == numPeople[i]);
+                BOOST_TEST(hq.GetNumRealFigures(i) == numPeople[i]);
+            }
         for(const auto i : helpers::enumRange<GoodType>())
-        {
-            BOOST_TEST_REQUIRE(hq.GetNumVisualWares(i) == numGoods[i]);
-            BOOST_TEST_REQUIRE(hq.GetNumRealWares(i) == numGoods[i]);
-        }
+            BOOST_TEST_CONTEXT("Good: " << rttr::enum_cast(i))
+            {
+                BOOST_TEST(hq.GetNumVisualWares(i) == numGoods[i]);
+                BOOST_TEST(hq.GetNumRealWares(i) == numGoods[i]);
+            }
     }
     /// Asserts that the expected and actual good count match for the player
     void testNumGoodsPlayer()
     {
         GamePlayer& player = world.GetPlayer(0);
         for(const auto i : helpers::enumRange<Job>())
-            BOOST_TEST_REQUIRE(player.GetInventory()[i] == numPeoplePlayer[i]);
+            BOOST_TEST(player.GetInventory()[i] == numPeoplePlayer[i]);
         for(const auto i : helpers::enumRange<GoodType>())
-            BOOST_TEST_REQUIRE(player.GetInventory()[i] == numGoodsPlayer[i]);
+            BOOST_TEST(player.GetInventory()[i] == numGoodsPlayer[i]);
     }
 };
 
@@ -155,8 +157,8 @@ BOOST_FIXTURE_TEST_CASE(OrderJob, EmptyWorldFixture1P)
     }
     // Ordering another one fails
     BOOST_TEST_REQUIRE(!hq->OrderJob(Job::Builder, wh, true));
-    BOOST_TEST_REQUIRE(hq->GetNumRealFigures(Job::Builder) == 0u);
-    BOOST_TEST_REQUIRE(hq->GetNumRealWares(GoodType::Hammer) == 0u);
+    BOOST_TEST(hq->GetNumRealFigures(Job::Builder) == 0u);
+    BOOST_TEST(hq->GetNumRealWares(GoodType::Hammer) == 0u);
 }
 
 BOOST_FIXTURE_TEST_CASE(DestroyBuilding, EmptyWorldFixture1P)

--- a/tests/s25Main/integration/testPacts.cpp
+++ b/tests/s25Main/integration/testPacts.cpp
@@ -8,6 +8,7 @@
 #include "postSystem/PostBox.h"
 #include "worldFixtures/WorldWithGCExecution.h"
 #include "gameTypes/GameTypesOutput.h"
+#include <s25util/boostTestHelpers.h>
 #include <boost/test/unit_test.hpp>
 
 namespace utf = boost::unit_test;
@@ -29,20 +30,22 @@ BOOST_FIXTURE_TEST_CASE(InitialPactStates, WorldWithGCExecution3P)
         const GamePlayer& player = world.GetPlayer(i);
         for(unsigned j = 0; j < world.GetNumPlayers(); j++)
         {
+            BOOST_TEST_INFO_SCOPE(i << " vs " << j);
             // Self is always an ally and not attackable
             if(i == j)
             {
-                BOOST_TEST_REQUIRE(player.IsAlly(j));
-                BOOST_TEST_REQUIRE(!player.IsAttackable(j));
+                BOOST_TEST(player.IsAlly(j));
+                BOOST_TEST(!player.IsAttackable(j));
             } else
             {
-                BOOST_TEST_REQUIRE(!player.IsAlly(j));
-                BOOST_TEST_REQUIRE(player.IsAttackable(j));
+                BOOST_TEST(!player.IsAlly(j));
+                BOOST_TEST(player.IsAttackable(j));
             }
             for(const auto p : helpers::enumRange<PactType>())
             {
-                BOOST_TEST_REQUIRE(player.GetPactState(p, j) == PactState::None);
-                BOOST_TEST_REQUIRE(player.GetRemainingPactTime(p, j) == 0u);
+                BOOST_TEST_INFO_SCOPE("Pact " << p);
+                BOOST_TEST(player.GetPactState(p, j) == PactState::None);
+                BOOST_TEST(player.GetRemainingPactTime(p, j) == 0u);
             }
         }
     }
@@ -87,8 +90,7 @@ void CheckPactState(const GameWorldBase& world, unsigned playerIdFrom, unsigned 
 }
 } // namespace
 
-BOOST_FIXTURE_TEST_CASE(MakePactTest,
-                        WorldWithGCExecution3P) //, *utf::depends_on("PactTestSuite/TestInitialPactStates"))
+BOOST_FIXTURE_TEST_CASE(MakePactTest, WorldWithGCExecution3P, *utf::depends_on("PactTestSuite/InitialPactStates"))
 {
     for(unsigned i = 0; i < world.GetNumPlayers(); i++)
         world.GetPostMgr().AddPostBox(i);
@@ -112,9 +114,9 @@ BOOST_FIXTURE_TEST_CASE(MakePactTest,
     BOOST_TEST_REQUIRE(postbox2.GetNumMsgs() == 1u);
     const auto* msg = dynamic_cast<const DiplomacyPostQuestion*>(postbox2.GetMsg(0));
     BOOST_TEST_REQUIRE(msg);
-    BOOST_TEST_REQUIRE(msg->GetPactType() == PactType::NonAgressionPact); //-V522
-    BOOST_TEST_REQUIRE(msg->GetPlayerId() == curPlayer);
-    BOOST_TEST_REQUIRE(msg->IsAccept() == true);
+    BOOST_TEST(msg->GetPactType() == PactType::NonAgressionPact); //-V522
+    BOOST_TEST(msg->GetPlayerId() == curPlayer);
+    BOOST_TEST(msg->IsAccept() == true);
     // should be in progress for player1
     CheckPactState(world, 1, 2, PactType::NonAgressionPact, PactState::InProgress);
 
@@ -136,7 +138,7 @@ BOOST_FIXTURE_TEST_CASE(MakePactTest,
     CheckPactState(world, 1, 2, PactType::TreatyOfAlliance, PactState::None);
 
     // Check duration
-    BOOST_TEST_REQUIRE(player1.GetRemainingPactTime(PactType::NonAgressionPact, 2) == duration);
+    BOOST_TEST(player1.GetRemainingPactTime(PactType::NonAgressionPact, 2) == duration);
 }
 
 // Creates a non-aggression pact between players 1 and 2
@@ -161,7 +163,7 @@ struct PactCreatedFixture : public WorldWithGCExecution3P
     }
 };
 
-BOOST_FIXTURE_TEST_CASE(PactDurationTest, PactCreatedFixture) //, *utf::depends_on("PactTestSuite/MakePactTest"))
+BOOST_FIXTURE_TEST_CASE(PactDurationTest, PactCreatedFixture, *utf::depends_on("PactTestSuite/MakePactTest"))
 {
     GamePlayer& player1 = world.GetPlayer(1);
 
@@ -181,11 +183,11 @@ BOOST_FIXTURE_TEST_CASE(PactDurationTest, PactCreatedFixture) //, *utf::depends_
         player1.TestPacts();
     }
     // On last GF the pact expired
-    BOOST_TEST_REQUIRE(player1.GetRemainingPactTime(PactType::NonAgressionPact, 2) == 0u);
+    BOOST_TEST(player1.GetRemainingPactTime(PactType::NonAgressionPact, 2) == 0u);
     CheckPactState(world, 1, 2, PactType::NonAgressionPact, PactState::None);
 }
 
-BOOST_FIXTURE_TEST_CASE(PactCanceling, PactCreatedFixture) //, *utf::depends_on("PactTestSuite/MakePactTest"))
+BOOST_FIXTURE_TEST_CASE(PactCanceling, PactCreatedFixture, *utf::depends_on("PactTestSuite/MakePactTest"))
 {
     PostBox& postbox1 = *world.GetPostMgr().GetPostBox(1);
     PostBox& postbox2 = *world.GetPostMgr().GetPostBox(2);
@@ -200,9 +202,9 @@ BOOST_FIXTURE_TEST_CASE(PactCanceling, PactCreatedFixture) //, *utf::depends_on(
     BOOST_TEST_REQUIRE(postbox1.GetNumMsgs() == 1u);
     msg = dynamic_cast<const DiplomacyPostQuestion*>(postbox1.GetMsg(0));
     BOOST_TEST_REQUIRE(msg);
-    BOOST_TEST_REQUIRE(msg->GetPlayerId() == 2u);
-    BOOST_TEST_REQUIRE(msg->GetPactType() == PactType::NonAgressionPact);
-    BOOST_TEST_REQUIRE(msg->IsAccept() == false);
+    BOOST_TEST(msg->GetPlayerId() == 2u);
+    BOOST_TEST(msg->GetPactType() == PactType::NonAgressionPact);
+    BOOST_TEST(msg->IsAccept() == false);
 
     // Same player tries to cancel again
     this->CancelPact(PactType::NonAgressionPact, 1);
@@ -225,8 +227,8 @@ BOOST_FIXTURE_TEST_CASE(PactCanceling, PactCreatedFixture) //, *utf::depends_on(
     BOOST_TEST_REQUIRE(postbox1.GetNumMsgs() == 3u);
     BOOST_TEST_REQUIRE(postbox2.GetNumMsgs() == 1u);
     // The new message should not be a question
-    BOOST_TEST_REQUIRE(!dynamic_cast<const DiplomacyPostQuestion*>(postbox1.GetMsg(postbox1.GetNumMsgs() - 1)));
-    BOOST_TEST_REQUIRE(!dynamic_cast<const DiplomacyPostQuestion*>(postbox2.GetMsg(postbox2.GetNumMsgs() - 1)));
+    BOOST_TEST(!dynamic_cast<const DiplomacyPostQuestion*>(postbox1.GetMsg(postbox1.GetNumMsgs() - 1)));
+    BOOST_TEST(!dynamic_cast<const DiplomacyPostQuestion*>(postbox2.GetMsg(postbox2.GetNumMsgs() - 1)));
 }
 
 BOOST_FIXTURE_TEST_CASE(SuggestNewPactAfterExpiration, PactCreatedFixture,

--- a/tests/testHelpers/rttr/test/TmpFolder.hpp
+++ b/tests/testHelpers/rttr/test/TmpFolder.hpp
@@ -23,6 +23,7 @@ public:
     }
     ~TmpFolder() { boost::filesystem::remove_all(folder); }
     const boost::filesystem::path& get() const { return folder; }
+    boost::filesystem::path operator/(const boost::filesystem::path& rhs) const { return folder / rhs; }
     operator const boost::filesystem::path &() const { return folder; }
 };
 } // namespace rttr::test


### PR DESCRIPTION
This is my first pull request. Please have mercy :D

GamePlayer::SuggestPact will not allow a request when pact.accepted = true
If you have a pact with a duration that has expired, accepted will never be reset. Just the duration will be set to 0.

I figured this would be the simplest way.

Please let me know if you need more stuff like testing. I am not familiar with that, so I would need more help on that.

A simple test map if it helps...
[testpact.zip](https://github.com/Return-To-The-Roots/s25client/files/10984927/testpact.zip) The AI sends a pact request and (if you accept) will send a new request as soon the previous pact expired.