### PR TITLE
Do not call GetHome() all dependent_figures

### DIFF
--- a/libs/s25main/buildings/nobBaseWarehouse.cpp
+++ b/libs/s25main/buildings/nobBaseWarehouse.cpp
@@ -66,8 +66,17 @@ void nobBaseWarehouse::DestroyBuilding()
 {
     // Den Waren und Figuren Bescheid sagen, die zu uns auf den Weg sind, dass wir nun nicht mehr existieren
     for(noFigure* dependent_figure : dependent_figures)
-        dependent_figure->GoHome();
+    {
+        // Only send figures home that are not already at this position.
+        if(dependent_figure->GetPos() == GetPos())
+        {
+            dependent_figure->SetGoalTonullptr();
+            dependent_figure->CutCurrentRoad();
+        } else
+            dependent_figure->GoHome();
+    }
     dependent_figures.clear();
+
     for(Ware* dependent_ware : dependent_wares)
         WareNotNeeded(dependent_ware);
     dependent_wares.clear();


### PR DESCRIPTION
In case a ship just unloaded soldiers at a harbour which is under attack and destroyed, then there are soldiers that are at the same position as the destroyed harbour but still on the way to it.

The GoHome method in noFigure::GoHome() does not cover this case. Since noFigure does not know about the destroyed hardbour, this case is catched in nobBaseWarehouse::DestroyBuilding()

Fix #1559 