### PR TITLE
Fix miner produced icon from iron to iron ore

### DIFF
--- a/libs/s25main/gameData/BuildingConsts.h
+++ b/libs/s25main/gameData/BuildingConsts.h
@@ -44,7 +44,7 @@ const helpers::EnumArray<BldWorkDescription, BuildingType> SUPPRESS_UNUSED BLD_W
   {Job::Private, boost::none, WaresNeeded(GoodType::Coins), 6},
   {Job::Miner, GoodType::Stones, WaresNeeded(GoodType::Fish, GoodType::Meat, GoodType::Bread), 2, false},
   {Job::Miner, GoodType::Coal, WaresNeeded(GoodType::Fish, GoodType::Meat, GoodType::Bread), 2, false},
-  {Job::Miner, GoodType::Iron, WaresNeeded(GoodType::Fish, GoodType::Meat, GoodType::Bread), 2, false},
+  {Job::Miner, GoodType::IronOre, WaresNeeded(GoodType::Fish, GoodType::Meat, GoodType::Bread), 2, false},
   {Job::Miner, GoodType::Gold, WaresNeeded(GoodType::Fish, GoodType::Meat, GoodType::Bread), 2, false},
   {Job::Scout}, // No production, just existence
   {},


### PR DESCRIPTION
Iron **ore** should be displayed as shown here:
(S2gold)
![image](https://user-images.githubusercontent.com/17598243/229822599-c5d20298-922f-42c2-be40-08c46ba414e5.png)
Currently Iron is displayed 
(s25rttr_20230312)
![image](https://user-images.githubusercontent.com/17598243/229823143-90ce32ce-04ec-489b-b9d1-07853f293dc0.png)
