### PR TITLE
Scaling font and text fields

### DIFF
--- a/libs/s25main/RescaleWindowProp.h
+++ b/libs/s25main/RescaleWindowProp.h
@@ -4,13 +4,16 @@
 
 #pragma once
 
+#define DefaultWidth 800
+#define DefaultHeigth 600
+
 /// Functor or static method to scale a window propertie from the real coordinates
 /// (relative to 800x600 resolution) to new coordinates given a size
 struct ScaleWindowPropUp
 {
     Extent size;
     ScaleWindowPropUp(const Extent& size) : size(size) {}
-
+    
     template<typename T_Pt>
     static T_Pt scale(const T_Pt& value, const Extent& size);
     template<typename T_Pt>
@@ -30,7 +33,7 @@ struct RescaleWindowProp
 template<typename T_Pt>
 inline T_Pt ScaleWindowPropUp::scale(const T_Pt& value, const Extent& sizeToScale)
 {
-    return T_Pt(value * sizeToScale / Extent(800, 600));
+    return T_Pt(value * sizeToScale / Extent(DefaultWidth, DefaultHeigth));
 }
 
 template<typename T_Pt>
@@ -42,7 +45,7 @@ inline T_Pt ScaleWindowPropUp::operator()(const T_Pt& value) const
 template<typename T_Pt>
 inline T_Pt RescaleWindowProp::operator()(const T_Pt& oldValue) const
 {
-    T_Pt realValue(oldValue.x * 800 / oldSize.x, oldValue.y * 600 / oldSize.y);
+    T_Pt realValue(oldValue.x * DefaultWidth / oldSize.x, oldValue.y * DefaultHeigth / oldSize.y);
     // Check for rounding errors
     T_Pt checkValue = ScaleWindowPropUp::scale(realValue, oldSize);
     if(checkValue.x < oldValue.x)

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -541,6 +541,11 @@ T_Pt Window::ScaleIf(const T_Pt& pt) const
     return scale_ ? Scale(pt) : pt;
 }
 
+float Window::ScaleHeigthIf(float heigth) const
+{
+    return scale_ ? float(Scale(Point<float>(heigth, heigth)).y) : heigth;
+}
+
 // Inlining removes those. so add it here
 template DrawPoint Window::ScaleIf(const DrawPoint&) const;
 template Extent Window::ScaleIf(const Extent&) const;

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -277,6 +277,8 @@ protected:
     /// Scales the value when scale_ is true, else returns the value
     template<class T_Pt>
     T_Pt ScaleIf(const T_Pt& pt) const;
+    /// Gets scale for heigth only
+    float ScaleHeigthIf(float heigth) const;
     /// setzt Scale-Wert, ob neue Controls skaliert werden sollen oder nicht.
     void SetScale(bool scale = true) { this->scale_ = scale; }
     /// zeichnet das Fenster.

--- a/libs/s25main/controls/ctrlText.cpp
+++ b/libs/s25main/controls/ctrlText.cpp
@@ -43,5 +43,5 @@ Rect ctrlText::GetBoundaryRect() const
 void ctrlText::Draw_()
 {
     if(!text.empty())
-        font->Draw(GetDrawPos(), text, format_, color_, maxWidth_);
+        font->DrawScaled(GetDrawPos(), text, format_, ScaleHeigthIf(1.0f), color_, maxWidth_);
 }

--- a/libs/s25main/ogl/glFont.cpp
+++ b/libs/s25main/ogl/glFont.cpp
@@ -173,7 +173,15 @@ inline void glFont::DrawChar(char32_t curChar, VertexArrays& vertices, DrawPoint
 void glFont::Draw(DrawPoint pos, const std::string& text, FontStyle format, unsigned color, unsigned short maxWidth,
                   const std::string& end) const
 {
+    DrawScaled(pos, text, format, 1.0f, color, maxWidth, end);
+}
+
+void glFont::DrawScaled(DrawPoint pos, const std::string& text, FontStyle format, float scale, unsigned color,
+                        unsigned short maxWidth, const std::string& end) const
+{
     RTTR_Assert(s25util::isValidUTF8(text));
+
+    DrawPoint originalPos = pos;
 
     unsigned maxNumChars;
     unsigned short textWidth;
@@ -249,11 +257,16 @@ void glFont::Draw(DrawPoint pos, const std::string& text, FontStyle format, unsi
     for(GlPoint& pt : texList.texCoords)
         pt /= texSize;
 
+    glPushMatrix();
+    glTranslatef(float(originalPos.x), float(originalPos.y), 0);
+    glScalef(scale, scale, 1);
     glVertexPointer(2, GL_FLOAT, 0, &texList.vertices[0]);
+    glTranslatef(float(-originalPos.x), float(-originalPos.y), 0);
     glTexCoordPointer(2, GL_FLOAT, 0, &texList.texCoords[0]);
     VIDEODRIVER.BindTexture(texture);
     glColor4ub(GetRed(color), GetGreen(color), GetBlue(color), GetAlpha(color));
     glDrawArrays(GL_QUADS, 0, texList.vertices.size());
+    glPopMatrix();
 }
 
 template<bool T_limitWidth>

--- a/libs/s25main/ogl/glFont.h
+++ b/libs/s25main/ogl/glFont.h
@@ -30,6 +30,9 @@ public:
     /// appended (included in maxWidth)
     void Draw(DrawPoint pos, const std::string& text, FontStyle format, unsigned color = COLOR_WHITE,
               unsigned short maxWidth = 0xFFFF, const std::string& end = "...") const;
+   
+    void DrawScaled(DrawPoint pos, const std::string& text, FontStyle format, float scale, unsigned color = COLOR_WHITE,
+                    unsigned short maxWidth = 0xFFFF, const std::string& end = "...") const;
 
     /// Return the width of the drawn text. If maxWidth is given then the width will be <= maxWidth and maxNumChars will
     /// be set to the maximum number of chars (not glyphs!) that fit into the width


### PR DESCRIPTION
So I'd like to resolve the lack of HDPI support - ISSUE-533

Only thing that is scaled for now is ctrlText (bottom on the screenshots), the rest of the text based controls should be straight forward to update. 

The approach with adding `ScaleHeigthIf` was easiest, however it is not very elegant, if you have better idea I am all for it

Another option would be for user-selectable scaling - 100% 125% ...
 
Example before at 5120x2160
![image](https://user-images.githubusercontent.com/17598243/231006008-22b01833-0b50-409f-8ba9-c84f7448ee51.png)
After at 5120x2160
![image](https://user-images.githubusercontent.com/17598243/231006208-f25ad8ad-1200-4640-addd-d535fc67f133.png)

Before at 800x600 
![image](https://user-images.githubusercontent.com/17598243/231006373-a51e65b2-50d5-4825-9bf3-af4262840bb4.png)
After at 800x600
![image](https://user-images.githubusercontent.com/17598243/231006485-c43c2102-66fe-44d2-9436-2e50381564ea.png)
