### PR TITLE
GHA: Test latest compilers & Boost 1.69

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,8 +30,8 @@ jobs:
           - { compiler: gcc-10,   os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, coverage: true }
           - { compiler: gcc-10,   os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
           - { compiler: gcc-10,   os: ubuntu-20.04, buildType: Release }
-          - { compiler: gcc-12,   os: ubuntu-22.04, buildType: Debug, cxxStandard: 14 }
-          - { compiler: gcc-12,   os: ubuntu-22.04, buildType: Release }
+          - { compiler: gcc-11,   os: ubuntu-22.04, buildType: Debug, cxxStandard: 14, boostVersion: 1.73.0 }
+          - { compiler: gcc-11,   os: ubuntu-22.04, buildType: Release,                boostVersion: 1.73.0 }
           # Linux clang
           - { compiler: clang-10, os: ubuntu-20.04, buildType: Debug }
           - { compiler: clang-11, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   CMAKE_VERSION: 3.26.0
-  BOOST_VERSION: 1.81.0
+  BOOST_VERSION: 1.69.0
   ADDITIONAL_CMAKE_FLAGS: -DRTTR_ENABLE_BENCHMARKS=ON
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           # MacOSX
-          - { compiler: clang,    os: macos-12,     buildType: Debug, cxxStandard: 14 }
+          - { compiler: clang,    os: macos-12,     buildType: Debug, cxxStandard: 14, boostVersion: 1.81.0 }
           # Linux GCC
           # GCC 9 is known to show a few warnings that GCC 10 has "fixed", make sure this doesn't happen for us
           - { compiler: gcc-9,    os: ubuntu-20.04, buildType: Debug }
@@ -109,6 +109,8 @@ jobs:
         run: |
           brew install cmake boost sdl2 sdl2_mixer gettext miniupnpc libiconv
           echo /usr/local/opt/gettext/bin >> $GITHUB_PATH
+          echo "Available Boost versions:"
+          ls /usr/local/Cellar/boost
           BOOST_ROOT=$(find /usr/local/Cellar/boost/${BOOST_VERSION}_* -maxdepth 0)
           echo "BOOST_ROOT=${BOOST_ROOT}" >> $GITHUB_ENV
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,15 +29,14 @@ jobs:
           - { compiler: gcc-9,    os: ubuntu-20.04, buildType: Debug }
           - { compiler: gcc-10,   os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, coverage: true }
           - { compiler: gcc-10,   os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
-          - { compiler: gcc-10,   os: ubuntu-20.04, buildType: Release, cxxStandard: 14 }
-          # Linux clang
-          - { compiler: clang-11, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }
-          - { compiler: clang-11, os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
-          - { compiler: clang-11, os: ubuntu-20.04, buildType: Release, cxxStandard: 14 }
-          # Linux latest GCC
+          - { compiler: gcc-10,   os: ubuntu-20.04, buildType: Release }
           - { compiler: gcc-12,   os: ubuntu-22.04, buildType: Debug, cxxStandard: 14 }
           - { compiler: gcc-12,   os: ubuntu-22.04, buildType: Release }
-          # Linux latest clang
+          # Linux clang
+          - { compiler: clang-10, os: ubuntu-20.04, buildType: Debug }
+          - { compiler: clang-11, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }
+          - { compiler: clang-11, os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
+          - { compiler: clang-11, os: ubuntu-20.04, buildType: Release }
           - { compiler: clang-16, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }
           - { compiler: clang-16, os: ubuntu-20.04, buildType: Release }
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,10 +34,12 @@ jobs:
           - { compiler: clang-11, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }
           - { compiler: clang-11, os: ubuntu-20.04, buildType: Debug, cxxStandard: 17 }
           - { compiler: clang-11, os: ubuntu-20.04, buildType: Release, cxxStandard: 14 }
-          # Linux Latest GCC
-          - { compiler: gcc-12,   os: ubuntu-22.04, buildType: Debug, cxxStandard: 14, coverage: true }
-          # Linux Latest clang
+          # Linux latest GCC
+          - { compiler: gcc-12,   os: ubuntu-22.04, buildType: Debug, cxxStandard: 14 }
+          - { compiler: gcc-12,   os: ubuntu-22.04, buildType: Release }
+          # Linux latest clang
           - { compiler: clang-16, os: ubuntu-20.04, buildType: Debug, cxxStandard: 14, externalSanitizer: true }
+          - { compiler: clang-16, os: ubuntu-20.04, buildType: Release }
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Followup to https://github.com/Return-To-The-Roots/s25client/pull/1558, see discussion at https://github.com/Return-To-The-Roots/s25client/pull/1558/files#r1161563495

Combination of #1575 & #1576, hence closes #1575 & closes #1576

Add GCC 12/11 to test and build with Clang 16 and its default C++ standard. So both latest GCC & Clang use the minimum required C++ standard and their default.

For GCC 12 we need Boost 1.82 which will be released soon.

@Flow86 This needs manual merge and adjustment of the required checks afterwards.