### PR TITLE
CI: Update Boost versions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,8 +27,8 @@ jobs:
           #  Use system clang (14)
           #   Use (compiler) default C++ 14 standard
           #   Use system cmake (version gets ignored below)
-          #   Use default boost
-          - { compiler: clang,    os: macos-12,     type: Debug }
+          #   Use boost installed on this GHA image
+          - { compiler: clang,    os: macos-12,     type: Debug, boost: 1.82.0 }
 
           # Linux:
           #  Oldest Compilers 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ platform:
   - x64
 
 environment:
-  BOOST_ROOT: C:\Libraries\boost_1_73_0
+  BOOST_ROOT: C:\Libraries\boost_1_77_0
   GENERATOR: Visual Studio 16 2019
   RTTR_DISABLE_ASSERT_BREAKPOINT: 1
 


### PR DESCRIPTION
- Boost on the GHA macos-12 image was updated to 1.82 as reported by @falbrechtskirchinger
- On Appveyor VS 2019 1.73 was replaced by 1.77

Closes #1595 