### PR TITLE
Add using alias PointF = Point<float> and refactor

### DIFF
--- a/libs/common/include/Point.h
+++ b/libs/common/include/Point.h
@@ -46,6 +46,7 @@ private:
 using Position = Point<int>;
 /// Type for describing an extent/size etc. (unsigned type)
 using Extent = Point<unsigned>;
+using PointF = Point<float>;
 //-V:all:810
 
 //////////////////////////////////////////////////////////////////////////

--- a/libs/libGamedata/gameData/TerrainDesc.h
+++ b/libs/libGamedata/gameData/TerrainDesc.h
@@ -55,7 +55,6 @@ enum class ETexType : uint8_t
 
 struct TerrainDesc
 {
-    using PointF = Point<float>;
     struct Triangle
     {
         PointF tip, left, right;

--- a/libs/s25main/TerrainRenderer.cpp
+++ b/libs/s25main/TerrainRenderer.cpp
@@ -56,7 +56,7 @@ static constexpr unsigned getFlatIndex(DescIdx<LandscapeDesc> ls, LandRoadType r
     return ls.value * helpers::NumEnumValues_v<LandRoadType> + rttr::enum_cast(road);
 }
 
-TerrainRenderer::PointF TerrainRenderer::GetNeighbourVertexPos(MapPoint pt, const Direction dir) const
+PointF TerrainRenderer::GetNeighbourVertexPos(MapPoint pt, const Direction dir) const
 {
     // Note: We want the real neighbour point which might be outside of the map to get the offset right
     Position ptNb = ::GetNeighbour(Position(pt), dir);
@@ -67,8 +67,8 @@ TerrainRenderer::PointF TerrainRenderer::GetNeighbourVertexPos(MapPoint pt, cons
     return GetVertexPos(t) + PointF(offset);
 }
 
-TerrainRenderer::PointF TerrainRenderer::GetNeighbourBorderPos(const MapPoint pt, const unsigned char triangle,
-                                                               const Direction dir) const
+PointF TerrainRenderer::GetNeighbourBorderPos(const MapPoint pt, const unsigned char triangle,
+                                              const Direction dir) const
 {
     // Note: We want the real neighbour point which might be outside of the map to get the offset right
     Position ptNb = ::GetNeighbour(Position(pt), dir);
@@ -205,7 +205,7 @@ void TerrainRenderer::GenerateVertices(const GameWorldViewer& gwv)
 
 void TerrainRenderer::UpdateVertexPos(const MapPoint pt, const GameWorldViewer& gwv)
 {
-    GetVertex(pt).pos = Point<float>(gwv.GetWorld().GetNodePos(pt));
+    GetVertex(pt).pos = PointF(gwv.GetWorld().GetNodePos(pt));
 }
 
 void TerrainRenderer::UpdateVertexColor(const MapPoint pt, const GameWorldViewer& gwv)

--- a/libs/s25main/TerrainRenderer.h
+++ b/libs/s25main/TerrainRenderer.h
@@ -27,8 +27,6 @@ glArchivItem_Bitmap* new_clone(const glArchivItem_Bitmap& bmp);
 class TerrainRenderer : private boost::noncopyable
 {
 public:
-    using PointF = Point<float>;
-
     TerrainRenderer();
     ~TerrainRenderer();
 

--- a/libs/s25main/ogl/glSmartBitmap.cpp
+++ b/libs/s25main/ogl/glSmartBitmap.cpp
@@ -217,8 +217,6 @@ void glSmartBitmap::generateTexture()
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bufSize.x, bufSize.y, 0, GL_BGRA, GL_UNSIGNED_BYTE, buffer.getPixelPtr());
 
-    using PointF = Point<float>;
-
     /* 0--3/4--7
      * |  |    |
      * 1--2/5--6

--- a/libs/s25main/ogl/glSmartBitmap.h
+++ b/libs/s25main/ogl/glSmartBitmap.h
@@ -35,7 +35,7 @@ private:
     void calcDimensions();
 
 public:
-    std::array<Point<float>, 8> texCoords;
+    std::array<PointF, 8> texCoords;
 
     glSmartBitmap();
     ~glSmartBitmap();

--- a/libs/s25main/ogl/glTexturePackerNode.cpp
+++ b/libs/s25main/ogl/glTexturePackerNode.cpp
@@ -40,7 +40,7 @@ bool glTexturePackerNode::insert(glSmartBitmap* b, libsiedler2::PixelBufferBGRA&
             b->drawTo(buffer, current->pos);
             current->bmp = b;
 
-            const Point<float> bufferSize(buffer.getWidth(), buffer.getHeight());
+            const PointF bufferSize(buffer.getWidth(), buffer.getHeight());
             Extent currentSize(current->size);
             if(b->isPlayer())
                 currentSize.x /= 2;

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -126,11 +126,11 @@ void GameWorldView::Draw(const RoadBuildState& rb, const MapPoint selected, bool
         glPushMatrix();
         glScalef(zoomFactor_, zoomFactor_, 1);
         // Offset to center view
-        Point<float> diff(size_.x - size_.x / zoomFactor_, size_.y - size_.y / zoomFactor_);
+        PointF diff(size_.x - size_.x / zoomFactor_, size_.y - size_.y / zoomFactor_);
         diff = diff / 2.f;
         glTranslatef(-diff.x, -diff.y, 0.f);
         // Also adjust mouse
-        mousePos = Position(Point<float>(mousePos) / zoomFactor_ + diff);
+        mousePos = Position(PointF(mousePos) / zoomFactor_ + diff);
         glMatrixMode(GL_MODELVIEW);
     }
 
@@ -623,7 +623,7 @@ void GameWorldView::CalcFxLx()
     if(zoomFactor_ != 1.f) //-V550
     {
         // Calc pixels we can remove from sides, as they are not drawn due to zoom
-        Point<float> diff(size_.x - size_.x / zoomFactor_, size_.y - size_.y / zoomFactor_);
+        PointF diff(size_.x - size_.x / zoomFactor_, size_.y - size_.y / zoomFactor_);
         // Stay centered by removing half the pixels from opposite sites
         diff = diff / 2.f;
         // Convert to map points
@@ -632,8 +632,8 @@ void GameWorldView::CalcFxLx()
         // Don't remove to much
         diff.x = std::floor(diff.x);
         diff.y = std::floor(diff.y);
-        firstPt = Position(Point<float>(firstPt) + diff);
-        lastPt = Position(Point<float>(lastPt) - diff);
+        firstPt = Position(PointF(firstPt) + diff);
+        lastPt = Position(PointF(lastPt) - diff);
     }
 }
 

--- a/tests/libGameData/testGameData.cpp
+++ b/tests/libGameData/testGameData.cpp
@@ -205,7 +205,6 @@ BOOST_AUTO_TEST_CASE(TextureCoords)
     WorldDescription desc;
     GameDataLoader loader(desc, tmp.get());
     BOOST_TEST_REQUIRE(loader.Load());
-    using PointF = TerrainDesc::PointF;
     // Border points are inset by half a pixel for OpenGL (sample middle of pixel!)
     // Overlapped uses the full rectangle
     const TerrainDesc::Triangle rsuO = desc.terrain.tryGet("terrain1")->GetRSUTriangle();

--- a/tests/s25Main/UI/testTexturePacker.cpp
+++ b/tests/s25Main/UI/testTexturePacker.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(SizeAndPosCorrect)
 
     // Sizes must be correct
     BOOST_TEST_REQUIRE(packer.getTextures().size() == 1u);
-    const Point<float> size(packer.getTextures()[0].getSize());
+    const PointF size(packer.getTextures()[0].getSize());
     for(const auto& bmp : smartBmps)
     {
         const auto curTexSize = bmp.texCoords[2] - bmp.texCoords[0];


### PR DESCRIPTION
Add a using alias `PointF = Point<float>`, remove a bunch of local aliases, and refactor uses of `Point<float>`. One use in `testPoint.cpp` is left unchanged for consistency within the test case.

Partly extracted from #1594 and expanded in scope.

To-do:
- [x] Remove CI commit from this PR once merged. (#1596)