### PR TITLE
Fix cursor overlapping tooltips

### DIFF
--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -857,9 +857,11 @@ void WindowManager::DrawToolTip()
     // Tooltip zeichnen
     if(curTooltip && lastMousePos.isValid())
     {
-        // Horizontal pace between mouse position and tooltip border
-        constexpr unsigned rightSpacing = 25;
-        constexpr unsigned leftSpacing = 10;
+        constexpr unsigned cursorWidth = 32;
+        constexpr unsigned cursorPadding = 5;
+        // Horizontal space between mouse position and tooltip border
+        constexpr unsigned rightSpacing = cursorWidth + cursorPadding;
+        constexpr unsigned leftSpacing = cursorPadding;
         DrawPoint ttPos = DrawPoint(lastMousePos.x + rightSpacing, lastMousePos.y);
         unsigned right_edge = ttPos.x + curTooltip->getWidth();
 


### PR DESCRIPTION
Tooltips are placed at a consistent distance and the cursor doesn't overlap.

Before:
(Excuse the screen tear. Didn't catch that when I took the screenshots.)
![fix_tooltip_overlap_before](https://github.com/Return-To-The-Roots/s25client/assets/320854/d49fedad-142b-447b-a915-cd85b7d5790c)

After:
![fix_tooltip_overlap_after](https://github.com/Return-To-The-Roots/s25client/assets/320854/8cf0754b-30d0-43de-8cc3-3535e0e69013)