### PR TITLE
Add support for additional display modes

### DIFF
--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -91,7 +91,7 @@ void VideoSDL2::UpdateCurrentSizes()
     SetNewSize(VideoMode(w, h), Extent(w2, h2));
 }
 
-bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bool fullscreen)
+bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
@@ -113,19 +113,20 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
     CHECK_SDL(SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8));
     CHECK_SDL(SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1));
 
-    int wndPos = SDL_WINDOWPOS_CENTERED;
-
+    const int wndPos = SDL_WINDOWPOS_CENTERED;
+    const auto fullscreen = (displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
+    const auto resizable = (displayMode & DisplayMode::Resizable) != DisplayMode::None;
     const auto requestedSize = fullscreen ? FindClosestVideoMode(size) : size;
+    const unsigned commonFlags = SDL_WINDOW_OPENGL | (resizable ? SDL_WINDOW_RESIZABLE : 0);
+    const unsigned fullscreenFlag = (fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
 
     window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
-                              SDL_WINDOW_OPENGL | (fullscreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE));
+                              commonFlags | fullscreenFlag);
 
     // Fallback to non-fullscreen
     if(!window && fullscreen)
-    {
-        window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
-                                  SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
-    }
+        window =
+          SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height, commonFlags);
 
     if(!window)
     {
@@ -133,10 +134,12 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
         return false;
     }
 
-    isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
+    const auto flags = SDL_GetWindowFlags(window);
+    SetFullscreenFlag((flags & SDL_WINDOW_FULLSCREEN) != 0);
+    SetResizableFlag((flags & SDL_WINDOW_RESIZABLE) != 0);
     UpdateCurrentSizes();
 
-    if(!isFullscreen_)
+    if(!IsFullscreen())
         MoveWindowToCenter();
 
     SDL_Surface* iconSurf =
@@ -161,27 +164,34 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
     return true;
 }
 
-bool VideoSDL2::ResizeScreen(const VideoMode& newSize, bool fullscreen)
+bool VideoSDL2::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
 
-    if(isFullscreen_ != fullscreen)
+    const auto fullscreen = (displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
+    const auto resizable = (displayMode & DisplayMode::Resizable) != DisplayMode::None;
+
+    if(IsFullscreen() != fullscreen)
     {
         SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
-        isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
-        if(!isFullscreen_)
-        {
-#if SDL_VERSION_ATLEAST(2, 0, 5)
-            SDL_SetWindowResizable(window, SDL_TRUE);
-#endif
+        SetFullscreenFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0);
+        if(!IsFullscreen())
             MoveWindowToCenter();
-        }
+    }
+
+    if(displayMode_ != displayMode)
+    {
+        if(!IsFullscreen())
+#if SDL_VERSION_ATLEAST(2, 0, 5)
+            SDL_SetWindowResizable(window, static_cast<SDL_bool>(resizable));
+#endif
+        SetResizableFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_RESIZABLE) != 0);
     }
 
     if(newSize != GetWindowSize())
     {
-        if(isFullscreen_)
+        if(IsFullscreen())
         {
             auto const targetMode = FindClosestVideoMode(newSize);
             SDL_DisplayMode target;
@@ -203,6 +213,7 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, bool fullscreen)
         }
         UpdateCurrentSizes();
     }
+
     return true;
 }
 
@@ -265,7 +276,7 @@ bool VideoSDL2::MessageLoop()
                 {
                     case SDL_WINDOWEVENT_RESIZED:
                     {
-                        isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
+                        SetFullscreenFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0);
                         VideoMode newSize(ev.window.data1, ev.window.data2);
                         if(newSize != GetWindowSize())
                         {

--- a/extras/videoDrivers/SDL2/VideoSDL2.h
+++ b/extras/videoDrivers/SDL2/VideoSDL2.h
@@ -24,8 +24,8 @@ public:
 
     bool Initialize() override;
 
-    bool CreateScreen(const std::string& title, const VideoMode& size, bool fullscreen) override;
-    bool ResizeScreen(const VideoMode& newSize, bool fullscreen) override;
+    bool CreateScreen(const std::string& title, const VideoMode& size, DisplayMode displayMode) override;
+    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
 
     void DestroyScreen() override;
 

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -129,26 +129,25 @@ void VideoWinAPI::CleanUp()
 /**
  *  Erstellt das Fenster mit entsprechenden Werten.
  *
- *  @param[in] width      Breite des Fensters
- *  @param[in] height     Höhe des Fensters
- *  @param[in] fullscreen Vollbildmodus ja oder nein
+ *  @param[in] width       Breite des Fensters
+ *  @param[in] height      Höhe des Fensters
+ *  @param[in] displayMode Fullscreen on/off, window resizable?
  *
  *  @return @p true bei Erfolg, @p false bei Fehler
  *
  *  @bug Hardwarecursor ist bei Fenstermodus sichtbar,
  *       Cursor deaktivieren ist fehlerhaft
  */
-bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSize, bool fullscreen)
+bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
 
-    if(!RegisterAndCreateWindow(title, newSize, fullscreen))
+    if(!RegisterAndCreateWindow(title, newSize, displayMode))
         return false;
 
-    if(fullscreen && !MakeFullscreen(GetWindowSize()))
+    if(bitset::isSet(displayMode, DisplayMode::Fullscreen) && !MakeFullscreen(GetWindowSize()))
         return false;
-    isFullscreen_ = fullscreen;
 
     if(!InitOGL())
         return false;
@@ -174,30 +173,31 @@ bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSiz
  *
  *  @todo Vollbildmodus ggf. wechseln
  */
-bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, bool fullscreen)
+bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
 {
     if(!initialized || !isWindowResizable)
         return false;
 
-    if(isFullscreen_ == fullscreen && newSize == GetWindowSize())
+    const auto fullscreen = bitset::isSet(displayMode, DisplayMode::Fullscreen);
+    if(IsFullscreen() == fullscreen && newSize == GetWindowSize())
         return true;
 
     ShowWindow(screen, SW_HIDE);
 
     VideoMode windowSize = fullscreen ? FindClosestVideoMode(newSize) : newSize;
     // Try to switch full screen first
-    if(isFullscreen_ && !fullscreen)
+    if(IsFullscreen() && !fullscreen)
     {
         if(ChangeDisplaySettings(nullptr, 0) != DISP_CHANGE_SUCCESSFUL)
             return false;
-    } else if(isFullscreen_ || fullscreen)
+    } else if(IsFullscreen() || fullscreen)
     {
         if(!MakeFullscreen(windowSize))
             return false;
     }
 
     // Fensterstyle ggf. ändern
-    std::pair<DWORD, DWORD> style = GetStyleFlags(isFullscreen_);
+    std::pair<DWORD, DWORD> style = GetStyleFlags(IsFullscreen());
     SetWindowLongPtr(screen, GWL_STYLE, style.first);
     SetWindowLongPtr(screen, GWL_EXSTYLE, style.second);
 
@@ -253,7 +253,7 @@ RECT VideoWinAPI::CalculateWindowRect(bool fullscreen, VideoMode& size) const
     return wRect;
 }
 
-bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, bool fullscreen)
+bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode)
 {
     std::wstring wTitle = boost::nowide::widen(title);
     windowClassName = wTitle.substr(0, wTitle.find(' '));
@@ -275,6 +275,7 @@ bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoM
         return false;
 
     // Create window
+    const auto fullscreen = bitset::isSet(displayMode, DisplayMode::Fullscreen);
     auto adjWindowSize = fullscreen ? FindClosestVideoMode(wndSize) : wndSize;
     RECT wRect = CalculateWindowRect(fullscreen, adjWindowSize);
 
@@ -405,7 +406,7 @@ void VideoWinAPI::DestroyScreen()
 
     UnregisterClassW(windowClassName.c_str(), GetModuleHandle(nullptr));
 
-    isFullscreen_ = false;
+    displayMode_ = bitset::set(displayMode_, DisplayMode::Fullscreen, false);
 }
 
 /**

--- a/extras/videoDrivers/WinAPI/WinAPI.h
+++ b/extras/videoDrivers/WinAPI/WinAPI.h
@@ -30,10 +30,10 @@ public:
     bool Initialize() override;
 
     /// Erstellt das Fenster mit entsprechenden Werten.
-    bool CreateScreen(const std::string& title, const VideoMode& newSize, bool fullscreen) override;
+    bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) override;
 
     /// Erstellt oder verändert das Fenster mit entsprechenden Werten.
-    bool ResizeScreen(const VideoMode& newSize, bool fullscreen) override;
+    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
 
     /// Schliesst das Fenster.
     void DestroyScreen() override;
@@ -66,7 +66,7 @@ private:
     std::pair<DWORD, DWORD> GetStyleFlags(bool fullscreen) const;
     /// Calculate the rect for the window and adjusts the (usable) size if required
     RECT CalculateWindowRect(bool fullscreen, VideoMode& size) const;
-    bool RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, bool fullscreen);
+    bool RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode);
     bool InitOGL();
     static bool MakeFullscreen(const VideoMode& resolution);
 

--- a/libs/driver/include/driver/VideoDriver.h
+++ b/libs/driver/include/driver/VideoDriver.h
@@ -29,7 +29,9 @@ public:
 
     VideoMode GetWindowSize() const override final { return windowSize_; }
     Extent GetRenderSize() const override final { return renderSize_; }
-    bool IsFullscreen() const override final { return isFullscreen_; }
+    DisplayMode GetDisplayMode() const override final { return displayMode_; }
+    bool IsFullscreen() const override final { return bitset::isSet(displayMode_, DisplayMode::Fullscreen); }
+    bool IsResizable() const override final { return bitset::isSet(displayMode_, DisplayMode::Fullscreen); }
 
     /// prüft auf Initialisierung.
     bool IsInitialized() const override final { return initialized; }
@@ -39,11 +41,14 @@ protected:
     VideoMode FindClosestVideoMode(const VideoMode& mode) const;
     void SetNewSize(VideoMode windowSize, Extent renderSize);
 
+    void SetFullscreenFlag(bool fullscreen) { displayMode_ = fullscreen ? (displayMode_ | DisplayMode::Fullscreen) : (displayMode_ & ~DisplayMode::Fullscreen); }
+    void SetResizableFlag(bool resizable) { displayMode_ = bitset::set(displayMode_, DisplayMode::Resizable, resizable); }
+
     VideoDriverLoaderInterface* CallBack; /// Das DriverCallback für Rückmeldungen.
     bool initialized;                     /// Initialisierungsstatus.
     MouseCoords mouse_xy;                 /// Status der Maus.
     std::array<bool, 512> keyboard;       /// Status der Tastatur;
-    bool isFullscreen_;                   /// Vollbild an/aus?
+    DisplayMode displayMode_;             /// Fullscreen/resizable?
 private:
     // cached as possibly used often
     VideoMode windowSize_;

--- a/libs/driver/src/VideoDriver.cpp
+++ b/libs/driver/src/VideoDriver.cpp
@@ -17,7 +17,7 @@ IVideoDriver::~IVideoDriver() = default;
  *  @param[in] CallBack DriverCallback für Rückmeldungen.
  */
 VideoDriver::VideoDriver(VideoDriverLoaderInterface* CallBack)
-    : CallBack(CallBack), initialized(false), isFullscreen_(false), renderSize_(0, 0)
+    : CallBack(CallBack), initialized(false), displayMode_(DisplayMode::Resizable), renderSize_(0, 0)
 {
     std::fill(keyboard.begin(), keyboard.end(), false);
 }

--- a/libs/s25main/GameManager.cpp
+++ b/libs/s25main/GameManager.cpp
@@ -12,6 +12,7 @@
 #include "desktops/dskLobby.h"
 #include "desktops/dskMainMenu.h"
 #include "desktops/dskSplash.h"
+#include "driver/VideoInterface.h"
 #include "drivers/AudioDriverWrapper.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "files.h"
@@ -48,9 +49,10 @@ bool GameManager::Start()
     }
 
     // Fenster erstellen
-    const auto screenSize =
-      settings_.video.fullscreen ? settings_.video.fullscreenSize : settings_.video.windowedSize; //-V807
-    if(!videoDriver_.CreateScreen(screenSize, settings_.video.fullscreen))
+    const auto screenSize = (settings_.video.displayMode & DisplayMode::Fullscreen) != DisplayMode::None ?
+                              settings_.video.fullscreenSize :
+                              settings_.video.windowedSize; //-V807
+    if(!videoDriver_.CreateScreen(screenSize, settings_.video.displayMode))
         return false;
     videoDriver_.setTargetFramerate(settings_.video.framerate);
     videoDriver_.SetMouseWarping(settings_.global.smartCursor);

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "DrawPoint.h"
+#include "driver/VideoInterface.h"
 #include "driver/VideoMode.h"
 #include "s25util/ProxySettings.h"
 #include "s25util/Singleton.h"
@@ -60,7 +61,7 @@ public:
     {
         VideoMode fullscreenSize, windowedSize;
         signed short framerate; // <0 for unlimited, 0 for HW Vsync
-        bool fullscreen;
+        DisplayMode displayMode;
         bool vbo;
         bool shared_textures;
     } video;

--- a/libs/s25main/desktops/dskBenchmark.cpp
+++ b/libs/s25main/desktops/dskBenchmark.cpp
@@ -131,7 +131,7 @@ void dskBenchmark::Msg_PaintAfter()
 void dskBenchmark::SetActive(bool activate)
 {
     if(!IsActive() && activate)
-        VIDEODRIVER.ResizeScreen(VideoMode(1600, 900), false);
+        VIDEODRIVER.ResizeScreen(VideoMode(1600, 900), DisplayMode::Resizable);
     dskMenuBase::SetActive(activate);
 }
 

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -379,7 +379,8 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     }
 
     // "Vollbild" setzen
-    groupGrafik->GetCtrl<ctrlOptionGroup>(ID_grpFullscreen)->SetSelection(SETTINGS.video.fullscreen); //-V807
+    groupGrafik->GetCtrl<ctrlOptionGroup>(ID_grpFullscreen)
+      ->SetSelection(bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen)); //-V807
 
     // "Limit Framerate" füllen
     auto* cbFrameRate = groupGrafik->GetCtrl<ctrlComboBox>(ID_cbFramerate);
@@ -502,7 +503,9 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
     switch(ctrl_id)
     {
         case ID_grpIpv6: SETTINGS.server.ipv6 = enabled; break;
-        case ID_grpFullscreen: SETTINGS.video.fullscreen = enabled; break;
+        case ID_grpFullscreen:
+            SETTINGS.video.displayMode = bitset::set(SETTINGS.video.displayMode, DisplayMode::Fullscreen, enabled);
+            break;
         case ID_grpVBO: SETTINGS.video.vbo = enabled; break;
         case ID_grpOptTextures: SETTINGS.video.shared_textures = enabled; break;
         case ID_grpMusic:
@@ -570,12 +573,12 @@ void dskOptions::Msg_ButtonClick(const unsigned ctrl_id)
 
             SETTINGS.Save();
 
-            if((SETTINGS.video.fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize()) //-V807
-               || SETTINGS.video.fullscreen != VIDEODRIVER.IsFullscreen())
+            const auto fullscreen = bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen);
+            if((fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize()) //-V807
+               || fullscreen != VIDEODRIVER.IsFullscreen())
             {
-                const auto screenSize =
-                  SETTINGS.video.fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
-                if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.fullscreen))
+                const auto screenSize = fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
+                if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
                 {
                     WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
                       _("Sorry!"), _("You need to restart your game to change the screen resolution!"), this,

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -92,7 +92,7 @@ void VideoDriverWrapper::UnloadDriver()
  *
  *  @return Bei Erfolg @p true ansonsten @p false
  */
-bool VideoDriverWrapper::CreateScreen(const VideoMode size, const bool fullscreen)
+bool VideoDriverWrapper::CreateScreen(const VideoMode size, const DisplayMode displayMode)
 {
     if(!videodriver)
     {
@@ -100,7 +100,7 @@ bool VideoDriverWrapper::CreateScreen(const VideoMode size, const bool fullscree
         return false;
     }
 
-    if(!videodriver->CreateScreen(rttr::version::GetTitle(), size, fullscreen))
+    if(!videodriver->CreateScreen(rttr::version::GetTitle(), size, displayMode))
     {
         s25util::fatal_error("Could not create window!");
         return false;
@@ -134,7 +134,7 @@ bool VideoDriverWrapper::CreateScreen(const VideoMode size, const bool fullscree
  *
  *  @return Bei Erfolg @p true ansonsten @p false
  */
-bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const bool fullscreen)
+bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const DisplayMode displayMode)
 {
     if(!videodriver)
     {
@@ -142,7 +142,7 @@ bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const bool fullscree
         return false;
     }
 
-    const bool result = videodriver->ResizeScreen(size, fullscreen);
+    const bool result = videodriver->ResizeScreen(size, displayMode);
 #ifdef _WIN32
     if(!videodriver->IsFullscreen())
     {
@@ -483,7 +483,17 @@ Extent VideoDriverWrapper::GetRenderSize() const
     return videodriver->GetRenderSize();
 }
 
+DisplayMode VideoDriverWrapper::GetDisplayMode() const
+{
+    return videodriver->GetDisplayMode();
+}
+
 bool VideoDriverWrapper::IsFullscreen() const
 {
     return videodriver->IsFullscreen();
+}
+
+bool VideoDriverWrapper::IsResizable() const
+{
+    return videodriver->IsResizable();
 }

--- a/libs/s25main/drivers/VideoDriverWrapper.h
+++ b/libs/s25main/drivers/VideoDriverWrapper.h
@@ -7,6 +7,7 @@
 #include "DriverWrapper.h"
 #include "Point.h"
 #include "driver/KeyEvent.h"
+#include "driver/VideoInterface.h"
 #include "driver/VideoMode.h"
 #include "s25util/Singleton.h"
 #include <memory>
@@ -35,9 +36,9 @@ public:
     IVideoDriver* GetDriver() const { return videodriver.get(); }
 
     /// Erstellt das Fenster.
-    bool CreateScreen(VideoMode size, bool fullscreen);
+    bool CreateScreen(VideoMode size, DisplayMode displayMode);
     /// Verändert Auflösung, Fenster/Fullscreen
-    bool ResizeScreen(VideoMode size, bool fullscreen);
+    bool ResizeScreen(VideoMode size, DisplayMode displayMode);
     /// Viewport (neu) setzen
     void RenewViewport();
     /// zerstört das Fenster.
@@ -68,7 +69,9 @@ public:
     VideoMode GetWindowSize() const;
     /// Get the renderer size in pixels
     Extent GetRenderSize() const;
+    DisplayMode GetDisplayMode() const;
     bool IsFullscreen() const;
+    bool IsResizable() const;
 
     bool IsLeftDown();
     bool IsRightDown();

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -9,6 +9,7 @@
 #include "controls/ctrlCheck.h"
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlOptionGroup.h"
+#include "driver/VideoInterface.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "helpers/format.hpp"
 #include "iwMsgbox.h"
@@ -31,7 +32,8 @@ iwSettings::iwSettings()
 
     // "Vollbild" setzen
     optiongroup = GetCtrl<ctrlOptionGroup>(3);
-    optiongroup->SetSelection((SETTINGS.video.fullscreen ? 1 : 2)); //-V807
+
+    optiongroup->SetSelection((bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen) ? 1 : 2)); //-V807
     VIDEODRIVER.ListVideoModes(video_modes);
 
     // "Auflösung"
@@ -63,12 +65,12 @@ iwSettings::~iwSettings()
         auto* SizeCombo = GetCtrl<ctrlComboBox>(0);
         SETTINGS.video.fullscreenSize = video_modes[SizeCombo->GetSelection().get()];
 
-        if((SETTINGS.video.fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize())
-           || SETTINGS.video.fullscreen != VIDEODRIVER.IsFullscreen())
+        const auto fullscreen = bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen);
+        if((fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize())
+           || fullscreen != VIDEODRIVER.IsFullscreen())
         {
-            const auto screenSize =
-              SETTINGS.video.fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
-            if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.fullscreen))
+            const auto screenSize = fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
+            if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
             {
                 WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
                   _("Sorry!"), _("You need to restart your game to change the screen resolution!"), this,
@@ -85,7 +87,10 @@ void iwSettings::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned se
 {
     switch(ctrl_id)
     {
-        case 3: SETTINGS.video.fullscreen = (selection == 1); break;
+        case 3:
+            SETTINGS.video.displayMode =
+              bitset::set(SETTINGS.video.displayMode, DisplayMode::Fullscreen, (selection == 1));
+            break;
     }
 }
 

--- a/tests/mockupDrivers/MockupVideoDriver.cpp
+++ b/tests/mockupDrivers/MockupVideoDriver.cpp
@@ -29,16 +29,16 @@ bool MockupVideoDriver::Initialize()
     return true;
 }
 
-bool MockupVideoDriver::CreateScreen(const std::string&, const VideoMode& newSize, bool fullscreen)
+bool MockupVideoDriver::CreateScreen(const std::string&, const VideoMode& newSize, DisplayMode displayMode)
 {
-    ResizeScreen(newSize, fullscreen);
+    ResizeScreen(newSize, displayMode);
     return true;
 }
 
-bool MockupVideoDriver::ResizeScreen(const VideoMode& newSize, bool fullscreen)
+bool MockupVideoDriver::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
 {
     SetNewSize(newSize, Extent(newSize.width, newSize.height));
-    isFullscreen_ = fullscreen;
+    displayMode_ = displayMode;
     return true;
 }
 

--- a/tests/mockupDrivers/MockupVideoDriver.h
+++ b/tests/mockupDrivers/MockupVideoDriver.h
@@ -13,8 +13,8 @@ public:
     ~MockupVideoDriver() override;
     const char* GetName() const override;
     bool Initialize() override;
-    bool CreateScreen(const std::string& title, const VideoMode& newSize, bool fullscreen) override;
-    bool ResizeScreen(const VideoMode& newSize, bool fullscreen) override;
+    bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) override;
+    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
     void DestroyScreen() override {}
     bool SwapBuffers() override { return true; }
     bool MessageLoop() override;

--- a/tests/s25Main/UI/testAnimations.cpp
+++ b/tests/s25Main/UI/testAnimations.cpp
@@ -681,7 +681,7 @@ BOOST_AUTO_TEST_CASE(MoveAniScale)
     video->tickCount_ += 1;
     dsk->Msg_PaintBefore();
     // Resize the screen and test that the final position got updated too
-    VIDEODRIVER.ResizeScreen(VideoMode(1024, 768), false);
+    VIDEODRIVER.ResizeScreen(VideoMode(1024, 768), DisplayMode::Resizable);
     // Pass the animation
     video->tickCount_ += 1100;
     dsk->Msg_PaintBefore();

--- a/tests/s25Main/UI/testVideoDriver.cpp
+++ b/tests/s25Main/UI/testVideoDriver.cpp
@@ -66,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
     {
         rttr::test::LogAccessor logAcc;
         VIDEODRIVER.DestroyScreen();
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
         logAcc.clearLog();
     }
 
@@ -87,7 +87,7 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
 
     {
         rttr::test::LogAccessor logAcc;
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
         logAcc.clearLog();
     }
     glGenTextures = rttrOglMock2::glGenTextures;

--- a/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
+++ b/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
@@ -28,7 +28,7 @@ void initGUITests()
         rttr::test::LogAccessor logAcc;
         VIDEODRIVER.LoadDriver(new MockupVideoDriver(&WINDOWMANAGER));
         RTTR_REQUIRE_LOG_CONTAINS("Mockup Video Driver", false);
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
         BOOST_TEST_CHECKPOINT("Load dummy files");
         LOADER.LoadDummyGUIFiles();
         BOOST_TEST_CHECKPOINT("Switch to Desktop");


### PR DESCRIPTION
Implement additional display modes in SDL2 and WinAPI backends:
* Windowed fullscreen
* Windowed (non-resizable)

Fixes #1512
Closes #1615

To-do:
- [ ] Rebase after #1612.
- [ ] Rework options screen and in-game settings window.

<details>
<summary>Notes and references:</summary>

* https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles
* https://src.chromium.org/viewvc/chrome/trunk/src/ui/views/win/fullscreen_handler.cc
</details>