### PR TITLE
Prevent drawing outside the window when shaded

### DIFF
--- a/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
@@ -98,6 +98,9 @@ void iwMilitaryBuilding::Draw_()
 {
     IngameWindow::Draw_();
 
+    if(IsMinimized())
+        return;
+
     // Schwarzer Untergrund für Goldanzeige
     const unsigned maxCoinCt = building->GetMaxCoinCt();
     DrawPoint goldPos = GetDrawPos() + DrawPoint((GetSize().x - 22 * maxCoinCt) / 2, 60);


### PR DESCRIPTION
The military building window would draw parts of its UI outside the window when shaded (aka. minimized).

![bug_militarybuilding_draws_outside_window_when_shaded](https://github.com/Return-To-The-Roots/s25client/assets/320854/4362ac14-cfd3-4439-9af6-9e86cb22e6eb)
