### PR TITLE
Clean up and refactor IngameWindow button handling

### DIFF
--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -30,8 +30,7 @@ const Extent IngameWindow::borderSize(1, 1);
 IngameWindow::IngameWindow(unsigned id, const DrawPoint& pos, const Extent& size, std::string title,
                            glArchivItem_Bitmap* background, bool modal, CloseBehavior closeBehavior, Window* parent)
     : Window(parent, id, pos, size), title_(std::move(title)), background(background), lastMousePos(0, 0),
-      last_down(false), last_down2(false), isModal_(modal), closeme(false), isMinimized_(false), isMoving(false),
-      closeBehavior_(closeBehavior)
+      isModal_(modal), closeme(false), isMinimized_(false), isMoving(false), closeBehavior_(closeBehavior)
 {
     std::fill(buttonState.begin(), buttonState.end(), ButtonState::Up);
     contentOffset.x = LOADER.GetImageN("resource", 38)->getWidth();     // left border

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Window.h"
+#include "helpers/EnumArray.h"
 #include "gameData/const_gui_ids.h"
 #include <array>
 #include <vector>
@@ -23,6 +24,16 @@ enum CloseBehavior
     /// Same as Regular, but doesn't (auto-)close on right-click
     NoRightClick,
 };
+
+enum class IwButton
+{
+    Close,
+    Minimize
+};
+constexpr auto maxEnumValue(IwButton)
+{
+    return IwButton::Minimize;
+}
 
 class IngameWindow : public Window
 {
@@ -99,22 +110,20 @@ protected:
     std::string title_;
     glArchivItem_Bitmap* background;
     DrawPoint lastMousePos;
-    std::array<ButtonState, 2> buttonState;
 
     /// Offset from left and top to actual content
     Extent contentOffset;
     /// Offset from content to right and bottom boundary
     Extent contentOffsetEnd;
 
-    /// Get bounds of close button (left)
-    Rect GetCloseButtonBounds() const;
-    /// Get bounds of minimize button (right)
-    Rect GetMinimizeButtonBounds() const;
-
 private:
+    /// Get bounds of given button
+    Rect GetButtonBounds(IwButton btn) const;
+
     bool isModal_;
     bool closeme;
     bool isMinimized_;
     bool isMoving;
     CloseBehavior closeBehavior_;
+    helpers::EnumArray<ButtonState, IwButton> buttonStates_;
 };

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -99,8 +99,6 @@ protected:
     std::string title_;
     glArchivItem_Bitmap* background;
     DrawPoint lastMousePos;
-    bool last_down;
-    bool last_down2;
     std::array<ButtonState, 2> buttonState;
 
     /// Offset from left and top to actual content


### PR DESCRIPTION
* Remove unused data members (`last_down`, `last_down2`).
* Refactor button handling for #1606.
* Fix incorrect texture used for the close button (pressed state).

~~I'll rebase #1606 and implement discussed changes before this is ready for consideration.~~