### PR TITLE
Refactor PersistentWindowSettings and persist window minimized state

### DIFF
--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -350,6 +350,7 @@ void Settings::LoadIngame()
             windows.persistentSettings[window.first].lastPos.x = iniWindow->getIntValue("pos_x");
             windows.persistentSettings[window.first].lastPos.y = iniWindow->getIntValue("pos_y");
             windows.persistentSettings[window.first].isOpen = iniWindow->getIntValue("is_open");
+            windows.persistentSettings[window.first].isMinimized = iniWindow->getValue("is_minimized", false);
         }
     } catch(std::runtime_error& e)
     {
@@ -502,6 +503,7 @@ void Settings::SaveIngame()
         iniWindow->setValue("pos_x", windows.persistentSettings[window.first].lastPos.x);
         iniWindow->setValue("pos_y", windows.persistentSettings[window.first].lastPos.y);
         iniWindow->setValue("is_open", windows.persistentSettings[window.first].isOpen);
+        iniWindow->setValue("is_minimized", windows.persistentSettings[window.first].isMinimized);
     }
 
     bfs::path settingsPathIngame = RTTRCONFIG.ExpandPath(s25::resources::ingameOptions);

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -26,6 +26,7 @@ struct PersistentWindowSettings
 {
     DrawPoint lastPos = DrawPoint::Invalid();
     bool isOpen = false;
+    bool isMinimized = false;
 };
 
 /// Configuration class

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -24,11 +24,8 @@ bool checkPort(int port);
 
 struct PersistentWindowSettings
 {
-    DrawPoint lastPos;
-    bool isOpen;
-
-    PersistentWindowSettings(DrawPoint lastPos, bool isOpen) : lastPos(lastPos), isOpen(isOpen) {}
-    PersistentWindowSettings() : lastPos(DrawPoint::Invalid()), isOpen(false) {}
+    DrawPoint lastPos = DrawPoint::Invalid();
+    bool isOpen = false;
 };
 
 /// Configuration class

--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -54,18 +54,19 @@ IngameWindow::IngameWindow(unsigned id, const DrawPoint& pos, const Extent& size
     // Save to settings that window is open
     SaveOpenStatus(true);
 
-    // Load lastPos before it is overwritten when restoring minimized state
-    const auto lastPos = (windowSettings_ ? windowSettings_->lastPos : DrawPoint::Invalid());
-
     // Restore minimized state
     if(windowSettings_ && windowSettings_->isMinimized)
-        SetMinimized();
+    {
+        isMinimized_ = true;
+        Extent minimizedSize(GetSize().x, contentOffset.y + contentOffsetEnd.y);
+        Window::Resize(minimizedSize);
+    }
 
-    // Restore last position or center the window
+    // Load last position or center the window
     if(pos == posLastOrCenter)
     {
-        if(lastPos.isValid())
-            SetPos(lastPos);
+        if(windowSettings_ && windowSettings_->lastPos.isValid())
+            SetPos(windowSettings_->lastPos);
         else
             MoveToCenter();
     } else if(pos == posCenter)

--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -54,11 +54,18 @@ IngameWindow::IngameWindow(unsigned id, const DrawPoint& pos, const Extent& size
     // Save to settings that window is open
     SaveOpenStatus(true);
 
-    // Load last position or center the window
+    // Load lastPos before it is overwritten when restoring minimized state
+    const auto lastPos = (windowSettings_ ? windowSettings_->lastPos : DrawPoint::Invalid());
+
+    // Restore minimized state
+    if(windowSettings_ && windowSettings_->isMinimized)
+        SetMinimized();
+
+    // Restore last position or center the window
     if(pos == posLastOrCenter)
     {
-        if(windowSettings_ && windowSettings_->lastPos.isValid())
-            SetPos(windowSettings_->lastPos);
+        if(lastPos.isValid())
+            SetPos(lastPos);
         else
             MoveToCenter();
     } else if(pos == posCenter)
@@ -132,6 +139,10 @@ void IngameWindow::SetMinimized(bool minimized)
         fullSize.y = iwHeight + contentOffset.y + contentOffsetEnd.y;
     this->isMinimized_ = minimized;
     Resize(fullSize);
+
+    // if possible save the minimized state to settings
+    if(windowSettings_)
+        windowSettings_->isMinimized = isMinimized_;
 }
 
 void IngameWindow::MouseLeftDown(const MouseCoords& mc)

--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -43,6 +43,9 @@ IngameWindow::IngameWindow(unsigned id, const DrawPoint& pos, const Extent& size
     contentOffsetEnd.x = LOADER.GetImageN("resource", 39)->getWidth();  // right border
     contentOffsetEnd.y = LOADER.GetImageN("resource", 40)->getHeight(); // bottom bar
 
+    const auto it = SETTINGS.windows.persistentSettings.find(GetGUIID());
+    windowSettings_ = (it == SETTINGS.windows.persistentSettings.cend() ? nullptr : &it->second);
+
     // For compatibility we treat the given height as the window height, not the content height
     // First we have to make sure the size is not to small
     Window::Resize(elMax(contentOffset + contentOffsetEnd, GetSize()));
@@ -54,9 +57,8 @@ IngameWindow::IngameWindow(unsigned id, const DrawPoint& pos, const Extent& size
     // Load last position or center the window
     if(pos == posLastOrCenter)
     {
-        const auto windowSettings = SETTINGS.windows.persistentSettings.find(GetGUIID());
-        if(windowSettings != SETTINGS.windows.persistentSettings.cend() && windowSettings->second.lastPos.isValid())
-            SetPos(windowSettings->second.lastPos);
+        if(windowSettings_ && windowSettings_->lastPos.isValid())
+            SetPos(windowSettings_->lastPos);
         else
             MoveToCenter();
     } else if(pos == posCenter)
@@ -111,11 +113,8 @@ void IngameWindow::SetPos(DrawPoint newPos)
         newPos.y = screenSize.y - GetSize().y;
 
     // if possible save the position to settings
-    const auto windowSettings = SETTINGS.windows.persistentSettings.find(GetGUIID());
-    if(windowSettings != SETTINGS.windows.persistentSettings.cend())
-    {
-        windowSettings->second.lastPos = newPos;
-    }
+    if(windowSettings_)
+        windowSettings_->lastPos = newPos;
 
     Window::SetPos(newPos);
 }
@@ -361,11 +360,8 @@ bool IngameWindow::IsMessageRelayAllowed() const
 
 void IngameWindow::SaveOpenStatus(bool isOpen) const
 {
-    auto windowSettings = SETTINGS.windows.persistentSettings.find(GetGUIID());
-    if(windowSettings != SETTINGS.windows.persistentSettings.cend())
-    {
-        windowSettings->second.isOpen = isOpen;
-    }
+    if(windowSettings_)
+        windowSettings_->isOpen = isOpen;
 }
 
 Rect IngameWindow::GetButtonBounds(IwButton btn) const

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -12,6 +12,7 @@
 
 class glArchivItem_Bitmap;
 class MouseCoords;
+struct PersistentWindowSettings;
 template<typename T>
 struct Point;
 
@@ -126,4 +127,5 @@ private:
     bool isMoving;
     CloseBehavior closeBehavior_;
     helpers::EnumArray<ButtonState, IwButton> buttonStates_;
+    PersistentWindowSettings* windowSettings_;
 };

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "DrawPoint.h"
+#include "Point.h"
 #include "PointOutput.h"
+#include "Settings.h"
 #include "WindowManager.h"
 #include "controls/ctrlButton.h"
 #include "controls/ctrlComboBox.h"
@@ -12,6 +15,7 @@
 #include "controls/ctrlProgress.h"
 #include "desktops/dskGameLobby.h"
 #include "helpers/format.hpp"
+#include "ingameWindows/IngameWindow.h"
 #include "ingameWindows/iwConnecting.h"
 #include "ingameWindows/iwDirectIPConnect.h"
 #include "ingameWindows/iwHelp.h"
@@ -19,6 +23,7 @@
 #include "ingameWindows/iwMsgbox.h"
 #include "uiHelper/uiHelpers.hpp"
 #include "gameTypes/GameTypesOutput.h"
+#include "gameData/const_gui_ids.h"
 #include "rttr/test/random.hpp"
 #include "s25util/StringConversion.h"
 #include <turtle/mock.hpp>
@@ -191,6 +196,35 @@ BOOST_AUTO_TEST_CASE(ConnectingWindow)
         wnd.Msg_ButtonClick(wnd.GetCtrls<ctrlButton>().at(0)->GetID());
         BOOST_TEST(wnd.ShouldBeClosed());
         BOOST_TEST((dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow())));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(SaveAndRestoreMinimized)
+{
+    constexpr auto id = CGI_MINIMAP;
+    auto it = SETTINGS.windows.persistentSettings.find(id);
+    BOOST_REQUIRE(it != SETTINGS.windows.persistentSettings.end());
+
+    {
+        it->second.isMinimized = false;
+
+        IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
+        BOOST_TEST(!wnd.IsMinimized());
+        BOOST_TEST(wnd.GetSize() == Extent(100, 100));
+
+        wnd.SetMinimized(true);
+        BOOST_TEST(it->second.isMinimized);
+    }
+
+    {
+        it->second.isMinimized = true;
+
+        IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
+        BOOST_TEST(wnd.IsMinimized());
+        BOOST_TEST(wnd.GetSize() != Extent(100, 100));
+
+        wnd.SetMinimized(false);
+        BOOST_TEST(!it->second.isMinimized);
     }
 }
 


### PR DESCRIPTION
* Remove unneeded `PersistentWindowSettings` constructors and move default initialization in class.
* Look up  `PersistentWindowSettings` only once in `IngameWindow` (assumes pointer stability). This will make more of a difference when more settings are saved in these PRs:
  * #1601
  * #1606
* Save and restore the minimized state of in-game windows. This required some more changes to avoid calling unqualified virtual `Resize()` from the constructor.