### PR TITLE
Synchronize game world view HUD visibility settings

### DIFF
--- a/libs/s25main/ingameWindows/iwObservate.cpp
+++ b/libs/s25main/ingameWindows/iwObservate.cpp
@@ -48,6 +48,11 @@ iwObservate::iwObservate(GameWorldView& gwv, const MapPoint selectedPt)
     // Fenster vergroessern/verkleinern
     btPos.x += btSize.x;
     AddImageButton(4, btPos, btSize, TextureColor::Grey, LOADER.GetImageN("io", 109), _("Resize window"));
+
+    // Synchronize visibility of HUD elements with parentView
+    parentView.CopyHudSettingsTo(*view, false);
+    gwvSettingsConnection =
+      parentView.onHudSettingsChanged.connect([this]() { parentView.CopyHudSettingsTo(*view, false); });
 }
 
 void iwObservate::Msg_ButtonClick(const unsigned ctrl_id)

--- a/libs/s25main/ingameWindows/iwObservate.h
+++ b/libs/s25main/ingameWindows/iwObservate.h
@@ -6,6 +6,7 @@
 
 #include "IngameWindow.h"
 #include "gameTypes/MapCoordinates.h"
+#include <boost/signals2.hpp>
 
 class GameWorldView;
 class MouseCoords;
@@ -29,6 +30,8 @@ class iwObservate : public IngameWindow
 
     /// id of object currently followed or INVALID_ID
     unsigned followMovableId;
+
+    boost::signals2::scoped_connection gwvSettingsConnection;
 
 public:
     iwObservate(GameWorldView& gwv, MapPoint selectedPt);

--- a/libs/s25main/world/GameWorldView.cpp
+++ b/libs/s25main/world/GameWorldView.cpp
@@ -545,7 +545,27 @@ void GameWorldView::DrawBoundaryStone(const MapPoint& pt, const DrawPoint pos, V
     }
 }
 
-/// Schaltet Produktivitäten/Namen komplett aus oder an
+void GameWorldView::ToggleShowBQ()
+{
+    show_bq = !show_bq;
+    SaveIngameSettingsValues();
+    onHudSettingsChanged();
+}
+
+void GameWorldView::ToggleShowNames()
+{
+    show_names = !show_names;
+    SaveIngameSettingsValues();
+    onHudSettingsChanged();
+}
+
+void GameWorldView::ToggleShowProductivity()
+{
+    show_productivity = !show_productivity;
+    SaveIngameSettingsValues();
+    onHudSettingsChanged();
+}
+
 void GameWorldView::ToggleShowNamesAndProductivity()
 {
     if(show_productivity && show_names)
@@ -553,6 +573,14 @@ void GameWorldView::ToggleShowNamesAndProductivity()
     else
         show_productivity = show_names = true;
     SaveIngameSettingsValues();
+    onHudSettingsChanged();
+}
+
+void GameWorldView::CopyHudSettingsTo(GameWorldView& other, bool copyBQ) const
+{
+    other.show_bq = (copyBQ ? show_bq : false);
+    other.show_names = show_names;
+    other.show_productivity = show_productivity;
 }
 
 void GameWorldView::MoveBy(const DrawPoint& numPixels)

--- a/libs/s25main/world/GameWorldView.h
+++ b/libs/s25main/world/GameWorldView.h
@@ -7,6 +7,7 @@
 #include "DrawPoint.h"
 #include "gameTypes/MapCoordinates.h"
 #include "gameTypes/MapTypes.h"
+#include <boost/signals2.hpp>
 #include <vector>
 
 class GameWorldBase;
@@ -80,26 +81,17 @@ public:
     float GetCurrentTargetZoomFactor() const;
     void SetNextZoomFactor();
 
-    /// Bauqualitäten anzeigen oder nicht
-    void ToggleShowBQ()
-    {
-        show_bq = !show_bq;
-        SaveIngameSettingsValues();
-    }
-    /// Gebäudenamen zeigen oder nicht
-    void ToggleShowNames()
-    {
-        show_names = !show_names;
-        SaveIngameSettingsValues();
-    }
-    /// Produktivität zeigen oder nicht
-    void ToggleShowProductivity()
-    {
-        show_productivity = !show_productivity;
-        SaveIngameSettingsValues();
-    };
-    /// Schaltet Produktivitäten/Namen komplett aus oder an
+    /// Show or hide construction aid
+    void ToggleShowBQ();
+    /// Show or hide building names
+    void ToggleShowNames();
+    /// Show or hide productivity
+    void ToggleShowProductivity();
+    /// Toggle names and productivity completely on or off
     void ToggleShowNamesAndProductivity();
+
+    /// Copy visibility of HUD elements from this view to another
+    void CopyHudSettingsTo(GameWorldView& other, bool copyBQ) const;
 
     void Draw(const RoadBuildState& rb, MapPoint selected, bool drawMouse, unsigned* water = nullptr);
 
@@ -127,6 +119,9 @@ public:
     Position GetLastPt() const { return lastPt; }
 
     void Resize(const Extent& newSize);
+
+    /// Triggered when visibility of HUD elements changes
+    boost::signals2::signal<void()> onHudSettingsChanged;
 
 private:
     void CalcFxLx();


### PR DESCRIPTION
Synchronize visibility of game world view HUD elements from parent to child views (like the observation window).

@Spikeone identified this bug in #1604 [here](https://github.com/Return-To-The-Roots/s25client/pull/1604#issuecomment-1638412706).