### PR TITLE
Fix button placement in minimized in-game windows

### DIFF
--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -112,6 +112,11 @@ Extent IngameWindow::GetIwSize() const
     return Extent(GetSize().x - contentOffset.x - contentOffsetEnd.x, iwHeight);
 }
 
+Extent IngameWindow::GetFullSize() const
+{
+    return Extent(GetSize().x, contentOffset.y + contentOffsetEnd.y + iwHeight);
+}
+
 DrawPoint IngameWindow::GetRightBottomBoundary()
 {
     return DrawPoint(GetSize() - contentOffsetEnd);

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -68,6 +68,8 @@ public:
     void SetIwSize(const Extent& newSize);
     /// Get the size of the (expanded) content area
     Extent GetIwSize() const;
+    /// Get the full size of the window, even when minimized
+    Extent GetFullSize() const;
     /// Get the current lower right corner of the content area
     DrawPoint GetRightBottomBoundary();
 

--- a/libs/s25main/ingameWindows/iwBuildings.cpp
+++ b/libs/s25main/ingameWindows/iwBuildings.cpp
@@ -67,10 +67,10 @@ iwBuildings::iwBuildings(GameWorldView& gwv, GameCommandFactory& gcFactory)
         }
     }
 
-    // Hilfe-Button
+    // "Help" button
     Extent btSize = Extent(30, 32);
-    AddImageButton(32, GetSize() - DrawPoint(14, 20) - btSize, btSize, TextureColor::Grey, LOADER.GetImageN("io", 225),
-                   _("Help"));
+    AddImageButton(32, GetFullSize() - DrawPoint(14, 20) - btSize, btSize, TextureColor::Grey,
+                   LOADER.GetImageN("io", 225), _("Help"));
 }
 
 /// Anzahlen der Gebäude zeichnen

--- a/libs/s25main/ingameWindows/iwDistribution.cpp
+++ b/libs/s25main/ingameWindows/iwDistribution.cpp
@@ -62,12 +62,12 @@ iwDistribution::iwDistribution(const GameWorldViewer& gwv, GameCommandFactory& g
     tab->SetSelection(0);
 
     const Extent btSize(32, 32);
-    // Hilfe
-    AddImageButton(2, DrawPoint(15, GetSize().y - 15 - btSize.y), btSize, TextureColor::Grey,
+    // "Help" button
+    AddImageButton(2, DrawPoint(15, GetFullSize().y - 15 - btSize.y), btSize, TextureColor::Grey,
                    LOADER.GetImageN("io", 225), _("Help"));
-    // Standardbelegung
-    AddImageButton(10, GetSize() - DrawPoint::all(15) - btSize, btSize, TextureColor::Grey, LOADER.GetImageN("io", 191),
-                   _("Default"));
+    // "Default" button
+    AddImageButton(10, GetFullSize() - DrawPoint::all(15) - btSize, btSize, TextureColor::Grey,
+                   LOADER.GetImageN("io", 191), _("Default"));
 
     iwDistribution::UpdateSettings();
 }

--- a/libs/s25main/ingameWindows/iwWares.cpp
+++ b/libs/s25main/ingameWindows/iwWares.cpp
@@ -130,12 +130,12 @@ iwWares::iwWares(unsigned id, const DrawPoint& pos, const Extent& size, const st
         }
     }
 
-    // "Blättern"
-    AddImageButton(0, DrawPoint(52, GetSize().y - 47), Extent(66, 32), TextureColor::Grey, LOADER.GetImageN("io", 84),
-                   _("Next page"));
-    // Hilfe
-    AddImageButton(12, DrawPoint(16, GetSize().y - 47), Extent(32, 32), TextureColor::Grey, LOADER.GetImageN("io", 225),
-                   _("Help"));
+    // "Next page" button
+    AddImageButton(0, DrawPoint(52, GetFullSize().y - 47), Extent(66, 32), TextureColor::Grey,
+                   LOADER.GetImageN("io", 84), _("Next page"));
+    // "Help" button
+    AddImageButton(12, DrawPoint(16, GetFullSize().y - 47), Extent(32, 32), TextureColor::Grey,
+                   LOADER.GetImageN("io", 225), _("Help"));
 
     waresPage.SetVisible(true);
     curPage_ = warePageID;


### PR DESCRIPTION
As mentioned, I've discovered a bug introduced in 938f355891d #1609. This is a very quick fix. Let me know if you'd prefer to store the full size in `IngameWindow` and add a `GetFullSize()` member function, or maybe a different solution entirely.

![inventory_buttons](https://github.com/Return-To-The-Roots/s25client/assets/320854/321f39eb-b822-463b-81ff-452038ad28ac)

Commit message follows:
<hr>

Some windows position their buttons based on GetSize().y, which results in incorrect placement if the window is persisted and minimized. Replace uses of GetSize().y with the full window height.

Affected windows:
* iwBuildings
* iwDistribution
* iwWares