### PR TITLE
Implement window snapping

### DIFF
--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -141,6 +141,7 @@ void Settings::LoadDefaults()
     interface.autosave_interval = 0;
     interface.revert_mouse = false;
     interface.enableWindowPinning = false;
+    interface.windowSnapDistance = 8;
     // }
 
     // addons
@@ -300,6 +301,7 @@ void Settings::Load()
         interface.autosave_interval = iniInterface->getIntValue("autosave_interval");
         interface.revert_mouse = iniInterface->getBoolValue("revert_mouse");
         interface.enableWindowPinning = iniInterface->getValue("enable_window_pinning", false);
+        interface.windowSnapDistance = iniInterface->getValue("window_snap_distance", 8);
         // }
 
         // addons
@@ -463,6 +465,7 @@ void Settings::Save()
     iniInterface->setValue("autosave_interval", interface.autosave_interval);
     iniInterface->setValue("revert_mouse", interface.revert_mouse);
     iniInterface->setValue("enable_window_pinning", interface.enableWindowPinning);
+    iniInterface->setValue("window_snap_distance", interface.windowSnapDistance);
     // }
 
     // addons

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -107,6 +107,7 @@ public:
         unsigned autosave_interval;
         bool revert_mouse;
         bool enableWindowPinning;
+        unsigned windowSnapDistance;
     } interface;
 
     struct

--- a/libs/s25main/SnapOffset.h
+++ b/libs/s25main/SnapOffset.h
@@ -1,0 +1,12 @@
+// Copyright (C) 2005 - 2023 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "Point.h"
+
+/// Type used for specifying how much a window has to be moved to snap to another window's edge. Signed base type!
+using SnapOffset = Position;
+//-V:SnapOffset:801
+//-V:SnapOffset:813

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -880,7 +880,9 @@ void WindowManager::DrawToolTip()
 
 SnapOffset WindowManager::snapWindow(Window* wnd, const Rect& wndRect) const
 {
-    constexpr int snapDistance = 15;
+    const auto snapDistance = static_cast<int>(SETTINGS.interface.windowSnapDistance);
+    if(snapDistance == 0)
+        return SnapOffset::all(0); // No snapping
 
     /// Progressive minimum distance to another window edge; initial value limits to at most snapDistance
     auto minDist = Extent::all(snapDistance + 1);

--- a/libs/s25main/WindowManager.h
+++ b/libs/s25main/WindowManager.h
@@ -4,7 +4,8 @@
 
 #pragma once
 
-#include "Point.h"
+#include "Rect.h"
+#include "SnapOffset.h"
 #include "driver/VideoDriverLoaderInterface.h"
 #include "s25util/Singleton.h"
 #include <list>
@@ -121,6 +122,8 @@ public:
 
     void SetCursor(Cursor cursor = Cursor::Hand);
     Cursor GetCursor() const { return cursor_; }
+
+    SnapOffset snapWindow(Window* wnd, const Rect& wndRect) const;
 
 private:
     class Tooltip;

--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -192,14 +192,8 @@ void IngameWindow::SetPinned(bool pinned)
 
 void IngameWindow::MouseLeftDown(const MouseCoords& mc)
 {
-    // Maus muss sich auf der Titelleiste befinden
-    Rect title_rect(LOADER.GetImageN("resource", 36)->getWidth(), 0,
-                    static_cast<unsigned short>(GetSize().x - LOADER.GetImageN("resource", 36)->getWidth()
-                                                - LOADER.GetImageN("resource", 37)->getWidth()),
-                    LOADER.GetImageN("resource", 43)->getHeight());
-    title_rect.move(GetDrawPos());
-
-    if(IsPointInRect(mc.GetPos(), title_rect))
+    // Check if the mouse is on the title bar
+    if(IsPointInRect(mc.GetPos(), GetButtonBounds(IwButton::Title)))
     {
         // start moving
         isMoving = true;

--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -454,7 +454,7 @@ void IngameWindow::MoveNextToMouse()
 
 bool IngameWindow::IsMessageRelayAllowed() const
 {
-    return !isMinimized_;
+    return !isMinimized_ && !isMoving;
 }
 
 void IngameWindow::SaveOpenStatus(bool isOpen) const

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "DrawPoint.h"
+#include "SnapOffset.h"
 #include "Window.h"
 #include "helpers/EnumArray.h"
 #include "gameData/const_gui_ids.h"
@@ -133,6 +134,7 @@ private:
     bool isPinned_;
     bool isMinimized_;
     bool isMoving;
+    SnapOffset snapOffset_;
     CloseBehavior closeBehavior_;
     helpers::EnumArray<ButtonState, IwButton> buttonStates_;
     PersistentWindowSettings* windowSettings_;

--- a/tests/s25Main/UI/testWindowManager.cpp
+++ b/tests/s25Main/UI/testWindowManager.cpp
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "DrawPoint.h"
 #include "PointOutput.h"
+#include "Settings.h"
 #include "WindowManager.h"
 #include "desktops/Desktop.h"
 #include "helpers/containerUtils.h"
@@ -533,6 +535,23 @@ BOOST_FIXTURE_TEST_CASE(PinnedWindows, uiHelper::Fixture)
     }
 
     mock::verify();
+}
+
+BOOST_FIXTURE_TEST_CASE(SnapWindow, uiHelper::Fixture)
+{
+    SETTINGS.interface.windowSnapDistance = 10;
+
+    WINDOWMANAGER.Show(std::make_unique<IngameWindow>(0, DrawPoint(0, 0), Extent(100, 100), "", nullptr));
+    auto* wnd =
+      &WINDOWMANAGER.Show(std::make_unique<IngameWindow>(0, DrawPoint(100, 0), Extent(100, 100), "", nullptr));
+
+    BOOST_TEST(WINDOWMANAGER.snapWindow(wnd, wnd->GetBoundaryRect()) == SnapOffset(0, 0));
+
+    wnd->SetPos(DrawPoint(111, 5));
+    BOOST_TEST(WINDOWMANAGER.snapWindow(wnd, wnd->GetBoundaryRect()) == SnapOffset(0, 0));
+
+    wnd->SetPos(DrawPoint(110, 5));
+    BOOST_TEST(WINDOWMANAGER.snapWindow(wnd, wnd->GetBoundaryRect()) == SnapOffset(-10, -5));
 }
 
 MOCK_BASE_CLASS(MockSettingsWnd, TransmitSettingsIgwAdapter)


### PR DESCRIPTION
Make windows align along edges within a certain snap distance.

Fixes #574

To-do:
- [x] Add setting.
- [x] Choose a sensible default distance. (8 seems reasonable. That's about what KWin uses.)
- [x] Add unit tests.
- [x] Rename to `snapWindow()` during final rebase.