### PR TITLE
Add player info (Number for human player, COMP for ai and change to defeated if player is defeated)

### DIFF
--- a/libs/s25main/ingameWindows/iwStatistics.h
+++ b/libs/s25main/ingameWindows/iwStatistics.h
@@ -31,6 +31,7 @@ private:
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Draw_() override;
     void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
+    void DrawPlayerBoxes();
     void DrawStatistic(StatisticType type);
     void DrawAxis();
 };


### PR DESCRIPTION
Add info to statistic window to see if player is defeated. Add info for computer player or human player.  Like in the original settler 2. So it is obvious to see which players are already defeated.
![noPlayerDefeated](https://github.com/Return-To-The-Roots/s25client/assets/33401986/ebd8e03b-3412-4d47-a1c7-fd6babcfa5b0)
![onePlayerDefeated](https://github.com/Return-To-The-Roots/s25client/assets/33401986/44fdc1db-50ae-41d7-9a1b-c2e340f77e5b)
![allPlayerDefeated](https://github.com/Return-To-The-Roots/s25client/assets/33401986/67ec4760-d307-4d86-b0aa-f5549a5f7ac3)
