### PR TITLE
Add new function to enable/disable preview of map to lua

### DIFF
--- a/doc/lua/events.md
+++ b/doc/lua/events.md
@@ -56,6 +56,9 @@ end
 Only meaningfull if `addonsAll=false` and `addonsSome=true`:
 Return a list with addonIds that the host can change.
 
+**isMapPreviewEnabled()**  
+Is map preview enabled. Default is true
+
 ## Game
 
 **onStart(isFirstStart)**  

--- a/libs/s25main/desktops/dskGameLobby.cpp
+++ b/libs/s25main/desktops/dskGameLobby.cpp
@@ -231,7 +231,8 @@ dskGameLobby::dskGameLobby(ServerType serverType, std::shared_ptr<GameLobby> gam
     combo->AddString(_("Very fast")); // Sehr Schnell
 
     // Karte laden, um Kartenvorschau anzuzeigen
-    if(!gameLobby_->isSavegame())
+    bool isMapPreviewEnabled = !lua || lua->IsMapPreviewEnabled();
+    if(!gameLobby_->isSavegame() && isMapPreviewEnabled)
     {
         // Map laden
         libsiedler2::Archiv mapArchiv;

--- a/libs/s25main/desktops/dskGameLobby.cpp
+++ b/libs/s25main/desktops/dskGameLobby.cpp
@@ -231,27 +231,36 @@ dskGameLobby::dskGameLobby(ServerType serverType, std::shared_ptr<GameLobby> gam
     combo->AddString(_("Very fast")); // Sehr Schnell
 
     // Karte laden, um Kartenvorschau anzuzeigen
-    bool isMapPreviewEnabled = !lua || lua->IsMapPreviewEnabled();
-    if(!gameLobby_->isSavegame() && isMapPreviewEnabled)
+    if(!gameLobby_->isSavegame())
     {
-        // Map laden
-        libsiedler2::Archiv mapArchiv;
-        // Karteninformationen laden
-        if(int ec = libsiedler2::loader::LoadMAP(GAMECLIENT.GetMapPath(), mapArchiv))
+        bool isMapPreviewEnabled = !lua || lua->IsMapPreviewEnabled();
+        if(!isMapPreviewEnabled)
         {
-            WINDOWMANAGER.ShowAfterSwitch(
-              std::make_unique<iwMsgbox>(_("Error"), _("Could not load map:\n") + libsiedler2::getErrorString(ec), this,
-                                         MsgboxButton::Ok, MsgboxIcon::ExclamationRed, 0));
+            AddTextDeepening(70, DrawPoint(560, 40), Extent(220, 220), TextureColor::Grey, _("No preview"), LargeFont,
+                             COLOR_YELLOW);
+            AddText(71, DrawPoint(670, 40 + 220 + 10), _("Map: ") + GAMECLIENT.GetMapTitle(), COLOR_YELLOW,
+                    FontStyle::CENTER, NormalFont);
         } else
         {
-            auto* map = static_cast<libsiedler2::ArchivItem_Map*>(mapArchiv.get(0));
-            ctrlPreviewMinimap* preview = AddPreviewMinimap(70, DrawPoint(560, 40), Extent(220, 220), map);
+            // Map laden
+            libsiedler2::Archiv mapArchiv;
+            // Karteninformationen laden
+            if(int ec = libsiedler2::loader::LoadMAP(GAMECLIENT.GetMapPath(), mapArchiv))
+            {
+                WINDOWMANAGER.ShowAfterSwitch(
+                  std::make_unique<iwMsgbox>(_("Error"), _("Could not load map:\n") + libsiedler2::getErrorString(ec),
+                                             this, MsgboxButton::Ok, MsgboxIcon::ExclamationRed, 0));
+            } else
+            {
+                auto* map = static_cast<libsiedler2::ArchivItem_Map*>(mapArchiv.get(0));
+                ctrlPreviewMinimap* preview = AddPreviewMinimap(70, DrawPoint(560, 40), Extent(220, 220), map);
 
-            // Titel der Karte, Y-Position relativ je nach Höhe der Minimap festlegen, daher nochmals danach
-            // verschieben, da diese Position sonst skaliert wird!
-            ctrlText* text = AddText(71, DrawPoint(670, 0), _("Map: ") + GAMECLIENT.GetMapTitle(), COLOR_YELLOW,
-                                     FontStyle::CENTER, NormalFont);
-            text->SetPos(DrawPoint(text->GetPos().x, preview->GetPos().y + preview->GetMapArea().bottom + 10));
+                // Titel der Karte, Y-Position relativ je nach Höhe der Minimap festlegen, daher nochmals danach
+                // verschieben, da diese Position sonst skaliert wird!
+                ctrlText* text = AddText(71, DrawPoint(670, 0), _("Map: ") + GAMECLIENT.GetMapTitle(), COLOR_YELLOW,
+                                         FontStyle::CENTER, NormalFont);
+                text->SetPos(DrawPoint(text->GetPos().x, preview->GetPos().y + preview->GetMapArea().bottom + 10));
+            }
         }
     }
 

--- a/libs/s25main/lua/LuaInterfaceGameBase.cpp
+++ b/libs/s25main/lua/LuaInterfaceGameBase.cpp
@@ -16,7 +16,7 @@ unsigned LuaInterfaceGameBase::GetVersion()
 
 unsigned LuaInterfaceGameBase::GetFeatureLevel()
 {
-    return 3;
+    return 4;
 }
 
 LuaInterfaceGameBase::LuaInterfaceGameBase(const ILocalGameState& localGameState) : localGameState(localGameState)

--- a/libs/s25main/lua/LuaInterfaceSettings.cpp
+++ b/libs/s25main/lua/LuaInterfaceSettings.cpp
@@ -237,3 +237,13 @@ std::vector<AddonId> LuaInterfaceSettings::GetAllowedAddons()
     }
     return std::vector<AddonId>();
 }
+
+bool LuaInterfaceSettings::IsMapPreviewEnabled()
+{
+    kaguya::LuaRef func = lua["isMapPreviewEnabled"];
+    if(func.type() == LUA_TFUNCTION)
+    {
+        return func.call<bool>();
+    }
+    return true;
+}

--- a/libs/s25main/lua/LuaInterfaceSettings.h
+++ b/libs/s25main/lua/LuaInterfaceSettings.h
@@ -35,6 +35,7 @@ public:
     bool IsChangeAllowed(const std::string& name, bool defaultVal = false);
     /// Get addons that are allowed to be changed
     std::vector<AddonId> GetAllowedAddons();
+    bool IsMapPreviewEnabled();
 
 private:
     IGameLobbyController& lobbyServerController_;

--- a/tests/s25Main/lua/testLuaSettings.cpp
+++ b/tests/s25Main/lua/testLuaSettings.cpp
@@ -149,6 +149,13 @@ BOOST_AUTO_TEST_CASE(Events)
     BOOST_TEST_REQUIRE(allowedAddons[0] == AddonId::LIMIT_CATAPULTS);
     BOOST_TEST_REQUIRE(allowedAddons[1] == AddonId::CHARBURNER);
     BOOST_TEST_REQUIRE(allowedAddons[2] == AddonId::TRADE);
+
+    BOOST_TEST(lua.IsMapPreviewEnabled()); // Not defined in lua -> Default to enabled
+    executeLua("function isMapPreviewEnabled()\n  return false\nend");
+    BOOST_TEST(!lua.IsMapPreviewEnabled());
+    executeLua("function isMapPreviewEnabled()\n  return true\nend");
+    BOOST_TEST(lua.IsMapPreviewEnabled());
+
     // Return invalid type -> ignored, but log output
     clearLog();
     executeLua("function getAllowedAddons()\n  return {'ADDON_FAIL_ME'}\nend");

--- a/tests/testData/maps/LuaFunctions.lua
+++ b/tests/testData/maps/LuaFunctions.lua
@@ -20,6 +20,10 @@ function getAllowedChanges()
 	return {general=true, addonsAll=false, addonsSome=true, swapping=false, playerState = not isSinglePlayer, ownNation = true, ownColor=true, ownTeam=false, aiNation = false, aiColor=false, aiTeam=false}
 end
 
+function isMapPreviewEnabled()
+	return false
+end
+
 function onSettingsInit(isSinglePlayerArg, isSavegameArg)
 	isSinglePlayer = isSinglePlayerArg
 	isSavegame = isSavegameArg


### PR DESCRIPTION
We need lua functionality to have possibility to disable the map preview for missions. So the user can not see the map in advance.

![previewdisabled](https://github.com/Return-To-The-Roots/s25client/assets/33401986/8a6b3880-9fc0-4a48-9d2b-f786e52027f6)
![previewenabled](https://github.com/Return-To-The-Roots/s25client/assets/33401986/2a8ae268-ee83-407a-a9bb-c3609879fef4)
