### PR TITLE
CI: Fix finding Boost on OSX

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+# Copyright (C) 2005 - 2023 Settlers Freaks <sf-team at siedler25.org>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -6,6 +6,14 @@ name: Unit tests
 
 on:
   push:
+    branches:
+      - master
+      - main
+      - develop
+      - bugfix/**
+      - feature/**
+      - fix/**
+      - pr/**
   pull_request:
 
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,8 +27,8 @@ jobs:
           #  Use system clang (14)
           #   Use (compiler) default C++ 14 standard
           #   Use system cmake (version gets ignored below)
-          #   Use boost installed on this GHA image
-          - { compiler: clang,    os: macos-12,     type: Debug, boost: 1.82.0 }
+          #   Use boost installed via brew
+          - { compiler: clang,    os: macos-12,     type: Debug }
 
           # Linux:
           #  Oldest Compilers 
@@ -149,8 +149,11 @@ jobs:
         run: |
           brew install cmake boost sdl2 sdl2_mixer gettext miniupnpc libiconv
           echo /usr/local/opt/gettext/bin >> $GITHUB_PATH
-          ls -la /usr/local/Cellar/boost/
-          BOOST_ROOT=$(find /usr/local/Cellar/boost/${BOOST_VERSION}_* -maxdepth 0)
+          echo "Available Boost installs: $(ls /usr/local/Cellar/boost/)"
+          # Use the latest (last folder)
+          BOOST_ROOT=$(find /usr/local/Cellar/boost/* -maxdepth 0 -type d | tail -n1)
+          [[ -n "$BOOST_ROOT" ]]
+          echo "Choosen Boost: $BOOST_ROOT"
           echo "BOOST_ROOT=${BOOST_ROOT}" >> $GITHUB_ENV
 
       - name: Setup CCache


### PR DESCRIPTION
The brew installed boost changed to a new version. Update the code to just always use the latest in that folder instead of a specific one.