### PR TITLE
Fix recalculating BQ around big static objects

### DIFF
--- a/libs/s25main/lua/LuaWorld.cpp
+++ b/libs/s25main/lua/LuaWorld.cpp
@@ -84,7 +84,10 @@ bool LuaWorld::AddStaticObject(int x, int y, unsigned id, unsigned file /* = 0xF
 
     gw.DestroyNO(pt, false);
     gw.SetNO(pt, new noStaticObject(pt, id, file, size));
-    gw.RecalcBQAroundPoint(pt);
+    if(size > 1)
+        gw.RecalcBQAroundPointBig(pt);
+    else if(size == 1)
+        gw.RecalcBQAroundPoint(pt);
     return true;
 }
 


### PR DESCRIPTION
The recalculation around big static objects did not work properly.

Before this patch:
![Screenshot from 2024-02-27 18-51-15](https://github.com/Return-To-The-Roots/s25client/assets/47030768/78802123-2701-4de9-824a-b0faf2c7c44f)
![Screenshot from 2024-02-27 18-51-20](https://github.com/Return-To-The-Roots/s25client/assets/47030768/cedf6fe3-bdce-4e49-8477-d4d2f90d815a)
![Screenshot from 2024-02-27 18-51-25](https://github.com/Return-To-The-Roots/s25client/assets/47030768/4765fbcb-1bd6-4518-b8c0-9c7cb5148493)

After this patch:
![Screenshot from 2024-02-29 11-50-50](https://github.com/Return-To-The-Roots/s25client/assets/47030768/cf8aa682-28f5-4fe6-b412-9901e738a9cd)

Maybe cause of #1516 and #1520