### PR TITLE
Fix high DPI issue on macOS

### DIFF
--- a/libs/driver/src/VideoDriver.cpp
+++ b/libs/driver/src/VideoDriver.cpp
@@ -27,7 +27,7 @@ VideoDriver::VideoDriver(VideoDriverLoaderInterface* CallBack)
 
 Position VideoDriver::GetMousePos() const
 {
-    return mouse_xy.pos;
+    return mouse_xy.pos * (int)dpiScale_;
 }
 
 /**

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -305,19 +305,19 @@ void VideoDriverWrapper::RenewViewport()
     if(!videodriver->IsOpenGL() || !renderer_)
         return;
 
-    const Extent renderSize = videodriver->GetRenderSize();
+    const Extent renderSize = getGuiScale().viewToScreen<Extent>(videodriver->GetRenderSize());
     const VideoMode windowSize = videodriver->GetWindowSize();
 
     // Set the viewport and scissor area to the entire window
-    glViewport(0, 0, windowSize.width, windowSize.height);
-    glScissor(0, 0, windowSize.width, windowSize.height);
+    glViewport(0, 0, renderSize.x, renderSize.y);
+    glScissor(0, 0, renderSize.x, renderSize.y);
 
     // Orthogonale Matrix erstellen
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
 
     // 0,0 should be top left corner
-    glOrtho(0, renderSize.x, renderSize.y, 0, -100, 100);
+    glOrtho(0, windowSize.width, windowSize.height, 0, -100, 100);
 
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();


### PR DESCRIPTION
The bug is described in #1621, and is about the game using only the bottom-left corner of the window to draw, and the mouse cursor bounding box not being correct (so you can't access Settings > Graphics, as it gets clamped by the bottom of the screen).

The first commit fixes the rendering to be full-screen again, but the mouse cursor is still "locked" into the top-left corner (but the buttons work).
The second make the mouse cursor move properly by scaling its position with the DPI, but that makes the buttons active area all wrong, and I can't see where the hit-testing is actually happening.