### PR TITLE
Overlay tabs in AI Debug Window are not displaying relevant information

### DIFF
--- a/libs/s25main/ingameWindows/iwAIDebug.cpp
+++ b/libs/s25main/ingameWindows/iwAIDebug.cpp
@@ -102,15 +102,15 @@ iwAIDebug::iwAIDebug(GameWorldView& gwv, const std::vector<const AIPlayer*>& ais
     overlays->AddString("BuildingQuality");
     overlays->AddString("Reachability");
     overlays->AddString("Farmed");
-    overlays->AddString("Wood");
-    overlays->AddString("Stones");
     overlays->AddString("Gold");
     overlays->AddString("Ironore");
     overlays->AddString("Coal");
     overlays->AddString("Granite");
+    overlays->AddString("Fish");
+    overlays->AddString("Wood");
+    overlays->AddString("Stones");
     overlays->AddString("Plantspace");
     overlays->AddString("Borderland");
-    overlays->AddString("Fish");
 
     // Show 7 lines of text and 1 empty line
     text = AddMultiline(ID_Text, DrawPoint(15, 120), Extent(250, 8 * NormalFont->getHeight()), TextureColor::Grey,


### PR DESCRIPTION
Hello!

According to the code in the OnDraw method
`else if(overlay < 13)
            font.Draw(curPos, helpers::toString(ai->GetResMapValue(pt, AIResource(overlay - 4))), FontStyle{},
                      COLOR_YELLOW);`
order of overlay tabs should be the same as AIResource enum order. In actual code branch, for example, "Wood" tab shows info about gold mine deposits.