### PR TITLE
fix AI interaction with granite mines with enabled Inexhaustible gran…

### DIFF
--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -977,7 +977,7 @@ MapPoint AIPlayerJH::FindPositionForBuildingAround(BuildingType type, const MapP
             foundPos = FindBestPosition(around, AIResource::Ironore, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::GraniteMine:
-			foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, searchRadius);
+          foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::Fishery:
             foundPos = FindBestPosition(around, AIResource::Fish, BUILDING_SIZE[type], searchRadius);

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -977,7 +977,7 @@ MapPoint AIPlayerJH::FindPositionForBuildingAround(BuildingType type, const MapP
             foundPos = FindBestPosition(around, AIResource::Ironore, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::GraniteMine:
-          foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, searchRadius);
+            foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::Fishery:
             foundPos = FindBestPosition(around, AIResource::Fish, BUILDING_SIZE[type], searchRadius);

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -977,13 +977,8 @@ MapPoint AIPlayerJH::FindPositionForBuildingAround(BuildingType type, const MapP
             foundPos = FindBestPosition(around, AIResource::Ironore, BuildingQuality::Mine, searchRadius);
             break;
         case BuildingType::GraniteMine:
-            if(!ggs.isEnabled(
-                 AddonId::INEXHAUSTIBLE_GRANITEMINES)) // inexhaustible granite mines do not require granite
-                foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, searchRadius);
-            else
-                foundPos = SimpleFindPosition(around, BuildingQuality::Mine, searchRadius);
+			foundPos = FindBestPosition(around, AIResource::Granite, BuildingQuality::Mine, searchRadius);
             break;
-
         case BuildingType::Fishery:
             foundPos = FindBestPosition(around, AIResource::Fish, BUILDING_SIZE[type], searchRadius);
             if(foundPos.isValid() && !ValidFishInRange(foundPos))


### PR DESCRIPTION
Hello!

Currently if addon "Inexhaustible granite mines" is enabled, AI place granite mine on any available mine place. (Because method "SimpleFindPosition" is used instead of "FindBestPosition") Then after building of mine is complete, AI reailizes that there is no resource available and demolishes granite mine.

The code comment says that "inexhaustible granite mines do not require granite" but i can't find any code line that proves that.
If that was originally intended to allow building granite mine on any mine place if addon is enabled, we need to add some code in resource map generator, probably. But I decided that this was not intended and just removed condition.