### PR TITLE
Add map selection control for campaigns including test

### DIFF
--- a/libs/libGamedata/gameData/SelectionMapInputData.h
+++ b/libs/libGamedata/gameData/SelectionMapInputData.h
@@ -1,0 +1,50 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+#include <boost/filesystem.hpp>
+#include <string>
+#include <vector>
+
+struct ImageResource
+{
+    boost::filesystem::path filePath;
+    unsigned index;
+    ImageResource(boost::filesystem::path path = boost::filesystem::path(), unsigned index = 0)
+        : filePath(std::move(path)), index(index){};
+};
+
+struct MissionSelectionInfo
+{
+    ///  The maskAreaColor is the color for the mission used in the missionMapMask
+    unsigned maskAreaColor = 0;
+    /// The position on which the conquered image and the marker image, if mission is selected,
+    /// are displayed. The offset is always counted from the origin of the map image.
+    Position ankerPos;
+};
+
+struct SelectionMapInputData
+{
+    SelectionMapInputData() = default;
+
+    /// Background image for the selection map
+    ImageResource background;
+    /// The map image itself.
+    ImageResource map;
+    /// This image is a mask that describes the mission areas of the map (image). It must be the same size
+    /// as the map image where the color of each pixel determines the mission it belongs to.
+    /// Each mission must have a unique color (specified in the missionSelectionInfos).
+    /// Any other color is treated as neutral area and ignored.
+    ImageResource missionMapMask;
+    /// The marker image shown when a mission is selected.
+    ImageResource marker;
+    /// The image shown when a mission is already finished.
+    ImageResource conquered;
+    /// Offset of the map image and missionMapMask image relative to the background image.
+    Position mapOffsetInBackground = {0, 0};
+    /// Color for drawing missions not playable yet. Usually this should be a partly transparent color
+    unsigned disabledColor = 0x70000000;
+    /// Contains an entry for each mission
+    std::vector<MissionSelectionInfo> missionSelectionInfos;
+};

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -394,6 +394,12 @@ ctrlText* Window::AddText(unsigned id, const DrawPoint& pos, const std::string& 
     return AddCtrl(new ctrlText(this, id, ScaleIf(pos), text, color, format, font));
 }
 
+ctrlMapSelection* Window::AddMapSelection(unsigned id, const DrawPoint& pos, const Extent& size,
+                                          const SelectionMapInputData& inputData)
+{
+    return AddCtrl(new ctrlMapSelection(this, id, ScaleIf(pos), ScaleIf(size), inputData));
+}
+
 TextFormatSetter Window::AddFormattedText(unsigned id, const DrawPoint& pos, const std::string& text, unsigned color,
                                           FontStyle format, const glFont* font)
 {

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -30,6 +30,7 @@ class ctrlEdit;
 class ctrlGroup;
 class ctrlImage;
 class ctrlList;
+class ctrlMapSelection;
 class ctrlMultiline;
 class ctrlMultiSelectGroup;
 class ctrlOptionGroup;
@@ -51,6 +52,7 @@ enum class GroupSelectType : unsigned;
 struct KeyEvent;
 struct ScreenResizeEvent;
 struct TableColumn;
+struct SelectionMapInputData;
 
 namespace libsiedler2 {
 class ArchivItem_Map;
@@ -176,6 +178,8 @@ public:
                         std::vector<TableColumn> columns);
     ctrlText* AddText(unsigned id, const DrawPoint& pos, const std::string& text, unsigned color, FontStyle format,
                       const glFont* font);
+    ctrlMapSelection* AddMapSelection(unsigned id, const DrawPoint& pos, const Extent& size,
+                                      const SelectionMapInputData& inputData);
     TextFormatSetter AddFormattedText(unsigned id, const DrawPoint& pos, const std::string& text, unsigned color,
                                       FontStyle format, const glFont* font);
     ctrlTimer* AddTimer(unsigned id, std::chrono::milliseconds timeout);

--- a/libs/s25main/controls/controls.h
+++ b/libs/s25main/controls/controls.h
@@ -16,6 +16,7 @@
 #include "ctrlImage.h"
 #include "ctrlImageButton.h"
 #include "ctrlList.h"
+#include "ctrlMapSelection.h"
 #include "ctrlMultiSelectGroup.h"
 #include "ctrlMultiline.h"
 #include "ctrlOptionGroup.h"

--- a/libs/s25main/controls/ctrlMapSelection.cpp
+++ b/libs/s25main/controls/ctrlMapSelection.cpp
@@ -1,0 +1,201 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "ctrlMapSelection.h"
+#include "CollisionDetection.h"
+#include "Loader.h"
+#include "RttrConfig.h"
+#include "driver/MouseCoords.h"
+#include "helpers/Range.h"
+#include "ogl/glArchivItem_Bitmap.h"
+#include <libsiedler2/ArchivItem_Bitmap.h>
+#include <libsiedler2/ColorBGRA.h>
+#include <libsiedler2/IAllocator.h>
+#include <libsiedler2/libsiedler2.h>
+#include <helpers/format.hpp>
+
+ctrlMapSelection::ctrlMapSelection(Window* parent, unsigned id, const DrawPoint& pos, const Extent& size,
+                                   const SelectionMapInputData& inputData)
+    : Window(parent, id, pos, size), inputData(inputData), missionStatus(inputData.missionSelectionInfos.size()),
+      preview(false)
+{
+    if(!LOADER.LoadFiles({inputData.background.filePath.string(), inputData.map.filePath.string(),
+                          inputData.missionMapMask.filePath.string(), inputData.marker.filePath.string(),
+                          inputData.conquered.filePath.string()}))
+        throw std::runtime_error("Loading of images for map failed.");
+
+    auto getImage = [](const ImageResource& res) {
+        return LOADER.GetImageN(ResourceId::make(res.filePath), res.index);
+    };
+
+    mapImages.background = getImage(inputData.background);
+    mapImages.map = getImage(inputData.map);
+    mapImages.missionMapMask = getImage(inputData.missionMapMask);
+    mapImages.marker = getImage(inputData.marker);
+    mapImages.conquered = getImage(inputData.conquered);
+    mapImages.enabledMask = createEnabledMask(mapImages.missionMapMask->GetSize());
+
+    if(!mapImages.isValid())
+        throw std::runtime_error("Setup of images for map failed");
+
+    updateEnabledMask();
+}
+
+ctrlMapSelection::~ctrlMapSelection() = default;
+
+void ctrlMapSelection::updateEnabledMask()
+{
+    for(const auto x : helpers::range(mapImages.enabledMask->getWidth()))
+    {
+        for(const auto y : helpers::range(mapImages.enabledMask->getHeight()))
+        {
+            const auto pixelColor = mapImages.missionMapMask->getPixel(x, y);
+            const auto matchingMission =
+              std::find_if(inputData.missionSelectionInfos.begin(), inputData.missionSelectionInfos.end(),
+                           [&pixelColor](const auto& val) { return val.maskAreaColor == pixelColor.asValue(); });
+
+            auto const index = std::distance(inputData.missionSelectionInfos.begin(), matchingMission);
+            if(matchingMission == inputData.missionSelectionInfos.end() || missionStatus[index].playable)
+            {
+                mapImages.enabledMask->setPixel(x, y, libsiedler2::ColorBGRA());
+            } else
+                mapImages.enabledMask->setPixel(x, y, libsiedler2::ColorBGRA(inputData.disabledColor));
+        }
+    }
+}
+
+void ctrlMapSelection::setMissionsStatus(const std::vector<MissionStatus>& status)
+{
+    if(inputData.missionSelectionInfos.size() != status.size())
+        throw std::runtime_error(
+          helpers::format("List has wrong size. %1% != %2%", inputData.missionSelectionInfos.size(), status.size()));
+
+    missionStatus = status;
+    updateEnabledMask();
+}
+
+void ctrlMapSelection::setSelection(size_t select)
+{
+    if(select < inputData.missionSelectionInfos.size())
+    {
+        if(missionStatus[select].playable)
+            currentSelectionPos = inputData.missionSelectionInfos[select].ankerPos;
+    } else
+        currentSelectionPos = Position::Invalid();
+}
+
+int ctrlMapSelection::getCurrentSelection() const
+{
+    const auto match = std::find_if(inputData.missionSelectionInfos.begin(), inputData.missionSelectionInfos.end(),
+                                    [&](const auto& val) { return val.ankerPos == currentSelectionPos; });
+    return match != inputData.missionSelectionInfos.end() ?
+             static_cast<int>(std::distance(inputData.missionSelectionInfos.begin(), match)) :
+             -1;
+}
+
+void ctrlMapSelection::setPreview(bool previewOnly)
+{
+    preview = previewOnly;
+}
+
+bool ctrlMapSelection::Msg_LeftUp(const MouseCoords& mc)
+{
+    if(!preview && IsMouseOver(mc.GetPos()))
+    {
+        const auto pickPos = invertScale(mc.GetPos() - getMapPosition());
+
+        const auto pixelColor =
+          mapImages.missionMapMask->getPixel(std::max(0, std::min(pickPos.x, (int)(mapImages.map->GetSize().x - 1))),
+                                             std::max(0, std::min(pickPos.y, (int)(mapImages.map->GetSize().y - 1))));
+
+        const auto matchingMission =
+          std::find_if(inputData.missionSelectionInfos.begin(), inputData.missionSelectionInfos.end(),
+                       [&pixelColor](const auto& val) { return val.maskAreaColor == pixelColor.asValue(); });
+
+        if(matchingMission != inputData.missionSelectionInfos.end())
+        {
+            setSelection(std::distance(inputData.missionSelectionInfos.begin(), matchingMission));
+            GetParent()->Msg_ButtonClick(GetID());
+        }
+        return true;
+    }
+    return false;
+}
+
+glArchivItem_Bitmap* ctrlMapSelection::createEnabledMask(const Extent& extent)
+{
+    auto enabledMask =
+      libsiedler2::getAllocator().create<libsiedler2::baseArchivItem_Bitmap>(libsiedler2::BobType::Bitmap);
+    enabledMask->init(extent.x, extent.y, libsiedler2::TextureFormat::BGRA);
+    auto* res = dynamic_cast<glArchivItem_Bitmap*>(enabledMask.get());
+    RTTR_Assert(!enabledMask.get() || res);
+    mapImages.enabledMaskMemory = std::move(enabledMask);
+    return res;
+}
+
+bool ctrlMapSelection::IsMouseOver(const Position& mousePos) const
+{
+    return IsPointInRect(mousePos, GetDrawRect());
+}
+
+float ctrlMapSelection::getScaleFactor()
+{
+    const auto ratio = PointF(GetSize()) / mapImages.background->GetSize();
+    return ratio.x < ratio.y ? ratio.x : ratio.y;
+}
+
+DrawPoint ctrlMapSelection::invertScale(const DrawPoint& scaleIt)
+{
+    return DrawPoint(scaleIt / getScaleFactor());
+}
+
+DrawPoint ctrlMapSelection::getBackgroundPosition()
+{
+    return GetDrawPos() + (GetSize() - scale(mapImages.background->GetSize())) / 2;
+}
+
+DrawPoint ctrlMapSelection::getMapOffsetRelativeToBackground()
+{
+    return scale(inputData.mapOffsetInBackground);
+}
+
+DrawPoint ctrlMapSelection::getMapPosition()
+{
+    return getBackgroundPosition() + getMapOffsetRelativeToBackground();
+}
+
+DrawPoint ctrlMapSelection::getScaledImageOriginOffset(glArchivItem_Bitmap* bitmap)
+{
+    return bitmap->GetOrigin() - scale(bitmap->GetOrigin());
+}
+
+void ctrlMapSelection::drawImageOnMap(glArchivItem_Bitmap* image, const Position& drawPos)
+{
+    image->DrawFull(
+      Rect(getMapPosition() + scale(drawPos) + getScaledImageOriginOffset(image), scale(image->GetSize())));
+}
+
+void ctrlMapSelection::Draw_()
+{
+    Window::Draw_();
+
+    mapImages.background->DrawFull(Rect(getBackgroundPosition(), scale(mapImages.background->GetSize())));
+
+    const Rect mapRect = Rect(getMapPosition(), scale(mapImages.map->GetSize()));
+    mapImages.map->DrawFull(mapRect);
+    mapImages.enabledMask->DrawFull(mapRect);
+
+    for(const auto idx : helpers::range(missionStatus.size()))
+    {
+        if(!missionStatus[idx].occupied)
+            continue;
+
+        drawImageOnMap(mapImages.conquered, inputData.missionSelectionInfos[idx].ankerPos);
+    }
+
+    if(!preview && currentSelectionPos.isValid())
+    {
+        drawImageOnMap(mapImages.marker, currentSelectionPos);
+    }
+}

--- a/libs/s25main/controls/ctrlMapSelection.h
+++ b/libs/s25main/controls/ctrlMapSelection.h
@@ -1,0 +1,73 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "DrawPoint.h"
+#include "Window.h"
+#include "ogl/glArchivItem_Bitmap.h"
+#include <gameData/SelectionMapInputData.h>
+
+class glArchivItem_Bitmap;
+
+struct MissionStatus
+{
+    bool playable = false;
+    bool occupied = false;
+};
+
+class ctrlMapSelection : public Window
+{
+public:
+    ctrlMapSelection(Window* parent, unsigned id, const DrawPoint& pos, const Extent& size,
+                     const SelectionMapInputData& inputData);
+    ~ctrlMapSelection() override;
+
+    void setMissionsStatus(const std::vector<MissionStatus>& status);
+    void setSelection(size_t select);
+    int getCurrentSelection() const;
+    void setPreview(bool previewOnly);
+
+    bool Msg_LeftUp(const MouseCoords& mc) override;
+
+protected:
+    bool IsMouseOver(const Position& mousePos) const;
+    void Draw_() override;
+
+    glArchivItem_Bitmap* createEnabledMask(const Extent& extent);
+    void updateEnabledMask();
+
+    float getScaleFactor();
+    template<class Type>
+    Type scale(const Type& scaleIt)
+    {
+        return Type(scaleIt * getScaleFactor());
+    }
+    DrawPoint invertScale(const DrawPoint& scaleIt);
+
+    DrawPoint getBackgroundPosition();
+    DrawPoint getMapOffsetRelativeToBackground();
+    DrawPoint getMapPosition();
+    DrawPoint getScaledImageOriginOffset(glArchivItem_Bitmap* bitmap);
+
+    void drawImageOnMap(glArchivItem_Bitmap* image, const Position& drawPos);
+
+    struct MapImages
+    {
+        glArchivItem_Bitmap* background;
+        glArchivItem_Bitmap* map;
+        glArchivItem_Bitmap* missionMapMask;
+        glArchivItem_Bitmap* marker;
+        glArchivItem_Bitmap* conquered;
+        glArchivItem_Bitmap* enabledMask;
+        std::unique_ptr<libsiedler2::baseArchivItem_Bitmap> enabledMaskMemory;
+        bool isValid() const { return map && background && missionMapMask && conquered && marker && enabledMask; };
+    };
+
+    MapImages mapImages;
+    SelectionMapInputData inputData;
+    std::vector<MissionStatus> missionStatus;
+    Position currentSelectionPos;
+    bool preview;
+};

--- a/tests/s25Main/UI/testMapSelection.cpp
+++ b/tests/s25Main/UI/testMapSelection.cpp
@@ -1,0 +1,259 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Loader.h"
+#include "RttrForeachPt.h"
+#include "controls/ctrlMapSelection.h"
+#include "driver/MouseCoords.h"
+#include "uiHelper/uiHelpers.hpp"
+#include "rttr/test/TmpFolder.hpp"
+#include <libsiedler2/Archiv.h>
+#include <libsiedler2/ArchivItem_Bitmap_Raw.h>
+#include <libsiedler2/PixelBufferBGRA.h>
+#include <libsiedler2/libsiedler2.h>
+#include <rttr/test/random.hpp>
+#include <turtle/mock.hpp>
+
+using namespace rttr::test;
+
+namespace {
+MOCK_BASE_CLASS(TestWindow, Window)
+{public: TestWindow(): Window(nullptr, randomValue<unsigned>(), DrawPoint(0, 0)){}};
+
+std::unique_ptr<libsiedler2::Archiv> createBitmapFromBuffer(libsiedler2::PixelBufferBGRA const& buffer,
+                                                            const libsiedler2::ArchivItem_Palette* palette = nullptr)
+{
+    using namespace libsiedler2;
+    auto bmpRaw = std::make_unique<ArchivItem_Bitmap_Raw>();
+    bmpRaw->create(buffer, palette);
+    auto bmp = std::make_unique<libsiedler2::Archiv>();
+    bmp->push(std::move(bmpRaw));
+    return bmp;
+}
+
+std::unique_ptr<libsiedler2::Archiv> createBitmapWithOneColor(Extent const& size, uint32_t const fillColor,
+                                                              const libsiedler2::ArchivItem_Palette* palette = nullptr)
+{
+    using namespace libsiedler2;
+    return createBitmapFromBuffer(PixelBufferBGRA(size.x, size.y, ColorBGRA(fillColor)), palette);
+}
+
+bool storeBitmap(boost::filesystem::path const& storePath, std::unique_ptr<libsiedler2::Archiv> const& bitmap)
+{
+    return libsiedler2::Write(storePath, *bitmap);
+}
+
+libsiedler2::PixelBufferBGRA createMapTestData(Extent const& size)
+{
+    /* Map Layout:
+        TB
+        BB
+    */
+    using namespace libsiedler2;
+    PixelBufferBGRA buffer(size.x, size.y);
+    RTTR_FOREACH_PT(Position, size)
+    {
+        if(pt.x >= static_cast<int>(size.x) / 2 || pt.y >= static_cast<int>(size.y) / 2)
+            buffer.set(pt.x, pt.y, ColorBGRA(0xff0000ff));
+    }
+    return buffer;
+}
+
+libsiedler2::PixelBufferBGRA createMissionMapMaskTestData(Extent const& size)
+{
+    /* Map Layout:
+        TR
+        GB
+    */
+    using namespace libsiedler2;
+    PixelBufferBGRA buffer(size.x, size.y);
+    RTTR_FOREACH_PT(Position, size)
+    {
+        if(pt.x >= static_cast<int>(size.x) / 2 && pt.y < static_cast<int>(size.y) / 2)
+            buffer.set(pt.x, pt.y, ColorBGRA(0xffff0000));
+        if(pt.x < static_cast<int>(size.x) / 2 && pt.y >= static_cast<int>(size.y) / 2)
+            buffer.set(pt.x, pt.y, ColorBGRA(0xff00ff00));
+        if(pt.x >= static_cast<int>(size.x) / 2 && pt.y >= static_cast<int>(size.y) / 2)
+            buffer.set(pt.x, pt.y, ColorBGRA(0xff0000ff));
+    }
+    return buffer;
+}
+
+SelectionMapInputData createInputForSelectionMap(rttr::test::TmpFolder const& tmp, Extent backgroundSize = {100, 100},
+                                                 Extent mapSize = {100, 100},
+                                                 Position mapOffsetInBackground = Position(0, 0),
+                                                 Extent overlaySize = {5, 5})
+{
+    uint32_t const disabledColor = 0x70000000;
+    uint32_t const red = 0xffff0000;
+    uint32_t const green = 0xff00ff00;
+    uint32_t const blue = 0xff0000ff;
+
+    auto backgroundPath = tmp.get() / "background.bmp";
+    auto mapPath = tmp.get() / "map.bmp";
+    auto missionmapmaskPath = tmp.get() / "missionmapmask.bmp";
+    auto markerPath = tmp.get() / "marker.bmp";
+    auto conqueredPath = tmp.get() / "conquered.bmp";
+
+    storeBitmap(backgroundPath, createBitmapWithOneColor(backgroundSize, red));
+    storeBitmap(mapPath, createBitmapFromBuffer(createMapTestData(mapSize)));
+    storeBitmap(missionmapmaskPath, createBitmapFromBuffer(createMissionMapMaskTestData(mapSize)));
+    storeBitmap(markerPath, createBitmapWithOneColor(overlaySize, green));
+    storeBitmap(conqueredPath, createBitmapWithOneColor(overlaySize, red));
+
+    return SelectionMapInputData{{backgroundPath.string(), 0},
+                                 {mapPath.string(), 0},
+                                 {missionmapmaskPath.string(), 0},
+                                 {markerPath.string(), 0},
+                                 {conqueredPath.string(), 0},
+                                 mapOffsetInBackground,
+                                 disabledColor,
+                                 {{red, {Position((mapSize.x * 3) / 4, mapSize.y / 4)}},
+                                  {green, {Position(mapSize.x / 4, (mapSize.y * 3) / 4)}},
+                                  {blue, {Position((mapSize.x * 3) / 4, (mapSize.y * 3) / 4)}}}};
+}
+
+void testMapSelection(Position const& windowPos, Extent const& windowExtent, Extent const& mapBackgroundSize,
+                      Extent const& mapSize, Position const& mapOffsetInBackground)
+{
+    TestWindow wnd;
+    Position offsetOfBackground = (windowExtent - mapBackgroundSize) / 2;
+
+    const Position firstMissionMidPoint((mapSize.x * 3) / 4, mapSize.y / 4);
+    const Position secondMissionMidPoint(mapSize.x / 4, (mapSize.y * 3) / 4);
+    const Position thirdMissionMidPoint((mapSize.x * 3) / 4, (mapSize.y * 3) / 4);
+    const Position freeQuadrantMidPoint(mapSize.x / 4, mapSize.y / 4);
+
+    rttr::test::TmpFolder tmp;
+    ctrlMapSelection ms(&wnd, 0, windowPos, windowExtent,
+                        createInputForSelectionMap(tmp, mapBackgroundSize, mapSize, mapOffsetInBackground));
+
+    // Activate first mission
+    ms.setMissionsStatus({{true, false}, {false, false}, {false, false}});
+    // Initial the selection is not set
+    BOOST_TEST(ms.getCurrentSelection() == -1);
+    // Click on non mission area => selection will not change
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + freeQuadrantMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == -1);
+    // Click on mission area of first mission => selection will change because mission is playable
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + firstMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    // Click on mission area of second mission => selection will not change because mission is not playable
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + secondMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    // Click on mission area of third mission => selection will not change because mission is not playable
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + thirdMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+
+    // Activate first and second mission
+    ms.setMissionsStatus({{true, false}, {true, false}, {false, false}});
+    // Selection stays the same as before
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    // Click on mission area of second mission => selection will change because mission is playable
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + secondMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 1);
+    // Click on mission area of third mission => selection will not change because mission is not playable
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + thirdMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 1);
+    // Click on non mission area => selection will not change
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + freeQuadrantMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 1);
+    // Click on mission area of first mission => selection will change because mission is playable
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + firstMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+
+    // Test selection
+    // Activate first and second mission
+    ms.setMissionsStatus({{true, false}, {true, false}, {false, false}});
+    // Setting selection to third mission not possible because mission is not playable => stay at previous value
+    ms.setSelection(2);
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    // Setting selection to second mission is possible because mission is playable
+    ms.setSelection(1);
+    BOOST_TEST(ms.getCurrentSelection() == 1);
+    // Setting selection to invalid mission resets selection to not set
+    ms.setSelection(3);
+    BOOST_TEST(ms.getCurrentSelection() == -1);
+    // Setting selection to third mission not possible because mission is not playable => stay at previous value
+    ms.setSelection(2);
+    BOOST_TEST(ms.getCurrentSelection() == -1);
+    // Setting selection to first mission is possible because mission is playable
+    ms.setSelection(0);
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+
+    // Activate all missions
+    ms.setMissionsStatus({{true, false}, {true, false}, {true, false}});
+
+    // Preview mode active selection cannot change
+    ms.setSelection(0);
+    ms.setPreview(true);
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + secondMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + thirdMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + freeQuadrantMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + firstMissionMidPoint));
+    BOOST_TEST(ms.getCurrentSelection() == 0);
+    ms.setPreview(false);
+
+    // Click all four sides and corners and midpoint of each mission to ensure mapping of areas is correct
+    std::vector<Position> midPoints = {firstMissionMidPoint, secondMissionMidPoint, thirdMissionMidPoint};
+    for(size_t mid = 0; mid < midPoints.size(); mid++)
+    {
+        for(int i = -1; i <= 1; i++)
+        {
+            for(int j = -1; j <= 1; j++)
+            {
+                Position borderPoint(midPoints[mid].x + i * (mapSize.x / 4), midPoints[mid].y + j * (mapSize.y / 4));
+                if(i == 1)
+                    borderPoint.x--;
+                if(j == 1)
+                    borderPoint.y--;
+
+                int deselectIndex = (mid + 1) < midPoints.size() ? (mid + 1) : 0;
+                ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + midPoints[deselectIndex]));
+                BOOST_TEST(ms.getCurrentSelection() == deselectIndex);
+                ms.Msg_LeftUp(MouseCoords(ms.GetPos() + offsetOfBackground + borderPoint));
+                BOOST_TEST(ms.getCurrentSelection() == static_cast<int>(mid));
+            }
+        }
+    }
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(MapSelection, uiHelper::Fixture)
+
+BOOST_AUTO_TEST_CASE(MapNoOffsetAndSameSize)
+{
+    Position const windowPos(0, 0);
+    Extent const windowSize(100, 100);
+    Extent const mapBackgroundSize = {100, 100};
+    Extent const mapSize = {100, 100};
+    Position const mapOffsetInBackground = Position(0, 0);
+    testMapSelection(windowPos, windowSize, mapBackgroundSize, mapSize, mapOffsetInBackground);
+}
+
+BOOST_AUTO_TEST_CASE(MapNoOffsetAndDifferentSizeInEachDirection)
+{
+    Position const windowPos(0, 0);
+    Extent const windowSize(200, 100);
+    Extent const mapBackgroundSize = {200, 100};
+    Extent const mapSize = {200, 100};
+    Position const mapOffsetInBackground = Position(0, 0);
+    testMapSelection(windowPos, windowSize, mapBackgroundSize, mapSize, mapOffsetInBackground);
+}
+
+BOOST_AUTO_TEST_CASE(MapNoOffsetAndDifferentSizeInEachDirectionPlusWindowOffset)
+{
+    Position const windowPos(10, 10);
+    Extent const windowSize(200, 100);
+    Extent const mapBackgroundSize = {200, 100};
+    Extent const mapSize = {200, 100};
+    Position const mapOffsetInBackground = Position(0, 0);
+    testMapSelection(windowPos, windowSize, mapBackgroundSize, mapSize, mapOffsetInBackground);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add map selection control for campaigns
<img width="1920" alt="map_selection_all_playable" src="https://github.com/Return-To-The-Roots/s25client/assets/33401986/47a2e320-9100-4812-a519-5d7261d1db9f">
<img width="1920" alt="map_selection_all_playable_occupied" src="https://github.com/Return-To-The-Roots/s25client/assets/33401986/aa8a1392-abd7-4d0e-b79c-06ae74f0124c">
<img width="1920" alt="map_selection_preview_campaign_screen" src="https://github.com/Return-To-The-Roots/s25client/assets/33401986/139422a8-1171-4d12-9a7f-f23c7be28944">
