### PR TITLE
Drop support for 32bit Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,10 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+// Copyright (C) 2005 - 2024 Settlers Freaks <sf-team at siedler25.org>
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 dockerRegistry = "registry.mytrap.de/"
 dockerCredentials = "gitlab-Flow86"
 dockerImages = [
-    "windows.i686"    : "rttr/cross-compiler/mingw/mingw-w64-docker:master",
     "windows.x86_64"  : "rttr/cross-compiler/mingw/mingw-w64-docker:master",
     "linux.x86_64"    : "rttr/cross-compiler/linux/linux-amd64-docker:master",
     "apple.x86_64"    : "rttr/cross-compiler/apple/apple-docker:master"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+Copyright (C) 2005 - 2024 Settlers Freaks <sf-team at siedler25.org>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
@@ -122,6 +122,7 @@ Then just run (tests or application) as usual.
 - boost (i.e from <http://www.boost.org/>)
 - Visual Studio (at least 2017, you can get the community edition for free)
 - Git Client (i.e TortoiseGit)
+- 32bit systems are not officially supported
 
 #### Steps
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
-# Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+# Copyright (C) 2005 - 2024 Settlers Freaks <sf-team at siedler25.org>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-version: 0.8.3.{build}
+version: 0.9.5.{build}
 
 branches:
   only:
@@ -15,10 +15,6 @@ image:
 configuration:
   - Debug
   - Release
-
-platform:
-  - Win32
-  - x64
 
 environment:
   BOOST_ROOT: C:\Libraries\boost_1_77_0
@@ -50,11 +46,10 @@ before_build:
   - if exist %INSTALL_DIR%\ (rmdir /S /Q %INSTALL_DIR%)
   - mkdir build
   - cd build
-  - if %platform% == x64 (if "%GENERATOR%" == "Visual Studio 2017" (set "GENERATOR=%GENERATOR% Win64"))
   # Enable LTCG for release builds (speeds up linking as /GL compiled modules are used)
   - if %configuration% == Release (set "cmakeFlags=-DCMAKE_EXE_LINKER_FLAGS=/LTCG -DCMAKE_SHARED_LINKER_FLAGS=/LTCG")
-  - echo "Configuring %GENERATOR% for %configuration% on %platform% with boost=%BOOST_ROOT%"
-  - cmake -G "%GENERATOR%" -A %platform% -DRTTR_ENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_BENCHMARKS=ON %cmakeFlags% ..
+  - echo "Configuring %GENERATOR% with boost=%BOOST_ROOT%"
+  - cmake -G "%GENERATOR%" -DRTTR_ENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DRTTR_EXTERNAL_BUILD_TESTING=ON -DRTTR_ENABLE_BENCHMARKS=ON %cmakeFlags% ..
 
 build_script: cmake --build . --config %configuration% --parallel 4
 


### PR DESCRIPTION
It is unlikely anyone is still required to use that in 2024

And as it is now too much trouble to maintain (32bit builds on Appveyor started to fail)
just drop it, at least officially.
It might still work but we don't test it anymore.

See https://github.com/Return-To-The-Roots/s25client/pull/1663 where I tried to fix the 32bit appveyor build which has been failing for a long time now. I guess we could rebuild or remove the static MSVC libcurl library (CMake started to choose it over the shared one "recently") but I'd say it's not worth the time