### PR TITLE
Make EnumRange iterators usable as iterators in std algorithms

### DIFF
--- a/libs/common/include/helpers/EnumRange.h
+++ b/libs/common/include/helpers/EnumRange.h
@@ -6,12 +6,23 @@
 
 #include "MaxEnumValue.h"
 #include <boost/config.hpp>
+#include <iterator>
 #include <type_traits>
 
 // Using BOOST_FORCEINLINE mostly for increased debug performance (doesn't work for MSVC though)
 #define RTTR_CONSTEXPR_INLINE constexpr BOOST_FORCEINLINE
 
 namespace helpers {
+template<class T>
+struct EnumIterTraits
+{
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = T;
+    using difference_type = std::make_signed_t<std::common_type_t<std::underlying_type_t<T>, int>>;
+    using pointer = T*;
+    using reference = T&;
+};
+
 /// Can be used in range-based for loops to iterate over each enum value
 /// Requires: T must be an enum with MaxEnumValue trait specialized
 ///           T must be simple: Start at zero, no gaps
@@ -19,7 +30,7 @@ template<class T>
 struct EnumRange
 {
     static_assert(std::is_enum<T>::value, "Must be an enum!");
-    class iterator
+    class iterator : public EnumIterTraits<T>
     {
         unsigned value;
 
@@ -41,7 +52,7 @@ template<class T>
 struct EnumRangeWithOffset
 {
     static_assert(std::is_enum<T>::value, "Must be an enum!");
-    class iterator
+    class iterator : public EnumIterTraits<T>
     {
         unsigned value;
 

--- a/tests/common/testEnumRange.cpp
+++ b/tests/common/testEnumRange.cpp
@@ -4,6 +4,7 @@
 
 #include "helpers/EnumRange.h"
 #include <boost/test/unit_test.hpp>
+#include <vector>
 
 enum PlainEnum
 {
@@ -90,4 +91,18 @@ BOOST_AUTO_TEST_CASE(OffsetWorks)
     for(const IntEnum e : helpers::enumRange(IntEnum::Forth))
         result.push_back(e);
     BOOST_TEST(result == expected);
+}
+
+BOOST_AUTO_TEST_CASE(CanAssignToRange)
+{
+    const auto enums = helpers::EnumRange<IntEnum>{};
+    std::vector<IntEnum> enums_vec(enums.begin(), enums.end());
+    std::vector<IntEnum> expected{IntEnum::First, IntEnum::Second, IntEnum::Third, IntEnum::Forth};
+    BOOST_TEST(enums_vec == expected);
+
+    expected.push_back(expected.front());
+    expected.erase(expected.begin());
+    const auto enums2 = helpers::enumRange(IntEnum::Second);
+    enums_vec = std::vector<IntEnum>(enums2.begin(), enums2.end());
+    BOOST_TEST(enums_vec == expected);
 }


### PR DESCRIPTION
The range iterator is a forward iterator, so add the necessary typedefs

See https://github.com/Return-To-The-Roots/s25client/pull/1657#discussion_r1594456973
