### PR TITLE
Consistently use GetWareTex  and GetWareTexStack instead of GetMapTexture

### DIFF
--- a/libs/s25main/buildings/noBuildingSite.cpp
+++ b/libs/s25main/buildings/noBuildingSite.cpp
@@ -192,12 +192,10 @@ void noBuildingSite::Draw(DrawPoint drawPt)
         // Bretter
         DrawPoint doorPos = drawPt + DrawPoint(GetDoorPointX(), GetDoorPointY());
         for(unsigned char i = 0; i < boards; ++i)
-            LOADER.GetMapTexture(WARE_STACK_TEX_MAP_OFFSET + rttr::enum_cast(GoodType::Boards))
-              ->DrawFull(doorPos - DrawPoint(5, 10 + i * 4));
+            LOADER.GetWareStackTex(GoodType::Boards)->DrawFull(doorPos - DrawPoint(5, 10 + i * 4));
         // Steine
         for(unsigned char i = 0; i < stones; ++i)
-            LOADER.GetMapTexture(WARE_STACK_TEX_MAP_OFFSET + rttr::enum_cast(GoodType::Stones))
-              ->DrawFull(doorPos + DrawPoint(8, -12 - i * 4));
+            LOADER.GetWareStackTex(GoodType::Stones)->DrawFull(doorPos + DrawPoint(8, -12 - i * 4));
 
         // bis dahin gebautes Haus zeichnen
 

--- a/libs/s25main/buildings/nobHarborBuilding.cpp
+++ b/libs/s25main/buildings/nobHarborBuilding.cpp
@@ -244,13 +244,11 @@ void nobHarborBuilding::Draw(DrawPoint drawPt)
         // Bretter
         DrawPoint boardsPos = drawPt + BOARDS_POS[nation];
         for(unsigned char i = 0; i < expedition.boards; ++i)
-            LOADER.GetMapTexture(WARE_STACK_TEX_MAP_OFFSET + rttr::enum_cast(GoodType::Boards))
-              ->DrawFull(boardsPos - DrawPoint(0, i * 4));
+            LOADER.GetWareStackTex(GoodType::Boards)->DrawFull(boardsPos - DrawPoint(0, i * 4));
         DrawPoint stonesPos = drawPt + STONES_POS[nation];
         // Steine
         for(unsigned char i = 0; i < expedition.stones; ++i)
-            LOADER.GetMapTexture(WARE_STACK_TEX_MAP_OFFSET + rttr::enum_cast(GoodType::Stones))
-              ->DrawFull(stonesPos - DrawPoint(0, i * 4));
+            LOADER.GetWareStackTex(GoodType::Stones)->DrawFull(stonesPos - DrawPoint(0, i * 4));
 
         // Und den Bauarbeiter, falls er schon da ist
         if(expedition.builder)

--- a/libs/s25main/ingameWindows/iwShip.cpp
+++ b/libs/s25main/ingameWindows/iwShip.cpp
@@ -279,7 +279,7 @@ void iwShip::DrawCargo()
 
             const auto draw_id = convertShieldToNation(ware, owner.nation);
 
-            LOADER.GetMapTexture(WARE_STACK_TEX_MAP_OFFSET + rttr::enum_cast(draw_id))->DrawFull(drawPt);
+            LOADER.GetWareStackTex(draw_id)->DrawFull(drawPt);
             drawPt.x += xStep;
             lineCounter++;
         }

--- a/libs/s25main/ingameWindows/iwTransport.cpp
+++ b/libs/s25main/ingameWindows/iwTransport.cpp
@@ -38,7 +38,7 @@ iwTransport::iwTransport(const GameWorldViewer& gwv, GameCommandFactory& gcFacto
     // Buttons der einzelnen Waren anlegen
     ctrlOptionGroup* group = AddOptionGroup(6, GroupSelectType::Illuminate);
 
-    auto getGoodTex = [](GoodType good) { return LOADER.GetMapTexture(WARES_TEX_MAP_OFFSET + rttr::enum_cast(good)); };
+    auto getGoodTex = [](GoodType good) { return LOADER.GetWareTex(good); };
     buttonData = {{{getGoodTex(GoodType::Coins), WARE_NAMES[GoodType::Coins]},
                    {LOADER.GetTextureN("io", 111), gettext_noop("Weapons")},
                    {getGoodTex(GoodType::Beer), WARE_NAMES[GoodType::Beer]},

--- a/libs/s25main/nodeObjs/noFlag.cpp
+++ b/libs/s25main/nodeObjs/noFlag.cpp
@@ -117,8 +117,7 @@ void noFlag::Draw(DrawPoint drawPt)
     // Waren (von hinten anfangen zu zeichnen)
     for(unsigned i = wares.size(); i > 0; --i)
     {
-        LOADER.GetMapTexture(WARE_STACK_TEX_MAP_OFFSET + rttr::enum_cast(wares[i - 1]->type))
-          ->DrawFull(drawPt + WARES_POS[i - 1]);
+        LOADER.GetWareStackTex(wares[i - 1]->type)->DrawFull(drawPt + WARES_POS[i - 1]);
     }
 }
 


### PR DESCRIPTION
Use GetWareTex and GetWareTexStack texture interface instead of GetMapTexture.

- Adding new textures for additional wares is much easier because we have only one place to add a lookup for the new texture. Otherwise we have to add the code at each calling place. This is needed for the new wine addon (#1669) to add the new goods wine and grapes.