### PR TITLE
Fix fisher not getting the fish he caught

### DIFF
--- a/libs/s25main/ogl/glFont.cpp
+++ b/libs/s25main/ogl/glFont.cpp
@@ -6,11 +6,10 @@
 #include "FontStyle.h"
 #include "Loader.h"
 #include "drivers/VideoDriverWrapper.h"
-#include "glArchivItem_Bitmap.h"
+#include "glArchivItem_Bitmap_Raw.h"
 #include "helpers/containerUtils.h"
 #include "libsiedler2/ArchivItem_Bitmap_Player.h"
 #include "libsiedler2/ArchivItem_Font.h"
-#include "libsiedler2/IAllocator.h"
 #include "libsiedler2/PixelBufferBGRA.h"
 #include "libsiedler2/libsiedler2.h"
 #include "s25util/utf8.h"
@@ -27,8 +26,8 @@ using utf8 = utf::utf_traits<char>;
 
 glFont::glFont(const libsiedler2::ArchivItem_Font& font) : maxCharSize(font.getDx(), font.getDy()), asciiMapping{}
 {
-    fontWithOutline = libsiedler2::getAllocator().create<glArchivItem_Bitmap>(libsiedler2::BobType::Bitmap);
-    fontNoOutline = libsiedler2::getAllocator().create<glArchivItem_Bitmap>(libsiedler2::BobType::Bitmap);
+    fontWithOutline = std::make_unique<glArchivItem_Bitmap_Raw>();
+    fontNoOutline = std::make_unique<glArchivItem_Bitmap_Raw>();
 
     // first, we have to find how much chars we really have
     unsigned numChars = 0;
@@ -79,7 +78,7 @@ glFont::glFont(const libsiedler2::ArchivItem_Font& font) : maxCharSize(font.getD
     fontNoOutline->create(bufferNoOutline);
     fontWithOutline->create(bufferWithOutline);
 
-    // Set the placeholder for non-existant glyphs. Use '?' (should always be possible)
+    // Set the placeholder for non-existent glyphs. Use '?' (should always be possible)
     if(CharExist(0xFFFD))
         placeHolder = GetCharInfo(0xFFFD);
     else if(CharExist('?'))

--- a/libs/s25main/world/World.cpp
+++ b/libs/s25main/world/World.cpp
@@ -160,7 +160,7 @@ GO_Type World::GetGOT(const MapPoint pt) const
 
 void World::ReduceResource(const MapPoint pt)
 {
-    uint8_t curAmount = GetNodeInt(pt).resources.getAmount();
+    const uint8_t curAmount = GetNodeInt(pt).resources.getAmount();
     RTTR_Assert(curAmount > 0);
     GetNodeInt(pt).resources.setAmount(curAmount - 1u);
 }

--- a/tests/s25Main/integration/testGameWorldView.cpp
+++ b/tests/s25Main/integration/testGameWorldView.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "PointOutput.h"
+#include "uiHelper/uiHelpers.hpp"
 #include "worldFixtures/CreateEmptyWorld.h"
 #include "worldFixtures/WorldFixture.h"
 #include "world/GameWorldView.h"
@@ -19,6 +20,8 @@ using EmptyWorldFixture1P = WorldFixture<CreateEmptyWorld, 1>;
 
 BOOST_FIXTURE_TEST_CASE(HasCorrectDrawCoords, EmptyWorldFixture1P)
 {
+    uiHelper::initGUITests(); // Required for GameWorldView
+
     GameWorldViewer gwv(0, world);
     const auto viewSize = rttr::test::randomPoint<Extent>(100, 1000);
     GameWorldView view(gwv, Position(0, 0), viewSize);
@@ -78,6 +81,8 @@ BOOST_FIXTURE_TEST_CASE(HasCorrectDrawCoords, EmptyWorldFixture1P)
 
 BOOST_FIXTURE_TEST_CASE(GetsCorrectMaxHeight, EmptyWorldFixture1P)
 {
+    uiHelper::initGUITests(); // Required for GameWorldView
+
     GameWorldViewer gwv(0, world);
     const auto viewSize = rttr::test::randomPoint<Extent>(100, 1000);
     GameWorldView view(gwv, Position(0, 0), viewSize);


### PR DESCRIPTION
The code triggers an assertion when 2 fishers try to get the last fish
from the same spot because only the first can get it.
So remove the fish when starting to fish such that it is already
unavailable when the 2nd starts fishing.

Fixes https://github.com/Return-To-The-Roots/s25client/issues/1674

Also a fix for some tests crashing depending on the order they are executed. (TextControlWorks & TableSorting due to glFont, the other due to the guiScale change)