### PR TITLE
Add version to replay and recorded game commands

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,8 +44,8 @@ jobs:
           #   Use (compiler) default C++ 14 standard
           #   Use system cmake
           #   Use system boost (min version)
-          - { compiler: gcc-9,    os: ubuntu-20.04, type: Debug, cmake: 3.16.3, boost: 1.69.0 }
-          - { compiler: clang-10, os: ubuntu-20.04, type: Debug, cmake: 3.16.3, boost: 1.69.0, externalSanitizer: true }
+          - { compiler: gcc-9,    os: ubuntu-20.04, type: Debug, cmake: 3.16.3, boost: 1.71.0 }
+          - { compiler: clang-10, os: ubuntu-20.04, type: Debug, cmake: 3.16.3, boost: 1.71.0, externalSanitizer: true }
           #
           #   Default compiler for Ubuntu 20.04
           #   Use (compiler) default C++ 14 standard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+# Copyright (C) 2005 - 2024 Settlers Freaks <sf-team at siedler25.org>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -306,20 +306,12 @@ if(BUILD_TESTING)
     list(APPEND BoostPackages unit_test_framework)
 endif()
 
-find_package(Boost 1.69 COMPONENTS ${BoostPackages})
+find_package(Boost 1.71 COMPONENTS ${BoostPackages})
 if(NOT Boost_FOUND)
-    message(FATAL_ERROR "You have to install boost (>=1.69) into contrib/boost or set (as CMake or environment variable) "
+    message(FATAL_ERROR "You have to install boost (>=1.71) into contrib/boost or set (as CMake or environment variable) "
     "BOOST_ROOT (currently: '${BOOST_ROOT}', Environment: '$ENV{BOOST_ROOT}'), "
     "BOOST_INCLUDEDIR (currently: '${BOOST_INCLUDEDIR}', Environment: '$ENV{BOOST_INCLUDEDIR}') "
     "since cmake was unable to find boost!")
-endif()
-if(Boost_VERSION VERSION_EQUAL 1.70)
-    # Bug in Boost 1.70: https://github.com/boostorg/boost_install/issues/5
-    if(Boost_USE_STATIC_LIBS)
-        set(BUILD_SHARED_LIBS OFF)
-    else()
-        set(BUILD_SHARED_LIBS ON)
-    endif()
 endif()
 
 option(RTTR_USE_SYSTEM_BOOST_NOWIDE "Use system installed Boost.Nowide. Fails if not found!" "${RTTR_USE_SYSTEM_LIBS}")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ branches:
   - master
 
 image:
-  - Visual Studio 2017
   - Visual Studio 2019
+  - Visual Studio 2022
 
 configuration:
   - Debug
@@ -35,10 +35,16 @@ matrix:
 for:
   - matrix:
       only:
-        - image: Visual Studio 2017
+        - image: Visual Studio 2019
     environment:
-      BOOST_ROOT: C:\Libraries\boost_1_69_0
-      GENERATOR: Visual Studio 15 2017
+      GENERATOR: Visual Studio 16 2019
+      BOOST_ROOT: C:\Libraries\boost_1_83_0
+  - matrix:
+      only:
+        - image: Visual Studio 2022
+    environment:
+      GENERATOR: Visual Studio 17 2022
+      BOOST_ROOT: C:\Libraries\boost_1_84_0
 
 install:
   - dir C:\Libraries
@@ -50,7 +56,6 @@ before_build:
   - if exist %INSTALL_DIR%\ (rmdir /S /Q %INSTALL_DIR%)
   - mkdir build
   - cd build
-  - if %platform% == x64 (if "%GENERATOR%" == "Visual Studio 2017" (set "GENERATOR=%GENERATOR% Win64"))
   # Enable LTCG for release builds (speeds up linking as /GL compiled modules are used)
   - if %configuration% == Release (set "cmakeFlags=-DCMAKE_EXE_LINKER_FLAGS=/LTCG -DCMAKE_SHARED_LINKER_FLAGS=/LTCG")
   - echo "Configuring %GENERATOR% for %configuration% on %platform% with boost=%BOOST_ROOT%"

--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -138,11 +138,10 @@ void HeadlessGame::RecordReplay(const bfs::path& path, unsigned random_init)
     mapInfo.mapData.CompressFromFile(mapInfo.filepath, &mapInfo.mapChecksum);
     mapInfo.type = MapType::OldMap;
 
-    replay_.random_init = random_init;
     for(unsigned playerId = 0; playerId < world_.GetNumPlayers(); ++playerId)
         replay_.AddPlayer(world_.GetPlayer(playerId));
     replay_.ggs = game_.ggs_;
-    if(!replay_.StartRecording(path, mapInfo))
+    if(!replay_.StartRecording(path, mapInfo, random_init))
         throw std::runtime_error("Replayfile could not be opened!");
 }
 

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -19,6 +19,10 @@
 
 #ifdef _WIN32
 #    include <boost/nowide/convert.hpp>
+#    ifndef WIN32_LEAN_AND_MEAN
+#        define WIN32_LEAN_AND_MEAN
+#    endif
+#    include <windows.h> // Avoid "Windows headers require the default packing option" due to SDL2
 #    include <SDL_syswm.h>
 #endif // _WIN32
 

--- a/libs/common/include/helpers/OptionalIO.h
+++ b/libs/common/include/helpers/OptionalIO.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "helpers/OptionalEnum.h"
+#include <optional>
 #include <ostream>
 
 namespace helpers {
@@ -14,3 +15,13 @@ std::ostream& operator<<(std::ostream& os, OptionalEnum<T> const& v)
     return (v) ? os << *v : os << "[empty]";
 }
 } // namespace helpers
+
+namespace std {
+// LCOV_EXCL_START
+template<typename T>
+static std::ostream& boost_test_print_type(std::ostream& os, std::optional<T> const& v)
+{
+    return (v) ? os << *v : os << "[empty]";
+}
+// LCOV_EXCL_STOP
+} // namespace std

--- a/libs/common/include/variant.h
+++ b/libs/common/include/variant.h
@@ -1,22 +1,20 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
-#include <boost/variant.hpp>
-#include <type_traits>
+#include <boost/variant2/variant.hpp>
+
+/// Shortcurs to avoid typing out boost::variant2
+template<typename... T>
+using boost_variant2 = boost::variant2::variant<T...>;
+
+using boost::variant2::get;
+using boost::variant2::get_if;
+using boost::variant2::holds_alternative;
 
 namespace detail {
-template<typename...>
-struct indexOf;
-template<typename T, typename... Rest>
-struct indexOf<T, T, Rest...> : std::integral_constant<size_t, 0>
-{};
-template<typename T, typename U, typename... Rest>
-struct indexOf<T, U, Rest...> : std::integral_constant<size_t, 1 + indexOf<T, Rest...>::value>
-{};
-
 template<typename... Lambdas>
 struct lambda_visitor;
 
@@ -35,12 +33,6 @@ struct lambda_visitor<Lambda1> : public Lambda1
     lambda_visitor(Lambda1 l1) : Lambda1(l1) {}
 };
 } // namespace detail
-
-template<class T, class... Types>
-bool holds_alternative(const boost::variant<Types...>& v) noexcept
-{
-    return v.which() == detail::indexOf<T, Types...>::value;
-}
 
 template<class... Fs>
 auto composeVisitor(Fs&&... fs)

--- a/libs/common/include/variant.h
+++ b/libs/common/include/variant.h
@@ -6,7 +6,7 @@
 
 #include <boost/variant2/variant.hpp>
 
-/// Shortcurs to avoid typing out boost::variant2
+/// Shortcuts to avoid typing out boost::variant2
 template<typename... T>
 using boost_variant2 = boost::variant2::variant<T...>;
 

--- a/libs/s25main/CMakeLists.txt
+++ b/libs/s25main/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+# Copyright (C) 2005 - 2024 Settlers Freaks <sf-team at siedler25.org>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/Debug.cpp
+++ b/libs/s25main/Debug.cpp
@@ -296,7 +296,7 @@ bool DebugInfo::SendReplay()
         rpl->Close();
 
         BinaryFile f;
-        if(f.Open(replayPath, OpenFileMode::OFM_READ))
+        if(f.Open(replayPath, OpenFileMode::Read))
         {
             if(!SendString("Replay"))
                 return false;
@@ -317,7 +317,7 @@ bool DebugInfo::SendReplay()
 bool DebugInfo::SendAsyncLog(const boost::filesystem::path& asyncLogFilepath)
 {
     BinaryFile file;
-    if(!file.Open(asyncLogFilepath, OFM_READ))
+    if(!file.Open(asyncLogFilepath, OpenFileMode::Read))
         return false;
 
     if(!SendString("AsyncLog"))

--- a/libs/s25main/GameCommand.cpp
+++ b/libs/s25main/GameCommand.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -9,7 +9,12 @@
 
 namespace gc {
 
-GameCommandPtr GameCommand::Deserialize(Serializer& ser)
+unsigned Deserializer::getCurrentVersion()
+{
+    return 0;
+}
+
+GameCommandPtr GameCommand::Deserialize(Deserializer& ser)
 {
     auto gcType = helpers::popEnum<GCType>(ser);
     GameCommand* gc;

--- a/libs/s25main/GameCommand.cpp
+++ b/libs/s25main/GameCommand.cpp
@@ -9,6 +9,7 @@
 
 namespace gc {
 
+/// Current version of the game commands, see VersionedDeserializer.
 unsigned Deserializer::getCurrentVersion()
 {
     return 0;

--- a/libs/s25main/GameCommand.h
+++ b/libs/s25main/GameCommand.h
@@ -1,9 +1,10 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
+#include "s25util/VersionedDeserializer.h"
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <RTTR_Assert.h>
 #include <cstdint>
@@ -13,6 +14,12 @@ class GameWorld;
 class GameCommandFactory;
 
 namespace gc {
+
+struct Deserializer : s25util::VersionedDeserializer<Deserializer>
+{
+    using s25util::VersionedDeserializer<Deserializer>::VersionedDeserializer;
+    static unsigned getCurrentVersion();
+};
 
 class GameCommand;
 // Use this for safely using Pointers to GameCommands
@@ -82,7 +89,7 @@ public:
     }
 
     /// Builds a GameCommand depending on Type
-    static GameCommandPtr Deserialize(Serializer& ser);
+    static GameCommandPtr Deserialize(Deserializer& ser);
 
     /// Serializes this GameCommand
     virtual void Serialize(Serializer& ser) const;

--- a/libs/s25main/GameCommands.h
+++ b/libs/s25main/GameCommands.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -441,11 +441,11 @@ public:
 class SetInventorySetting : public Coords
 {
     GC_FRIEND_DECL;
-    boost::variant<GoodType, Job> what;
+    boost_variant2<GoodType, Job> what;
     InventorySetting state;
 
 protected:
-    SetInventorySetting(const MapPoint pt, boost::variant<GoodType, Job> what, const InventorySetting state)
+    SetInventorySetting(const MapPoint pt, boost_variant2<GoodType, Job> what, const InventorySetting state)
         : Coords(GCType::SetInventorySetting, pt), what(std::move(what)), state(state)
     {}
     SetInventorySetting(Serializer& ser) : Coords(GCType::SetInventorySetting, ser)
@@ -464,7 +464,7 @@ public:
         Coords::Serialize(ser);
 
         ser.PushBool(holds_alternative<Job>(what));
-        boost::apply_visitor([&ser](auto type) { helpers::pushEnum<uint8_t>(ser, type); }, what);
+        visit([&ser](auto type) { helpers::pushEnum<uint8_t>(ser, type); }, what);
         ser.PushUnsignedChar(static_cast<uint8_t>(state));
     }
 
@@ -775,13 +775,13 @@ private:
 class TradeOverLand : public Coords
 {
     GC_FRIEND_DECL;
-    boost::variant<GoodType, Job> what;
+    boost_variant2<GoodType, Job> what;
     /// Number of wares/figures we want to trade
     uint32_t count;
 
 protected:
     /// Note: Can only trade wares or figures!
-    TradeOverLand(const MapPoint pt, boost::variant<GoodType, Job> what, const uint32_t count)
+    TradeOverLand(const MapPoint pt, boost_variant2<GoodType, Job> what, const uint32_t count)
         : Coords(GCType::Trade, pt), what(std::move(what)), count(count)
     {}
     TradeOverLand(Serializer& ser) : Coords(GCType::Trade, ser)
@@ -799,7 +799,7 @@ public:
         Coords::Serialize(ser);
 
         ser.PushBool(holds_alternative<Job>(what));
-        boost::apply_visitor([&ser](auto type) { helpers::pushEnum<uint8_t>(ser, type); }, what);
+        visit([&ser](auto type) { helpers::pushEnum<uint8_t>(ser, type); }, what);
         ser.PushUnsignedInt(count);
     }
 

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -26,7 +26,6 @@
 #include "postSystem/DiplomacyPostQuestion.h"
 #include "postSystem/PostManager.h"
 #include "random/Random.h"
-#include "variant.h"
 #include "world/GameWorld.h"
 #include "world/TradeRoute.h"
 #include "nodeObjs/noFlag.h"
@@ -2170,7 +2169,7 @@ struct WarehouseDistanceComparator
 };
 
 /// Send wares to warehouse wh
-void GamePlayer::Trade(nobBaseWarehouse* goalWh, const boost::variant<GoodType, Job>& what, unsigned count) const
+void GamePlayer::Trade(nobBaseWarehouse* goalWh, const boost_variant2<GoodType, Job>& what, unsigned count) const
 {
     if(!world.GetGGS().isEnabled(AddonId::TRADE))
         return;
@@ -2195,9 +2194,9 @@ void GamePlayer::Trade(nobBaseWarehouse* goalWh, const boost::variant<GoodType, 
     {
         // Get available wares
         const unsigned available =
-          boost::apply_visitor(composeVisitor([wh](GoodType gt) { return wh->GetAvailableWaresForTrading(gt); },
-                                              [wh](Job job) { return wh->GetAvailableFiguresForTrading(job); }),
-                               what);
+          boost::variant2::visit(composeVisitor([wh](GoodType gt) { return wh->GetAvailableWaresForTrading(gt); },
+                                                [wh](Job job) { return wh->GetAvailableFiguresForTrading(job); }),
+                                 what);
         if(available == 0)
             continue;
 

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -8,6 +8,7 @@
 #include "GamePlayerInfo.h"
 #include "helpers/EnumArray.h"
 #include "helpers/MultiArray.h"
+#include "variant.h"
 #include "gameTypes/BuildingType.h"
 #include "gameTypes/Inventory.h"
 #include "gameTypes/MapCoordinates.h"
@@ -15,7 +16,6 @@
 #include "gameTypes/SettingsTypes.h"
 #include "gameTypes/StatisticTypes.h"
 #include "gameData/MaxPlayers.h"
-#include <boost/variant/variant_fwd.hpp>
 #include <array>
 #include <list>
 #include <memory>
@@ -281,7 +281,7 @@ public:
     /// IMPORTANT: Warehouses can be destroyed. So check them first before using!
     std::vector<nobBaseWarehouse*> GetWarehousesForTrading(const nobBaseWarehouse& goalWh) const;
     /// Send wares to warehouse wh
-    void Trade(nobBaseWarehouse* goalWh, const boost::variant<GoodType, Job>& what, unsigned count) const;
+    void Trade(nobBaseWarehouse* goalWh, const boost_variant2<GoodType, Job>& what, unsigned count) const;
 
     void EnableBuilding(BuildingType type) { building_enabled[type] = true; }
     void DisableBuilding(BuildingType type) { building_enabled[type] = false; }

--- a/libs/s25main/Replay.cpp
+++ b/libs/s25main/Replay.cpp
@@ -27,7 +27,10 @@ std::string Replay::GetSignature() const
 ///     - Remove all code handling this version.
 ///     - Reset this version to 0
 ///     - Increase the version in GetVersion
-static const uint8_t currentReplayDataVersion = 0;
+///
+/// Changelog:
+/// 1: Unused first CommandType (End) removed
+static const uint8_t currentReplayDataVersion = 1;
 // clang-format on
 
 /// Format version of replay files
@@ -319,7 +322,7 @@ std::optional<unsigned> Replay::ReadGF()
 boost_variant2<Replay::ChatCommand, Replay::GameCommand> Replay::ReadCommand()
 {
     RTTR_Assert(IsReplaying());
-    const auto type = static_cast<CommandType>(file_.ReadUnsignedChar());
+    const auto type = static_cast<CommandType>(file_.ReadUnsignedChar() - (subVersion_ == 0 ? 1 : 0));
     switch(type)
     {
         case CommandType::Chat: return ChatCommand(file_);

--- a/libs/s25main/Replay.cpp
+++ b/libs/s25main/Replay.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/Replay.h
+++ b/libs/s25main/Replay.h
@@ -98,4 +98,7 @@ protected:
     /// Position of the last GF value in the file
     unsigned lastGfFilePos_ = 0;
     MapType mapType_ = MapType(0);
+
+    /// Sub version for backwards compatibility (i.e. allow loading older files with same file version)
+    uint8_t subVersion_ = 0;
 };

--- a/libs/s25main/Replay.h
+++ b/libs/s25main/Replay.h
@@ -44,19 +44,19 @@ public:
     /// Stop recording. Will compress the data and return true if that succeeded. The file will be closed in any case
     bool StopRecording();
 
-    /// Replaydatei gÃ¼ltig?
-    bool IsValid() const { return file_.IsValid(); }
-    bool IsRecording() const { return isRecording_ && file_.IsValid(); }
-    bool IsReplaying() const { return !isRecording_ && file_.IsValid(); }
+    /// Replaydatei gültig?
+    bool IsValid() const { return file_.IsOpen(); }
+    bool IsRecording() const { return isRecording_ && file_.IsOpen(); }
+    bool IsReplaying() const { return !isRecording_ && file_.IsOpen(); }
     const boost::filesystem::path& GetPath() const;
 
     /// Loads the header and optionally the mapInfo (former "extended header")
     bool LoadHeader(const boost::filesystem::path& filepath);
     bool LoadGameData(MapInfo& mapInfo);
 
-    /// FÃ¼gt ein Chat-Kommando hinzu (schreibt)
+    /// Fügt ein Chat-Kommando hinzu (schreibt)
     void AddChatCommand(unsigned gf, uint8_t player, ChatDestination dest, const std::string& str);
-    /// FÃ¼gt ein Spiel-Kommando hinzu (schreibt)
+    /// Fügt ein Spiel-Kommando hinzu (schreibt)
     void AddGameCommand(unsigned gf, uint8_t player, const PlayerGameCommands& cmds);
 
     /// Liest RC-Type aus, liefert false, wenn das Replay zu Ende ist

--- a/libs/s25main/Replay.h
+++ b/libs/s25main/Replay.h
@@ -40,7 +40,7 @@ public:
     };
     struct GameCommand
     {
-        GameCommand(BinaryFile& file);
+        GameCommand(BinaryFile& file, unsigned version);
         uint8_t player;
         PlayerGameCommands cmds;
     };
@@ -100,4 +100,5 @@ protected:
 
     /// Sub version for backwards compatibility (i.e. allow loading older files with same file version)
     uint8_t subVersion_ = 0;
+    uint8_t gcVersion_ = 0;
 };

--- a/libs/s25main/Replay.h
+++ b/libs/s25main/Replay.h
@@ -28,7 +28,6 @@ class Replay : public SavedFile
 public:
     enum class CommandType
     {
-        End,
         Chat,
         Game,
     };

--- a/libs/s25main/Replay.h
+++ b/libs/s25main/Replay.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/ReplayInfo.h
+++ b/libs/s25main/ReplayInfo.h
@@ -6,20 +6,18 @@
 
 #include "Replay.h"
 #include <boost/filesystem/path.hpp>
+#include <optional>
 #include <string>
 
 struct ReplayInfo
 {
-    ReplayInfo() : async(0), end(false), next_gf(0), all_visible(false) {}
-
-    /// Replaydatei
+    /// Replay file
     Replay replay;
     boost::filesystem::path filename;
-    /// Replay asynchron (Meldung nur einmal ausgeben!)
-    int async;
-    bool end;
-    // Nächster Replay-Command-Zeitpunkt (in GF)
-    unsigned next_gf;
-    /// Alles sichtbar (FoW deaktiviert)
+    /// Number of async GFs
+    int async = 0;
+    // GF for the next replay command if any
+    std::optional<unsigned> next_gf;
+    /// FoW deactivated?
     bool all_visible;
 };

--- a/libs/s25main/ReplayInfo.h
+++ b/libs/s25main/ReplayInfo.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/SavedFile.cpp
+++ b/libs/s25main/SavedFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/SavedFile.h
+++ b/libs/s25main/SavedFile.h
@@ -52,10 +52,10 @@ public:
     void AddPlayer(const BasePlayerInfo& player);
     void ClearPlayers();
 
-    std::string GetLastErrorMsg() const { return lastErrorMsg; }
+    const std::string& GetLastErrorMsg() const { return lastErrorMsg; }
 
     std::string GetRevision() const;
-    std::string GetMapName() const { return mapName_; }
+    const std::string& GetMapName() const { return mapName_; }
     s25util::time64_t GetSaveTime() const { return saveTime_; }
     const std::vector<std::string>& GetPlayerNames() const { return playerNames_; }
 

--- a/libs/s25main/Savegame.cpp
+++ b/libs/s25main/Savegame.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -30,7 +30,7 @@ bool Savegame::Save(const boost::filesystem::path& filepath, const std::string& 
 {
     BinaryFile file;
 
-    return file.Open(filepath, OFM_WRITE) && Save(file, mapName);
+    return file.Open(filepath, OpenFileMode::Write) && Save(file, mapName);
 }
 
 bool Savegame::Save(BinaryFile& file, const std::string& mapName)
@@ -47,7 +47,7 @@ bool Savegame::Load(const boost::filesystem::path& filePath, const SaveGameDataT
 {
     BinaryFile file;
 
-    return file.Open(filePath, OFM_READ) && Load(file, what);
+    return file.Open(filePath, OpenFileMode::Read) && Load(file, what);
 }
 
 bool Savegame::Load(BinaryFile& file, const SaveGameDataToLoad what)

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -83,7 +83,7 @@
 /// Usage: Always save for the most current version but include loading code that can cope with file format changes
 /// If a format change occurred that can still be handled increase this version and handle it in the loading code.
 /// If the change is to big to handle increase the version in Savegame.cpp and remove all code referencing GetGameDataVersion.
-/// Then reset this number to 1.
+/// Then reset this number to 0.
 /// TODO: Let GO_Type start at 0 again when resetting this
 /// Changelog:
 /// 2: All player buildings together, variable width size for containers and ship names

--- a/libs/s25main/buildings/nobBaseWarehouse.h
+++ b/libs/s25main/buildings/nobBaseWarehouse.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -6,10 +6,10 @@
 
 #include "DataChangedObservable.h"
 #include "nobBaseMilitary.h"
+#include "variant.h"
 #include "gameTypes/GoodsAndPeopleArray.h"
 #include "gameTypes/InventorySetting.h"
 #include "gameTypes/VirtualInventory.h"
-#include <boost/variant.hpp>
 #include <array>
 #include <list>
 #include <memory>
@@ -89,13 +89,13 @@ private:
     friend class gc::SetInventorySetting;
     friend class gc::SetAllInventorySettings;
     /// Verändert Ein/Auslagerungseinstellungen
-    void SetInventorySetting(const boost::variant<GoodType, Job>& what, InventorySetting state);
+    void SetInventorySetting(const boost_variant2<GoodType, Job>& what, InventorySetting state);
 
     /// Verändert alle Ein/Auslagerungseinstellungen einer Kategorie (also Waren oder Figuren)(real)
     void SetAllInventorySettings(bool isJob, const std::vector<InventorySetting>& states);
 
     /// Lässt einen bestimmten Waren/Job-Typ ggf auslagern
-    void CheckOuthousing(const boost::variant<GoodType, Job>& what);
+    void CheckOuthousing(const boost_variant2<GoodType, Job>& what);
     void HandleCollectEvent();
     void HandleSendoutEvent();
     void HandleRecrutingEvent();
@@ -169,7 +169,7 @@ public:
         return GetInventorySetting(ware).IsSet(setting);
     }
 
-    void SetInventorySettingVisual(const boost::variant<GoodType, Job>& what, InventorySetting state);
+    void SetInventorySettingVisual(const boost_variant2<GoodType, Job>& what, InventorySetting state);
 
     /// Bestellt einen Träger
     void OrderCarrier(noRoadNode& goal, RoadSegment& workplace);
@@ -278,7 +278,7 @@ public:
     /// Available figures of a specific type that can be used for trading
     unsigned GetAvailableFiguresForTrading(Job job) const;
     /// Starts a trade caravane from this warehouse
-    void StartTradeCaravane(const boost::variant<GoodType, Job>& what, unsigned count, const TradeRoute& tr,
+    void StartTradeCaravane(const boost_variant2<GoodType, Job>& what, unsigned count, const TradeRoute& tr,
                             nobBaseWarehouse* goal);
 
     /// For debug only

--- a/libs/s25main/controls/ctrlChat.cpp
+++ b/libs/s25main/controls/ctrlChat.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -8,7 +8,6 @@
 #include "ctrlScrollBar.h"
 #include "driver/MouseCoords.h"
 #include "ogl/glFont.h"
-#include "variant.h"
 #include "s25util/Log.h"
 
 /// Breite der Scrollbar
@@ -118,7 +117,7 @@ void ctrlChat::Draw_()
     for(unsigned i = 0; i < show_lines; ++i)
     {
         DrawPoint curTextPos = textPos;
-        if(PrimaryChatLine* line = boost::get<PrimaryChatLine>(&chat_lines[i + pos]))
+        if(PrimaryChatLine* line = get_if<PrimaryChatLine>(&chat_lines[i + pos]))
         {
             // Zeit, Spieler und danach Textnachricht
             if(!line->time_string.empty())
@@ -140,7 +139,7 @@ void ctrlChat::Draw_()
                 curTextPos.x += bracket2_size;
             }
         }
-        boost::apply_visitor(
+        visit(
           [this, curTextPos](const auto& line) { // Draw msg
               this->font->Draw(curTextPos, line.msg, FontStyle{}, line.msg_color);
           },

--- a/libs/s25main/controls/ctrlChat.h
+++ b/libs/s25main/controls/ctrlChat.h
@@ -1,11 +1,11 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
 #include "Window.h"
-#include <boost/variant.hpp>
+#include "variant.h"
 #include <vector>
 class MouseCoords;
 class glFont;
@@ -64,7 +64,7 @@ private:
         /// Farbe der Chatnachricht
         unsigned msg_color;
     };
-    using ChatLine = boost::variant<PrimaryChatLine, SecondaryChatLine>;
+    using ChatLine = boost_variant2<PrimaryChatLine, SecondaryChatLine>;
 
     TextureColor tc;    /// Hintergrundtextur.
     const glFont* font; /// Schriftart.

--- a/libs/s25main/desktops/dskGameLoader.cpp
+++ b/libs/s25main/desktops/dskGameLoader.cpp
@@ -132,8 +132,11 @@ void dskGameLoader::Msg_Timer(const unsigned /*ctrl_id*/)
 
 void dskGameLoader::ShowErrorMsg(const std::string& error)
 {
-    WINDOWMANAGER.Show(
-      std::make_unique<iwMsgbox>(_("Error"), error, this, MsgboxButton::Ok, MsgboxIcon::ExclamationRed, 0));
+    auto wnd = std::make_unique<iwMsgbox>(_("Error"), error, this, MsgboxButton::Ok, MsgboxIcon::ExclamationRed, 0);
+    if(IsActive())
+        WINDOWMANAGER.Show(std::move(wnd));
+    else
+        WINDOWMANAGER.ShowAfterSwitch(std::move(wnd));
     GetCtrl<ctrlTimer>(1)->Stop();
 }
 

--- a/libs/s25main/factories/GameCommandFactory.cpp
+++ b/libs/s25main/factories/GameCommandFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -102,7 +102,7 @@ bool GameCommandFactory::NotifyAlliesOfLocation(const MapPoint pt)
     return AddGC(new gc::NotifyAlliesOfLocation(pt));
 }
 
-bool GameCommandFactory::SetInventorySetting(const MapPoint pt, const boost::variant<GoodType, Job>& what,
+bool GameCommandFactory::SetInventorySetting(const MapPoint pt, const boost_variant2<GoodType, Job>& what,
                                              InventorySetting state)
 {
     return AddGC(new gc::SetInventorySetting(pt, what, state));
@@ -189,7 +189,7 @@ bool GameCommandFactory::StartStopExplorationExpedition(const MapPoint pt, bool 
     return AddGC(new gc::StartStopExplorationExpedition(pt, start));
 }
 
-bool GameCommandFactory::TradeOverLand(const MapPoint pt, const boost::variant<GoodType, Job>& what, unsigned count)
+bool GameCommandFactory::TradeOverLand(const MapPoint pt, const boost_variant2<GoodType, Job>& what, unsigned count)
 {
     return AddGC(new gc::TradeOverLand(pt, what, count));
 }

--- a/libs/s25main/factories/GameCommandFactory.h
+++ b/libs/s25main/factories/GameCommandFactory.h
@@ -1,10 +1,11 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
 #include "GameCommand.h"
+#include "variant.h"
 #include "gameTypes/BuildingType.h"
 #include "gameTypes/Direction.h"
 #include "gameTypes/GoodTypes.h"
@@ -13,7 +14,6 @@
 #include "gameTypes/PactTypes.h"
 #include "gameTypes/SettingsTypes.h"
 #include "gameTypes/ShipDirection.h"
-#include <boost/variant.hpp>
 #include <vector>
 
 struct InventorySetting;
@@ -57,7 +57,7 @@ public:
     bool SetProductionEnabled(MapPoint pt, bool enabled);
     bool NotifyAlliesOfLocation(MapPoint pt);
     /// Sets inventory settings for a warehouse
-    bool SetInventorySetting(MapPoint pt, const boost::variant<GoodType, Job>& what, InventorySetting state);
+    bool SetInventorySetting(MapPoint pt, const boost_variant2<GoodType, Job>& what, InventorySetting state);
     bool SetAllInventorySettings(MapPoint pt, bool isJob, const std::vector<InventorySetting>& states);
     bool ChangeReserve(MapPoint pt, unsigned char rank, unsigned count);
     bool CheatArmageddon();
@@ -78,7 +78,7 @@ public:
     /// Cancels an expedition
     bool CancelExpedition(unsigned shipID);
     bool StartStopExplorationExpedition(MapPoint pt, bool start);
-    bool TradeOverLand(MapPoint pt, const boost::variant<GoodType, Job>& what, unsigned count);
+    bool TradeOverLand(MapPoint pt, const boost_variant2<GoodType, Job>& what, unsigned count);
 
 protected:
     virtual ~GameCommandFactory() = default;

--- a/libs/s25main/figures/nofTradeDonkey.cpp
+++ b/libs/s25main/figures/nofTradeDonkey.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -9,18 +9,17 @@
 #include "buildings/nobBaseWarehouse.h"
 #include "network/GameClient.h"
 #include "ogl/glArchivItem_Bitmap.h"
-#include "variant.h"
 #include "world/GameWorld.h"
 #include "gameData/BuildingProperties.h"
 #include "gameData/GameConsts.h"
 #include "gameData/JobConsts.h"
 
 nofTradeDonkey::nofTradeDonkey(const MapPoint pos, const unsigned char player,
-                               const boost::variant<GoodType, Job>& what)
-    : noFigure(holds_alternative<Job>(what) ? boost::get<Job>(what) : Job::PackDonkey, pos, player), successor(nullptr)
+                               const boost_variant2<GoodType, Job>& what)
+    : noFigure(holds_alternative<Job>(what) ? get<Job>(what) : Job::PackDonkey, pos, player), successor(nullptr)
 {
     if(holds_alternative<GoodType>(what))
-        gt = boost::get<GoodType>(what);
+        gt = get<GoodType>(what);
 }
 
 nofTradeDonkey::nofTradeDonkey(SerializedGameData& sgd, const unsigned obj_id)

--- a/libs/s25main/figures/nofTradeDonkey.h
+++ b/libs/s25main/figures/nofTradeDonkey.h
@@ -1,13 +1,13 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
 #include "figures/noFigure.h"
+#include "variant.h"
 #include "gameTypes/GoodTypes.h"
 #include "gameTypes/TradeDirection.h"
-#include <boost/variant.hpp>
 #include <deque>
 
 class SerializedGameData;
@@ -38,7 +38,7 @@ private:
     }
 
 public:
-    nofTradeDonkey(MapPoint pos, unsigned char player, const boost::variant<GoodType, Job>& what);
+    nofTradeDonkey(MapPoint pos, unsigned char player, const boost_variant2<GoodType, Job>& what);
     nofTradeDonkey(SerializedGameData& sgd, unsigned obj_id);
 
     void Destroy() override

--- a/libs/s25main/ingameWindows/iwAction.cpp
+++ b/libs/s25main/ingameWindows/iwAction.cpp
@@ -185,7 +185,7 @@ iwAction::iwAction(GameInterface& gi, GameWorldView& gwv, const Tabs& tabs, MapP
     {
         ctrlGroup* group = main_tab->AddTab(LOADER.GetImageN("io", 70), _("Erect flag"), TAB_FLAG);
 
-        switch(boost::get<FlagType>(params))
+        switch(get<FlagType>(params))
         {
             case FlagType::Normal:
             {
@@ -236,7 +236,7 @@ iwAction::iwAction(GameInterface& gi, GameWorldView& gwv, const Tabs& tabs, MapP
         ctrlGroup* group = main_tab->AddTab(LOADER.GetImageN("io", 45), _("Erect flag"), TAB_SETFLAG);
 
         unsigned nr = 70;
-        if(boost::get<FlagType>(params) == FlagType::WaterFlag)
+        if(get<FlagType>(params) == FlagType::WaterFlag)
             nr = 94;
 
         // Straße aufwerten ggf anzeigen
@@ -266,7 +266,7 @@ iwAction::iwAction(GameInterface& gi, GameWorldView& gwv, const Tabs& tabs, MapP
     if(tabs.attack)
     {
         ctrlGroup* group = main_tab->AddTab(LOADER.GetImageN("io", 98), _("Attack options"), TAB_ATTACK);
-        available_soldiers_count = boost::get<SoldierCount>(params);
+        available_soldiers_count = get<SoldierCount>(params);
         AddAttackControls(group, available_soldiers_count);
         selected_soldiers_count = 1;
     }

--- a/libs/s25main/ingameWindows/iwAction.h
+++ b/libs/s25main/ingameWindows/iwAction.h
@@ -1,12 +1,12 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
 #include "IngameWindow.h"
+#include "variant.h"
 #include "gameTypes/MapCoordinates.h"
-#include <boost/variant.hpp>
 #include <array>
 
 class GameInterface;
@@ -26,7 +26,7 @@ public:
                     /// werden
         WaterFlag   /// Flagge mit Anker drauf (Wasserstraße kann gebaut werden)
     };
-    using Params = boost::variant<FlagType, SoldierCount>;
+    using Params = boost_variant2<FlagType, SoldierCount>;
 
     enum class BuildTab
     {

--- a/libs/s25main/ingameWindows/iwTrade.cpp
+++ b/libs/s25main/ingameWindows/iwTrade.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -15,13 +15,13 @@
 #include "helpers/toString.h"
 #include "ogl/FontStyle.h"
 #include "ogl/glArchivItem_Bitmap.h"
+#include "variant.h"
 #include "world/GameWorldBase.h"
 #include "world/GameWorldViewer.h"
 #include "gameData/GoodConsts.h"
 #include "gameData/JobConsts.h"
 #include "gameData/ShieldConsts.h"
 #include "gameData/const_gui_ids.h"
-#include <boost/variant/variant.hpp>
 
 iwTrade::iwTrade(const nobBaseWarehouse& wh, const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
     : IngameWindow(CGI_BUILDING + MapBase::CreateGUIID(wh.GetPos()), IngameWindow::posAtMouse, Extent(400, 194),
@@ -79,7 +79,7 @@ void iwTrade::Msg_ButtonClick(const unsigned /*ctrl_id*/)
     // pressed the send button
     const unsigned short ware_figure_selection = GetCtrl<ctrlComboBox>(4)->GetSelection().get();
     const bool isJob = this->GetCtrl<ctrlComboBox>(2)->GetSelection() == 1u;
-    boost::variant<GoodType, Job> what;
+    boost_variant2<GoodType, Job> what;
     if(isJob)
         what = jobs[ware_figure_selection];
     else

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1442,13 +1442,12 @@ void GameClient::StartReplayRecording(const unsigned random_init)
 {
     replayinfo = std::make_unique<ReplayInfo>();
     replayinfo->filename = s25util::Time::FormatTime("%Y-%m-%d_%H-%i-%s") + ".rpl";
-    replayinfo->replay.random_init = random_init;
 
     WritePlayerInfo(replayinfo->replay);
     replayinfo->replay.ggs = game->ggs_;
 
-    // Datei speichern
-    if(!replayinfo->replay.StartRecording(RTTRCONFIG.ExpandPath(s25::folders::replays) / replayinfo->filename, mapinfo))
+    if(!replayinfo->replay.StartRecording(RTTRCONFIG.ExpandPath(s25::folders::replays) / replayinfo->filename, mapinfo,
+                                          random_init))
     {
         LOG.write(_("Replayfile couldn't be opened. No replay will be recorded\n"));
         replayinfo.reset();
@@ -1534,12 +1533,10 @@ bool GameClient::StartReplay(const boost::filesystem::path& path)
     }
 
     replayMode = true;
-    replayinfo->async = 0;
-    replayinfo->end = false;
 
     try
     {
-        StartGame(replayinfo->replay.random_init);
+        StartGame(replayinfo->replay.getSeed());
     } catch(SerializedGameData::Error& error)
     {
         LOG.write(_("Error when loading game from replay: %s\n")) % error.what();
@@ -1547,7 +1544,7 @@ bool GameClient::StartReplay(const boost::filesystem::path& path)
         return false;
     }
 
-    replayinfo->replay.ReadGF(&replayinfo->next_gf);
+    replayinfo->next_gf = replayinfo->replay.ReadGF();
 
     return true;
 }

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/network/GameClientGF_Replay.cpp
+++ b/libs/s25main/network/GameClientGF_Replay.cpp
@@ -8,6 +8,7 @@
 #include "helpers/format.hpp"
 #include "network/ClientInterface.h"
 #include "network/GameClient.h"
+#include "variant.h"
 #include "s25util/Log.h"
 
 void GameClient::ExecuteGameFrame_Replay()
@@ -15,62 +16,54 @@ void GameClient::ExecuteGameFrame_Replay()
     AsyncChecksum checksum = AsyncChecksum::create(*game);
 
     const unsigned curGF = GetGFNumber();
-    RTTR_Assert(replayinfo->next_gf >= curGF || curGF > replayinfo->replay.GetLastGF()); //-V807
+    RTTR_Assert(replayinfo->next_gf.value_or(curGF) >= curGF || curGF > replayinfo->replay.GetLastGF()); //-V807
 
     bool cmdsExecuted = false;
+    auto& replay = replayinfo->replay;
     // Execute all commands from the replay for the current GF
-    while(replayinfo->next_gf == curGF)
+    while(replayinfo->next_gf && replayinfo->next_gf == curGF)
     {
-        // What type of command follows?
-        ReplayCommand rc = replayinfo->replay.ReadRCType();
+        const auto cmd = replay.ReadCommand();
+        visit(
+          composeVisitor(
+            [this](const Replay::ChatCommand& cmd) {
+                if(ci)
+                    ci->CI_Chat(cmd.player, cmd.dest, cmd.msg);
+            },
+            [this, &cmdsExecuted, &checksum, curGF](const Replay::GameCommand& cmd) {
+                cmdsExecuted = true;
 
-        if(rc == ReplayCommand::Chat)
-        {
-            uint8_t player, dest;
-            std::string message;
-            replayinfo->replay.ReadChatCommand(player, dest, message);
+                ExecuteAllGCs(cmd.player, cmd.cmds);
+                const AsyncChecksum& msgChecksum = cmd.cmds.checksum;
 
-            if(ci)
-                ci->CI_Chat(player, ChatDestination(dest), message);
-        } else if(rc == ReplayCommand::Game)
-        {
-            cmdsExecuted = true;
-
-            PlayerGameCommands msg;
-            uint8_t gcPlayer;
-            replayinfo->replay.ReadGameCommand(gcPlayer, msg);
-
-            // Execute them
-            ExecuteAllGCs(gcPlayer, msg);
-            AsyncChecksum& msgChecksum = msg.checksum;
-
-            // Check for async if checksum data is valid
-            if(msgChecksum.randChecksum != 0 && msgChecksum != checksum)
-            {
-                // Show message if this is the first async GF
-                if(replayinfo->async == 0)
+                // Check for async if checksum data is valid
+                if(msgChecksum.randChecksum != 0 && msgChecksum != checksum)
                 {
-                    if(ci)
+                    // Show message if this is the first async GF
+                    if(replayinfo->async == 0)
                     {
-                        ci->CI_ReplayAsync(helpers::format(
-                          _("Warning: The played replay is not in sync with the original match. (GF: %u)"), curGF));
+                        if(ci)
+                        {
+                            ci->CI_ReplayAsync(helpers::format(
+                              _("Warning: The played replay is not in sync with the original match. (GF: %u)"), curGF));
+                        }
+
+                        LOG.write("Async at GF %u: Checksum %i:%i ObjCt %u:%u ObjIdCt %u:%u\n") % curGF
+                          % msgChecksum.randChecksum % checksum.randChecksum % msgChecksum.objCt % checksum.objCt
+                          % msgChecksum.objIdCt % checksum.objIdCt;
+
+                        // and pause the game for further investigation
+                        framesinfo.isPaused = true;
+                        if(skiptogf)
+                            skiptogf = 0;
                     }
 
-                    LOG.write("Async at GF %u: Checksum %i:%i ObjCt %u:%u ObjIdCt %u:%u\n") % curGF
-                      % msgChecksum.randChecksum % checksum.randChecksum % msgChecksum.objCt % checksum.objCt
-                      % msgChecksum.objIdCt % checksum.objIdCt;
-
-                    // and pause the game for further investigation
-                    framesinfo.isPaused = true;
-                    if(skiptogf)
-                        skiptogf = 0;
+                    replayinfo->async++;
                 }
-
-                replayinfo->async++;
-            }
-        }
+            }),
+          cmd);
         // Read GF of next command
-        replayinfo->replay.ReadGF(&replayinfo->next_gf);
+        replayinfo->next_gf = replayinfo->replay.ReadGF();
     }
 
     // Run game simulation
@@ -97,15 +90,14 @@ void GameClient::ExecuteGameFrame_Replay()
 
         if(replayinfo->async != 0)
         {
-            // Messenger im Game
+            // in-game messenger
             if(ci)
             {
                 ci->CI_ReplayEndReached(
                   helpers::format(_("Notice: Overall asynchronous frame count: %u"), replayinfo->async));
             }
         }
-
-        replayinfo->end = true;
+        replayinfo->next_gf.reset();
         framesinfo.isPaused = true;
         if(skiptogf)
             skiptogf = GetGFNumber();

--- a/libs/s25main/network/GameClientGF_Replay.cpp
+++ b/libs/s25main/network/GameClientGF_Replay.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/network/GameMessage_GameCommand.cpp
+++ b/libs/s25main/network/GameMessage_GameCommand.cpp
@@ -24,7 +24,8 @@ void GameMessage_GameCommand::Serialize(Serializer& ser) const
 void GameMessage_GameCommand::Deserialize(Serializer& ser)
 {
     GameMessageWithPlayer::Deserialize(ser);
-    cmds.Deserialize(ser);
+    gc::Deserializer deser(ser);
+    cmds.Deserialize(deser);
 }
 
 bool GameMessage_GameCommand::Run(GameMessageInterface* callback) const

--- a/libs/s25main/network/GameServerPlayer.h
+++ b/libs/s25main/network/GameServerPlayer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -7,7 +7,7 @@
 #include "NetworkPlayer.h"
 #include "Timer.h"
 #include "helpers/SmoothedValue.hpp"
-#include <variant.h>
+#include "variant.h"
 
 /// Player connected to the server
 class GameServerPlayer : public NetworkPlayer
@@ -58,8 +58,8 @@ public:
     /// Set player not lagging (anymore)
     void setNotLagging();
 
-    auto& getPendingSwaps() { return boost::get<ActiveState>(state_).pendingSwaps; }
+    auto& getPendingSwaps() { return get<ActiveState>(state_).pendingSwaps; }
 
 private:
-    boost::variant<JustConnectedState, MapSendingState, ActiveState> state_;
+    boost_variant2<JustConnectedState, MapSendingState, ActiveState> state_;
 };

--- a/libs/s25main/network/PlayerGameCommands.cpp
+++ b/libs/s25main/network/PlayerGameCommands.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -14,7 +14,7 @@ void PlayerGameCommands::Serialize(Serializer& ser) const
         gc->Serialize(ser);
 }
 
-void PlayerGameCommands::Deserialize(Serializer& ser)
+void PlayerGameCommands::Deserialize(gc::Deserializer& ser)
 {
     checksum.Deserialize(ser);
 

--- a/libs/s25main/network/PlayerGameCommands.h
+++ b/libs/s25main/network/PlayerGameCommands.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/network/PlayerGameCommands.h
+++ b/libs/s25main/network/PlayerGameCommands.h
@@ -14,7 +14,7 @@ struct PlayerGameCommands
 {
     /// Checksum for this NWF
     AsyncChecksum checksum;
-    /// The game gammands for this NWF
+    /// The game commands for this NWF
     std::vector<gc::GameCommandPtr> gcs;
 
     PlayerGameCommands() = default;
@@ -22,5 +22,5 @@ struct PlayerGameCommands
         : checksum(checksum), gcs(std::move(gcs))
     {}
     void Serialize(Serializer& ser) const;
-    void Deserialize(Serializer& ser);
+    void Deserialize(gc::Deserializer& ser);
 };

--- a/libs/s25main/world/GameWorld.cpp
+++ b/libs/s25main/world/GameWorld.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/world/MapBase.cpp
+++ b/libs/s25main/world/MapBase.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/world/MapSerializer.cpp
+++ b/libs/s25main/world/MapSerializer.cpp
@@ -179,10 +179,9 @@ void MapSerializer::Deserialize(GameWorldBase& world, SerializedGameData& sgd, G
     {
         if(sgd.PopUnsignedInt() != 0xC0DEBA5E)
             throw SerializedGameData::Error(_("Invalid id for lua data"));
-        // If there is a script, there is also save data. Pop that first
-        unsigned luaSaveSize = sgd.PopUnsignedInt();
-        Serializer luaSaveState;
-        sgd.PopRawData(luaSaveState.GetDataWritable(luaSaveSize), luaSaveSize);
+        // If there is a script, there is also save data. Store reference to that
+        const auto luaSaveSize = sgd.PopUnsignedInt();
+        Serializer luaSaveState(sgd.PopAndDiscard(luaSaveSize), luaSaveSize);
         if(sgd.PopUnsignedInt() != 0xC001C0DE)
             throw SerializedGameData::Error(_("Invalid end-id for lua data"));
 

--- a/libs/s25main/world/MapSerializer.cpp
+++ b/libs/s25main/world/MapSerializer.cpp
@@ -183,7 +183,6 @@ void MapSerializer::Deserialize(GameWorldBase& world, SerializedGameData& sgd, G
         unsigned luaSaveSize = sgd.PopUnsignedInt();
         Serializer luaSaveState;
         sgd.PopRawData(luaSaveState.GetDataWritable(luaSaveSize), luaSaveSize);
-        luaSaveState.SetLength(luaSaveSize);
         if(sgd.PopUnsignedInt() != 0xC001C0DE)
             throw SerializedGameData::Error(_("Invalid end-id for lua data"));
 

--- a/tests/s25Main/autoplay/main.cpp
+++ b/tests/s25Main/autoplay/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/tests/s25Main/integration/testEconomyMode.cpp
+++ b/tests/s25Main/integration/testEconomyMode.cpp
@@ -148,8 +148,8 @@ BOOST_FIXTURE_TEST_CASE(EconomyModeSerialization, EconModeFixture)
     newWorld.getEconHandler()->UpdateAmounts();
     for(const auto& teamPair : boost::combine(econTeams, econTeamsAfter))
     {
-        const EconomyModeHandler::EconTeam& before = boost::get<0>(teamPair);
-        const EconomyModeHandler::EconTeam& after = boost::get<1>(teamPair);
+        const EconomyModeHandler::EconTeam& before = get<0>(teamPair);
+        const EconomyModeHandler::EconTeam& after = get<1>(teamPair);
         BOOST_TEST_REQUIRE(before.playersInTeam == after.playersInTeam);
         BOOST_TEST_REQUIRE(before.amountsTheTeamCollected == after.amountsTheTeamCollected);
         BOOST_TEST_REQUIRE(before.goodTypeWins == after.goodTypeWins);

--- a/tests/s25Main/integration/testSerialization.cpp
+++ b/tests/s25Main/integration/testSerialization.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/tests/s25Main/integration/testTrading.cpp
+++ b/tests/s25Main/integration/testTrading.cpp
@@ -14,7 +14,7 @@
 #include "gameData/JobConsts.h"
 #include <rttr/test/LogAccessor.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/variant/variant.hpp>
+#include <variant.h>
 
 struct TradeFixture : public WorldWithGCExecution3P
 {

--- a/tests/s25Main/worldFixtures/GCExecutor.h
+++ b/tests/s25Main/worldFixtures/GCExecutor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -6,7 +6,6 @@
 
 #include "GameCommand.h"
 #include "factories/GameCommandFactory.h"
-#include "s25util/Serializer.h"
 #include <boost/test/unit_test.hpp>
 
 class GCExecutor : public GameCommandFactory
@@ -19,7 +18,7 @@ protected:
     bool AddGC(gc::GameCommandPtr gc) override
     {
         // Go through serialization to check if that works too
-        Serializer ser;
+        gc::Deserializer ser;
         gc->Serialize(ser);
         gc.reset();
         gc = gc::GameCommand::Deserialize(ser);


### PR DESCRIPTION
For e.g. #1673 we should have some backwards compatibility to allow loading older replays even if there are some changes to serialized game commands.

The main contribution to this is the `VersionedSerializer` class in libutil which is an adapter over the serializer adding a version. To be as uninvasive as possible it allows to be used only for parts. E.g. an instance being passed a `Serializer` instance can create a `VersionedSerializer` on top of it for the duration of the method and afterwards the caller can use the original `Serializer` without even knowing about this process. This is done by recording the position of the Serializer and advancing it by the amount of bytes read through the Adapter.

I also translated/updated the docstrings and while doing that I found some places for major improvements:

- The random seed needs to be set when recording a replay, so require passing it
- We don't need `Replay::IsValid` but only `IsRecording/IsReplaying`
- `ReadGF` can return a proper optional instead of a bool setting a pointer param
- Reading a replay command involved reading the type and calling the right function afterwards. To much detail on the caller -> Use a variant
- Boost.Variant2 is superior to both Boost.Variant and `std::variant` by being trivial in some cases and being never empty, so use it and add a typedef for easier usability (instead of `boost::variant2::variant`)
- Return `std::string` references for some accessors instead of copies
- `GetDataWritable + SetLength` is inconvenient as we always need them paired up, so do that in one function
- Allow a Deserializer to use an existing buffer, i.e. don't copy data when passed to the ctor of `Serializer`
