### PR TITLE
Add classic campaigns straight to single player screen

### DIFF
--- a/libs/s25main/QuickStartGame.cpp
+++ b/libs/s25main/QuickStartGame.cpp
@@ -80,7 +80,7 @@ bool QuickStartGame(const boost::filesystem::path& mapOrReplayPath, const std::v
     }
 
     const CreateServerInfo csi(isSinglePlayer ? ServerType::Local : ServerType::Direct, SETTINGS.server.localPort,
-                               _("Unlimited Play"));
+                               _("Unlimited play"));
 
     LOG.write(_("Loading game...\n"));
     const std::string extension = s25util::toLower(mapOrReplayPath.extension().string());

--- a/libs/s25main/desktops/CreatedFrom.h
+++ b/libs/s25main/desktops/CreatedFrom.h
@@ -1,0 +1,11 @@
+// Copyright (C) 2024 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+enum class CreatedFrom
+{
+	CampaignSelection,
+	SinglePlayer,
+};

--- a/libs/s25main/desktops/dskCampaignMissionMapSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignMissionMapSelection.cpp
@@ -7,6 +7,7 @@
 #include "WindowManager.h"
 #include "controls/ctrlMapSelection.h"
 #include "dskCampaignSelection.h"
+#include "dskSinglePlayer.h"
 #include "ingameWindows/iwConnecting.h"
 #include "ingameWindows/iwMsgbox.h"
 #include "lua/CampaignDataLoader.h"
@@ -31,8 +32,10 @@ constexpr int spacingBetweenButtons = 2;
 } // namespace
 
 dskCampaignMissionMapSelection::dskCampaignMissionMapSelection(CreateServerInfo csi,
-                                                               boost::filesystem::path campaignFolder)
-    : Desktop(LOADER.GetImageN("setup015", 0)), campaignFolder_(std::move(campaignFolder)), csi_(std::move(csi))
+                                                               boost::filesystem::path campaignFolder,
+                                                               CreatedFrom createdFrom)
+    : Desktop(LOADER.GetImageN("setup015", 0)), campaignFolder_(std::move(campaignFolder)), csi_(std::move(csi)),
+      createdFrom_(createdFrom)
 {
     AddTextButton(ID_Start, DrawPoint(300, 530), buttonSize, TextureColor::Red1, _("Start"), NormalFont);
     AddTextButton(ID_Back, DrawPoint(300, 530 + buttonSize.y + spacingBetweenButtons), buttonSize, TextureColor::Red1,
@@ -50,6 +53,8 @@ dskCampaignMissionMapSelection::dskCampaignMissionMapSelection(CreateServerInfo 
         mapSelection->setMissionsStatus(std::vector<MissionStatus>(settings_->getNumMaps(), {true, true}));
     }
 }
+
+dskCampaignMissionMapSelection::~dskCampaignMissionMapSelection() = default;
 
 void dskCampaignMissionMapSelection::StartServer(const boost::filesystem::path& mapPath,
                                                  const boost::optional<boost::filesystem::path>& luaPath)
@@ -72,8 +77,12 @@ void dskCampaignMissionMapSelection::StartServer(const boost::filesystem::path& 
 void dskCampaignMissionMapSelection::Msg_ButtonClick(unsigned ctrl_id)
 {
     if(ctrl_id == ID_Back)
-        WINDOWMANAGER.Switch(std::make_unique<dskCampaignSelection>(csi_));
-    else if(ctrl_id == ID_Start)
+    {
+        if(createdFrom_ == CreatedFrom::SinglePlayer)
+            WINDOWMANAGER.Switch(std::make_unique<dskSinglePlayer>());
+        else
+            WINDOWMANAGER.Switch(std::make_unique<dskCampaignSelection>(csi_));
+    } else if(ctrl_id == ID_Start)
     {
         if(GetCtrl<ctrlMapSelection>(ID_MapSelection))
         {

--- a/libs/s25main/desktops/dskCampaignMissionMapSelection.h
+++ b/libs/s25main/desktops/dskCampaignMissionMapSelection.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "CreatedFrom.h"
 #include "desktops/Desktop.h"
 #include "network/CreateServerInfo.h"
 #include <boost/filesystem.hpp>
@@ -15,7 +16,9 @@ struct CampaignDescription;
 class dskCampaignMissionMapSelection : public Desktop
 {
 public:
-    dskCampaignMissionMapSelection(CreateServerInfo csi, boost::filesystem::path campaignFolder);
+    dskCampaignMissionMapSelection(CreateServerInfo csi, boost::filesystem::path campaignFolder,
+                                   CreatedFrom createdFrom);
+    ~dskCampaignMissionMapSelection();
 
 private:
     void Msg_ButtonClick(unsigned ctrl_id) override;
@@ -25,4 +28,5 @@ private:
     CreateServerInfo csi_;
     std::unique_ptr<CampaignDescription> settings_;
     boost::signals2::scoped_connection onErrorConnection_;
+    CreatedFrom createdFrom_;
 };

--- a/libs/s25main/desktops/dskCampaignMissionSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignMissionSelection.cpp
@@ -10,6 +10,7 @@
 #include "controls/ctrlImageButton.h"
 #include "controls/ctrlText.h"
 #include "dskCampaignSelection.h"
+#include "dskSinglePlayer.h"
 #include "ingameWindows/iwConnecting.h"
 #include "ingameWindows/iwMsgbox.h"
 #include "lua/CampaignDataLoader.h"
@@ -51,9 +52,10 @@ int getStartOffsetMissionButtonsY()
 }
 } // namespace
 
-dskCampaignMissionSelection::dskCampaignMissionSelection(CreateServerInfo csi, boost::filesystem::path campaignFolder)
+dskCampaignMissionSelection::dskCampaignMissionSelection(CreateServerInfo csi, boost::filesystem::path campaignFolder,
+                                                         CreatedFrom createdFrom)
     : Desktop(LOADER.GetImageN("setup015", 0)), campaignFolder_(std::move(campaignFolder)), csi_(std::move(csi)),
-      currentPage_(0), lastPage_(0), missionsPerPage_(10)
+      currentPage_(0), lastPage_(0), missionsPerPage_(10), createdFrom_(createdFrom)
 {
     const unsigned int btOffset = getStartOffsetMissionButtonsY()
                                   + missionsPerPage_ * (buttonSize.y + distanceBetweenMissionButtonsY)
@@ -90,6 +92,8 @@ dskCampaignMissionSelection::dskCampaignMissionSelection(CreateServerInfo csi, b
 
     UpdateMissionPage();
 }
+
+dskCampaignMissionSelection::~dskCampaignMissionSelection() = default;
 
 void dskCampaignMissionSelection::UpdateMissionPage()
 {
@@ -159,8 +163,12 @@ void dskCampaignMissionSelection::Msg_Group_ButtonClick(unsigned group_id, unsig
 void dskCampaignMissionSelection::Msg_ButtonClick(unsigned ctrl_id)
 {
     if(ctrl_id == ID_Back)
-        WINDOWMANAGER.Switch(std::make_unique<dskCampaignSelection>(csi_));
-    else if(ctrl_id >= ID_FirstPage && ctrl_id <= ID_LastPage)
+    {
+        if(createdFrom_ == CreatedFrom::SinglePlayer)
+            WINDOWMANAGER.Switch(std::make_unique<dskSinglePlayer>());
+        else
+            WINDOWMANAGER.Switch(std::make_unique<dskCampaignSelection>(csi_));
+    } else if(ctrl_id >= ID_FirstPage && ctrl_id <= ID_LastPage)
     {
         // Destroy all controls first (the whole group)
         DeleteCtrl(ID_GroupStart + currentPage_);

--- a/libs/s25main/desktops/dskCampaignMissionSelection.h
+++ b/libs/s25main/desktops/dskCampaignMissionSelection.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "CreatedFrom.h"
 #include "desktops/Desktop.h"
 #include "network/CreateServerInfo.h"
 #include <boost/filesystem.hpp>
@@ -15,7 +16,8 @@ struct CampaignDescription;
 class dskCampaignMissionSelection : public Desktop
 {
 public:
-    dskCampaignMissionSelection(CreateServerInfo csi, boost::filesystem::path campaignFolder);
+    dskCampaignMissionSelection(CreateServerInfo csi, boost::filesystem::path campaignFolder, CreatedFrom createdFrom);
+    ~dskCampaignMissionSelection();
 
 private:
     void UpdateMissionPage();
@@ -30,4 +32,5 @@ private:
     std::unique_ptr<CampaignDescription> settings_;
     unsigned missionsPerPage_;
     boost::signals2::scoped_connection onErrorConnection_;
+    CreatedFrom createdFrom_;
 };

--- a/libs/s25main/desktops/dskCampaignSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignSelection.cpp
@@ -169,9 +169,11 @@ bool dskCampaignSelection::hasMapSelectionScreen()
 void dskCampaignSelection::showCampaignMissionSelectionScreen()
 {
     if(hasMapSelectionScreen())
-        WINDOWMANAGER.Switch(std::make_unique<dskCampaignMissionMapSelection>(csi_, getSelectedCampaignPath()));
+        WINDOWMANAGER.Switch(std::make_unique<dskCampaignMissionMapSelection>(csi_, getSelectedCampaignPath(),
+                                                                              CreatedFrom::CampaignSelection));
     else
-        WINDOWMANAGER.Switch(std::make_unique<dskCampaignMissionSelection>(csi_, getSelectedCampaignPath()));
+        WINDOWMANAGER.Switch(std::make_unique<dskCampaignMissionSelection>(csi_, getSelectedCampaignPath(),
+                                                                           CreatedFrom::CampaignSelection));
 }
 
 boost::filesystem::path dskCampaignSelection::getSelectedCampaignPath()

--- a/libs/s25main/desktops/dskSinglePlayer.cpp
+++ b/libs/s25main/desktops/dskSinglePlayer.cpp
@@ -10,6 +10,8 @@
 #include "Settings.h"
 #include "WindowManager.h"
 #include "controls/ctrlButton.h"
+#include "dskCampaignMissionMapSelection.h"
+#include "dskCampaignMissionSelection.h"
 #include "dskCampaignSelection.h"
 #include "dskMainMenu.h"
 #include "dskSelectMap.h"
@@ -37,17 +39,17 @@ dskSinglePlayer::dskSinglePlayer()
 {
     RTTR_Assert(dskMenuBase::ID_FIRST_FREE <= 3);
 
-    AddTextButton(3, DrawPoint(115, 180), Extent(220, 22), TextureColor::Green2, _("Resume last game"), NormalFont);
-    AddTextButton(7, DrawPoint(115, 210), Extent(220, 22), TextureColor::Green2, _("Load game"), NormalFont);
-
-    AddTextButton(5, DrawPoint(115, 250), Extent(220, 22), TextureColor::Green2, std::string(_("Campaigns")),
+    AddTextButton(5, DrawPoint(115, 180), Extent(220, 22), TextureColor::Green2, std::string(_("All Campaigns")),
                   NormalFont);
-    AddTextButton(6, DrawPoint(115, 280), Extent(220, 22), TextureColor::Green2, _("Unlimited Play"), NormalFont);
-
-    AddTextButton(4, DrawPoint(115, 320), Extent(220, 22), TextureColor::Green2, _("Play Replay"), NormalFont);
-
+    AddTextButton(9, DrawPoint(115, 210), Extent(220, 22), TextureColor::Green2, std::string(_("Roman Campaign")),
+                  NormalFont);
+    AddTextButton(10, DrawPoint(115, 240), Extent(220, 22), TextureColor::Green2, std::string(_("World Campaign")),
+                  NormalFont);
+    AddTextButton(3, DrawPoint(115, 270), Extent(220, 22), TextureColor::Green2, _("Resume last game"), NormalFont);
+    AddTextButton(7, DrawPoint(115, 300), Extent(220, 22), TextureColor::Green2, _("Load game"), NormalFont);
+    AddTextButton(6, DrawPoint(115, 330), Extent(220, 22), TextureColor::Green2, _("Unlimited play"), NormalFont);
+    AddTextButton(4, DrawPoint(115, 360), Extent(220, 22), TextureColor::Green2, _("Play Replay"), NormalFont);
     AddTextButton(8, DrawPoint(115, 390), Extent(220, 22), TextureColor::Red1, _("Back"), NormalFont);
-
     AddImage(11, DrawPoint(20, 20), LOADER.GetImageN("logo", 0));
 }
 
@@ -126,17 +128,31 @@ void dskSinglePlayer::Msg_ButtonClick(const unsigned ctrl_id)
             WINDOWMANAGER.Switch(std::make_unique<dskMainMenu>());
         }
         break;
+        case 9: // Roman campaign
+        {
+            WINDOWMANAGER.Switch(std::make_unique<dskCampaignMissionSelection>(
+              createLocalGameInfo(_("Campaign")),
+              bfs::path{RTTRCONFIG.ExpandPath(s25::folders::campaignsBuiltin)} / "roman", CreatedFrom::SinglePlayer));
+        }
+        break;
+        case 10: // World campaign
+        {
+            WINDOWMANAGER.Switch(std::make_unique<dskCampaignMissionMapSelection>(
+              createLocalGameInfo(_("Campaign")),
+              bfs::path{RTTRCONFIG.ExpandPath(s25::folders::campaignsBuiltin)} / "world", CreatedFrom::SinglePlayer));
+        }
+        break;
     }
 }
 
 void dskSinglePlayer::PrepareSinglePlayerServer()
 {
-    WINDOWMANAGER.Switch(std::make_unique<dskSelectMap>(createLocalGameInfo(_("Unlimited Play"))));
+    WINDOWMANAGER.Switch(std::make_unique<dskSelectMap>(createLocalGameInfo(_("Unlimited play"))));
 }
 
 void dskSinglePlayer::PrepareLoadGame()
 {
-    CreateServerInfo csi = createLocalGameInfo(_("Unlimited Play"));
+    CreateServerInfo csi = createLocalGameInfo(_("Unlimited play"));
 
     WINDOWMANAGER.Switch(std::make_unique<dskSelectMap>(csi));
     WINDOWMANAGER.ShowAfterSwitch(std::make_unique<iwLoad>(csi));


### PR DESCRIPTION
Adds the Roman and world campaigns straight to the single player screen in order not to have to go through the campaign selection screen. Useful for testing and provides a look that is almost identical to what the S2 main screen offered.

![Zrzut ekranu 2024-07-23 124955](https://github.com/user-attachments/assets/8c2d23a8-6c70-4088-abee-5a1ccc75db57)
![Zrzut ekranu 2024-07-23 130747](https://github.com/user-attachments/assets/feb39d68-adf9-4c75-9069-a82de809f062)
