### PR TITLE
Fix updater

### DIFF
--- a/tools/release/bin/rttr.sh.cmake
+++ b/tools/release/bin/rttr.sh.cmake
@@ -41,7 +41,7 @@ if [ $noupdate -eq 0 ] ; then
 		echo "checking for an update ..."
 		cp $DIR/../libexec/s25rttr/s25update /tmp/s25update.$$
 		chmod 0755 /tmp/s25update.$$
-		/tmp/s25update.$$ --verbose --dir "$DIR/../" @STABLE_PARAM@
+		/tmp/s25update.$$ --dir "$DIR/../" @STABLE_PARAM@
 		if [ -z "$(diff -q /tmp/s25update.$$ $DIR/../libexec/s25rttr/s25update)" ] ; then
 			PARAM=noupdate
 		fi


### PR DESCRIPTION
Fixes https://github.com/Return-To-The-Roots/s25client/issues/1697

Reason was an inverted condition because the decision of downloading to file or memory was done in 2 places that needed to be kept in sync. Using a RAII wrapper for cURL makes it easier to merge those such that a single condition handles the distinction. It also makes the code cleaner.