### PR TITLE
Fix inverted cursor is not saved in global settings

### DIFF
--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -548,9 +548,7 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
             SETTINGS.global.submit_debug_data = selection;
             break;
         case ID_grpUPNP: SETTINGS.global.use_upnp = enabled; break;
-        case ID_grpInvertScroll:
-            SETTINGS.interface.invertMouse = enabled;
-            break;
+        case ID_grpInvertScroll: SETTINGS.interface.invertMouse = enabled; break;
         case ID_grpSmartCursor:
             SETTINGS.global.smartCursor = enabled;
             VIDEODRIVER.SetMouseWarping(enabled);

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -548,6 +548,9 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
             SETTINGS.global.submit_debug_data = selection;
             break;
         case ID_grpUPNP: SETTINGS.global.use_upnp = enabled; break;
+        case ID_grpInvertScroll:
+            SETTINGS.interface.invertMouse = enabled;
+            break;
         case ID_grpSmartCursor:
             SETTINGS.global.smartCursor = enabled;
             VIDEODRIVER.SetMouseWarping(enabled);


### PR DESCRIPTION
The inverted cursor setting never was applied when activating in settings. Just when activating ingame in advanced options. 

Just a very small fix.