### PR TITLE
Fix & Update Github Actions CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -107,12 +107,11 @@ jobs:
           - { compiler: gcc-11,   os: ubuntu-22.04, type: RelWithDebInfo, cmake: 3.22.1, boost: 1.74.0 }
           #
           #  Latest Compilers
-          #   GCC 12 needs boost 1.82 to compile correctly
+          #   Use default boost
           #   Use (compiler) default C++ 17 standard
           #   Use default cmake
-          - { compiler: gcc-12,   os: ubuntu-22.04, type: Debug, boost: 1.82.0 }
-          #   Use default boost
-          - { compiler: clang-16, os: ubuntu-20.04, type: Debug, externalSanitizer: true }
+          - { compiler: gcc-14,   os: ubuntu-24.04, type: Debug }
+          - { compiler: clang-18, os: ubuntu-24.04, type: Debug, externalSanitizer: true }
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -76,11 +76,11 @@ jobs:
       matrix:
         include:
           # MacOSX:
-          #  Use system clang (14)
+          #  Use system clang (15)
           #   Use (compiler) default C++ 14 standard
           #   Use system cmake (version gets ignored below)
           #   Use boost installed via brew
-          - { compiler: clang,    os: macos-12,     type: Debug }
+          - { compiler: clang,    os: macos-14,     type: Debug }
 
           # Linux:
           #  Oldest Compilers 


### PR DESCRIPTION
The `macos-12` runner image is now removed. `macos-15` is available as preview, `macos-latest` is still at 14, so use that.

Also update the "latest GCC &Clang" compilers to the currently latest versions