### PR TITLE
Workaround GUI scaling issues with HighDPI enabled.

### DIFF
--- a/extras/videoDrivers/SDL2/CMakeLists.txt
+++ b/extras/videoDrivers/SDL2/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+# Copyright (C) 2005 - 2024 Settlers Freaks <sf-team at siedler25.org>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 set(SDL2_BUILDING_LIBRARY ON)
-find_package(SDL2 2.0.2)
+find_package(SDL2 2.0.5)
 
 if(SDL2_FOUND)
     add_library(videoSDL2 SHARED ${RTTR_DRIVER_INTERFACE} VideoSDL2.cpp VideoSDL2.h icon.h icon.cpp)

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -133,10 +133,7 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
 
     const auto requestedSize = fullscreen ? FindClosestVideoMode(size) : size;
     unsigned commonFlags = SDL_WINDOW_OPENGL;
-
-#if SDL_VERSION_ATLEAST(2, 0, 1)
     commonFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
-#endif
 
     window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
                               commonFlags | (fullscreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE));
@@ -193,9 +190,7 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, bool fullscreen)
         isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
         if(!isFullscreen_)
         {
-#if SDL_VERSION_ATLEAST(2, 0, 5)
             SDL_SetWindowResizable(window, SDL_TRUE);
-#endif
             MoveWindowToCenter();
         }
     }
@@ -391,10 +386,8 @@ bool VideoSDL2::MessageLoop()
             case SDL_MOUSEWHEEL:
             {
                 int y = ev.wheel.y;
-#if SDL_VERSION_ATLEAST(2, 0, 4)
                 if(ev.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
                     y = -y;
-#endif
                 if(y > 0)
                     CallBack->Msg_WheelUp(mouse_xy);
                 else if(y < 0)
@@ -471,18 +464,11 @@ void* VideoSDL2::GetMapPointer() const
 void VideoSDL2::MoveWindowToCenter()
 {
     SDL_Rect usableBounds;
-#if SDL_VERSION_ATLEAST(2, 0, 5)
     CHECK_SDL(SDL_GetDisplayUsableBounds(SDL_GetWindowDisplayIndex(window), &usableBounds));
     int top, left, bottom, right;
     CHECK_SDL(SDL_GetWindowBordersSize(window, &top, &left, &bottom, &right));
     usableBounds.w -= left + right;
     usableBounds.h -= top + bottom;
-#else
-    CHECK_SDL(SDL_GetDisplayBounds(SDL_GetWindowDisplayIndex(window), &usableBounds));
-    // rough estimates
-    usableBounds.w -= 10;
-    usableBounds.h -= 30;
-#endif
     if(usableBounds.w < GetWindowSize().width || usableBounds.h < GetWindowSize().height)
     {
         SDL_SetWindowSize(window, usableBounds.w, usableBounds.h);

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -133,7 +133,9 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
 
     const auto requestedSize = fullscreen ? FindClosestVideoMode(size) : size;
     unsigned commonFlags = SDL_WINDOW_OPENGL;
-    commonFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
+    // TODO: Fix GUI scaling with High DPI support enabled.
+    // See https://github.com/Return-To-The-Roots/s25client/issues/1621
+    // commonFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
     window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
                               commonFlags | (fullscreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE));


### PR DESCRIPTION
Disable High DPI support/request for now until the GUI scaling is adjusted to support it.

See https://github.com/Return-To-The-Roots/s25client/issues/1621

Also require SDL2 2.0.5+ as even the EoL Ubuntu 18.04 (bionic) provides 2.0.8 so we can remove our checks/workarounds.