### PR TITLE
Fix testCheats when running standalone

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,13 +15,15 @@ def transformIntoStep(architecture, dockerImage, buildScript) {
     return {
         timeout(120) {
             def wspwd = pwd()
+            def ccache_dir_host = "$HOME/.ccache-$architecture"
             dir("build-$architecture") {
                 sh 'touch .git-keep'
+                sh "mkdir -p '$ccache_dir_host'"
                 withDockerRegistry( registry: [credentialsId: dockerCredentials, url: 'https://'+dockerRegistry ] ) {
                     withDockerContainer(
                         image: dockerRegistry+dockerImage,
                         args: " \
-                            -v $HOME/.ccache:/.ccache \
+                            -v $ccache_dir_host:/.ccache \
                             -v $wspwd/source:/source:ro \
                             -v $wspwd/result:/result \
                         ") {

--- a/tools/ci/jenkins/build.sh
+++ b/tools/ci/jenkins/build.sh
@@ -47,7 +47,7 @@ fi
 
 BUILD_TYPE=Release
 
-rm -rf _CPack_Packages *.tar.bz2 *.zip CMakeFiles CMakeCache.txt
+rm -rf -- _CPack_Packages *.tar.bz2 *.zip CMakeFiles CMakeCache.txt
 
 RTTR_VERSION=OFF
 if [ "$deploy_to" == "stable" ] ; then
@@ -65,7 +65,7 @@ cmake \
     -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_FILE \
     -DRTTR_ENABLE_WERROR=ON \
     -DRTTR_USE_STATIC_BOOST=ON \
-    -DRTTR_VERSION=$RTTR_VERSION \
+    -DRTTR_VERSION="$RTTR_VERSION" \
     -DRTTR_REVISION=OFF \
     -DRTTR_BUNDLE=ON \
     -DRTTR_EXTERNAL_BUILD_TESTING=ON \
@@ -92,4 +92,5 @@ if [ -z "$files" ] ; then
     exit 1
 fi
 
+# shellcheck disable=SC2086
 cp -av $files $result_dir/

--- a/tools/ci/jenkins/build.sh
+++ b/tools/ci/jenkins/build.sh
@@ -47,7 +47,8 @@ fi
 
 BUILD_TYPE=Release
 
-rm -rf -- _CPack_Packages *.tar.bz2 *.zip CMakeFiles CMakeCache.txt
+rm -rf -- _CPack_Packages *.tar.bz2 *.zip CMakeCache.txt
+find . -type d -name "CMakeFiles" -exec rm -r {} +
 
 RTTR_VERSION=OFF
 if [ "$deploy_to" == "stable" ] ; then


### PR DESCRIPTION
The test creates a desktop instance that requires access to the VideoDriver and potentially resources (graphics) which are not available at this point. This leads to failures when the test is not started after a test installing a test-videodriver in the same process.

Manually create the required instances without that desktop.