### PR TITLE
Don't draw content of ship window if minimized 

### DIFF
--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -427,6 +427,7 @@ void IngameWindow::Draw_()
             background->DrawPart(Rect(GetPos() + DrawPoint(contentOffset), GetIwSize()));
 
         Window::Draw_();
+        DrawContent();
     }
 
     // The 2 rects on the bottom left and right

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -104,6 +104,8 @@ public:
 
 protected:
     void Draw_() override;
+    /// Called when not minimized after the frame and background have been drawn
+    virtual void DrawContent() {}
 
     /// Verschiebt Fenster in die Bildschirmmitte
     void MoveToCenter();

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -103,7 +103,7 @@ public:
     GUI_ID GetGUIID() const { return static_cast<GUI_ID>(Window::GetID()); }
 
 protected:
-    void Draw_() override;
+    void Draw_() final;
     /// Called when not minimized after the frame and background have been drawn
     virtual void DrawContent() {}
 

--- a/libs/s25main/ingameWindows/iwEconomicProgress.cpp
+++ b/libs/s25main/ingameWindows/iwEconomicProgress.cpp
@@ -103,13 +103,8 @@ iwEconomicProgress::iwEconomicProgress(const GameWorldViewer& gwv)
 
 iwEconomicProgress::~iwEconomicProgress() = default;
 
-void iwEconomicProgress::Draw_()
+void iwEconomicProgress::DrawContent()
 {
-    IngameWindow::Draw_();
-
-    if(IsMinimized())
-        return;
-
     // draw team colors
     DrawPoint curTeamRectPos = GetDrawPos() + DrawPoint(padding1.x + wareIconSize.x + txtBoxWidth, padding1.y);
     for(auto& team : teamOrder)

--- a/libs/s25main/ingameWindows/iwEconomicProgress.h
+++ b/libs/s25main/ingameWindows/iwEconomicProgress.h
@@ -24,7 +24,7 @@ private:
     /// Order in which the teams are displayed
     std::vector<const EconomyModeHandler::EconTeam*> teamOrder;
 
-    void Draw_() override;
+    void DrawContent() override;
 
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_PaintBefore() override;

--- a/libs/s25main/ingameWindows/iwMerchandiseStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwMerchandiseStatistics.cpp
@@ -142,13 +142,8 @@ void iwMerchandiseStatistics::Msg_OptionGroupChange(const unsigned ctrl_id, cons
     }
 }
 
-void iwMerchandiseStatistics::Draw_()
+void iwMerchandiseStatistics::DrawContent()
 {
-    IngameWindow::Draw_();
-
-    if(IsMinimized())
-        return;
-
     DrawRectangles();
     DrawAxis();
     DrawStatistic();

--- a/libs/s25main/ingameWindows/iwMerchandiseStatistics.h
+++ b/libs/s25main/ingameWindows/iwMerchandiseStatistics.h
@@ -38,8 +38,8 @@ private:
     // Maximalwert der y-Achse
     ctrlText* maxValue;
 
+    void DrawContent() override;
     // Durchgereichte Methoden vom Window
-    void Draw_() override;
     void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
 };

--- a/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwMilitaryBuilding.cpp
@@ -94,13 +94,8 @@ iwMilitaryBuilding::iwMilitaryBuilding(GameWorldView& gwv, GameCommandFactory& g
     }
 }
 
-void iwMilitaryBuilding::Draw_()
+void iwMilitaryBuilding::DrawContent()
 {
-    IngameWindow::Draw_();
-
-    if(IsMinimized())
-        return;
-
     // Schwarzer Untergrund für Goldanzeige
     const unsigned maxCoinCt = building->GetMaxCoinCt();
     DrawPoint goldPos = GetDrawPos() + DrawPoint((GetSize().x - 22 * maxCoinCt) / 2, 60);

--- a/libs/s25main/ingameWindows/iwMilitaryBuilding.h
+++ b/libs/s25main/ingameWindows/iwMilitaryBuilding.h
@@ -25,6 +25,6 @@ public:
     static void DemolitionNotAllowed(const GlobalGameSettings& ggs);
 
 private:
-    void Draw_() override;
+    void DrawContent() override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
 };

--- a/libs/s25main/ingameWindows/iwObservate.h
+++ b/libs/s25main/ingameWindows/iwObservate.h
@@ -37,12 +37,13 @@ public:
     iwObservate(GameWorldView& gwv, MapPoint selectedPt);
 
 private:
-    void Draw_() override;
+    void DrawContent() override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
     bool Msg_MouseMove(const MouseCoords& mc) override;
     bool Msg_RightDown(const MouseCoords& mc) override;
     bool Msg_RightUp(const MouseCoords& mc) override;
+    void Msg_Timer(unsigned ctrl_id) override;
     /// Move view to the object we currently follow, return true if it can still be found
     bool MoveToFollowedObj();
-    inline bool MoveToFollowedObj(MapPoint ptToCheck);
+    bool MoveToFollowedObj(MapPoint ptToCheck);
 };

--- a/libs/s25main/ingameWindows/iwShip.cpp
+++ b/libs/s25main/ingameWindows/iwShip.cpp
@@ -69,12 +69,9 @@ iwShip::iwShip(GameWorldView& gwv, GameCommandFactory& gcFactory, const noShip* 
           ->SetVisible(false);
 }
 
-void iwShip::Draw_()
+void iwShip::DrawContent()
 {
     static boost::format valByValFmt{"%1%/%2%"};
-    IngameWindow::Draw_();
-    if(IsMinimized())
-        return;
 
     const GamePlayer& owner = gwv.GetWorld().GetPlayer(player);
     // Schiff holen

--- a/libs/s25main/ingameWindows/iwShip.cpp
+++ b/libs/s25main/ingameWindows/iwShip.cpp
@@ -73,6 +73,9 @@ void iwShip::Draw_()
 {
     static boost::format valByValFmt{"%1%/%2%"};
     IngameWindow::Draw_();
+    if(IsMinimized())
+        return;
+
     const GamePlayer& owner = gwv.GetWorld().GetPlayer(player);
     // Schiff holen
     noShip* ship = (player == 0xff) ? nullptr : owner.GetShipByID(ship_id);

--- a/libs/s25main/ingameWindows/iwShip.h
+++ b/libs/s25main/ingameWindows/iwShip.h
@@ -22,7 +22,7 @@ public:
            const DrawPoint& pos = IngameWindow::posAtMouse);
 
 private:
-    void Draw_() override;
+    void DrawContent() override;
     void Msg_ButtonClick(unsigned ctrl_id) override;
 
     void DrawCargo();

--- a/libs/s25main/ingameWindows/iwStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwStatistics.cpp
@@ -262,13 +262,8 @@ void iwStatistics::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned 
     }
 }
 
-void iwStatistics::Draw_()
+void iwStatistics::DrawContent()
 {
-    IngameWindow::Draw_();
-
-    if(IsMinimized())
-        return;
-
     // Draw the alliances and the colored boxes under the portraits
     DrawPlayerOverlays();
 

--- a/libs/s25main/ingameWindows/iwStatistics.h
+++ b/libs/s25main/ingameWindows/iwStatistics.h
@@ -30,7 +30,7 @@ private:
     unsigned numPlayingPlayers;
 
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Draw_() override;
+    void DrawContent() override;
     void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
     void DrawPlayerBox(DrawPoint const& drawPt, const GamePlayer& player);
     void DrawPlayerAlliances(DrawPoint const& drawPt, const GamePlayer& player);

--- a/tests/s25Main/UI/testWindowManager.cpp
+++ b/tests/s25Main/UI/testWindowManager.cpp
@@ -145,7 +145,7 @@ MOCK_BASE_CLASS(TestIngameWnd, IngameWindow)
         closed.erase(std::remove(closed.begin(), closed.end(), this), closed.end());
     }
     ~TestIngameWnd() override { closed.push_back(this); }
-    MOCK_METHOD(Draw_, 0, void())
+    MOCK_METHOD(DrawContent, 0, void())
     MOCK_METHOD(Msg_KeyDown, 1)
     static std::vector<TestIngameWnd*> closed;
 };
@@ -164,7 +164,7 @@ BOOST_FIXTURE_TEST_CASE(ShowIngameWnd, uiHelper::Fixture)
 {
     auto* wnd = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP));
     BOOST_TEST_REQUIRE(wnd);
-    MOCK_EXPECT(wnd->Draw_).once();
+    MOCK_EXPECT(wnd->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(wnd);
     BOOST_TEST(!WINDOWMANAGER.GetCurrentDesktop()->IsActive());
@@ -179,8 +179,8 @@ BOOST_FIXTURE_TEST_CASE(ShowIngameWnd, uiHelper::Fixture)
     wnd = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP));
     auto* wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP));
     BOOST_TEST_REQUIRE((wnd && wnd2));
-    MOCK_EXPECT(wnd->Draw_).once();
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd->DrawContent).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ALIVE(wnd);
     REQUIRE_WINDOW_ACTIVE(wnd2);
@@ -192,7 +192,7 @@ BOOST_FIXTURE_TEST_CASE(ShowIngameWnd, uiHelper::Fixture)
     wnd2->Close();
     wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(wnd->GetID()));
     BOOST_TEST_REQUIRE(wnd2);
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_DESTROYED(wnd);
     REQUIRE_WINDOW_ACTIVE(wnd2);
@@ -211,7 +211,7 @@ BOOST_FIXTURE_TEST_CASE(ToggleIngameWnd, uiHelper::Fixture)
     // When no window with the ID is open, then this is just Show
     auto* wnd = WINDOWMANAGER.ToggleWindow(std::make_unique<TestIngameWnd>(CGI_HELP));
     BOOST_TEST_REQUIRE(wnd);
-    MOCK_EXPECT(wnd->Draw_).once();
+    MOCK_EXPECT(wnd->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(wnd);
     BOOST_TEST(!WINDOWMANAGER.GetCurrentDesktop()->IsActive());
@@ -220,7 +220,7 @@ BOOST_FIXTURE_TEST_CASE(ToggleIngameWnd, uiHelper::Fixture)
     wnd->Close();
     auto* wnd2 = WINDOWMANAGER.ToggleWindow(std::make_unique<TestIngameWnd>(CGI_HELP));
     BOOST_TEST_REQUIRE(wnd2);
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(wnd2);
     REQUIRE_WINDOW_DESTROYED(wnd);
@@ -240,8 +240,8 @@ BOOST_FIXTURE_TEST_CASE(ToggleIngameWnd, uiHelper::Fixture)
     wnd = WINDOWMANAGER.ToggleWindow(std::make_unique<TestIngameWnd>(CGI_HELP));
     wnd2 = WINDOWMANAGER.ToggleWindow(std::make_unique<TestIngameWnd>(CGI_SETTINGS));
     BOOST_TEST_REQUIRE((wnd && wnd2));
-    MOCK_EXPECT(wnd->Draw_).once();
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd->DrawContent).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ALIVE(wnd);
     REQUIRE_WINDOW_ACTIVE(wnd2);
@@ -254,7 +254,7 @@ BOOST_FIXTURE_TEST_CASE(ReplaceIngameWnd, uiHelper::Fixture)
 {
     // When no window with the ID is open, then this is just Show
     auto* wnd = &WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_HELP));
-    MOCK_EXPECT(wnd->Draw_).once();
+    MOCK_EXPECT(wnd->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(wnd);
     BOOST_TEST(!WINDOWMANAGER.GetCurrentDesktop()->IsActive());
@@ -263,7 +263,7 @@ BOOST_FIXTURE_TEST_CASE(ReplaceIngameWnd, uiHelper::Fixture)
     wnd->Close();
     auto* wnd2 = &WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_HELP));
     BOOST_TEST_REQUIRE(wnd2);
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(wnd2);
     REQUIRE_WINDOW_DESTROYED(wnd);
@@ -273,7 +273,7 @@ BOOST_FIXTURE_TEST_CASE(ReplaceIngameWnd, uiHelper::Fixture)
     wnd = wnd2;
     wnd2 = &WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_HELP));
     BOOST_TEST_REQUIRE(wnd2);
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_DESTROYED(wnd);
     REQUIRE_WINDOW_ACTIVE(wnd2);
@@ -283,8 +283,8 @@ BOOST_FIXTURE_TEST_CASE(ReplaceIngameWnd, uiHelper::Fixture)
     wnd = wnd2;
     wnd2 = &WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_SETTINGS));
     BOOST_TEST_REQUIRE(wnd2);
-    MOCK_EXPECT(wnd->Draw_).once();
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd->DrawContent).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ALIVE(wnd);
     REQUIRE_WINDOW_ACTIVE(wnd2);
@@ -295,8 +295,8 @@ BOOST_FIXTURE_TEST_CASE(ReplaceIngameWnd, uiHelper::Fixture)
     wnd = &WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_SETTINGS, true));
     wnd2 = &WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_SETTINGS, true));
     BOOST_TEST_REQUIRE((wnd && wnd2));
-    MOCK_EXPECT(wnd->Draw_).once();
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd->DrawContent).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(wnd);
     REQUIRE_WINDOW_ALIVE(wnd2);
@@ -309,42 +309,42 @@ BOOST_FIXTURE_TEST_CASE(ModalWindowPlacement, uiHelper::Fixture)
 {
     // new modal windows get placed before older ones
     auto& wnd = WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_MSGBOX, true));
-    MOCK_EXPECT(wnd.Draw_).once();
+    MOCK_EXPECT(wnd.DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(&wnd);
     auto& wnd2 = WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_MSGBOX, true));
-    MOCK_EXPECT(wnd.Draw_).once();
-    MOCK_EXPECT(wnd2.Draw_).once();
+    MOCK_EXPECT(wnd.DrawContent).once();
+    MOCK_EXPECT(wnd2.DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(&wnd);
     auto& wnd3 = WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_MISSION_STATEMENT, true));
-    MOCK_EXPECT(wnd.Draw_).once();
-    MOCK_EXPECT(wnd2.Draw_).once();
-    MOCK_EXPECT(wnd3.Draw_).once();
+    MOCK_EXPECT(wnd.DrawContent).once();
+    MOCK_EXPECT(wnd2.DrawContent).once();
+    MOCK_EXPECT(wnd3.DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(&wnd);
     auto& wnd4 = WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_MSGBOX));
-    MOCK_EXPECT(wnd.Draw_).once();
-    MOCK_EXPECT(wnd2.Draw_).once();
-    MOCK_EXPECT(wnd3.Draw_).once();
-    MOCK_EXPECT(wnd4.Draw_).once();
+    MOCK_EXPECT(wnd.DrawContent).once();
+    MOCK_EXPECT(wnd2.DrawContent).once();
+    MOCK_EXPECT(wnd3.DrawContent).once();
+    MOCK_EXPECT(wnd4.DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(&wnd);
     auto& wnd5 = WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_HELP, true));
-    MOCK_EXPECT(wnd.Draw_).once();
-    MOCK_EXPECT(wnd2.Draw_).once();
-    MOCK_EXPECT(wnd3.Draw_).once();
-    MOCK_EXPECT(wnd4.Draw_).once();
-    MOCK_EXPECT(wnd5.Draw_).once();
+    MOCK_EXPECT(wnd.DrawContent).once();
+    MOCK_EXPECT(wnd2.DrawContent).once();
+    MOCK_EXPECT(wnd3.DrawContent).once();
+    MOCK_EXPECT(wnd4.DrawContent).once();
+    MOCK_EXPECT(wnd5.DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(&wnd);
     auto& wnd6 = WINDOWMANAGER.ReplaceWindow(std::make_unique<TestIngameWnd>(CGI_SETTINGS));
-    MOCK_EXPECT(wnd.Draw_).once();
-    MOCK_EXPECT(wnd2.Draw_).once();
-    MOCK_EXPECT(wnd3.Draw_).once();
-    MOCK_EXPECT(wnd4.Draw_).once();
-    MOCK_EXPECT(wnd5.Draw_).once();
-    MOCK_EXPECT(wnd6.Draw_).once();
+    MOCK_EXPECT(wnd.DrawContent).once();
+    MOCK_EXPECT(wnd2.DrawContent).once();
+    MOCK_EXPECT(wnd3.DrawContent).once();
+    MOCK_EXPECT(wnd4.DrawContent).once();
+    MOCK_EXPECT(wnd5.DrawContent).once();
+    MOCK_EXPECT(wnd6.DrawContent).once();
     WINDOWMANAGER.Draw();
     REQUIRE_WINDOW_ACTIVE(&wnd);
     // Now we have the following order
@@ -355,7 +355,7 @@ BOOST_FIXTURE_TEST_CASE(ModalWindowPlacement, uiHelper::Fixture)
     for(TestIngameWnd* curWnd : expectedOrder)
     {
         MOCK_EXPECT(curWnd->Msg_KeyDown).once().in(s).returns(true);
-        MOCK_EXPECT(curWnd->Draw_); // Ignore all draw calls
+        MOCK_EXPECT(curWnd->DrawContent); // Ignore all draw calls
     }
     // Way outside any window, should still be handled
     KeyEvent ke{KeyType::Char, 'a', false, false, false};
@@ -385,7 +385,7 @@ BOOST_FIXTURE_TEST_CASE(EscClosesWindow, uiHelper::Fixture)
     auto* wnd3 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, true));
     WINDOWMANAGER.Msg_KeyDown(evEsc);
     WINDOWMANAGER.Msg_KeyDown(evEsc);
-    MOCK_EXPECT(wnd1->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
     REQUIRE_WINDOW_DESTROYED(wnd2);
@@ -399,7 +399,7 @@ BOOST_FIXTURE_TEST_CASE(EscClosesWindow, uiHelper::Fixture)
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
     WINDOWMANAGER.Msg_KeyDown(evEsc);
     REQUIRE_WINDOW_ALIVE(wnd1);
-    MOCK_EXPECT(wnd1->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
 
@@ -408,8 +408,8 @@ BOOST_FIXTURE_TEST_CASE(EscClosesWindow, uiHelper::Fixture)
     WINDOWMANAGER.Msg_KeyDown(evEsc);
     REQUIRE_WINDOW_ALIVE(wnd1);
     REQUIRE_WINDOW_ALIVE(wnd2);
-    MOCK_EXPECT(wnd1->Draw_).once();
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd2);
 }
@@ -428,7 +428,7 @@ BOOST_FIXTURE_TEST_CASE(RightclickClosesWindow, uiHelper::Fixture)
     auto* wnd1 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP));
     auto* wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP));
     WINDOWMANAGER.Msg_RightDown(evRDown);
-    MOCK_EXPECT(wnd1->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
     REQUIRE_WINDOW_DESTROYED(wnd2);
@@ -438,13 +438,13 @@ BOOST_FIXTURE_TEST_CASE(RightclickClosesWindow, uiHelper::Fixture)
     WINDOWMANAGER.Msg_RightDown(evRDown);
     REQUIRE_WINDOW_ALIVE(wnd1);
     REQUIRE_WINDOW_ALIVE(wnd3);
-    MOCK_EXPECT(wnd1->Draw_).once();
-    MOCK_EXPECT(wnd3->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
+    MOCK_EXPECT(wnd3->DrawContent).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd3);
     REQUIRE_WINDOW_DESTROYED(wnd2);
     WINDOWMANAGER.Msg_RightDown(evRDown);
-    MOCK_EXPECT(wnd1->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
     WINDOWMANAGER.Draw();
     WINDOWMANAGER.Msg_RightDown(evRDown);
     WINDOWMANAGER.Draw();
@@ -455,15 +455,15 @@ BOOST_FIXTURE_TEST_CASE(RightclickClosesWindow, uiHelper::Fixture)
     wnd1 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, false, CloseBehavior::Custom));
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
     WINDOWMANAGER.Msg_RightDown(evRDown);
-    MOCK_EXPECT(wnd1->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd1);
 
     wnd2 = &WINDOWMANAGER.Show(std::make_unique<TestIngameWnd>(CGI_HELP, true, CloseBehavior::NoRightClick));
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd2);
     WINDOWMANAGER.Msg_RightDown(evRDown);
-    MOCK_EXPECT(wnd1->Draw_).once();
-    MOCK_EXPECT(wnd2->Draw_).once();
+    MOCK_EXPECT(wnd1->DrawContent).once();
+    MOCK_EXPECT(wnd2->DrawContent).once();
     WINDOWMANAGER.Draw();
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd2);
 }
@@ -482,7 +482,7 @@ BOOST_FIXTURE_TEST_CASE(PinnedWindows, uiHelper::Fixture)
         {
             BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd);
             WINDOWMANAGER.Msg_KeyDown(evEsc);
-            MOCK_EXPECT(wnd->Draw_).once();
+            MOCK_EXPECT(wnd->DrawContent).once();
             WINDOWMANAGER.Draw();
             BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd);
         }
@@ -520,7 +520,7 @@ BOOST_FIXTURE_TEST_CASE(PinnedWindows, uiHelper::Fixture)
         BOOST_TEST_CONTEXT("Pinned")
         {
             WINDOWMANAGER.Msg_RightDown(evRDown);
-            MOCK_EXPECT(wnd->Draw_).once();
+            MOCK_EXPECT(wnd->DrawContent).once();
             WINDOWMANAGER.Draw();
             BOOST_TEST_REQUIRE(WINDOWMANAGER.GetTopMostWindow() == wnd);
         }


### PR DESCRIPTION
Fixes https://github.com/Return-To-The-Roots/s25client/issues/1742

To avoid this whole class of issues introduce `IngameWindow::DrawContent` to allow  subclasses to handle only drawing its own content not also
checking whether they actually should or the window is minimized.

Also move the logic out of iwObservate::Draw to a timer. No need to update every frame, every second is enough.