### PR TITLE
Fix failure to detect failures when loading (Lua) game data

### DIFF
--- a/libs/libGamedata/lua/GameDataLoader.cpp
+++ b/libs/libGamedata/lua/GameDataLoader.cpp
@@ -72,7 +72,7 @@ void GameDataLoader::Include(const std::string& filepath)
     {
         constexpr int maxIncludeDepth = 10;
         // Protect against cycles and stack overflows
-        if(++curIncludeDepth_ >= maxIncludeDepth)
+        if(curIncludeDepth_ >= maxIncludeDepth)
             throw LuaIncludeError(helpers::format("Maximum include depth of %1% is reached!", maxIncludeDepth));
         const auto isAllowedChar = [](const char c) {
             return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '/'
@@ -94,6 +94,7 @@ void GameDataLoader::Include(const std::string& filepath)
             throw LuaIncludeError("File is outside the lua data directory!");
         const auto oldCurFile = curFile_;
         curFile_ = absFilePath;
+        ++curIncludeDepth_;
         errorInIncludeFile_ |= !loadScript(absFilePath);
         curFile_ = oldCurFile;
         RTTR_Assert(curIncludeDepth_ > 0);

--- a/libs/libGamedata/lua/GameDataLoader.cpp
+++ b/libs/libGamedata/lua/GameDataLoader.cpp
@@ -20,8 +20,7 @@
 namespace bfs = boost::filesystem;
 
 GameDataLoader::GameDataLoader(WorldDescription& worldDesc, const boost::filesystem::path& basePath)
-    : worldDesc_(worldDesc), basePath_(basePath.lexically_normal().make_preferred()), curIncludeDepth_(0),
-      errorInIncludeFile_(false)
+    : worldDesc_(worldDesc), basePath_(basePath.lexically_normal().make_preferred()), curIncludeDepth_(0)
 {
     Register(lua);
 
@@ -39,10 +38,7 @@ bool GameDataLoader::Load()
 {
     curFile_ = basePath_ / "default.lua";
     curIncludeDepth_ = 0;
-    errorInIncludeFile_ = false;
-    if(!loadScript(curFile_))
-        return false;
-    return !errorInIncludeFile_;
+    return loadScript(curFile_);
 }
 
 void GameDataLoader::Register(kaguya::State& state)
@@ -88,7 +84,8 @@ void GameDataLoader::Include(const std::string& filepath)
         const auto oldCurFile = curFile_;
         curFile_ = absFilePath;
         ++curIncludeDepth_;
-        errorInIncludeFile_ |= !loadScript(absFilePath);
+        if(!loadScript(absFilePath))
+            throw std::runtime_error(helpers::format("Include file '%1%' cannot be included", filepath));
         curFile_ = oldCurFile;
         RTTR_Assert(curIncludeDepth_ > 0);
         --curIncludeDepth_;

--- a/libs/libGamedata/lua/GameDataLoader.cpp
+++ b/libs/libGamedata/lua/GameDataLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -40,15 +40,8 @@ bool GameDataLoader::Load()
     curFile_ = basePath_ / "default.lua";
     curIncludeDepth_ = 0;
     errorInIncludeFile_ = false;
-    try
-    {
-        if(!loadScript(curFile_))
-            return false;
-    } catch(const std::exception& e)
-    {
-        LOG.write("Failed to load game data!\nReason: %1%\nCurrent file being processed: %2%\n") % e.what() % curFile_;
+    if(!loadScript(curFile_))
         return false;
-    }
     return !errorInIncludeFile_;
 }
 

--- a/libs/libGamedata/lua/GameDataLoader.h
+++ b/libs/libGamedata/lua/GameDataLoader.h
@@ -33,7 +33,6 @@ private:
     WorldDescription& worldDesc_;
     boost::filesystem::path basePath_, curFile_;
     int curIncludeDepth_;
-    bool errorInIncludeFile_;
 };
 
 void loadGameData(WorldDescription& worldDesc);

--- a/libs/libGamedata/lua/GameDataLoader.h
+++ b/libs/libGamedata/lua/GameDataLoader.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/tests/s25Main/network/testGameClient.cpp
+++ b/tests/s25Main/network/testGameClient.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2022 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -12,6 +12,7 @@
 #include "network/GameMessages.h"
 #include "gameTypes/GameTypesOutput.h"
 #include "test/testConfig.h"
+#include "rttr/test/ConfigOverride.hpp"
 #include "rttr/test/LogAccessor.hpp"
 #include "rttr/test/random.hpp"
 #include "s25util/boostTestHelpers.h"
@@ -50,17 +51,13 @@ MOCK_BASE_CLASS(MockClientInterface, ClientInterface)
 
 class CustomUserMapFolderFixture
 {
-    boost::filesystem::path oldUserData;
+    rttr::test::ConfigOverride parent_;
 
 public:
-    TmpFolder tmpUserdata;
-    CustomUserMapFolderFixture() : tmpUserdata(rttr::test::rttrTestDataDirOut)
+    CustomUserMapFolderFixture() : parent_("USERDATA", rttr::test::rttrTestDataDirOut)
     {
-        oldUserData = RTTRCONFIG.ExpandPath("<RTTR_USERDATA>");
-        RTTRCONFIG.overridePathMapping("USERDATA", tmpUserdata);
         bfs::create_directories(RTTRCONFIG.ExpandPath(s25::folders::mapsPlayed));
     }
-    ~CustomUserMapFolderFixture() { RTTRCONFIG.overridePathMapping("USERDATA", oldUserData); }
 };
 
 } // namespace

--- a/tests/testHelpers/CMakeLists.txt
+++ b/tests/testHelpers/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(testHelpers STATIC
     rttr/test/BaseFixture.cpp
     rttr/test/BaseFixture.hpp
     rttr/test/BufferedWriter.hpp
+    rttr/test/ConfigOverride.hpp
     rttr/test/Fixture.cpp
     rttr/test/Fixture.hpp
     rttr/test/LocaleResetter.hpp

--- a/tests/testHelpers/rttr/test/ConfigOverride.hpp
+++ b/tests/testHelpers/rttr/test/ConfigOverride.hpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "RttrConfig.h"
+
+namespace rttr::test {
+/// Temporarily change a RTTRCONFIG path
+class ConfigOverride
+{
+    const std::string entry;
+    boost::filesystem::path oldPath;
+
+public:
+    ConfigOverride(std::string pathEntry, const boost::filesystem::path& newPath)
+        : entry(std::move(pathEntry)), oldPath(RTTRCONFIG.ExpandPath("<RTTR_" + entry + ">"))
+    {
+        RTTRCONFIG.overridePathMapping(entry, newPath);
+    }
+    ~ConfigOverride() { RTTRCONFIG.overridePathMapping(entry, std::move(oldPath)); }
+};
+} // namespace rttr::test


### PR DESCRIPTION
One Windows CI was failing with a strange error that I cannot reproduce locally.

After a lot investigation I conclude that it is an optimization issue. Example:

```
  main: include(foo)
    foo: include(bar)
      bar: error out
    foo stores error from including bar
  main stores (no) error from including foo
```

The error storing happens as `anyError |= !load(...)`. During optimization I assume it loads `anyError` before calling `load` which down the chain sets `anyError` to true but because `main` does not get an error from `foo` and preloaded the "false" we store false again overwriting the `true`.

But actually the error should propagate upwards: When main includes foo which includes bar and that aborts, then foo should also abort and not continue and same for main.

So the fix here is to throw an error if the `loadScript` on an `include` fails.   
I played a bit with having `loadScript` throw an exception instead of returning true/false to "accumulate" error description. However as Lua errors (including exceptions) are logged we'll already have that in the log:
``` 
Include file 'bar' cannot be included
Include file 'foo' cannot be included
```

The caller of `GameData::Load` can then decide what to do with the failed main just like with any other error, e.g. syntax errors.

Includes a consistency fix and adds a missing test for game data loading (an error case actually)

Closes #1762