### PR TITLE
Fix failure to detect failures when loading (Lua) game data

### DIFF
--- a/libs/libGamedata/lua/GameDataLoader.cpp
+++ b/libs/libGamedata/lua/GameDataLoader.cpp
@@ -84,11 +84,12 @@ void GameDataLoader::Include(const std::string& filepath)
         const auto oldCurFile = curFile_;
         curFile_ = absFilePath;
         ++curIncludeDepth_;
-        if(!loadScript(absFilePath))
-            throw std::runtime_error(helpers::format("Include file '%1%' cannot be included", filepath));
+        const bool fileLoaded = loadScript(absFilePath);
         curFile_ = oldCurFile;
         RTTR_Assert(curIncludeDepth_ > 0);
         --curIncludeDepth_;
+        if(!fileLoaded)
+            throw std::runtime_error(helpers::format("Include file '%1%' cannot be included", filepath));
     } catch(const LuaIncludeError& e)
     {
         throw std::runtime_error(helpers::format("Include file '%1%' cannot be included: %2%", filepath, e.what()));

--- a/libs/libGamedata/lua/GameDataLoader.cpp
+++ b/libs/libGamedata/lua/GameDataLoader.cpp
@@ -20,8 +20,7 @@
 namespace bfs = boost::filesystem;
 
 GameDataLoader::GameDataLoader(WorldDescription& worldDesc, const boost::filesystem::path& basePath)
-    : worldDesc_(worldDesc), basePath_(basePath.lexically_normal().make_preferred()), curIncludeDepth_(0),
-      errorInIncludeFile_(false)
+    : worldDesc_(worldDesc), basePath_(basePath.lexically_normal().make_preferred()), curIncludeDepth_(0)
 {
     Register(lua);
 
@@ -39,10 +38,7 @@ bool GameDataLoader::Load()
 {
     curFile_ = basePath_ / "default.lua";
     curIncludeDepth_ = 0;
-    errorInIncludeFile_ = false;
-    if(!loadScript(curFile_))
-        return false;
-    return !errorInIncludeFile_;
+    return loadScript(curFile_);
 }
 
 void GameDataLoader::Register(kaguya::State& state)
@@ -88,7 +84,8 @@ void GameDataLoader::Include(const std::string& filepath)
         const auto oldCurFile = curFile_;
         curFile_ = absFilePath;
         ++curIncludeDepth_;
-        errorInIncludeFile_ |= !loadScript(absFilePath);
+        if(!loadScript(absFilePath))
+            throw std::runtime_error(helpers::format("Include file '%1%' cannot be included", filepath));
         curFile_ = oldCurFile;
         RTTR_Assert(curIncludeDepth_ > 0);
         --curIncludeDepth_;

--- a/libs/libGamedata/lua/GameDataLoader.h
+++ b/libs/libGamedata/lua/GameDataLoader.h
@@ -33,7 +33,6 @@ private:
     WorldDescription& worldDesc_;
     boost::filesystem::path basePath_, curFile_;
     int curIncludeDepth_;
-    bool errorInIncludeFile_;
 };
 
 void loadGameData(WorldDescription& worldDesc);


### PR DESCRIPTION
One Windows CI was failing with a strange error that I cannot reproduce locally.

After a lot investigation I conclude that it is an optimization issue. Example:

```
  main: include(foo)
    foo: include(bar)
      bar: error out
    foo stores error from including bar
  main stores (no) error from including foo
```

The error storing happens as `anyError |= !load(...)`. During optimization I assume it loads `anyError` before calling `load` which down the chain sets `anyError` to true but because `main` does not get an error from `foo` and preloaded the "false" we store false again overwriting the `true`.

But actually the error should propagate upwards: When main includes foo which includes bar and that aborts, then foo should also abort and not continue and same for main.

So the fix here is to throw an error if the `loadScript` on an `include` fails.   
I played a bit with having `loadScript` throw an exception instead of returning true/false to "accumulate" error description. However as Lua errors (including exceptions) are logged we'll already have that in the log:
``` 
Include file 'bar' cannot be included
Include file 'foo' cannot be included
```

The caller of `GameData::Load` can then decide what to do with the failed main just like with any other error, e.g. syntax errors.

Includes a consistency fix and adds a missing test for game data loading (an error case actually)

@Flow86 if you want clean MRs the merge order would be:
- [x] #1762 
- [x] #1766 
- This