### PR TITLE
Fix random failures in network tests 

### DIFF
--- a/tests/s25Main/network/testGameClient.cpp
+++ b/tests/s25Main/network/testGameClient.cpp
@@ -15,6 +15,7 @@
 #include "test/testConfig.h"
 #include "rttr/test/ConfigOverride.hpp"
 #include "rttr/test/LogAccessor.hpp"
+#include "rttr/test/TmpFolder.hpp"
 #include "rttr/test/random.hpp"
 #include "s25util/boostTestHelpers.h"
 #include "s25util/tmpFile.h"
@@ -56,10 +57,13 @@ MOCK_BASE_CLASS(MockClientInterface, ClientInterface)
 
 class CustomUserMapFolderFixture
 {
+    rttr::test::TmpFolder tmpFolder_;
     rttr::test::ConfigOverride parent_;
 
 public:
-    CustomUserMapFolderFixture() : parent_("USERDATA", rttr::test::rttrTestDataDirOut)
+    // We need an empty folder for each test to avoid reusing maps downloaded in previous tests
+    // which breaks expected flow of events when this map is reused.
+    CustomUserMapFolderFixture() : parent_("USERDATA", tmpFolder_)
     {
         bfs::create_directories(RTTRCONFIG.ExpandPath(s25::folders::mapsPlayed));
     }

--- a/tests/s25Main/network/testGameClient.cpp
+++ b/tests/s25Main/network/testGameClient.cpp
@@ -5,6 +5,7 @@
 #include "JoinPlayerInfo.h"
 #include "RttrConfig.h"
 #include "TestServer.h"
+#include "enum_cast.hpp"
 #include "files.h"
 #include "network/ClientInterface.h"
 #include "network/GameClient.h"
@@ -28,6 +29,10 @@ namespace bfs = boost::filesystem;
 
 // LCOV_EXCL_START
 BOOST_TEST_DONT_PRINT_LOG_VALUE(ClientState)
+static std::ostream& operator<<(std::ostream& os, const ConnectState& state)
+{
+    return os << rttr::enum_cast(state);
+}
 // LCOV_EXCL_STOP
 
 namespace {


### PR DESCRIPTION
The tests verify the expected flow of events/state machine in the client
during a connect-map-download cycle.
If the map exists the flow is different as the map is reused and not
requested again.

Use a new folder for each test to avoid this.

Also add a test for the caching behavior observed "by accident".

Requires:
- [x] #1762