### PR TITLE
Fix clang tidy on ci

### DIFF
--- a/tools/ci/runClangTidy.sh
+++ b/tools/ci/runClangTidy.sh
@@ -15,7 +15,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug \
 SRC_DIR="$(cd .. && pwd)"
 FILTER="extras|libs|tests|external/(libendian|liblobby|libsiedler2|libutil|mygettext|s25edit|s25update)"
 
-script -q -c "run-clang-tidy-10 -p . \
+script -q -c "run-clang-tidy-18 -p . \
     -quiet \
     -header-filter \"${SRC_DIR}/(${FILTER})\" \
     \"${SRC_DIR}/(${FILTER})\"" /dev/null \

--- a/tools/runClangTidy.sh
+++ b/tools/runClangTidy.sh
@@ -15,7 +15,7 @@ Check that it is generated (-DCMAKE_EXPORT_COMPILE_COMMANDS=ON)" >&2
 fi
 
 
-NAMES=(run-clang-tidy-10.py run-clang-tidy-9.py run-clang-tidy-8.py run-clang-tidy.py)
+NAMES=(run-clang-tidy-18.py run-clang-tidy-10.py run-clang-tidy-9.py run-clang-tidy-8.py run-clang-tidy.py)
 for fn in "${NAMES[@]}"; do
     if which "${fn}" &> /dev/null; then
         CLANG_TIDY_CMD="${fn}"


### PR DESCRIPTION
The ci uses clang and clang tidy packages version 18 but the scripts call the old clangtidy version 10. The clang tidy step succeds but the checks are never executed because clang tidy is not found. 