### PR TITLE
Use C++17 variable templates for traits

### DIFF
--- a/libs/common/include/Point.h
+++ b/libs/common/include/Point.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -20,7 +20,7 @@ template<typename T>
 struct Point //-V690
 {
     using ElementType = T;
-    static_assert(std::is_arithmetic<ElementType>::value, "Requires an arithmetic type");
+    static_assert(std::is_arithmetic_v<ElementType>, "Requires an arithmetic type");
 
     static constexpr auto MinElementValue = std::numeric_limits<T>::min();
     static constexpr auto MaxElementValue = std::numeric_limits<T>::max();
@@ -35,15 +35,15 @@ struct Point //-V690
     T x, y;
     constexpr Point() noexcept : x(getInvalidValue()), y(getInvalidValue()) {}
     constexpr Point(const T x, const T y) noexcept : x(x), y(y) {}
-    template<typename U, std::enable_if_t<!(std::is_integral<T>::value && std::is_floating_point<U>::value), int> = 0>
+    template<typename U, std::enable_if_t<!(std::is_integral_v<T> && std::is_floating_point_v<U>), int> = 0>
     constexpr explicit Point(const Point<U>& pt) noexcept : x(static_cast<T>(pt.x)), y(static_cast<T>(pt.y))
     {}
     /// Convert floating-point to integer by truncating
-    template<typename U, std::enable_if_t<std::is_integral<T>::value && std::is_floating_point<U>::value, int> = 0>
+    template<typename U, std::enable_if_t<std::is_integral_v<T> && std::is_floating_point_v<U>, int> = 0>
     constexpr explicit Point(Truncate_t, const Point<U>& pt) noexcept : x(static_cast<T>(pt.x)), y(static_cast<T>(pt.y))
     {}
     /// Convert floating-point to integer with rounding (default behavior)
-    template<typename U, std::enable_if_t<std::is_integral<T>::value && std::is_floating_point<U>::value, int> = 0>
+    template<typename U, std::enable_if_t<std::is_integral_v<T> && std::is_floating_point_v<U>, int> = 0>
     constexpr explicit Point(const Point<U>& pt) noexcept : x(helpers::iround<T>(pt.x)), y(helpers::iround<T>(pt.y))
     {}
     constexpr Point(const Point&) = default;
@@ -99,7 +99,7 @@ struct type_identity
 /// Convert the type T to a signed type if the condition is true (safe for float types)
 template<bool cond, typename T>
 using make_signed_if_t =
-  typename std::conditional_t<cond && !std::is_signed<T>::value, std::make_signed<T>, type_identity<T>>::type;
+  typename std::conditional_t<cond && !std::is_signed_v<T>, std::make_signed<T>, type_identity<T>>::type;
 
 // clang-format off
 
@@ -109,26 +109,25 @@ using make_signed_if_t =
 template<typename T, typename U>
 using mixed_type_t =
   make_signed_if_t<
-    std::is_signed<T>::value || std::is_signed<U>::value,
+    std::is_signed_v<T> || std::is_signed_v<U>,
     typename std::conditional_t<
-        std::is_floating_point<T>::value == std::is_floating_point<U>::value, // both are FP or not FP?
+        std::is_floating_point_v<T> == std::is_floating_point_v<U>, // both are FP or not FP?
         std::conditional<(sizeof(T) > sizeof(U)), T, U>, // Take the larger type
-        std::conditional<std::is_floating_point<T>::value, T, U> // Take the floating point type
+        std::conditional<std::is_floating_point_v<T>, T, U> // Take the floating point type
     >::type
   >;
 
 template<typename T, typename U>
-using IsNonLossyOp = std::integral_constant<bool,
+constexpr bool is_lossles_op_v = 
     // We can do T = T <op> U (except overflow) if:
-    std::is_floating_point<T>::value || std::is_signed<T>::value || std::is_unsigned<U>::value
->;
+    std::is_floating_point_v<T> || std::is_signed_v<T> || std::is_unsigned_v<U>;
 
 // clang-format on
 
 template<typename T, typename U>
-using require_nonLossyOp = std::enable_if_t<IsNonLossyOp<T, U>::value>;
+using require_lossless_op = std::enable_if_t<is_lossles_op_v<T, U>>;
 template<typename T>
-using require_arithmetic = std::enable_if_t<std::is_arithmetic<T>::value>;
+using require_arithmetic = std::enable_if_t<std::is_arithmetic_v<T>>;
 
 } // namespace detail
 
@@ -153,7 +152,7 @@ constexpr auto prodOfComponents(const Point<T>& pt) noexcept
 {
     // Let the compiler handle conversion to at least 32 bits keeping float types
     using op_type = decltype(T{} * uint32_t{});
-    using ResultType = ::detail::make_signed_if_t<std::is_signed<T>::value, op_type>;
+    using ResultType = ::detail::make_signed_if_t<std::is_signed_v<T>, op_type>;
     return static_cast<ResultType>(pt.x * pt.y);
 }
 
@@ -198,7 +197,7 @@ RTTR_GEN_ARITH(/)
 
 // Scaling operators
 
-template<typename T, typename U, class = detail::require_nonLossyOp<T, U>>
+template<typename T, typename U, class = detail::require_lossless_op<T, U>>
 constexpr Point<T>& operator*=(Point<T>& lhs, U factor) noexcept
 {
     return lhs *= Point<T>::all(factor);
@@ -216,7 +215,7 @@ constexpr auto operator*(const T left, const Point<U>& factor) noexcept
     return factor * left;
 }
 
-template<typename T, typename U, class = detail::require_nonLossyOp<T, U>>
+template<typename T, typename U, class = detail::require_lossless_op<T, U>>
 constexpr Point<T>& operator/=(Point<T>& lhs, U div) noexcept
 {
     return lhs /= Point<T>::all(div);

--- a/libs/common/include/Rect.h
+++ b/libs/common/include/Rect.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -21,7 +21,7 @@ struct RectBase
 {
     using position_type = Point<T>;
     using extent_elem_type =
-      typename std::conditional_t<std::is_integral<T>::value, std::make_unsigned<T>, std::common_type<T>>::type;
+      typename std::conditional_t<std::is_integral_v<T>, std::make_unsigned<T>, std::common_type<T>>::type;
     using extent_type = Point<extent_elem_type>;
     T left, top, right, bottom;
     constexpr RectBase() : RectBase(position_type::all(0), extent_type::all(0)) {}

--- a/libs/common/include/helpers/EnumRange.h
+++ b/libs/common/include/helpers/EnumRange.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -29,7 +29,7 @@ struct EnumIterTraits
 template<class T>
 struct EnumRange
 {
-    static_assert(std::is_enum<T>::value, "Must be an enum!");
+    static_assert(std::is_enum_v<T>, "Must be an enum!");
     class iterator : public EnumIterTraits<T>
     {
         unsigned value;
@@ -51,7 +51,7 @@ struct EnumRange
 template<class T>
 struct EnumRangeWithOffset
 {
-    static_assert(std::is_enum<T>::value, "Must be an enum!");
+    static_assert(std::is_enum_v<T>, "Must be an enum!");
     class iterator : public EnumIterTraits<T>
     {
         unsigned value;

--- a/libs/common/include/helpers/MaxEnumValue.h
+++ b/libs/common/include/helpers/MaxEnumValue.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -14,13 +14,17 @@ namespace helpers {
 template<class T>
 struct MaxEnumValue
 {
-    static_assert(std::is_enum<T>::value, "T must be an enum");
+    static_assert(std::is_enum_v<T>, "T must be an enum");
     static constexpr T value = maxEnumValue(T{});
 };
 
-/// Return the maximum value of an Enum
+/// Return the highest enumerator of an enum type
 template<class T_Enum>
-inline constexpr unsigned MaxEnumValue_v = static_cast<std::underlying_type_t<T_Enum>>(MaxEnumValue<T_Enum>::value);
+inline constexpr T_Enum MaxEnumerator_v = MaxEnumValue<T_Enum>::value;
+
+/// Return the maximum numeric value of an Enum
+template<class T_Enum>
+inline constexpr unsigned MaxEnumValue_v = static_cast<std::underlying_type_t<T_Enum>>(MaxEnumerator_v<T_Enum>);
 
 /// Return the number of enumerators for an enum type
 template<class T_Enum>

--- a/libs/common/include/helpers/OptionalEnum.h
+++ b/libs/common/include/helpers/OptionalEnum.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -16,7 +16,7 @@ namespace helpers {
 template<class T>
 class OptionalEnum
 {
-    static_assert(std::is_enum<T>::value, "Only works for enums");
+    static_assert(std::is_enum_v<T>, "Only works for enums");
     using underlying_type = std::underlying_type_t<T>;
 
 public:

--- a/libs/common/include/helpers/Range.h
+++ b/libs/common/include/helpers/Range.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -16,7 +16,7 @@ namespace helpers {
 template<typename T>
 class range
 {
-    static_assert(std::is_integral<T>::value, "Must be an integral!");
+    static_assert(std::is_integral_v<T>, "Must be an integral!");
     const T startValue_;
     const T endValue_;
 

--- a/libs/common/include/helpers/containerUtils.h
+++ b/libs/common/include/helpers/containerUtils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -21,6 +21,8 @@ namespace detail {
     template<class T>
     struct has_pop_front<T, std::void_t<decltype(T::pop_front())>> : std::true_type
     {};
+    template<class T>
+    constexpr bool has_pop_front_v = has_pop_front<T>::value;
 
     template<class T, class U, typename = void>
     struct has_find : std::false_type
@@ -29,6 +31,8 @@ namespace detail {
     template<class T, class U>
     struct has_find<T, U, std::void_t<decltype(std::declval<T>().find(std::declval<U>()))>> : std::true_type
     {};
+    template<class T, class U>
+    constexpr bool has_find_v = has_find<T, U>::value;
 } // namespace detail
 
 /// Removes an element from a container by its reverse iterator and returns an iterator to the next element
@@ -62,7 +66,7 @@ template<typename T>
 void pop_front(T& container)
 {
     RTTR_Assert(!container.empty());
-    if constexpr(detail::has_pop_front<T>::value)
+    if constexpr(detail::has_pop_front_v<T>)
         container.pop_front();
     else
         container.erase(container.begin());
@@ -72,7 +76,7 @@ void pop_front(T& container)
 template<typename T, typename U>
 auto find(T& container, const U& value)
 {
-    if constexpr(detail::has_find<T, U>::value)
+    if constexpr(detail::has_find_v<T, U>)
         return container.find(value);
     else
     {

--- a/libs/common/include/helpers/make_array.h
+++ b/libs/common/include/helpers/make_array.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -10,7 +10,7 @@ namespace helpers {
 template<class D = void, class... Types>
 constexpr auto make_array(Types&&... t)
 {
-    using ResultType = std::conditional_t<std::is_same<D, void>::value, std::common_type_t<Types...>, D>;
+    using ResultType = std::conditional_t<std::is_same_v<D, void>, std::common_type_t<Types...>, D>;
     return std::array<ResultType, sizeof...(Types)>{{ResultType(std::forward<Types>(t))...}};
 }
 

--- a/libs/common/include/helpers/mathFuncs.h
+++ b/libs/common/include/helpers/mathFuncs.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -36,12 +36,12 @@ template<typename T, typename U>
 constexpr U clamp(T val, U min, U max) noexcept
 {
     using Common = std::common_type_t<T, U>;
-    if(std::is_signed<T>::value && !std::is_signed<U>::value)
+    if(std::is_signed_v<T> && !std::is_signed_v<U>)
     {
         // min/max is unsigned -> No negative values possible
         if(val < 0)
             return min;
-    } else if(!std::is_signed<T>::value && std::is_signed<U>::value)
+    } else if(!std::is_signed_v<T> && std::is_signed_v<U>)
     {
         // min/max is signed
         if(max < 0)
@@ -85,12 +85,12 @@ constexpr T inverseLerp(const T startVal, const T endVal, const T value) noexcep
 // TODO can be constexpr in C++20
 /// Arithmetically round floating point values to integers
 template<typename IntType, typename FloatType,
-         std::enable_if_t<std::is_integral<IntType>::value && std::is_floating_point<FloatType>::value, int> = 0>
+         std::enable_if_t<std::is_integral_v<IntType> && std::is_floating_point_v<FloatType>, int> = 0>
 IntType iround(const FloatType val) noexcept
 {
     RTTR_Assert(std::isfinite(val));
 
-    if(std::is_unsigned<IntType>::value)
+    if(std::is_unsigned_v<IntType>)
         RTTR_Assert_Msg(!(val < 0), "Floating-point value must not be negative when casting to unsigned integer type.");
 
     return static_cast<IntType>(std::lround(val));

--- a/libs/common/include/helpers/random.h
+++ b/libs/common/include/helpers/random.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -19,7 +19,7 @@ T randomValue(RandomT& rng, T min = std::numeric_limits<T>::min(), T max = std::
     // 1 byte types are not supported, expand to 2 bytes instead
     using IntDistribution = std::uniform_int_distribution<std::conditional_t<sizeof(T) == 1, int16_t, T>>;
     using Distribution =
-      std::conditional_t<std::is_floating_point<T>::value, std::uniform_real_distribution<T>, IntDistribution>;
+      std::conditional_t<std::is_floating_point_v<T>, std::uniform_real_distribution<T>, IntDistribution>;
     Distribution distr(min, max);
     return static_cast<T>(distr(rng));
 }

--- a/libs/common/include/helpers/serializeEnums.h
+++ b/libs/common/include/helpers/serializeEnums.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -17,7 +17,7 @@ std::range_error makeOutOfRange(unsigned value, unsigned maxValue);
 template<typename T_SavedType, typename T>
 void pushEnum(Serializer& ser, const T val)
 {
-    static_assert(std::is_same<T_SavedType, std::underlying_type_t<T>>::value,
+    static_assert(std::is_same_v<T_SavedType, std::underlying_type_t<T>>,
                   "Wrong saved type"); // Required for the popEnum method
     constexpr auto maxValue = helpers::MaxEnumValue_v<T>;
     static_assert(std::numeric_limits<T_SavedType>::max() >= maxValue, "SavedType cannot hold all enum values");

--- a/libs/common/include/helpers/toString.h
+++ b/libs/common/include/helpers/toString.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -10,22 +10,21 @@
 namespace helpers {
 
 /// Wrapper around std::to_string handling correct casts for small ints and enums
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+template<typename T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 std::string toString(const T value)
 {
     return std::to_string(value);
 }
 
-template<typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
+template<typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 std::string toString(const T value)
 {
     constexpr bool typeAtLeastInt = sizeof(T) >= sizeof(int);
-    using TargetType =
-      std::conditional_t<typeAtLeastInt, T, std::conditional_t<std::is_signed<T>::value, int, unsigned>>;
+    using TargetType = std::conditional_t<typeAtLeastInt, T, std::conditional_t<std::is_signed_v<T>, int, unsigned>>;
     return std::to_string(static_cast<TargetType>(value));
 }
 
-template<typename T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+template<typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
 std::string toString(const T value)
 {
     return toString(static_cast<std::underlying_type_t<T>>(value));

--- a/libs/libsamplerate/include/samplerate.hpp
+++ b/libs/libsamplerate/include/samplerate.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -44,8 +44,10 @@ namespace detail {
     template<class T>
     struct has_src_clone<T, std::void_t<decltype(src_clone(std::declval<T>(), nullptr))>> : std::true_type
     {};
+    template<class T>
+    constexpr bool has_src_clone_v = has_src_clone<T>::value;
 
-    template<typename T, bool = has_src_clone<T*>::value>
+    template<typename T, bool = has_src_clone_v<T*>>
     class State
     {
         T* state_;

--- a/libs/s25main/GameCommands.cpp
+++ b/libs/s25main/GameCommands.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -95,8 +95,7 @@ ChangeDistribution::ChangeDistribution(Deserializer& ser) : GameCommand(GCType::
     else
     {
         std::array<Distributions::value_type,
-                   std::tuple_size<Distributions>::value - 3>
-          tmpData; // 3 entries for wine addon
+                   std::tuple_size_v<Distributions> - 3> tmpData; // 3 entries for wine addon
         helpers::popContainer(ser, tmpData);
         size_t srcIdx = 0, tgtIdx = 0;
         for(const auto& mapping : distributionMap)

--- a/libs/s25main/desktops/dskBenchmark.cpp
+++ b/libs/s25main/desktops/dskBenchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -300,7 +300,7 @@ void dskBenchmark::finishTest()
         curTest_ = Benchmark::None;
     else
     {
-        if(curTest_ == helpers::MaxEnumValue<Benchmark>::value)
+        if(curTest_ == helpers::MaxEnumerator_v<Benchmark>)
             curTest_ = Benchmark::None;
         else
         {

--- a/libs/s25main/gameTypes/SettingsTypes.h
+++ b/libs/s25main/gameTypes/SettingsTypes.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -19,7 +19,7 @@ using DistributionMapping = std::tuple<GoodType, BuildingType, uint8_t>;
 using DistributionMap = std::array<DistributionMapping, 26>;
 extern const DistributionMap distributionMap;
 /// List of the percentage a building should get from a specific ware
-using Distributions = std::array<uint8_t, std::tuple_size<DistributionMap>::value>;
+using Distributions = std::array<uint8_t, std::tuple_size_v<DistributionMap>>;
 /// Ordering of building types by priority. All buildings in here except unused and HQ
 using BuildOrders = std::array<BuildingType, helpers::NumEnumValues_v<BuildingType> - NUM_UNUSED_BLD_TYPES - 1>;
 /// Mapping transport priority -> standard transport priority of ware(group):

--- a/libs/s25main/ingameWindows/iwTransport.h
+++ b/libs/s25main/ingameWindows/iwTransport.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -23,7 +23,7 @@ private:
     const GameWorldViewer& gwv;
     GameCommandFactory& gcFactory;
 
-    static constexpr auto numButtons = std::tuple_size<TransportOrders>::value;
+    static constexpr auto numButtons = std::tuple_size_v<TransportOrders>;
     std::array<ButtonData, numButtons> buttonData;
 
     TransportOrders pendingOrder;

--- a/libs/s25main/mapGenerator/RandomUtility.h
+++ b/libs/s25main/mapGenerator/RandomUtility.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -71,7 +71,7 @@ public:
     template<typename T>
     T RandomValue(T min, T max)
     {
-        static_assert(std::is_integral<T>::value, "T must be an integral type.");
+        static_assert(std::is_integral_v<T>, "T must be an integral type.");
         std::uniform_int_distribution<T> distr(min, max);
         return distr(rng_);
     }

--- a/libs/s25main/ogl/FontStyle.h
+++ b/libs/s25main/ogl/FontStyle.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -9,7 +9,9 @@
 namespace detail {
 template<class T>
 struct GetFontStyleMask;
-}
+template<class T>
+constexpr unsigned GetFontStyleMask_v = GetFontStyleMask<T>::value;
+} // namespace detail
 
 class FontStyle
 {
@@ -38,20 +40,20 @@ public:
     };
 
     constexpr FontStyle() = default;
-    template<class T_Enum, typename = std::enable_if_t<std::is_enum<T_Enum>::value>>
+    template<class T_Enum, typename = std::enable_if_t<std::is_enum_v<T_Enum>>>
     constexpr FontStyle(T_Enum style) : value(style)
     {}
 
-    template<class T_Enum, typename = std::enable_if_t<std::is_enum<T_Enum>::value>>
+    template<class T_Enum, typename = std::enable_if_t<std::is_enum_v<T_Enum>>>
     constexpr FontStyle operator|(T_Enum style) const
     {
-        return (value & ~detail::GetFontStyleMask<T_Enum>::value) | style;
+        return (value & ~detail::GetFontStyleMask_v<T_Enum>) | style;
     }
 
-    template<class T_Enum, typename = std::enable_if_t<std::is_enum<T_Enum>::value>>
+    template<class T_Enum, typename = std::enable_if_t<std::is_enum_v<T_Enum>>>
     constexpr bool is(T_Enum style) const
     {
-        return (value & detail::GetFontStyleMask<T_Enum>::value) == style;
+        return (value & detail::GetFontStyleMask_v<T_Enum>) == style;
     }
 
 private:

--- a/libs/s25main/random/DefaultLCG.h
+++ b/libs/s25main/random/DefaultLCG.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -23,7 +23,7 @@ public:
     DefaultLCG() { seed(); }
     explicit DefaultLCG(result_type initSeed) { seed(initSeed); }
     template<class T_SeedSeq>
-    explicit DefaultLCG(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral<T_SeedSeq>::value>* = nullptr)
+    explicit DefaultLCG(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral_v<T_SeedSeq>>* = nullptr)
     {
         seed(seedSeq);
     }
@@ -31,7 +31,7 @@ public:
     void seed() { seed(0x1337); }
     void seed(unsigned newSeed) { state_ = newSeed; }
     template<class T_SeedSeq>
-    void seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral<T_SeedSeq>::value>* = nullptr);
+    void seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral_v<T_SeedSeq>>* = nullptr);
 
     /// Return random value in [min, max]
     result_type operator()();
@@ -51,7 +51,7 @@ private:
 };
 
 template<class T_SeedSeq>
-inline void DefaultLCG::seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral<T_SeedSeq>::value>*)
+inline void DefaultLCG::seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral_v<T_SeedSeq>>*)
 {
     unsigned seedVal;
     seedSeq.generate(&seedVal, (&seedVal) + 1);

--- a/libs/s25main/random/XorShift.h
+++ b/libs/s25main/random/XorShift.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -25,7 +25,7 @@ public:
     XorShift() { seed(); }
     explicit XorShift(uint64_t initSeed) { seed(initSeed); }
     template<class T_SeedSeq>
-    explicit XorShift(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral<T_SeedSeq>::value>* = nullptr)
+    explicit XorShift(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral_v<T_SeedSeq>>* = nullptr)
     {
         seed(seedSeq);
     }
@@ -33,7 +33,7 @@ public:
     void seed() { seed(0x1337); }
     void seed(uint64_t newSeed);
     template<class T_SeedSeq>
-    void seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral<T_SeedSeq>::value>* = nullptr);
+    void seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral_v<T_SeedSeq>>* = nullptr);
 
     /// Return random value in [min, max]
     result_type operator()();
@@ -53,7 +53,7 @@ private:
 };
 
 template<class T_SeedSeq>
-inline void XorShift::seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral<T_SeedSeq>::value>*)
+inline void XorShift::seed(T_SeedSeq& seedSeq, std::enable_if_t<!std::is_integral_v<T_SeedSeq>>*)
 {
     std::array<uint32_t, 2> seeds;
     seedSeq.generate(seeds.begin(), seeds.end());

--- a/libs/s25main/world/MapBase.h
+++ b/libs/s25main/world/MapBase.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -123,7 +123,7 @@ detail::GetPointsResult_t<T_TransformPt> MapBase::GetPointsInRadius(const MapPoi
     ::detail::GetPointsResult_t<T_TransformPt> result;
     if(T_maxResults > 0)
         result.reserve(T_maxResults);
-    else if(std::is_same<T_IsValidPt, AlwaysTrue>::value)
+    else if(std::is_same_v<T_IsValidPt, AlwaysTrue>)
     {
         // For every additional radius we get 6 * curRadius more points. Hence we have 6 * sum(1..radius) points + the
         // center point if requested This can be reduced via the gauss formula to the following:

--- a/tests/common/testMathHelpers.cpp
+++ b/tests/common/testMathHelpers.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Interpolate, T, TimeTypes)
     {
         const auto startVal = randomValue<int>(-1000, 1000);
         const auto endVal = randomValue<int>(startVal + 10, startVal + 1000);
-        if(std::is_signed<RepT>::value)
+        if(std::is_signed_v<RepT>)
         {
             // Elapsed time less than zero
             BOOST_TEST(helpers::interpolate(startVal, endVal, T(randomValue<int>(-10000, -1)), T(randomValue<int>(1)))
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Interpolate, T, TimeTypes)
     {
         const auto startVal = randomValue<unsigned>(0u, 500000u);
         const auto endVal = randomValue<unsigned>(startVal + 10u);
-        if(std::is_signed<RepT>::value)
+        if(std::is_signed_v<RepT>)
         {
             // Elapsed time less than zero
             BOOST_TEST(helpers::interpolate(startVal, endVal, T(randomValue<int>(-10000, -1)), T(randomValue<int>(1)))

--- a/tests/common/testPoint.cpp
+++ b/tests/common/testPoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(negate_point, T, SignedTypes)
     y = abs(y);
     const UnsignedPoint pt2(x, y);
     const auto negated = -pt2;
-    static_assert(std::is_same<decltype(negated.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(negated.x), T>, "Result must be signed");
     BOOST_TEST(negated == SignedPoint(-x, -y));
 }
 
@@ -68,15 +68,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(add_points, T, SignedTypes)
     UnsignedPoint pt2(x2, y2);
 
     const auto result = pt + pt2;
-    static_assert(std::is_same<decltype(result.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(result.x), T>, "Result must be signed");
     BOOST_TEST(result == SignedPoint(x + x2, y + y2));
 
     const auto resultSigned = pt + SignedPoint(pt2);
-    static_assert(std::is_same<decltype(resultSigned.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(resultSigned.x), T>, "Result must be signed");
     BOOST_TEST(resultSigned == result);
 
     const auto resultUnsigned = UnsignedPoint(pt) + pt2;
-    static_assert(std::is_same<decltype(resultUnsigned.x), U>::value, "Result must be unsigned");
+    static_assert(std::is_same_v<decltype(resultUnsigned.x), U>, "Result must be unsigned");
     BOOST_TEST(resultUnsigned == UnsignedPoint(result));
 
     pt += SignedPoint(pt2);
@@ -100,18 +100,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subtract_points, T, SignedTypes)
     const UnsignedPoint pt2(x2, y2);
 
     const auto result = pt - pt2;
-    static_assert(std::is_same<decltype(result.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(result.x), T>, "Result must be signed");
     BOOST_TEST(result == SignedPoint(x - x2, y - y2));
 
     const auto resultSigned = pt - SignedPoint(pt2);
-    static_assert(std::is_same<decltype(resultSigned.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(resultSigned.x), T>, "Result must be signed");
     BOOST_TEST(resultSigned == result);
 
     const auto x3 = randomValue<U>(x2);
     const auto y3 = randomValue<U>(y2);
     UnsignedPoint pt3(x3, y3);
     const auto resultUnsigned = pt3 - pt2;
-    static_assert(std::is_same<decltype(resultUnsigned.x), U>::value, "Result must be unsigned");
+    static_assert(std::is_same_v<decltype(resultUnsigned.x), U>, "Result must be unsigned");
     BOOST_TEST(resultUnsigned == UnsignedPoint(x3 - x2, y3 - y2));
 
     pt -= SignedPoint(pt2);
@@ -135,15 +135,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(multiply_points, T, SignedTypes)
     UnsignedPoint pt2(x2, y2);
 
     const auto result = pt * pt2;
-    static_assert(std::is_same<decltype(result.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(result.x), T>, "Result must be signed");
     BOOST_TEST(result == SignedPoint(x * x2, y * y2));
 
     const auto resultSigned = pt * SignedPoint(pt2);
-    static_assert(std::is_same<decltype(resultSigned.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(resultSigned.x), T>, "Result must be signed");
     BOOST_TEST(resultSigned == result);
 
     const auto resultUnsigned = UnsignedPoint(pt) * pt2;
-    static_assert(std::is_same<decltype(resultUnsigned.x), U>::value, "Result must be unsigned");
+    static_assert(std::is_same_v<decltype(resultUnsigned.x), U>, "Result must be unsigned");
     BOOST_TEST(resultUnsigned == UnsignedPoint(result));
 
     pt *= SignedPoint(pt2);
@@ -162,18 +162,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(scale_point, T, SignedTypes)
     const auto scale = randomValue<U>(1, 100);
 
     const auto result = pt * scale;
-    static_assert(std::is_same<decltype(result.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(result.x), T>, "Result must be signed");
     BOOST_TEST(result == pt * SignedPoint::all(scale));
 
     const auto resultSigned = pt * T(scale);
-    static_assert(std::is_same<decltype(resultSigned.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(resultSigned.x), T>, "Result must be signed");
     BOOST_TEST(resultSigned == result);
 
     x = abs(x);
     y = abs(y);
     UnsignedPoint pt2(x, y);
     const auto resultUnsigned = pt2 * scale;
-    static_assert(std::is_same<decltype(resultUnsigned.x), U>::value, "Result must be unsigned");
+    static_assert(std::is_same_v<decltype(resultUnsigned.x), U>, "Result must be unsigned");
     BOOST_TEST(resultUnsigned == pt2 * UnsignedPoint::all(scale));
 
     pt *= scale;
@@ -197,18 +197,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(divide_points, T, SignedTypes)
     UnsignedPoint pt2(x2, y2);
 
     const auto result = pt / pt2;
-    static_assert(std::is_same<decltype(result.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(result.x), T>, "Result must be signed");
     BOOST_TEST(result == SignedPoint(x / static_cast<T>(x2), y / static_cast<T>(y2)));
 
     const auto resultSigned = pt / SignedPoint(pt2);
-    static_assert(std::is_same<decltype(resultSigned.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(resultSigned.x), T>, "Result must be signed");
     BOOST_TEST(resultSigned == result);
 
     const auto x3 = randomValue<U>(x2);
     const auto y3 = randomValue<U>(y2);
     UnsignedPoint pt3(x3, y3);
     const auto resultUnsigned = pt3 / pt2;
-    static_assert(std::is_same<decltype(resultUnsigned.x), U>::value, "Result must be unsigned");
+    static_assert(std::is_same_v<decltype(resultUnsigned.x), U>, "Result must be unsigned");
     BOOST_TEST(resultUnsigned == UnsignedPoint(x3 / x2, y3 / y2));
 
     pt /= SignedPoint(pt2);
@@ -229,21 +229,21 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unscale_point, T, SignedTypes)
     SignedPoint pt(x, y);
     const auto scale = randomValue<U>(1, 100);
 
-    constexpr auto epsilon = std::conditional_t<std::is_same<T, float>::value, float, double>(0.00001);
+    constexpr auto epsilon = std::conditional_t<std::is_same_v<T, float>, float, double>(0.00001);
 
     const auto result = pt / scale;
-    static_assert(std::is_same<decltype(result.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(result.x), T>, "Result must be signed");
     TEST_POINTS_CLOSE(result, pt / SignedPoint::all(scale), epsilon);
 
     const auto resultSigned = pt / T(scale);
-    static_assert(std::is_same<decltype(resultSigned.x), T>::value, "Result must be signed");
+    static_assert(std::is_same_v<decltype(resultSigned.x), T>, "Result must be signed");
     TEST_POINTS_CLOSE(resultSigned, result, epsilon);
 
     x = abs(x);
     y = abs(y);
     UnsignedPoint pt2(x, y);
     const auto resultUnsigned = pt2 / scale;
-    static_assert(std::is_same<decltype(resultUnsigned.x), U>::value, "Result must be unsigned");
+    static_assert(std::is_same_v<decltype(resultUnsigned.x), U>, "Result must be unsigned");
     TEST_POINTS_CLOSE(resultUnsigned, pt2 / UnsignedPoint::all(scale), epsilon);
 
     pt /= scale;

--- a/tests/libsamplerate_cpp/testSamplerate.cpp
+++ b/tests/libsamplerate_cpp/testSamplerate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(CtorAndBaseFuncsWork)
     s1.setRatio(44100. / 22050.); // No exceptions thrown
 }
 
-template<typename T, std::enable_if_t<std::is_copy_constructible<T>::value>* = nullptr>
+template<typename T, std::enable_if_t<std::is_copy_constructible_v<T>>* = nullptr>
 void cloneTests(T& s1)
 {
     samplerate::State s2 = s1;
@@ -56,7 +56,7 @@ void cloneTests(T& s1)
     BOOST_TEST(s1.getState() != s3.getState());
 }
 
-template<typename T, std::enable_if_t<!std::is_copy_constructible<T>::value>* = nullptr>
+template<typename T, std::enable_if_t<!std::is_copy_constructible_v<T>>* = nullptr>
 void cloneTests(const T&)
 {}
 

--- a/tests/s25Main/integration/testFrontierDistance.cpp
+++ b/tests/s25Main/integration/testFrontierDistance.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -39,7 +39,7 @@ struct FrontierWorld : public WorldFixture<T_WorldCreator, 2, T_width, T_height>
         const GamePlayer& p1 = world.GetPlayer(1);
         milBld0Pos = p0.GetHQPos() - MapPoint(0, 2);
         milBld1Pos = p1.GetHQPos() - MapPoint(0, 2);
-        if(std::is_same<T_WorldCreator, CreateEmptyWorld>::value)
+        if(std::is_same_v<T_WorldCreator, CreateEmptyWorld>)
         { // Assumed by distributions and sizes
             BOOST_TEST_REQUIRE(milBld0Pos.y == milBld1Pos.y);
         }


### PR DESCRIPTION
This is shorter and easier to read and otherwise flagged by clang-tidy as `modernize-type-traits`