### PR TITLE
Allow to disable statistics for eight player

### DIFF
--- a/libs/s25main/ingameWindows/iwStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwStatistics.cpp
@@ -172,7 +172,8 @@ void iwStatistics::Msg_ButtonClick(const unsigned ctrl_id)
         case 4:
         case 5:
         case 6:
-        case 7: // Spielerportraits
+        case 7:
+        case 8: // Spielerportraits
             activePlayers[ctrl_id - 1] = !activePlayers[ctrl_id - 1];
             break;
         case 25: // Hilfe


### PR DESCRIPTION
The statistics for the eight player can not be hidden by clicking the portrait of the player in the statistics window. This works for all other players