### PR TITLE
Fixed crash on linux

### DIFF
--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -232,7 +232,13 @@ void VideoSDL2::PrintError(const std::string& msg) const
 void VideoSDL2::ShowErrorMessage(const std::string& title, const std::string& message)
 {
     // window==nullptr is okay too ("no parent")
+#ifdef __linux__
+    // When using window, SDL will try to use a system tool like "zenity" which isn't always installed on every distro so rttr will crash
+    // But without a window it will use an x11 backend that should be available on x11 AND wayland for compatibility reasons
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), nullptr);
+#else
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), window);
+#endif
 }
 
 void VideoSDL2::HandlePaste()

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -233,8 +233,9 @@ void VideoSDL2::ShowErrorMessage(const std::string& title, const std::string& me
 {
     // window==nullptr is okay too ("no parent")
 #ifdef __linux__
-    // When using window, SDL will try to use a system tool like "zenity" which isn't always installed on every distro so rttr will crash
-    // But without a window it will use an x11 backend that should be available on x11 AND wayland for compatibility reasons
+    // When using window, SDL will try to use a system tool like "zenity" which isn't always installed on every distro
+    // so rttr will crash. But without a window it will use an x11 backend that should be available on x11 AND wayland
+    // for compatibility reasons
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), nullptr);
 #else
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), window);


### PR DESCRIPTION
When RTTR failes to find the game files a SDL message box is created to ask the user to install the files.
But when passing a valid SDL_window to the message box, SDL tries to use tools like zenity or kdialog.
This libraries are not always installed on every linux distribution and the program just crashes.
Using nullptr instead of a window object makes SDL use an x11 backend to display the message box.
This should work for every x11 or wayland system.

At least it works for me (wayland)

Fixes https://github.com/Return-To-The-Roots/s25client/issues/1788