### PR TITLE
Fix UB in test

### DIFF
--- a/tests/s25Main/UI/testControls.cpp
+++ b/tests/s25Main/UI/testControls.cpp
@@ -58,8 +58,8 @@ BOOST_AUTO_TEST_SUITE(Controls)
 
 BOOST_FIXTURE_TEST_CASE(MouseOver, uiHelper::Fixture)
 {
-    const auto pos = rttr::test::randomPoint<DrawPoint>(0, std::numeric_limits<DrawPoint::ElementType>::max() / 2);
-    const auto size = rttr::test::randomPoint<Extent>(10, std::numeric_limits<DrawPoint::ElementType>::max() / 2);
+    const auto pos = rttr::test::randomPoint<DrawPoint>();
+    const auto size = rttr::test::randomPoint<Extent>(10);
     const auto font = createMockFont({'H', 'e', 'l', 'o', '?'});
     ctrlTextButton bt(nullptr, 1, pos, size, TextureColor::Bricks, "Hello", font.get(), "");
     BOOST_TEST(bt.IsMouseOver(pos));

--- a/tests/testHelpers/rttr/test/random.hpp
+++ b/tests/testHelpers/rttr/test/random.hpp
@@ -29,7 +29,8 @@ inline bool randomBool()
 }
 template<typename T>
 auto randomPoint(typename T::ElementType min = std::numeric_limits<typename T::ElementType>::min(),
-                 typename T::ElementType max = std::numeric_limits<typename T::ElementType>::max())
+                 // Avoid overflow in some calculations by limiting max
+                 typename T::ElementType max = std::numeric_limits<typename T::ElementType>::max() / 32)
 {
     return T{randomValue(min, max), randomValue(min, max)};
 }


### PR DESCRIPTION
The maximum value for a random point was INT_MAX/2. We had at some point: `point + size*2` which overflows when size is in the range of INT_MAX/2. See https://github.com/Return-To-The-Roots/s25client/actions/runs/18046457107/job/51366141584?pr=1800

Use an upper bound of /32 for the random point values.