### PR TITLE
Fixing crash in CampaignSelection

### DIFF
--- a/libs/s25main/desktops/dskCampaignSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignSelection.cpp
@@ -88,6 +88,7 @@ dskCampaignSelection::dskCampaignSelection(CreateServerInfo csi)
     AddTextButton(ID_btBack, DrawPoint(380, 560), Extent(200, 22), TextureColor::Red1, _("Back"), NormalFont);
     AddTextButton(ID_Next, DrawPoint(590, 560), Extent(200, 22), TextureColor::Green2, _("Continue"), NormalFont);
 
+    GetCtrl<ctrlButton>(ID_Next)->SetEnabled(false);
     showCampaignInfo(false);
 
     // Delay loading until screen is shown such that possible error message boxes are shown after switching to this


### PR DESCRIPTION
**Changes Summary**

In the campaign selection screen, it is possible to click "next" without previously selecting any campaign from the table, which results in a crash. This PR fixes it by having the "next" button disabled upon creation.