### PR TITLE
Convert `MouseCoord` to plain struct

### DIFF
--- a/libs/driver/include/driver/MouseCoords.h
+++ b/libs/driver/include/driver/MouseCoords.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sfteam at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sfteam at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -6,30 +6,18 @@
 
 #include "Point.h"
 
-///////////////////////////////////////////////////////////////////////////////
-/**
- *  Mausstatusstruct
- *
- *  @author OLiver
- */
-class MouseCoords
+/// State of mouse buttons and position
+struct MouseCoords
 {
-public:
-    MouseCoords() : pos(0, 0), ldown(false), rdown(false), dbl_click(false) {}
-    MouseCoords(int x, int y, bool ldown = false, bool rdown = false, bool dbl_click = false)
-        : pos(x, y), ldown(ldown), rdown(rdown), dbl_click(dbl_click)
-    {}
-    MouseCoords(Position pos, bool ldown = false, bool rdown = false, bool dbl_click = false)
-        : pos(pos), ldown(ldown), rdown(rdown), dbl_click(dbl_click)
-    {}
+    MouseCoords() = default;
+    MouseCoords(Position pos) : pos(pos) {}
+    MouseCoords(int x, int y) : pos(x, y) {}
 
-    Position pos;
-    bool ldown;     /// Linke Maustaste gedrückt
-    bool rdown;     /// Rechte Maustaste gedrückt
-    bool dbl_click; /// Linke Maustaste - Doppelklick
-
-    Position GetPos() const { return pos; }
+    Position pos = Position(0, 0);
+    bool ldown = false;     /// left button down
+    bool rdown = false;     /// right button down
+    bool dbl_click = false; /// double-click (left button)
 };
 
-/// Maximale Zeitdifferenz in ms für einen Doppeklick
-const unsigned DOUBLE_CLICK_INTERVAL = 500;
+/// Maximum interval between two clicks to be considered a double-click (in milliseconds)
+constexpr unsigned DOUBLE_CLICK_INTERVAL = 500;

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -115,7 +115,7 @@ bool Window::RelayMouseMessage(MouseMsgHandler msg, const MouseCoords& mc)
     // Use reverse iterator because the topmost (=last elements) should receive the messages first!
     for(Window* wnd : childIdToWnd_ | boost::adaptors::map_values | boost::adaptors::reversed)
     {
-        if(!lockedAreas_.empty() && IsInLockedRegion(mc.GetPos(), wnd))
+        if(!lockedAreas_.empty() && IsInLockedRegion(mc.pos, wnd))
             continue;
 
         if(wnd->visible_ && wnd->active_ && CALL_MEMBER_FN(*wnd, msg)(mc))
@@ -572,5 +572,5 @@ bool Window::IsMouseOver() const
 
 bool Window::IsMouseOver(const MouseCoords& mousePos) const
 {
-    return IsPointInRect(mousePos.GetPos(), GetBoundaryRect());
+    return IsPointInRect(mousePos.pos, GetBoundaryRect());
 }

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -47,7 +47,7 @@ class ctrlVarText;
 class glArchivItem_Bitmap;
 class glFont;
 class ITexture;
-class MouseCoords;
+struct MouseCoords;
 enum class GroupSelectType : unsigned;
 struct KeyEvent;
 struct ScreenResizeEvent;

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -308,7 +308,7 @@ void WindowManager::Msg_LeftDown(MouseCoords mc)
         return;
     }
 
-    IngameWindow* foundWindow = FindWindowAtPos(mc.GetPos());
+    IngameWindow* foundWindow = FindWindowAtPos(mc.pos);
 
     // Haben wir ein Fenster gefunden gehabt?
     if(foundWindow)
@@ -356,13 +356,13 @@ void WindowManager::Msg_LeftUp(MouseCoords mc)
 
     // Ggf. Doppelklick untersuche
     unsigned time_now = VIDEODRIVER.GetTickCount();
-    if(time_now - lastLeftClickTime < DOUBLE_CLICK_INTERVAL && mc.GetPos() == lastLeftClickPos)
+    if(time_now - lastLeftClickTime < DOUBLE_CLICK_INTERVAL && mc.pos == lastLeftClickPos)
     {
         mc.dbl_click = true;
     } else
     {
         // Werte wieder erneut speichern
-        lastLeftClickPos = mc.GetPos();
+        lastLeftClickPos = mc.pos;
         lastLeftClickTime = time_now;
     }
 
@@ -410,7 +410,7 @@ void WindowManager::Msg_RightDown(const MouseCoords& mc)
     // Right-click closes (most) windows, so check that
     if(!windows.empty())
     {
-        IngameWindow* foundWindow = FindWindowAtPos(mc.GetPos());
+        IngameWindow* foundWindow = FindWindowAtPos(mc.pos);
         if(windows.back()->IsModal())
         {
             // We have a modal window -> Activate it
@@ -503,7 +503,7 @@ void WindowManager::Msg_WheelUp(const MouseCoords& mc)
         return;
     }
 
-    IngameWindow* foundWindow = FindWindowAtPos(mc.GetPos());
+    IngameWindow* foundWindow = FindWindowAtPos(mc.pos);
 
     if(foundWindow)
     {
@@ -550,7 +550,7 @@ void WindowManager::Msg_WheelDown(const MouseCoords& mc)
         activeWnd.RelayMouseMessage(&Window::Msg_WheelDown, mc);
         return;
     }
-    IngameWindow* foundWindow = FindWindowAtPos(mc.GetPos());
+    IngameWindow* foundWindow = FindWindowAtPos(mc.pos);
 
     if(foundWindow)
     {

--- a/libs/s25main/WindowManager.h
+++ b/libs/s25main/WindowManager.h
@@ -16,7 +16,7 @@
 class Window;
 class Desktop;
 class IngameWindow;
-class MouseCoords;
+struct MouseCoords;
 struct KeyEvent;
 class ctrlBaseTooltip;
 

--- a/libs/s25main/controls/ctrlButton.h
+++ b/libs/s25main/controls/ctrlButton.h
@@ -10,7 +10,7 @@
 
 #include <string>
 
-class MouseCoords;
+struct MouseCoords;
 
 /// Buttonklasse
 class ctrlButton : public Window, public ctrlBaseTooltip

--- a/libs/s25main/controls/ctrlChat.cpp
+++ b/libs/s25main/controls/ctrlChat.cpp
@@ -235,7 +235,7 @@ bool ctrlChat::Msg_LeftUp(const MouseCoords& mc)
 
 bool ctrlChat::Msg_WheelUp(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(), Rect(GetDrawPos() + DrawPoint(2, 2), GetSize() - Extent(2, 4))))
+    if(IsPointInRect(mc.pos, Rect(GetDrawPos() + DrawPoint(2, 2), GetSize() - Extent(2, 4))))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(-3);
@@ -246,7 +246,7 @@ bool ctrlChat::Msg_WheelUp(const MouseCoords& mc)
 
 bool ctrlChat::Msg_WheelDown(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(), Rect(GetDrawPos() + DrawPoint(2, 2), GetSize() - Extent(2, 4))))
+    if(IsPointInRect(mc.pos, Rect(GetDrawPos() + DrawPoint(2, 2), GetSize() - Extent(2, 4))))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(+3);

--- a/libs/s25main/controls/ctrlChat.h
+++ b/libs/s25main/controls/ctrlChat.h
@@ -7,7 +7,7 @@
 #include "Window.h"
 #include "variant.h"
 #include <vector>
-class MouseCoords;
+struct MouseCoords;
 class glFont;
 
 /// ChatCtrl-Klasse für ein ChatCtrl.

--- a/libs/s25main/controls/ctrlCheck.cpp
+++ b/libs/s25main/controls/ctrlCheck.cpp
@@ -19,7 +19,7 @@ ctrlCheck::ctrlCheck(Window* parent, unsigned id, const DrawPoint& pos, const Ex
 
 bool ctrlCheck::Msg_LeftDown(const MouseCoords& mc)
 {
-    if(!readonly && IsPointInRect(mc.GetPos(), GetDrawRect()))
+    if(!readonly && IsPointInRect(mc.pos, GetDrawRect()))
     {
         check = !check;
         GetParent()->Msg_CheckboxChange(GetID(), check);
@@ -31,7 +31,7 @@ bool ctrlCheck::Msg_LeftDown(const MouseCoords& mc)
 
 bool ctrlCheck::Msg_MouseMove(const MouseCoords& mc)
 {
-    if(IsMouseOver(mc.GetPos()))
+    if(IsMouseOver(mc.pos))
     {
         ShowTooltip();
         return true;

--- a/libs/s25main/controls/ctrlCheck.h
+++ b/libs/s25main/controls/ctrlCheck.h
@@ -7,7 +7,7 @@
 #include "Window.h"
 #include "ctrlBaseTooltip.h"
 #include <string>
-class MouseCoords;
+struct MouseCoords;
 class glFont;
 
 class ctrlCheck : public Window, public ctrlBaseTooltip

--- a/libs/s25main/controls/ctrlComboBox.cpp
+++ b/libs/s25main/controls/ctrlComboBox.cpp
@@ -96,14 +96,14 @@ bool ctrlComboBox::Msg_LeftDown(const MouseCoords& mc)
     auto* list = GetCtrl<ctrlList>(0);
 
     // Irgendwo anders hingeklickt --> Liste ausblenden
-    if(!readonly && !IsPointInRect(mc.GetPos(), GetFullDrawRect(list)))
+    if(!readonly && !IsPointInRect(mc.pos, GetFullDrawRect(list)))
     {
         // Liste wieder ausblenden
         ShowList(false);
         return false;
     }
 
-    if(!readonly && IsPointInRect(mc.GetPos(), GetDrawRect()))
+    if(!readonly && IsPointInRect(mc.pos, GetDrawRect()))
     {
         // Liste wieder ein/ausblenden
         ShowList(!list->IsVisible());
@@ -128,7 +128,7 @@ bool ctrlComboBox::Msg_RightDown(const MouseCoords& mc)
     bool ret = RelayMouseMessage(&Window::Msg_RightDown, mc);
 
     // Clicked on list -> close it
-    if(!readonly && IsPointInRect(mc.GetPos(), list->GetDrawRect()))
+    if(!readonly && IsPointInRect(mc.pos, list->GetDrawRect()))
     {
         // Liste wieder ausblenden
         ShowList(false);
@@ -143,10 +143,10 @@ bool ctrlComboBox::Msg_WheelUp(const MouseCoords& mc)
         return false;
 
     auto* list = GetCtrl<ctrlList>(0);
-    if(list->IsVisible() && IsPointInRect(mc.GetPos(), list->GetDrawRect()))
+    if(list->IsVisible() && IsPointInRect(mc.pos, list->GetDrawRect()))
         return RelayMouseMessage(&Window::Msg_WheelUp, mc);
 
-    if(IsPointInRect(mc.GetPos(), GetDrawRect()))
+    if(IsPointInRect(mc.pos, GetDrawRect()))
     {
         // Don't scroll too far down
         if(list->GetSelection().value_or(0u) > 0u)
@@ -164,13 +164,13 @@ bool ctrlComboBox::Msg_WheelDown(const MouseCoords& mc)
 
     auto* list = GetCtrl<ctrlList>(0);
 
-    if(list->IsVisible() && IsPointInRect(mc.GetPos(), list->GetDrawRect()))
+    if(list->IsVisible() && IsPointInRect(mc.pos, list->GetDrawRect()))
     {
         // Scrolled in opened list ->
         return RelayMouseMessage(&Window::Msg_WheelDown, mc);
     }
 
-    if(IsPointInRect(mc.GetPos(), GetDrawRect()))
+    if(IsPointInRect(mc.pos, GetDrawRect()))
     {
         // Will be ignored by the list if to high
         list->SetSelection(list->GetSelection() ? *list->GetSelection() + 1u : 0u);

--- a/libs/s25main/controls/ctrlComboBox.h
+++ b/libs/s25main/controls/ctrlComboBox.h
@@ -6,7 +6,7 @@
 
 #include "Window.h"
 #include "ctrlList.h"
-class MouseCoords;
+struct MouseCoords;
 class glFont;
 
 class ctrlComboBox final : public Window

--- a/libs/s25main/controls/ctrlEdit.cpp
+++ b/libs/s25main/controls/ctrlEdit.cpp
@@ -219,7 +219,7 @@ void ctrlEdit::Resize(const Extent& newSize)
  */
 bool ctrlEdit::Msg_LeftDown(const MouseCoords& mc)
 {
-    SetFocus(IsPointInRect(mc.GetPos(), GetDrawRect()));
+    SetFocus(IsPointInRect(mc.pos, GetDrawRect()));
     return false; // "Unhandled" so other edits can handle this too and set their focus accordingly
 }
 

--- a/libs/s25main/controls/ctrlEdit.h
+++ b/libs/s25main/controls/ctrlEdit.h
@@ -6,7 +6,7 @@
 
 #include "Window.h"
 
-class MouseCoords;
+struct MouseCoords;
 class glFont;
 class ctrlTextDeepening;
 struct KeyEvent;

--- a/libs/s25main/controls/ctrlGroup.cpp
+++ b/libs/s25main/controls/ctrlGroup.cpp
@@ -4,7 +4,7 @@
 
 #include "ctrlGroup.h"
 
-class MouseCoords;
+struct MouseCoords;
 struct KeyEvent;
 
 ctrlGroup::ctrlGroup(Window* parent, unsigned id) : Window(parent, id, DrawPoint(0, 0)) {}

--- a/libs/s25main/controls/ctrlGroup.h
+++ b/libs/s25main/controls/ctrlGroup.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "Window.h"
-class MouseCoords;
+struct MouseCoords;
 struct KeyEvent;
 
 enum class GroupSelectType : unsigned

--- a/libs/s25main/controls/ctrlImage.cpp
+++ b/libs/s25main/controls/ctrlImage.cpp
@@ -21,7 +21,7 @@ bool ctrlImage::Msg_MouseMove(const MouseCoords& mc)
 {
     if(GetImage())
     {
-        if(IsMouseOver(mc.GetPos()))
+        if(IsMouseOver(mc.pos))
             ShowTooltip();
         else
             HideTooltip();

--- a/libs/s25main/controls/ctrlImage.h
+++ b/libs/s25main/controls/ctrlImage.h
@@ -8,7 +8,7 @@
 #include "controls/ctrlBaseImage.h"
 #include "controls/ctrlBaseTooltip.h"
 
-class MouseCoords;
+struct MouseCoords;
 class ITexture;
 
 class ctrlImage : public Window, public ctrlBaseTooltip, public ctrlBaseImage

--- a/libs/s25main/controls/ctrlIngameMinimap.cpp
+++ b/libs/s25main/controls/ctrlIngameMinimap.cpp
@@ -77,11 +77,11 @@ bool ctrlIngameMinimap::Msg_MouseMove(const MouseCoords& mc)
     if(mc.ldown)
     {
         // Mauszeiger auf der Karte?
-        if(IsPointInRect(mc.GetPos(), GetMapDrawArea()))
+        if(IsPointInRect(mc.pos, GetMapDrawArea()))
         {
             // Koordinate feststellen
-            DrawPoint mapCoord = (mc.GetPos() - DrawPoint(GetMapDrawArea().getOrigin()))
-                                 * DrawPoint(minimap.GetMapSize()) / DrawPoint(GetCurMapSize());
+            DrawPoint mapCoord = (mc.pos - DrawPoint(GetMapDrawArea().getOrigin())) * DrawPoint(minimap.GetMapSize())
+                                 / DrawPoint(GetCurMapSize());
 
             gwv.MoveToMapPt(MapPoint(mapCoord));
 

--- a/libs/s25main/controls/ctrlIngameMinimap.h
+++ b/libs/s25main/controls/ctrlIngameMinimap.h
@@ -8,7 +8,7 @@
 
 class GameWorldView;
 class IngameMinimap;
-class MouseCoords;
+struct MouseCoords;
 class Window;
 
 /// Minimap-Control für Ingame

--- a/libs/s25main/controls/ctrlList.cpp
+++ b/libs/s25main/controls/ctrlList.cpp
@@ -88,7 +88,7 @@ bool ctrlList::Msg_LeftUp(const MouseCoords& mc)
     auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
 
     // Wenn Maus in der Liste
-    if(IsPointInRect(mc.GetPos(), GetListDrawArea()))
+    if(IsPointInRect(mc.pos, GetListDrawArea()))
     {
         // Doppelklick? Dann noch einen extra Eventhandler aufrufen
         if(mc.dbl_click && GetParent() && selection_)
@@ -104,7 +104,7 @@ bool ctrlList::Msg_LeftUp(const MouseCoords& mc)
 bool ctrlList::Msg_WheelUp(const MouseCoords& mc)
 {
     // If mouse in list or scrollbar
-    if(IsPointInRect(mc.GetPos(), GetFullDrawArea()))
+    if(IsPointInRect(mc.pos, GetFullDrawArea()))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(-1);
@@ -117,7 +117,7 @@ bool ctrlList::Msg_WheelUp(const MouseCoords& mc)
 bool ctrlList::Msg_WheelDown(const MouseCoords& mc)
 {
     // If mouse in list
-    if(IsPointInRect(mc.GetPos(), GetFullDrawArea()))
+    if(IsPointInRect(mc.pos, GetFullDrawArea()))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(+1);

--- a/libs/s25main/controls/ctrlList.h
+++ b/libs/s25main/controls/ctrlList.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-class MouseCoords;
+struct MouseCoords;
 class glFont;
 
 class ctrlList : public Window

--- a/libs/s25main/controls/ctrlMapSelection.cpp
+++ b/libs/s25main/controls/ctrlMapSelection.cpp
@@ -121,7 +121,7 @@ bool ctrlMapSelection::Msg_LeftUp(const MouseCoords& mc)
 {
     if(!preview && IsMouseOver(mc))
     {
-        const auto pickPos = invertScale(mc.GetPos() - getMapPosition());
+        const auto pickPos = invertScale(mc.pos - getMapPosition());
 
         const auto pixelColor = mapImages.missionMapMask
                                   ->getPixel(helpers::clamp(pickPos.x, 0u, mapImages.map->GetSize().x - 1),

--- a/libs/s25main/controls/ctrlMultiSelectGroup.cpp
+++ b/libs/s25main/controls/ctrlMultiSelectGroup.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "ctrlMultiSelectGroup.h"
-class MouseCoords;
+struct MouseCoords;
 
 ctrlMultiSelectGroup::ctrlMultiSelectGroup(Window* parent, unsigned id, GroupSelectType select_type)
     : ctrlGroup(parent, id), select_type(select_type)

--- a/libs/s25main/controls/ctrlMultiSelectGroup.h
+++ b/libs/s25main/controls/ctrlMultiSelectGroup.h
@@ -7,7 +7,7 @@
 #include "ctrlButton.h"
 #include "ctrlGroup.h"
 #include <set>
-class MouseCoords;
+struct MouseCoords;
 class Window;
 
 /// Verwaltet eine Gruppe von n Buttons, von denen 0 bis n gleichzeitig ausgewählt sind

--- a/libs/s25main/controls/ctrlMultiline.cpp
+++ b/libs/s25main/controls/ctrlMultiline.cpp
@@ -147,7 +147,7 @@ bool ctrlMultiline::Msg_LeftUp(const MouseCoords& mc)
 bool ctrlMultiline::Msg_WheelUp(const MouseCoords& mc)
 {
     const Extent padding(PADDING, PADDING);
-    if(IsPointInRect(mc.GetPos(), Rect(GetDrawPos() + DrawPoint(padding), GetSize() - padding * 2u)))
+    if(IsPointInRect(mc.pos, Rect(GetDrawPos() + DrawPoint(padding), GetSize() - padding * 2u)))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(-3);
@@ -159,7 +159,7 @@ bool ctrlMultiline::Msg_WheelUp(const MouseCoords& mc)
 bool ctrlMultiline::Msg_WheelDown(const MouseCoords& mc)
 {
     const Extent padding(PADDING, PADDING);
-    if(IsPointInRect(mc.GetPos(), Rect(GetDrawPos() + DrawPoint(padding), GetSize() - padding * 2u)))
+    if(IsPointInRect(mc.pos, Rect(GetDrawPos() + DrawPoint(padding), GetSize() - padding * 2u)))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(+3);

--- a/libs/s25main/controls/ctrlMultiline.h
+++ b/libs/s25main/controls/ctrlMultiline.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-class MouseCoords;
+struct MouseCoords;
 class glFont;
 
 class ctrlMultiline : public Window

--- a/libs/s25main/controls/ctrlOptionGroup.h
+++ b/libs/s25main/controls/ctrlOptionGroup.h
@@ -7,7 +7,7 @@
 #include "ctrlButton.h"
 #include "ctrlGroup.h"
 #include <boost/optional.hpp>
-class MouseCoords;
+struct MouseCoords;
 class Window;
 
 /// Verwaltet eine Gruppe von Buttons, die als Optionsbuttons benötigt werden

--- a/libs/s25main/controls/ctrlProgress.cpp
+++ b/libs/s25main/controls/ctrlProgress.cpp
@@ -138,7 +138,7 @@ bool ctrlProgress::Msg_LeftDown(const MouseCoords& mc)
     // Test if clicked on progress bar
     DrawPoint progressOrigin = GetDrawPos() + DrawPoint(padding_) + DrawPoint(GetSize().y + 2, 4);
     Extent progressSize = GetSize() - Extent((GetSize().y + 1) * 2, 8) - padding_ * 2u;
-    if(IsPointInRect(mc.GetPos(), Rect(progressOrigin, progressSize)))
+    if(IsPointInRect(mc.pos, Rect(progressOrigin, progressSize)))
     {
         position =
           helpers::iround<uint16_t>(static_cast<double>((mc.pos.x - progressOrigin.x) * maximum) / progressSize.x);
@@ -158,7 +158,7 @@ bool ctrlProgress::Msg_LeftUp(const MouseCoords& mc)
 bool ctrlProgress::Msg_WheelUp(const MouseCoords& mc)
 {
     // If mouse is over the controls, simulate button click
-    if(IsPointInRect(mc.GetPos(), GetDrawRect()))
+    if(IsPointInRect(mc.pos, GetDrawRect()))
     {
         Msg_ButtonClick(1);
         return true;
@@ -169,7 +169,7 @@ bool ctrlProgress::Msg_WheelUp(const MouseCoords& mc)
 bool ctrlProgress::Msg_WheelDown(const MouseCoords& mc)
 {
     // If mouse is over the controls, simulate button click
-    if(IsPointInRect(mc.GetPos(), GetDrawRect()))
+    if(IsPointInRect(mc.pos, GetDrawRect()))
     {
         Msg_ButtonClick(0);
         return true;
@@ -185,7 +185,7 @@ bool ctrlProgress::Msg_MouseMove(const MouseCoords& mc)
     Extent offset(GetSize().y + padding_.x, 0);
     DrawPoint rectOrig = GetDrawPos() + DrawPoint(offset);
     Extent rectSize = GetSize() - offset * 2u;
-    if(IsPointInRect(mc.GetPos(), Rect(rectOrig, rectSize)))
+    if(IsPointInRect(mc.pos, Rect(rectOrig, rectSize)))
     {
         WINDOWMANAGER.SetToolTip(this, tooltip_);
         return true;

--- a/libs/s25main/controls/ctrlProgress.h
+++ b/libs/s25main/controls/ctrlProgress.h
@@ -6,7 +6,7 @@
 
 #include "Window.h"
 #include "controls/ctrlBaseTooltip.h"
-class MouseCoords;
+struct MouseCoords;
 
 class ctrlProgress : public Window, public ctrlBaseTooltip
 {

--- a/libs/s25main/controls/ctrlScrollBar.cpp
+++ b/libs/s25main/controls/ctrlScrollBar.cpp
@@ -51,13 +51,13 @@ bool ctrlScrollBar::Msg_LeftUp(const MouseCoords& mc)
 
 bool ctrlScrollBar::Msg_LeftDown(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(),
+    if(IsPointInRect(mc.pos,
                      Rect(GetDrawPos().x, GetDrawPos().y + button_height + sliderPos, GetSize().x, sliderHeight)))
     {
         // Maus auf dem Scrollbutton
         isMouseScrolling = true;
         return true;
-    } else if(IsPointInRect(mc.GetPos(), Rect(GetDrawPos().x, GetDrawPos().y + button_height, GetSize().x, sliderPos)))
+    } else if(IsPointInRect(mc.pos, Rect(GetDrawPos().x, GetDrawPos().y + button_height, GetSize().x, sliderPos)))
     {
         // Clicked above slider -> Move half a slider height up
         if(sliderPos < sliderHeight / 2)
@@ -71,8 +71,8 @@ bool ctrlScrollBar::Msg_LeftDown(const MouseCoords& mc)
     {
         unsigned short bottomSliderPos = button_height + sliderPos + sliderHeight;
 
-        if(IsPointInRect(mc.GetPos(), Rect(GetDrawPos().x, GetDrawPos().y + bottomSliderPos, GetSize().x,
-                                           GetSize().y - (bottomSliderPos + button_height))))
+        if(IsPointInRect(mc.pos, Rect(GetDrawPos().x, GetDrawPos().y + bottomSliderPos, GetSize().x,
+                                      GetSize().y - (bottomSliderPos + button_height))))
         {
             // Clicked below slider -> Move half a slider height down
             sliderPos += sliderHeight / 2;

--- a/libs/s25main/controls/ctrlScrollBar.h
+++ b/libs/s25main/controls/ctrlScrollBar.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "Window.h"
-class MouseCoords;
+struct MouseCoords;
 
 class ctrlScrollBar final : public Window
 {

--- a/libs/s25main/controls/ctrlTab.cpp
+++ b/libs/s25main/controls/ctrlTab.cpp
@@ -7,7 +7,7 @@
 #include "ctrlButton.h"
 #include "ctrlGroup.h"
 #include "ogl/glArchivItem_Bitmap.h"
-class MouseCoords;
+struct MouseCoords;
 
 ctrlTab::ctrlTab(Window* parent, unsigned id, const DrawPoint& pos, unsigned short width)
     : Window(parent, id, pos, Extent(width, 45)), tab_count(0), tab_selection(0)

--- a/libs/s25main/controls/ctrlTab.h
+++ b/libs/s25main/controls/ctrlTab.h
@@ -8,7 +8,7 @@
 #include <array>
 
 class ctrlGroup;
-class MouseCoords;
+struct MouseCoords;
 class glArchivItem_Bitmap;
 
 class ctrlTab : public Window

--- a/libs/s25main/controls/ctrlTable.cpp
+++ b/libs/s25main/controls/ctrlTable.cpp
@@ -366,7 +366,7 @@ Rect ctrlTable::GetFullDrawArea() const
 
 bool ctrlTable::Msg_LeftDown(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(), GetContentDrawArea()))
+    if(IsPointInRect(mc.pos, GetContentDrawArea()))
     {
         SetSelection(GetSelectionFromMouse(mc));
         if(GetParent())
@@ -379,7 +379,7 @@ bool ctrlTable::Msg_LeftDown(const MouseCoords& mc)
 
 bool ctrlTable::Msg_RightDown(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(), GetContentDrawArea()))
+    if(IsPointInRect(mc.pos, GetContentDrawArea()))
     {
         SetSelection(GetSelectionFromMouse(mc));
         if(GetParent())
@@ -404,7 +404,7 @@ boost::optional<unsigned> ctrlTable::GetSelectionFromMouse(const MouseCoords& mc
 bool ctrlTable::Msg_WheelUp(const MouseCoords& mc)
 {
     // If mouse in list or scrollbar
-    if(IsPointInRect(mc.GetPos(), GetFullDrawArea()))
+    if(IsPointInRect(mc.pos, GetFullDrawArea()))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(-1);
@@ -415,7 +415,7 @@ bool ctrlTable::Msg_WheelUp(const MouseCoords& mc)
 
 bool ctrlTable::Msg_WheelDown(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(), GetFullDrawArea()))
+    if(IsPointInRect(mc.pos, GetFullDrawArea()))
     {
         auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
         scrollbar->Scroll(+1);
@@ -426,7 +426,7 @@ bool ctrlTable::Msg_WheelDown(const MouseCoords& mc)
 
 bool ctrlTable::Msg_LeftUp(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(), GetContentDrawArea()))
+    if(IsPointInRect(mc.pos, GetContentDrawArea()))
     {
         if(mc.dbl_click && GetParent())
         {

--- a/libs/s25main/controls/ctrlTable.h
+++ b/libs/s25main/controls/ctrlTable.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-class MouseCoords;
+struct MouseCoords;
 class glFont;
 struct KeyEvent;
 

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -469,7 +469,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
     DrawPoint btOrig(VIDEODRIVER.GetRenderSize().x / 2 - LOADER.GetImageN("resource", 29)->getWidth() / 2 + 44,
                      VIDEODRIVER.GetRenderSize().y - LOADER.GetImageN("resource", 29)->getHeight() + 4);
     Extent btSize = Extent(37, 32) * 4u;
-    if(IsPointInRect(mc.GetPos(), Rect(btOrig, btSize)))
+    if(IsPointInRect(mc.pos, Rect(btOrig, btSize)))
         return false;
 
     // Start scrolling also on Ctrl + left click
@@ -489,7 +489,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
         if(selPt == road.point)
         {
             // Selektierter Punkt ist der gleiche wie der Straßenpunkt --> Fenster mit Wegbau abbrechen
-            ShowRoadWindow(mc.GetPos());
+            ShowRoadWindow(mc.pos);
         } else
         {
             // altes Roadwindow schließen
@@ -501,7 +501,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
             {
                 MapPoint targetPt = selPt;
                 if(!BuildRoadPart(targetPt))
-                    ShowRoadWindow(mc.GetPos());
+                    ShowRoadWindow(mc.pos);
             } else if(worldViewer.GetBQ(selPt) != BuildingQuality::Nothing)
             {
                 // Wurde bereits auf das gebaute Stück geklickt?
@@ -517,7 +517,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
                         if(selPt == targetPt)
                             GI_BuildRoad();
                     } else if(selPt == targetPt)
-                        ShowRoadWindow(mc.GetPos());
+                        ShowRoadWindow(mc.pos);
                 }
             }
             // Wurde auf eine Flagge geklickt und ist diese Flagge nicht der Weganfangspunkt?
@@ -529,7 +529,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
                     if(selPt == targetPt)
                         GI_BuildRoad();
                 } else if(selPt == targetPt)
-                    ShowRoadWindow(mc.GetPos());
+                    ShowRoadWindow(mc.pos);
             } else
             {
                 unsigned tbr = GetIdInCurBuildRoad(selPt);
@@ -537,7 +537,7 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
                 if(tbr)
                     DemolishRoad(tbr);
                 else
-                    ShowRoadWindow(mc.GetPos());
+                    ShowRoadWindow(mc.pos);
             }
         }
     } else
@@ -684,9 +684,9 @@ bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
         // aktuelle Mausposition merken, da diese durch das Schließen verändert werden kann
         if(actionwindow)
             actionwindow->Close();
-        VIDEODRIVER.SetMousePos(mc.GetPos());
+        VIDEODRIVER.SetMousePos(mc.pos);
 
-        ShowActionWindow(action_tabs, cSel, mc.GetPos(), enable_military_buildings);
+        ShowActionWindow(action_tabs, cSel, mc.pos, enable_military_buildings);
     }
 
     return true;
@@ -712,11 +712,11 @@ bool dskGameInterface::Msg_MouseMove(const MouseCoords& mc)
     if(SETTINGS.interface.invertMouse)
         acceleration = -acceleration;
 
-    gwv.MoveBy((mc.GetPos() - startScrollPt) * acceleration);
+    gwv.MoveBy((mc.pos - startScrollPt) * acceleration);
     VIDEODRIVER.SetMousePos(startScrollPt);
 
     if(!SETTINGS.global.smartCursor)
-        startScrollPt = mc.GetPos();
+        startScrollPt = mc.pos;
     return true;
 }
 

--- a/libs/s25main/desktops/dskGameInterface.h
+++ b/libs/s25main/desktops/dskGameInterface.h
@@ -25,7 +25,7 @@
 class IngameWindow;
 class glArchivItem_Bitmap;
 class GlobalGameSettings;
-class MouseCoords;
+struct MouseCoords;
 class PostBox;
 class PostMsg;
 struct BuildingNote;

--- a/libs/s25main/desktops/dskMainMenu.cpp
+++ b/libs/s25main/desktops/dskMainMenu.cpp
@@ -84,7 +84,7 @@ void dskMainMenu::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult 
 bool dskMainMenu::Msg_LeftUp(const MouseCoords& mc)
 {
     auto* txtVersion = GetCtrl<Window>(dskMenuBase::ID_txtVersion);
-    if(mc.dbl_click && IsPointInRect(mc.GetPos(), txtVersion->GetBoundaryRect()))
+    if(mc.dbl_click && IsPointInRect(mc.pos, txtVersion->GetBoundaryRect()))
     {
         WINDOWMANAGER.Switch(std::make_unique<dskTest>());
         return true;

--- a/libs/s25main/desktops/dskSplash.h
+++ b/libs/s25main/desktops/dskSplash.h
@@ -6,7 +6,7 @@
 
 #include "Desktop.h"
 #include <memory>
-class MouseCoords;
+struct MouseCoords;
 
 /// Klasse des Splashscreen Desktops.
 class dskSplash : public Desktop

--- a/libs/s25main/desktops/dskTest.cpp
+++ b/libs/s25main/desktops/dskTest.cpp
@@ -173,7 +173,7 @@ bool dskTest::Msg_RightUp(const MouseCoords& mc)
     std::vector<ctrlButton*> bts = GetCtrls<ctrlButton>();
     for(ctrlButton* bt : bts)
     {
-        if(IsPointInRect(mc.GetPos(), bt->GetDrawRect()))
+        if(IsPointInRect(mc.pos, bt->GetDrawRect()))
         {
             bt->SetChecked(!bt->GetCheck());
             return true;

--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -193,18 +193,18 @@ void IngameWindow::SetPinned(bool pinned)
 void IngameWindow::MouseLeftDown(const MouseCoords& mc)
 {
     // Check if the mouse is on the title bar
-    if(IsPointInRect(mc.GetPos(), GetButtonBounds(IwButton::Title)))
+    if(IsPointInRect(mc.pos, GetButtonBounds(IwButton::Title)))
     {
         // start moving
         isMoving = true;
         snapOffset_ = SnapOffset::all(0);
-        lastMousePos = mc.GetPos();
+        lastMousePos = mc.pos;
     } else
     {
         // Check the buttons
         for(const auto btn : helpers::enumRange<IwButton>())
         {
-            if(IsPointInRect(mc.GetPos(), GetButtonBounds(btn)))
+            if(IsPointInRect(mc.pos, GetButtonBounds(btn)))
                 buttonStates_[btn] = ButtonState::Pressed;
         }
     }
@@ -223,7 +223,7 @@ void IngameWindow::MouseLeftUp(const MouseCoords& mc)
                && (btn == IwButton::Title || btn == IwButton::PinOrMinimize)))
             continue;
 
-        if(IsPointInRect(mc.GetPos(), GetButtonBounds(btn)))
+        if(IsPointInRect(mc.pos, GetButtonBounds(btn)))
         {
             switch(btn)
             {
@@ -256,7 +256,7 @@ void IngameWindow::MouseMove(const MouseCoords& mc)
     if(isMoving)
     {
         // Calculate new window boundary rectangle without snapping
-        DrawPoint delta = mc.GetPos() - lastMousePos;
+        DrawPoint delta = mc.pos - lastMousePos;
         Rect wndRect = GetBoundaryRect();
         RTTR_Assert(wndRect.getOrigin() == GetPos()); // The rest of the code assumes this to be true
         wndRect.move(delta - snapOffset_);
@@ -271,19 +271,19 @@ void IngameWindow::MouseMove(const MouseCoords& mc)
           elMin(elMax(newPos, DrawPoint::all(0)), DrawPoint(VIDEODRIVER.GetRenderSize() - wndRect.getSize()));
         // …and use it to fix the mouse position if moved too far
         if(newPosBounded != newPos)
-            VIDEODRIVER.SetMousePos(newPosBounded - wndRect.getOrigin() + mc.GetPos());
+            VIDEODRIVER.SetMousePos(newPosBounded - wndRect.getOrigin() + mc.pos);
 
         // Set new position and re-calculate snap offset (window position may have been out of bounds)
         SetPos(newPos + snapOffset_);
         snapOffset_ = GetPos() - newPosBounded;
 
-        lastMousePos = mc.GetPos();
+        lastMousePos = mc.pos;
     } else
     {
         // Check the buttons
         for(const auto btn : helpers::enumRange<IwButton>())
         {
-            if(IsPointInRect(mc.GetPos(), GetButtonBounds(btn)))
+            if(IsPointInRect(mc.pos, GetButtonBounds(btn)))
                 buttonStates_[btn] = mc.ldown ? ButtonState::Pressed : ButtonState::Hover;
             else
                 buttonStates_[btn] = ButtonState::Up;

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 class glArchivItem_Bitmap;
-class MouseCoords;
+struct MouseCoords;
 struct PersistentWindowSettings;
 template<typename T>
 struct Point;

--- a/libs/s25main/ingameWindows/iwAddons.h
+++ b/libs/s25main/ingameWindows/iwAddons.h
@@ -11,7 +11,7 @@
 
 class AddonGui;
 class GlobalGameSettings;
-class MouseCoords;
+struct MouseCoords;
 
 enum class AddonChangeAllowed
 {

--- a/libs/s25main/ingameWindows/iwObservate.cpp
+++ b/libs/s25main/ingameWindows/iwObservate.cpp
@@ -251,7 +251,7 @@ bool iwObservate::Msg_MouseMove(const MouseCoords& mc)
         if(SETTINGS.interface.invertMouse)
             acceleration = -acceleration;
 
-        view->MoveBy((mc.GetPos() - scrollOrigin) * acceleration);
+        view->MoveBy((mc.pos - scrollOrigin) * acceleration);
         VIDEODRIVER.SetMousePos(scrollOrigin);
     }
 
@@ -260,13 +260,13 @@ bool iwObservate::Msg_MouseMove(const MouseCoords& mc)
 
 bool iwObservate::Msg_RightDown(const MouseCoords& mc)
 {
-    if(IsPointInRect(mc.GetPos(), Rect(view->GetPos(), view->GetSize()))
-       && !IsPointInRect(mc.GetPos(), GetCtrl<ctrlImageButton>(1)->GetDrawRect())
-       && !IsPointInRect(mc.GetPos(), GetCtrl<ctrlImageButton>(2)->GetDrawRect())
-       && !IsPointInRect(mc.GetPos(), GetCtrl<ctrlImageButton>(3)->GetDrawRect())
-       && !IsPointInRect(mc.GetPos(), GetCtrl<ctrlImageButton>(4)->GetDrawRect()))
+    if(IsPointInRect(mc.pos, Rect(view->GetPos(), view->GetSize()))
+       && !IsPointInRect(mc.pos, GetCtrl<ctrlImageButton>(1)->GetDrawRect())
+       && !IsPointInRect(mc.pos, GetCtrl<ctrlImageButton>(2)->GetDrawRect())
+       && !IsPointInRect(mc.pos, GetCtrl<ctrlImageButton>(3)->GetDrawRect())
+       && !IsPointInRect(mc.pos, GetCtrl<ctrlImageButton>(4)->GetDrawRect()))
     {
-        scrollOrigin = mc.GetPos();
+        scrollOrigin = mc.pos;
 
         isScrolling = true;
         followMovableId = 0;

--- a/libs/s25main/ingameWindows/iwObservate.h
+++ b/libs/s25main/ingameWindows/iwObservate.h
@@ -9,7 +9,7 @@
 #include <boost/signals2.hpp>
 
 class GameWorldView;
-class MouseCoords;
+struct MouseCoords;
 
 /// Observing window (shows a part of the world in an extra window)
 class iwObservate : public IngameWindow

--- a/tests/s25Main/UI/testControls.cpp
+++ b/tests/s25Main/UI/testControls.cpp
@@ -163,7 +163,9 @@ BOOST_FIXTURE_TEST_CASE(EditShowsCorrectChars, uiHelper::Fixture)
         std::string curText = std::accumulate(curChars.begin(), curChars.end(), std::string{});
         edt.SetText(curText);
         // Activate
-        edt2.Msg_LeftDown(MouseCoords(edt2.GetPos(), true));
+        MouseCoords mc(edt2.GetPos());
+        mc.ldown = true;
+        edt2.Msg_LeftDown(mc);
         edt2.Msg_PaintAfter();
         edt2.Msg_KeyDown(KeyEvent{KeyType::Char, c, false, false, false});
         // Remove chars from front until in size
@@ -176,7 +178,9 @@ BOOST_FIXTURE_TEST_CASE(EditShowsCorrectChars, uiHelper::Fixture)
         BOOST_TEST_REQUIRE(txt2->GetText() == curText);
     }
     // Check navigating of cursor
-    edt.Msg_LeftDown(MouseCoords(edt.GetPos(), true)); // Activate
+    MouseCoords mc(edt2.GetPos());
+    mc.ldown = true;
+    edt.Msg_LeftDown(mc); // Activate
     edt.Msg_PaintAfter();
     int curCursorPos = curChars.size(); // Current cursor should be at end
     while(!curChars.empty())

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -41,6 +41,20 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(rttr::mapGenerator::IslandAmount)
 
 BOOST_FIXTURE_TEST_SUITE(IngameWindows, uiHelper::Fixture)
 
+static MouseCoords makeLeftDown(const Position pos)
+{
+    MouseCoords mc(pos);
+    mc.ldown = true;
+    return mc;
+}
+
+static MouseCoords makeLeftDblClick(const Position pos)
+{
+    MouseCoords mc(pos);
+    mc.ldown = mc.dbl_click = true;
+    return mc;
+}
+
 BOOST_AUTO_TEST_CASE(MinimizeWindow)
 {
     iwHelp wnd("Foo barFoo barFoo barFoo bar\n\n\n\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\n");
@@ -277,7 +291,7 @@ BOOST_AUTO_TEST_CASE(TitleBarButtons)
         BOOST_TEST_CONTEXT("Left title bar button closes window")
         {
             IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
-            const MouseCoords evLDown{wnd.GetPos() + DrawPoint(4, 4), true};
+            const MouseCoords evLDown = makeLeftDown(wnd.GetPos() + DrawPoint(4, 4));
 
             BOOST_TEST(!wnd.ShouldBeClosed());
             BOOST_TEST(!wnd.IsMinimized());
@@ -294,7 +308,7 @@ BOOST_AUTO_TEST_CASE(TitleBarButtons)
         BOOST_TEST_CONTEXT("Double-click on the window title has no effect")
         {
             IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
-            const MouseCoords evLDblDown{wnd.GetPos() + DrawPoint(wnd.GetSize().x / 2, 4), true, false, true};
+            const MouseCoords evLDblDown = makeLeftDblClick(wnd.GetPos() + DrawPoint(wnd.GetSize().x / 2, 4));
 
             BOOST_TEST(!wnd.ShouldBeClosed());
             BOOST_TEST(!wnd.IsMinimized());
@@ -312,7 +326,7 @@ BOOST_AUTO_TEST_CASE(TitleBarButtons)
         BOOST_TEST_CONTEXT("Right title bar button minimizes window")
         {
             IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
-            const MouseCoords evLDown{wnd.GetPos() + DrawPoint(wnd.GetSize().x, 0) + DrawPoint(-4, 4), true};
+            const MouseCoords evLDown = makeLeftDown(wnd.GetPos() + DrawPoint(wnd.GetSize().x, 0) + DrawPoint(-4, 4));
 
             BOOST_TEST(!wnd.ShouldBeClosed());
             BOOST_TEST(!wnd.IsMinimized());
@@ -335,7 +349,7 @@ BOOST_AUTO_TEST_CASE(TitleBarButtons)
         BOOST_TEST_CONTEXT("Left title bar button closes window")
         {
             IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
-            const MouseCoords evLDown{wnd.GetPos() + DrawPoint(4, 4), true};
+            const MouseCoords evLDown = makeLeftDown(wnd.GetPos() + DrawPoint(4, 4));
 
             BOOST_TEST(!wnd.ShouldBeClosed());
             BOOST_TEST(!wnd.IsMinimized());
@@ -352,7 +366,7 @@ BOOST_AUTO_TEST_CASE(TitleBarButtons)
         BOOST_TEST_CONTEXT("Double-click on the window title minimizes")
         {
             IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
-            const MouseCoords evLDblDown{wnd.GetPos() + DrawPoint(wnd.GetSize().x / 2, 4), true, false, true};
+            const MouseCoords evLDblDown = makeLeftDblClick(wnd.GetPos() + DrawPoint(wnd.GetSize().x / 2, 4));
 
             BOOST_TEST(!wnd.ShouldBeClosed());
             BOOST_TEST(!wnd.IsMinimized());
@@ -371,7 +385,7 @@ BOOST_AUTO_TEST_CASE(TitleBarButtons)
         BOOST_TEST_CONTEXT("Right title bar button pins window")
         {
             IngameWindow wnd(id, IngameWindow::posLastOrCenter, Extent(100, 100), "Test Window", nullptr);
-            const MouseCoords evLDown{wnd.GetPos() + DrawPoint(wnd.GetSize().x, 0) + DrawPoint(-4, 4), true};
+            const MouseCoords evLDown = makeLeftDown(wnd.GetPos() + DrawPoint(wnd.GetSize().x, 0) + DrawPoint(-4, 4));
 
             BOOST_TEST(!wnd.ShouldBeClosed());
             BOOST_TEST(!wnd.IsMinimized());
@@ -562,11 +576,11 @@ BOOST_AUTO_TEST_CASE(WindowSnapping)
 
     {
         const DrawPoint mousePosRel = DrawPoint(wnd2.GetSize().x / 2, 4);
-        const MouseCoords evLDown{wnd2.GetPos() + mousePosRel, true};
+        const MouseCoords evLDown = makeLeftDown(wnd2.GetPos() + mousePosRel);
         wnd2.MouseLeftDown(evLDown);
 
         {
-            const auto mc = MouseCoords{evLDown.pos + DrawPoint(-80, 0), true};
+            const auto mc = makeLeftDown(evLDown.pos + DrawPoint(-80, 0));
             VIDEODRIVER.SetMousePos(mc.pos);
             wnd2.MouseMove(mc);
             BOOST_TEST(wnd2.GetPos() == DrawPoint(120, 480)); // Not in snap range yet
@@ -574,7 +588,7 @@ BOOST_AUTO_TEST_CASE(WindowSnapping)
         }
 
         {
-            const auto mc = MouseCoords{evLDown.pos + DrawPoint(-90, 0), true};
+            const auto mc = makeLeftDown(evLDown.pos + DrawPoint(-90, 0));
             VIDEODRIVER.SetMousePos(mc.pos);
             wnd2.MouseMove(mc);
             BOOST_TEST(wnd2.GetPos() == DrawPoint(100, 480)); // In snap range
@@ -584,7 +598,7 @@ BOOST_AUTO_TEST_CASE(WindowSnapping)
         }
 
         {
-            const auto mc = MouseCoords{evLDown.pos + DrawPoint(-90, 30), true};
+            const auto mc = makeLeftDown(evLDown.pos + DrawPoint(-90, 30));
             // Reset mouse position to ensure it's properly updated in MouseMove()
             VIDEODRIVER.SetMousePos(Position(0, 0));
             wnd2.MouseMove(mc);
@@ -601,13 +615,13 @@ BOOST_AUTO_TEST_CASE(WindowSnapping)
           std::make_unique<IngameWindow>(0, DrawPoint(200, 0), Extent(100, 100), "Test Window 3", nullptr)));
 
         const DrawPoint mousePosRel = DrawPoint(wnd3.GetSize().x / 2, 4);
-        const MouseCoords evLDown{wnd3.GetPos() + mousePosRel, true};
+        const MouseCoords evLDown = makeLeftDown(wnd3.GetPos() + mousePosRel);
         wnd3.MouseLeftDown(evLDown);
 
         {
             wnd1.SetPos(DrawPoint(0, 0));
             wnd2.SetPos(DrawPoint(5, 0));
-            const auto mc = MouseCoords{evLDown.pos + DrawPoint(-90, 0), true};
+            const auto mc = makeLeftDown(evLDown.pos + DrawPoint(-90, 0));
             VIDEODRIVER.SetMousePos(mc.pos);
             wnd3.MouseMove(mc);
             // In snap range of wnd1 and wnd2, but closest to wnd2
@@ -620,7 +634,7 @@ BOOST_AUTO_TEST_CASE(WindowSnapping)
         {
             wnd1.SetPos(DrawPoint(5, 0));
             wnd2.SetPos(DrawPoint(0, 0));
-            const auto mc = MouseCoords{evLDown.pos + DrawPoint(-90, 0), true};
+            const auto mc = makeLeftDown(evLDown.pos + DrawPoint(-90, 0));
             VIDEODRIVER.SetMousePos(mc.pos);
             wnd3.MouseMove(mc);
             // In snap range of wnd1 and wnd2, but closest to wnd1

--- a/tests/s25Main/integration/testDskGameInterface.cpp
+++ b/tests/s25Main/integration/testDskGameInterface.cpp
@@ -70,9 +70,10 @@ BOOST_FIXTURE_TEST_CASE(Scrolling, GameInterfaceFixture)
     SETTINGS.interface.invertMouse = false;
 
     Position startPos(10, 15);
-    MouseCoords mouse(startPos, false, true);
+    MouseCoords mouse(startPos);
     // Regular scrolling: Right down, 2 moves, right up
     {
+        mouse.rdown = true;
         WINDOWMANAGER.Msg_RightDown(mouse);
         BOOST_TEST_REQUIRE(WINDOWMANAGER.GetCursor() == Cursor::Scroll);
         DrawPoint pos = view->GetOffset();
@@ -156,7 +157,8 @@ BOOST_FIXTURE_TEST_CASE(ScrollingWhileRoadBuilding, GameInterfaceFixture)
     gameDesktop->GI_StartRoadBuilding(hqPos, false);
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetCursor() == Cursor::Remove);
     Position startPos(10, 15);
-    MouseCoords mouse(startPos, false, true);
+    MouseCoords mouse(startPos);
+    mouse.rdown = true;
     // Regular scrolling
     WINDOWMANAGER.Msg_RightDown(mouse);
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetCursor() == Cursor::Scroll);
@@ -195,7 +197,8 @@ BOOST_FIXTURE_TEST_CASE(ScrollingWithCtrl, GameInterfaceFixture)
 {
     const int acceleration = 2;
     Position startPos(10, 15);
-    MouseCoords mouse(startPos, true);
+    MouseCoords mouse(startPos);
+    mouse.ldown = true;
     uiHelper::GetVideoDriver()->modKeyState_.ctrl = true;
     WINDOWMANAGER.Msg_LeftDown(mouse);
     BOOST_TEST_REQUIRE(WINDOWMANAGER.GetCursor() == Cursor::Scroll);


### PR DESCRIPTION
The only method `GetPos` is no longer required as the `pos` is already a `Point` instance.

I also removed the constructors as `MouseCoords(mc2.GetPos(), false, false, true)` constructs are error prone and hard to read due to the repeated arguments of same type