### PR TITLE
Fixing build error for gcc-15: Adding include

### DIFF
--- a/libs/s25main/notifications/NotificationManager.h
+++ b/libs/s25main/notifications/NotificationManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "notifications/Subscription.h"
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <unordered_map>


### PR DESCRIPTION
Fixing build error when using gcc-15. ~~Also adding GitHub Actions Unit test.~~ Fixes #1770.

To observe the build fail to build without this patch, you can save the following Dockerfile and run with `docker build .`. To see the build succeed, you can simulate this patch by uncommenting the line `#RUN sed -i 's/#include </#include <cstdint>\n#include </' ../libs/s25main/notifications/NotificationManager.h`, and then running `docker build .` again.

```
FROM ubuntu:25.10
RUN apt-get update && apt-get install -y \
    libcurl4-gnutls-dev \
    git \
    build-essential \
    cmake \
    libsdl2-dev \
    libsdl2-mixer-dev \
    libboost-all-dev \
    libminiupnpc-dev \
    lua5.3 \
    liblua5.3-dev \
    libbz2-dev \
    gettext

RUN git clone --recursive https://github.com/Return-To-The-Roots/s25client.git

RUN mkdir s25client/build
WORKDIR s25client/build
#RUN sed -i 's/#include </#include <cstdint>\n#include </' ../libs/s25main/notifications/NotificationManager.h
RUN cmake -DRRTR_ENABLE_WERROR=off -DCMAKE_BUILD_TYPE=Release ..
RUN make
```