### PR TITLE
Incrase max lobby login name length to 30

### DIFF
--- a/libs/s25main/ingameWindows/iwLobbyConnect.cpp
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.cpp
@@ -57,7 +57,7 @@ iwLobbyConnect::iwLobbyConnect()
 
     AddText(ID_txtUser, curLblPos, _("Username:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     ctrlEdit* user =
-      AddEdit(ID_edtUser, DrawPoint(ctrlStartPos, curLblPos.y), edtSize, TextureColor::Green2, NormalFont);
+      AddEdit(ID_edtUser, DrawPoint(ctrlStartPos, curLblPos.y), edtSize, TextureColor::Green2, NormalFont, 30);
     user->SetFocus();
     user->SetText(SETTINGS.lobby.name); //-V807
     curLblPos.y += 30;


### PR DESCRIPTION
Don't limit to 15 chars.

Also refactor for using relative positions and English comments.