### PR TITLE
#1836 Add LUA function to disallow changing player portraits

### DIFF
--- a/doc/lua/events.md
+++ b/doc/lua/events.md
@@ -43,8 +43,8 @@ If a key does not exist, a default value is used:
 - addonsSome(false): Can only change addons in list returned by `getAllowedAddons`
 - swapping(false): Swap places
 - playerState(false): Change player slots (add/change AI, ...)
-- ownNation, ownColor, ownTeam (all true): Change values player
-- aiNation, aiColor, aiTeam (all true): Change values of AI  
+- ownNation, ownColor, ownTeam, ownPortrait (all true): Change values player
+- aiNation, aiColor, aiTeam, aiPortrait (all true): Change values of AI  
 
 ```lua
 function getAllowedChanges()

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -271,6 +271,18 @@ ctrlDeepening* Window::AddColorDeepening(unsigned id, const DrawPoint& pos, cons
     return AddCtrl(new ctrlColorDeepening(this, id, ScaleIf(pos), ScaleIf(size), tc, fillColor));
 }
 
+ctrlDeepening* Window::AddImageDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
+                                         ITexture* image)
+{
+    return AddCtrl(new ctrlImageDeepening(this, id, ScaleIf(pos), ScaleIf(size), tc, image));
+}
+
+ctrlDeepening* Window::AddImageDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
+                                         glArchivItem_Bitmap* image)
+{
+    return AddImageDeepening(id, pos, size, tc, static_cast<ITexture*>(image));
+}
+
 ctrlEdit* Window::AddEdit(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font,
                           unsigned short maxlength, bool password, bool disabled, bool notify)
 {

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -158,6 +158,11 @@ public:
                                     FontStyle style = FontStyle::CENTER | FontStyle::VCENTER);
     ctrlDeepening* AddColorDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                      unsigned fillColor);
+    ctrlDeepening* AddImageDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
+                                     ITexture* image);
+    ctrlDeepening* AddImageDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
+                                     glArchivItem_Bitmap* image);
+
     ctrlEdit* AddEdit(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font,
                       unsigned short maxlength = 0, bool password = false, bool disabled = false, bool notify = false);
     ctrlGroup* AddGroup(unsigned id);

--- a/libs/s25main/controls/controls.h
+++ b/libs/s25main/controls/controls.h
@@ -15,6 +15,7 @@
 #include "ctrlGroup.h"
 #include "ctrlImage.h"
 #include "ctrlImageButton.h"
+#include "ctrlImageDeepening.h"
 #include "ctrlList.h"
 #include "ctrlMapSelection.h"
 #include "ctrlMultiSelectGroup.h"

--- a/libs/s25main/controls/ctrlImageDeepening.cpp
+++ b/libs/s25main/controls/ctrlImageDeepening.cpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "ctrlImageDeepening.h"
+#include <ogl/ITexture.h>
+
+ctrlImageDeepening::ctrlImageDeepening(Window* parent, unsigned id, DrawPoint pos, const Extent& size, TextureColor tc,
+                                       ITexture* image)
+    : ctrlDeepening(parent, id, pos, size, tc), ctrlBaseImage(image)
+{}
+
+void ctrlImageDeepening::DrawContent() const
+{
+    // Adding of origin compensates for its substraction inside ITexture::Draw()
+    DrawImage(Rect(GetDrawPos() + GetImage()->GetOrigin(), GetSize()));
+}

--- a/libs/s25main/controls/ctrlImageDeepening.h
+++ b/libs/s25main/controls/ctrlImageDeepening.h
@@ -1,0 +1,19 @@
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "controls/ctrlDeepening.h"
+#include "ctrlBaseImage.h"
+
+/// Image Deepening
+class ctrlImageDeepening : public ctrlDeepening, public ctrlBaseImage
+{
+public:
+    ctrlImageDeepening(Window* parent, unsigned id, DrawPoint pos, const Extent& size, TextureColor tc,
+                       ITexture* image);
+
+protected:
+    void DrawContent() const override;
+};

--- a/libs/s25main/desktops/dskGameLobby.cpp
+++ b/libs/s25main/desktops/dskGameLobby.cpp
@@ -438,6 +438,7 @@ void dskGameLobby::UpdatePlayerRow(const unsigned row)
         bool allowNationChange = allowPlayerChange;
         bool allowColorChange = allowPlayerChange;
         bool allowTeamChange = allowPlayerChange;
+        bool allowPortaitChange = allowPlayerChange;
         if(lua)
         {
             if(localPlayerId_ == row)
@@ -445,11 +446,13 @@ void dskGameLobby::UpdatePlayerRow(const unsigned row)
                 allowNationChange &= lua->IsChangeAllowed("ownNation", true);
                 allowColorChange &= lua->IsChangeAllowed("ownColor", true);
                 allowTeamChange &= lua->IsChangeAllowed("ownTeam", true);
+                allowPortaitChange &= lua->IsChangeAllowed("ownPortrait", true);
             } else
             {
                 allowNationChange &= lua->IsChangeAllowed("aiNation", true);
                 allowColorChange &= lua->IsChangeAllowed("aiColor", true);
                 allowTeamChange &= lua->IsChangeAllowed("aiTeam", true);
+                allowPortaitChange &= lua->IsChangeAllowed("aiPortrait", true);
             }
         }
 
@@ -461,8 +464,12 @@ void dskGameLobby::UpdatePlayerRow(const unsigned row)
                                     NormalFont, COLOR_YELLOW);
 
         const auto& portrait = Portraits[player.portraitIndex];
-        group->AddImageButton(ID_btPortrait, DrawPoint(315, cy), Extent(34, 22), tc,
-                              LOADER.GetImageN(portrait.resourceId, portrait.resourceIndex), _(portrait.name));
+        if(allowPortaitChange)
+            group->AddImageButton(ID_btPortrait, DrawPoint(315, cy), Extent(34, 22), tc,
+                                  LOADER.GetImageN(portrait.resourceId, portrait.resourceIndex), _(portrait.name));
+        else
+            group->AddImageDeepening(ID_btPortrait, DrawPoint(315, cy), Extent(34, 22), tc,
+                                     LOADER.GetImageN(portrait.resourceId, portrait.resourceIndex));
 
         if(allowColorChange)
             group->AddColorButton(ID_btColor, DrawPoint(354, cy), Extent(30, 22), tc, 0);
@@ -965,9 +972,11 @@ void dskGameLobby::ChangePortrait(const unsigned player, const unsigned portrait
 {
     RTTR_Assert(portraitIndex < Portraits.size());
     const auto& portrait = Portraits[portraitIndex];
-    auto* ctrl = GetCtrl<ctrlGroup>(ID_grpPlayerStart + player)->GetCtrl<ctrlImageButton>(ID_btPortrait);
+    auto* ctrl = GetCtrl<ctrlGroup>(ID_grpPlayerStart + player)->GetCtrl<ctrlBaseImage>(ID_btPortrait);
     ctrl->SetImage(LOADER.GetImageN(portrait.resourceId, portrait.resourceIndex));
-    ctrl->SetTooltip(_(portrait.name));
+    auto* ctrlButton = GetCtrl<ctrlGroup>(ID_grpPlayerStart + player)->GetCtrl<ctrlImageButton>(ID_btPortrait);
+    if(ctrlButton)
+        ctrlButton->SetTooltip(_(portrait.name));
 }
 
 void dskGameLobby::ChangePing(unsigned playerId)


### PR DESCRIPTION
Add LUA function to disallow changing player portrait and use it
- Add new ctrl class ctrlImageDeeping
- Adjust docu
- Use new functionality in game lobby
Fixes #1836