### PR TITLE
Hide harbor military settings when sea attacks are disabled

### DIFF
--- a/libs/s25main/ingameWindows/iwMilitary.cpp
+++ b/libs/s25main/ingameWindows/iwMilitary.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -16,58 +16,78 @@
 #include "gameData/SettingTypeConv.h"
 #include "gameData/const_gui_ids.h"
 
+namespace {
+enum
+{
+    ID_btHelp,
+    ID_btDefault,
+    ID_Offset, // ID of control corresponding to MILITARY_SETTINGS_SCALE[0]
+};
+}
+
 iwMilitary::iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory)
     : TransmitSettingsIgwAdapter(CGI_MILITARY, IngameWindow::posLastOrCenter, Extent(168, 330), _("Military"),
                                  LOADER.GetImageN("io", 5)),
       gcFactory(gcFactory)
 {
-    // Einzelne Balken
-    const Extent progSize(132, 26);
-    const Extent progPadding(4, 4);
-    AddProgress(0, DrawPoint(17, 25), progSize, TextureColor::Grey, 119, 120, MILITARY_SETTINGS_SCALE[0], "",
-                progPadding, 0, _("Fewer recruits"), _("More recruits")); /* pitch: progPadding */
-    AddProgress(1, DrawPoint(17, 57), progSize, TextureColor::Grey, 121, 122, MILITARY_SETTINGS_SCALE[1], "",
+    // Setting bars
+    constexpr Extent progSize(132, 26);
+    constexpr Extent progPadding(4, 4);
+    constexpr unsigned progSpacing = 6;
+    DrawPoint curPos((GetSize().x - progSize.x) / 2, 25); // Same space left and right
+    AddProgress(ID_Offset, curPos, progSize, TextureColor::Grey, 119, 120, MILITARY_SETTINGS_SCALE[0], "", progPadding,
+                0, _("Fewer recruits"), _("More recruits")); /* pitch: progPadding */
+    curPos.y += progSize.y + progSpacing;
+    AddProgress(ID_Offset + 1, curPos, progSize, TextureColor::Grey, 121, 122, MILITARY_SETTINGS_SCALE[1], "",
                 progPadding, 0, _("Weak defense"), _("Strong defense"));
-    AddProgress(2, DrawPoint(17, 89), progSize, TextureColor::Grey, 123, 124, MILITARY_SETTINGS_SCALE[2], "",
-                progPadding, 0, _("Fewer defenders"), _("More defenders"));
-    AddProgress(3, DrawPoint(17, 121), progSize, TextureColor::Grey, 209, 210, MILITARY_SETTINGS_SCALE[3], "",
+    curPos.y += progSize.y + progSpacing;
+    auto* ctrl = AddProgress(ID_Offset + 2, curPos, progSize, TextureColor::Grey, 123, 124, MILITARY_SETTINGS_SCALE[2],
+                             "", progPadding, 0, _("Fewer defenders"), _("More defenders"));
+    // Hide defender setting if changing defender behavior is disabled
+    if(gwv.GetWorld().GetGGS().getSelection(AddonId::DEFENDER_BEHAVIOR) == 1)
+        ctrl->SetVisible(false);
+    else
+        curPos.y += progSize.y + progSpacing;
+    AddProgress(ID_Offset + 3, curPos, progSize, TextureColor::Grey, 209, 210, MILITARY_SETTINGS_SCALE[3], "",
                 progPadding, 0, _("Less attackers"), _("More attackers"));
-    AddProgress(4, DrawPoint(17, 153), progSize, TextureColor::Grey, 129, 130, MILITARY_SETTINGS_SCALE[4], "",
+    curPos.y += progSize.y + progSpacing;
+    AddProgress(ID_Offset + 4, curPos, progSize, TextureColor::Grey, 129, 130, MILITARY_SETTINGS_SCALE[4], "",
                 progPadding, 0, _("Interior"), _("Interior"));
-    AddProgress(5, DrawPoint(17, 185), progSize, TextureColor::Grey, 127, 128, MILITARY_SETTINGS_SCALE[5], "",
+    curPos.y += progSize.y + progSpacing;
+    AddProgress(ID_Offset + 5, curPos, progSize, TextureColor::Grey, 127, 128, MILITARY_SETTINGS_SCALE[5], "",
                 progPadding, 0, _("Center of country"), _("Center of country"));
-    AddProgress(6, DrawPoint(17, 217), progSize, TextureColor::Grey, 1000, 1001, MILITARY_SETTINGS_SCALE[6], "",
-                progPadding, 0, _("Near harbor points"), _("Near harbor points"));
-    AddProgress(7, DrawPoint(17, 249), progSize, TextureColor::Grey, 125, 126, MILITARY_SETTINGS_SCALE[7], "",
+    curPos.y += progSize.y + progSpacing;
+    ctrl = AddProgress(ID_Offset + 6, curPos, progSize, TextureColor::Grey, 1000, 1001, MILITARY_SETTINGS_SCALE[6], "",
+                       progPadding, 0, _("Near harbor points"), _("Near harbor points"));
+    // Hide changing harbor area if sea attacks are disabled
+    if(!gwv.GetWorld().GetGGS().isEnabled(AddonId::SEA_ATTACK))
+        ctrl->SetVisible(false);
+    else
+        curPos.y += progSize.y + progSpacing;
+    AddProgress(ID_Offset + 7, curPos, progSize, TextureColor::Grey, 125, 126, MILITARY_SETTINGS_SCALE[7], "",
                 progPadding, 0, _("Border areas"), _("Border areas"));
 
-    // unteren 2 Buttons
-    AddImageButton(20, DrawPoint(18, 282), Extent(30, 32), TextureColor::Grey, LOADER.GetImageN("io", 225), _("Help"));
-    AddImageButton(21, DrawPoint(120, 282), Extent(30, 32), TextureColor::Grey, LOADER.GetImageN("io", 191),
-                   _("Default"));
-
-    // Falls Verteidiger ändern verboten ist, einfach die Bar ausblenden
-    if(gwv.GetWorld().GetGGS().getSelection(AddonId::DEFENDER_BEHAVIOR) == 1)
-    {
-        GetCtrl<ctrlProgress>(2)->SetVisible(false);
-    }
+    // Buttons at bottom
+    constexpr Extent buttonSize(30, 32);
+    curPos.y = GetRightBottomBoundary().y - buttonSize.y - 5;
+    AddImageButton(ID_btHelp, curPos, buttonSize, TextureColor::Grey, LOADER.GetImageN("io", 225), _("Help"));
+    curPos.x += progSize.x - buttonSize.x;
+    AddImageButton(ID_btDefault, curPos, buttonSize, TextureColor::Grey, LOADER.GetImageN("io", 191), _("Default"));
 
     iwMilitary::UpdateSettings();
 }
 
-/// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
 void iwMilitary::TransmitSettings()
 {
     if(GAMECLIENT.IsReplayModeOn())
         return;
 
-    // Wurden Einstellungen geändert?
     if(settings_changed)
     {
-        // Einstellungen speichern
+        // Save settings
         MilitarySettings milSettings = GAMECLIENT.visual_settings.military_settings;
         for(unsigned char i = 0; i < milSettings.size(); ++i)
-            milSettings[i] = (unsigned char)GetCtrl<ctrlProgress>(i)->GetPosition();
+            milSettings[i] = (unsigned char)GetCtrl<ctrlProgress>(ID_Offset + i)->GetPosition();
 
         if(gcFactory.ChangeMilitary(milSettings))
         {
@@ -79,7 +99,6 @@ void iwMilitary::TransmitSettings()
 
 void iwMilitary::Msg_ProgressChange(const unsigned /*ctrl_id*/, const unsigned short /*position*/)
 {
-    // Einstellungen wurden geändert
     settings_changed = true;
 }
 
@@ -88,7 +107,7 @@ void iwMilitary::UpdateSettings(const MilitarySettings& military_settings)
     if(GAMECLIENT.IsReplayModeOn())
         GAMECLIENT.ResetVisualSettings();
     for(unsigned i = 0; i < military_settings.size(); ++i)
-        GetCtrl<ctrlProgress>(i)->SetPosition(military_settings[i]);
+        GetCtrl<ctrlProgress>(ID_Offset + i)->SetPosition(military_settings[i]);
 }
 
 void iwMilitary::UpdateSettings()
@@ -101,8 +120,7 @@ void iwMilitary::Msg_ButtonClick(const unsigned ctrl_id)
     switch(ctrl_id)
     {
         default: return;
-        // Default button
-        case 20:
+        case ID_btHelp:
         {
             WINDOWMANAGER.ReplaceWindow(
               std::make_unique<iwHelp>(_("This is where you can make adjustments to all military matters. "
@@ -117,7 +135,7 @@ void iwMilitary::Msg_ButtonClick(const unsigned ctrl_id)
                                          "interior, in the center of the country and on its borders.")));
         }
         break;
-        case 21:
+        case ID_btDefault:
         {
             UpdateSettings(GAMECLIENT.default_settings.military_settings);
             settings_changed = true;

--- a/libs/s25main/ingameWindows/iwMilitary.h
+++ b/libs/s25main/ingameWindows/iwMilitary.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -10,7 +10,7 @@
 class GameCommandFactory;
 class GameWorldViewer;
 
-/// Fenster mit den Militäreinstellungen.
+/// Window for changing military settings, e.g. occupation distribution
 class iwMilitary final : public TransmitSettingsIgwAdapter
 {
     GameCommandFactory& gcFactory;
@@ -19,10 +19,10 @@ public:
     iwMilitary(const GameWorldViewer& gwv, GameCommandFactory& gcFactory);
 
 private:
-    /// Updatet die Steuerelemente mit den übergebenen Einstellungen
+    /// Update controls with given military settings
     void UpdateSettings(const MilitarySettings& military_settings);
     void UpdateSettings() override;
-    /// Sendet veränderte Einstellungen (an den Client), falls sie verändert wurden
+    /// Send changed values to client, if any have changed
     void TransmitSettings() override;
 
     void Msg_ProgressChange(unsigned ctrl_id, unsigned short position) override;


### PR DESCRIPTION
Fixes #1838

<img width="182" height="344" alt="mil" src="https://github.com/user-attachments/assets/5ddb515c-6e07-46e0-89c7-d6964941210d" />

Alternatively we could make those 2 bars disabled. That avoids the empty space but could cause confusion.

We have a similar issue when the addon disables the defender bar and that gets hidden. So hiding this one too is consistent at least.

Additionally this PR puts the empty space at the bottom not in the middle of the bars by moving the following ones up.