### PR TITLE
Fix detection of selected playlist on window open

### DIFF
--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -171,9 +171,7 @@ void iwMusicPlayer::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned s
         WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be loaded!"), this,
                                                       MsgboxButton::Ok, MsgboxIcon::ExclamationRed));
     }
-    const bool isReadOnly = isReadonlyPlaylist(playlistName);
-    for(const auto id : {ID_btRemovePlaylist, ID_btSave})
-        GetCtrl<ctrlButton>(id)->SetEnabled(!isReadOnly);
+    UpdateSaveChangeButtonsState();
 }
 
 void iwMusicPlayer::Msg_ListChooseItem(const unsigned /*ctrl_id*/, const unsigned selection)
@@ -234,6 +232,14 @@ void iwMusicPlayer::UpdateFromPlaylist(const Playlist& playlist)
 
     SetRepeats(playlist.getNumRepeats());
     SetRandomPlayback(playlist.isRandomized());
+}
+
+void iwMusicPlayer::UpdateSaveChangeButtonsState()
+{
+    const auto playlistName = GetCtrl<ctrlComboBox>(ID_cbPlaylist)->GetSelectedText();
+    const bool isReadOnly = !playlistName || isReadonlyPlaylist(*playlistName);
+    for(const auto id : {ID_btRemovePlaylist, ID_btSave})
+        GetCtrl<ctrlButton>(id)->SetEnabled(!isReadOnly);
 }
 
 Playlist iwMusicPlayer::MakePlaylist()
@@ -441,4 +447,5 @@ void iwMusicPlayer::UpdatePlaylistCombo(const std::string& highlight_entry)
             cbPlaylist->SetSelection(i);
         ++i;
     }
+    UpdateSaveChangeButtonsState();
 }

--- a/libs/s25main/ingameWindows/iwMusicPlayer.h
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -9,10 +9,10 @@
 
 class Playlist;
 
-/// Fenster zum Einstellen des Musik-Players
+/// Window for changing music player options and playlists
 class iwMusicPlayer final : public IngameWindow
 {
-    /// Kleines Fenster zur Eingabe von Text
+    /// Small window for text input
     class InputWindow final : public IngameWindow
     {
         const unsigned win_id;
@@ -25,8 +25,7 @@ class iwMusicPlayer final : public IngameWindow
         void Msg_EditEnter(unsigned ctrl_id) override;
     };
 
-    /// Merken, ob Veränderungen an den Musikeinstellungen durchgeführt wurden und ob deswegen
-    /// beim Schließen des Fensters das ganze neu gestartet werden muss
+    /// Set to true if anything changed to (re)start music on close
     bool changed;
 
 public:
@@ -42,11 +41,13 @@ private:
     bool GetRandomPlayback() const;
     void SetRandomPlayback(bool random_playback);
 
-    /// Updatet die Playlist- Combo, selektiert entsprechenden Eintrag, falls vorhanden
+    /// Fill combobox with all playlists and selects given entry if present
     void UpdatePlaylistCombo(const std::string& highlight_entry);
 
     bool SaveCurrentPlaylist();
     void UpdateFromPlaylist(const Playlist&);
+    // Enable/Disable buttons for changing playlist contents
+    void UpdateSaveChangeButtonsState();
     Playlist MakePlaylist();
 
     void Msg_ListChooseItem(unsigned ctrl_id, unsigned selection) override;


### PR DESCRIPTION
The path to the playlist needs to be resolved before comparison or it
will always fail.
That in turn leads to selecting the first playlist as-if the current one
didn't exist, and restarting the playlist.

Also ensure that in this case the save/delete buttons are correctly disabled.

Fixes https://github.com/Return-To-The-Roots/s25client/issues/1844