### PR TITLE
Show donkey icon for donkey breeder

### DIFF
--- a/libs/s25main/BuildingRegister.cpp
+++ b/libs/s25main/BuildingRegister.cpp
@@ -153,7 +153,7 @@ helpers::EnumArray<uint16_t, BuildingType> BuildingRegister::CalcProductivities(
 
 unsigned BuildingRegister::CalcAverageProductivity(BuildingType bldType) const
 {
-    if(!BLD_WORK_DESC[bldType].producedWare)
+    if(holds_alternative<boost::none_t>(BLD_WORK_DESC[bldType].producedWare))
         return 0;
     unsigned productivity = 0;
     const auto& buildings = GetBuildings(bldType);
@@ -173,7 +173,7 @@ unsigned short BuildingRegister::CalcAverageProductivity() const
     unsigned numBlds = 0;
     for(const auto bldType : helpers::enumRange<BuildingType>())
     {
-        if(!BLD_WORK_DESC[bldType].producedWare)
+        if(holds_alternative<boost::none_t>(BLD_WORK_DESC[bldType].producedWare))
             continue;
 
         const auto& buildings = GetBuildings(bldType);

--- a/libs/s25main/gameData/BuildingConsts.h
+++ b/libs/s25main/gameData/BuildingConsts.h
@@ -70,9 +70,8 @@ const helpers::EnumArray<BldWorkDescription, BuildingType> SUPPRESS_UNUSED BLD_W
   {Job::Helper, GoodType::Water},
   {Job::Shipwright, GoodType::Boat, WaresNeeded(GoodType::Boards)},
   {Job::Farmer, GoodType::Grain},
-  {Job::DonkeyBreeder, GoodType::Nothing,
-   WaresNeeded(GoodType::Grain, GoodType::Water)}, // Produces a job. TODO: Better way
-  {},                                              // Harbour
+  {Job::DonkeyBreeder, Job::PackDonkey, WaresNeeded(GoodType::Grain, GoodType::Water)},
+  {}, // Harbour
 }};
 
 /// Smoke consts for all buildings and nations

--- a/libs/s25main/gameTypes/BuildingTypes.h
+++ b/libs/s25main/gameTypes/BuildingTypes.h
@@ -9,6 +9,7 @@
 #include "JobTypes.h"
 #include "Point.h"
 #include "helpers/OptionalEnum.h"
+#include "variant.h"
 #include <cassert>
 
 struct BuildingCost
@@ -44,7 +45,7 @@ struct BldWorkDescription
     /// Worker belonging to the building, if any
     helpers::OptionalEnum<Job> job = boost::none;
     /// Ware produced, if any
-    helpers::OptionalEnum<GoodType> producedWare = boost::none;
+    boost_variant2<GoodType, Job, boost::none_t> producedWare = boost::none;
     // Required for use in aggregate initialization
     // NOLINTBEGIN(readability-redundant-member-init)
     /// Wares the building needs, if any

--- a/libs/s25main/ingameWindows/iwBuilding.cpp
+++ b/libs/s25main/ingameWindows/iwBuilding.cpp
@@ -44,11 +44,16 @@ iwBuilding::iwBuilding(GameWorldView& gwv, GameCommandFactory& gcFactory, nobUsu
     AddImage(1, DrawPoint(117, 114), &building->GetBuildingImage());
 
     // Symbol der produzierten Ware (falls hier was produziert wird)
-    const auto producedWare = BLD_WORK_DESC[building->GetBuildingType()].producedWare;
-    if(producedWare && producedWare != GoodType::Nothing)
+    const auto& producedWare = BLD_WORK_DESC[building->GetBuildingType()].producedWare;
+    ITexture* tex = visit(
+      composeVisitor([](GoodType gt) -> ITexture* { return gt != GoodType::Nothing ? LOADER.GetWareTex(gt) : nullptr; },
+                     [](Job job) -> ITexture* { return LOADER.GetJobTex(job); },
+                     [](boost::none_t) -> ITexture* { return nullptr; }),
+      producedWare);
+    if(tex)
     {
         AddImage(2, DrawPoint(196, 39), LOADER.GetMapTexture(2298));
-        AddImage(3, DrawPoint(196, 39), LOADER.GetWareTex(*producedWare));
+        AddImage(3, DrawPoint(196, 39), tex);
     }
 
     // Info

--- a/tests/s25Main/simple/testGameData.cpp
+++ b/tests/s25Main/simple/testGameData.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(ProductionBuildingsAreNobUsual)
         if(!BuildingProperties::IsValid(bld))
             continue;
         // Only nobUsuals can produce wares (though not all do)
-        if(BLD_WORK_DESC[bld].producedWare)
+        if(!holds_alternative<boost::none_t>(BLD_WORK_DESC[bld].producedWare))
         {
             BOOST_TEST_INFO("bld: " << bld);
             BOOST_TEST(BuildingProperties::IsUsual(bld));


### PR DESCRIPTION
Refactor `BLD_WORK_DESC` to use a variant so we can signify producing a job type and set the to donkeys for the donkey breeder.

See #1837 