### PR TITLE
fix nix-shell for recent nixpkgs versions

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,16 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 {
-  pkgs ? import <nixpkgs> { overlays = [
-    # This is a workaround for https://github.com/NixOS/nixpkgs/issues/146759
-    # NixOS does currently ship an incomple SDL2 installation when withStatic=false.
-    # See https://nixpk.gs/pr-tracker.html?pr=149601 as state for a PR on NixOS side.
-    (final: prev: {
-      SDL2 = prev.SDL2.override {
-        withStatic = true;
-      };
-    })];
-  }
+  pkgs ? import <nixpkgs> { },
 }:
 
 with pkgs;
@@ -33,9 +24,10 @@ mkShell {
     curl
     gettext
     libiconv
+    libsamplerate
+    lua
     miniupnpc
     SDL2
     SDL2_mixer
-    libsamplerate
   ];
 }


### PR DESCRIPTION
Updates the projects `nix-shell` to be compatible with current nixpkgs revisions.
Should work on 25.11 and unstable releases.

Background of the breakage is, that SDL2  was dropped in nixpkgs in favor of sdl2-compat, thus the override interface that was used here is no longer available. ref https://github.com/NixOS/nixpkgs/pull/409013/

And lua seemed to be missing. Cmake was looking for it, when i test compiled recent master.

fixes #1866

@wizzup for testing
