### PR TITLE
Capture spacebar under Wayland (#1855)

### DIFF
--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -888,6 +888,10 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
         case 's': // Show/hide productivity overlay
             gwv.ToggleShowProductivity();
             return true;
+        case ' ': // Show/hide construction aid
+            // workaround for Wayland which does not capture SDLK_SPACE when SDL_StartTextInput() was called
+            gwv.ToggleShowBQ();
+            return true;
         case 26: // ctrl+z
             gwv.SetZoomFactor(ZOOM_FACTORS[ZOOM_DEFAULT_INDEX]);
             return true;


### PR DESCRIPTION
Key press event `SDLK_SPACE` is not emitted under Wayland, when `SDL_StartTextInput()` is enabled.

Fixes #1855 