### PR TITLE
Revert "Capture spacebar under Wayland (#1855)" (#1873)

### DIFF
--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -925,10 +925,6 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
         case 's': // Show/hide productivity overlay
             gwv.ToggleShowProductivity();
             return true;
-        case ' ': // Show/hide construction aid
-            // workaround for Wayland which does not capture SDLK_SPACE when SDL_StartTextInput() was called
-            gwv.ToggleShowBQ();
-            return true;
         case 26: // ctrl+z
             gwv.SetZoomFactor(ZOOM_FACTORS[ZOOM_DEFAULT_INDEX]);
             return true;


### PR DESCRIPTION
Reverts Return-To-The-Roots/s25client#1872 that broke the spacebar on xorg