### PR TITLE
Allow relative path for campaign images

### DIFF
--- a/doc/AddingCustomCampaign.md
+++ b/doc/AddingCustomCampaign.md
@@ -147,3 +147,6 @@ RTTR/campaigns/garden/mapscreen/map_mask.bmp
 RTTR/campaigns/garden/mapscreen/marker.bmp
 RTTR/campaigns/garden/mapscreen/conquered.bmp
 ```
+
+Note that for custom campaigns, placed in `<RTTR_USERDATA>/campaigns/` the top-level `RTTR` folder won't exist.
+Hence, `<RTTR_RTTR>/campaigns/` should not be used in the campaign description file to refer to campaign files.

--- a/doc/AddingCustomCampaign.md
+++ b/doc/AddingCustomCampaign.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 # Add a custom campaign
 
-You can have a look into the already existing original Settlers 2 campaigns in the subfolders `RTTR/campaigns/roman` and `RTTR/campaigns/continent` for an example.
+You can take a look into the already existing original Settlers 2 campaigns in the subfolders `RTTR/campaigns/roman` and `RTTR/campaigns/continent` for an example.
 We will now create an example campaign `garden`.
 
 ## Location for adding a new campaign
@@ -41,18 +41,20 @@ campaign = {
     name = _"name",
     shortDescription = _"shortDescription",
     longDescription = _"longDescription",
-    image = "<RTTR_RTTR>/campaigns/garden/garden.bmp",
+    image = "<RTTR_RTTR>/campaigns/garden/garden.bmp", -- Same as: image = "garden.bmp",
     maxHumanPlayers= 1,
     difficulty = "easy",
-    mapFolder = "<RTTR_RTTR>/campaigns/garden",
-    luaFolder = "<RTTR_RTTR>/campaigns/garden",
+    mapFolder = "<RTTR_RTTR>/campaigns/garden", -- optional
+    luaFolder = "<RTTR_RTTR>/campaigns/garden", -- optional
     maps = { "MISS01.WLD","MISS02.WLD"},
     selectionMap = {
-        background = {"<RTTR_GAME>/campaigns/garden/mapscreen/background.bmp", 0},
-        map = {"<RTTR_GAME>/campaigns/garden/mapscreen/map.bmp", 0},
-        missionMapMask = {"<RTTR_GAME>/campaigns/garden/mapscreen/map_mask.bmp", 0},
-        marker = {"<RTTR_GAME>/campaigns/garden/mapscreen/marker.bmp", 0},
-        conquered = {"<RTTR_GAME>/campaigns/garden/mapscreen/conquered.bmp", 0},
+        background = {"<RTTR_RTTR>/campaigns/garden/mapscreen/background.bmp", 0},
+        map = {"<RTTR_RTTR>/campaigns/garden/mapscreen/map.bmp", 0},
+        missionMapMask = {"<RTTR_RTTR>/campaigns/garden/mapscreen/map_mask.bmp", 0},
+        marker = {"<RTTR_RTTR>/campaigns/garden/mapscreen/marker.bmp", 0},
+        conquered = {"<RTTR_RTTR>/campaigns/garden/mapscreen/conquered.bmp", 0},
+        -- Each '<RTTR_RTTR>/campaigns/garden/' is optional: Paths are treated as relative to campaign file.
+        -- E.g.: conquered = {"mapscreen/conquered.bmp", 0},
         backgroundOffset = {0, 0},
         disabledColor = 0x70000000,
         missionSelectionInfos = {
@@ -75,7 +77,7 @@ The Lua campaign interface is versioned using a major version. Every time a feat
 
 Every map script must have 1 function:
 `getRequiredLuaVersion()`
-You need to implement this and return the version your script works with. If it does not match the current version an error will be shown and the script will not be used.
+You need to implement this and return the version your script works with. If it is higher than the current version an error will be shown and the script will not be used.
 
 ### Explanation of the campaign table fields
 
@@ -95,7 +97,7 @@ If you want a field to be translated you have to add the translation as describe
 
 Hints:
 
-- To work on case-sensitive OS (like Linux) the file name of the Lua file must have the same case as the map file name. This applies to the map names in the campaign.lua file too.
+- To work on case-sensitive OS (like Linux) the file name of the Lua file must have the same case as the map file name. This applies to the map names in the `campaign.lua` file too.
 For example: `MISS01.WLD, MISS01.lua` is correct and `MISS01.WLD, miss01.lua` will not work on Linux
 - The Lua file of a map must have the same name as the map itself but with the extension `.lua` to be found.
 - The Lua and the map file don't need to be in the same folder because the path can be specified separately.
@@ -107,7 +109,7 @@ For example: `MISS01.WLD, MISS01.lua` is correct and `MISS01.WLD, miss01.lua` wi
 
 ### Optional map selection screen {#selection-map}
 
-This parameter is optional and can be omitted in the Lua campaign file. If this parameter is specified the selection screen for the missions of a campaign is replaced by a selection map. Like the one used in the original settlers 2 world campaign.
+This parameter is optional and can be omitted in the Lua campaign file. If this parameter is specified the selection screen for the missions of a campaign is replaced by a selection map. Like the one used in the original Settlers 2 world campaign.
 
 We have the following parameters:
 
@@ -123,6 +125,11 @@ We have the following parameters:
 Hint:  
 All the images are described by the path to the image file and an index parameter. Usually the index parameter is zero.
 For special image formats containing multiple images in an archive this is the index of the image to use.
+
+### Image paths
+
+The paths to the campaign image and selection map images can be relative to the campaign folder and at most inside a single subfolder.  
+E.g. `images/garden.bmp` and `mapscreen/conquered.bmp` work, but `images/mapscreen/conquered.bmp` does not.
 
 ## Final view of the example garden campaign folder
 

--- a/doc/AddingCustomCampaign.md
+++ b/doc/AddingCustomCampaign.md
@@ -88,7 +88,7 @@ If you want a field to be translated you have to add the translation as describe
   3. `name`: The name of the campaign
   4. `shortDescription`: Short description of the campaign (like a headline to get a rough imagination of the campaign)
   5. `longDescription`: Extended description describing the campaign in detail. Will be shown in the campaign selection screen, when the campaign is selected.
-  6. `image`: Path to an image displayed in the campaign selection screen. You can omit this if you do no want to provide an image.
+  6. `image`: Path to an image displayed in the campaign selection screen. Can be any "archive" with an image, e.g. `.bmp`, `.lbm`. You can omit this if you do no want to provide an image.
   7. `maxHumanPlayers`: For now this is always 1 until we support multiplayer campaigns
   8. `difficulty`: Difficulty of the campaign. Should be one of the values easy, medium or hard.
   9. `mapFolder` and `luaFolder`: Path to the folder containing the campaign maps and associated Lua files. Usually your campaign folder or a subfolder of it.

--- a/doc/lua/functions.md
+++ b/doc/lua/functions.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+Copyright (C) 2005 - 2026 Settlers Freaks <sf-team at siedler25.org>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
@@ -24,7 +24,8 @@ Reference: [libs/libGamedata/lua/LuaInterfaceBase.cpp](../../libs/libGamedata/lu
 **rttr:GetFeatureLevel()**  
 Get the current feature level of the LUA interface.
 Increases here indicate new features.
-The current version is **6**.
+The current version is **7**.  
+See [list of changes](main.md#versioning).
 
 **rttr:Log(message)**  
 Log the message to console.

--- a/doc/lua/main.md
+++ b/doc/lua/main.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2005 - 2021 Settlers Freaks <sf-team at siedler25.org>
+Copyright (C) 2005 - 2026 Settlers Freaks <sf-team at siedler25.org>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
@@ -46,6 +46,10 @@ Every map script must have 1 function:
 You need to implement this and return the major/main version your script works with.
 If it does not match the current version an error will be shown and the script will not be used.
 See also `rttr:GetFeatureLevel()`.
+
+### Feature level 7
+
+- Allow relative paths for images referenced by campaign files.
 
 ## Example
 

--- a/libs/libGamedata/gameData/CampaignDescription.cpp
+++ b/libs/libGamedata/gameData/CampaignDescription.cpp
@@ -26,9 +26,10 @@ CampaignDescription::CampaignDescription(const boost::filesystem::path& campaign
                 if(!parentPath.parent_path().has_parent_path())
                 {
                     // Only alpha-numeric folder names are allowed
-                    const auto isNonAlNum = [](const char c) {
-                        return !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'));
+                    const auto isAlNum = [](const char c) {
+                        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
                     };
+                    const auto isNonAlNum = [isAlNum](const char c) { return !isAlNum(c); };
                     lua::assertTrue(!helpers::contains_if(parentPath.string(), isNonAlNum),
                                     helpers::format(_("Invalid path '%1%': Must be alpha-numeric"), path));
                     return (campaignPath / tmpPath).string();

--- a/libs/libGamedata/gameData/CampaignDescription.h
+++ b/libs/libGamedata/gameData/CampaignDescription.h
@@ -20,7 +20,7 @@ struct CampaignDescription
     std::string name;
     std::string shortDescription;
     std::string longDescription;
-    std::optional<boost::filesystem::path> image;
+    std::optional<std::string> image;
     unsigned maxHumanPlayers = 1;
     std::string difficulty;
     std::optional<SelectionMapInputData> selectionMapData;

--- a/libs/libGamedata/gameData/CampaignDescription.h
+++ b/libs/libGamedata/gameData/CampaignDescription.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -20,7 +20,7 @@ struct CampaignDescription
     std::string name;
     std::string shortDescription;
     std::string longDescription;
-    std::optional<std::string> image;
+    std::optional<boost::filesystem::path> image;
     unsigned maxHumanPlayers = 1;
     std::string difficulty;
     std::optional<SelectionMapInputData> selectionMapData;

--- a/libs/libGamedata/gameData/SelectionMapInputData.cpp
+++ b/libs/libGamedata/gameData/SelectionMapInputData.cpp
@@ -225,8 +225,7 @@ struct lua_type_traits<ImageResource>
         const LuaStackRef table(l, index);
         if(table.type() != LUA_TTABLE || table.size() != 2)
             throw LuaTypeMismatch();
-        std::string path = table[1];
-        return get_type(boost::filesystem::path(path), table[2]);
+        return get_type(table[1], table[2]);
     }
     static int push(lua_State* l, push_type v) { return util::push_args(l, v.filePath, v.index); }
 };

--- a/libs/libGamedata/gameData/SelectionMapInputData.h
+++ b/libs/libGamedata/gameData/SelectionMapInputData.h
@@ -15,10 +15,9 @@ class LuaRef;
 
 struct ImageResource
 {
-    boost::filesystem::path filePath;
+    std::string filePath;
     unsigned index;
-    ImageResource(boost::filesystem::path path = boost::filesystem::path(), unsigned index = 0)
-        : filePath(std::move(path)), index(index){};
+    ImageResource(std::string path = "", unsigned index = 0) : filePath(std::move(path)), index(index){};
 };
 
 struct MissionSelectionInfo

--- a/libs/libGamedata/lua/CampaignDataLoader.cpp
+++ b/libs/libGamedata/lua/CampaignDataLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2023 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -17,7 +17,7 @@
 
 unsigned CampaignDataLoader::GetVersion()
 {
-    return 2;
+    return 3;
 }
 
 CampaignDataLoader::CampaignDataLoader(CampaignDescription& campaignDesc, const boost::filesystem::path& basePath)

--- a/libs/s25main/controls/ctrlMapSelection.cpp
+++ b/libs/s25main/controls/ctrlMapSelection.cpp
@@ -21,7 +21,7 @@
 ctrlMapSelection::MapImages::MapImages(const SelectionMapInputData& data)
 {
     auto getImage = [](const ImageResource& res) {
-        auto* img = LOADER.GetImageN(ResourceId::make(res.filePath), res.index);
+        auto* img = LOADER.GetImageN(ResourceId::fromPath(res.filePath), res.index);
         if(!img)
             throw std::runtime_error(
               helpers::format(_("Loading of images %s for map selection failed."), res.filePath));
@@ -31,7 +31,7 @@ ctrlMapSelection::MapImages::MapImages(const SelectionMapInputData& data)
     {
         std::vector<std::string> pathsToLoad;
         for(const auto& res : {data.background, data.map, data.missionMapMask, data.marker, data.conquered})
-            pathsToLoad.push_back(res.filePath.string());
+            pathsToLoad.push_back(res.filePath);
         LOADER.LoadFiles(pathsToLoad);
     }
 

--- a/libs/s25main/desktops/dskCampaignSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignSelection.cpp
@@ -137,7 +137,7 @@ void dskCampaignSelection::Msg_TableSelectItem(const unsigned ctrl_id, const boo
             mapSelection->setMissionsStatus(std::vector<MissionStatus>(campaign.getNumMaps(), {true, true}));
             mapSelection->setPreview(true);
         } else if(campaign.image)
-            campaignImage_ = LOADER.GetImageN(ResourceId::fromPath(*campaign.image), 0);
+            campaignImage_ = LOADER.GetImageN(ResourceId::make(*campaign.image), 0);
         else
             campaignImage_ = nullptr;
     }
@@ -173,7 +173,7 @@ void dskCampaignSelection::Msg_Timer(unsigned ctrl_id)
     for(const auto& campaign : campaigns_)
     {
         if(campaign.image)
-            resourcesToLoad.insert(*campaign.image);
+            resourcesToLoad.insert(campaign.image->string());
     }
     LOADER.LoadFiles({resourcesToLoad.begin(), resourcesToLoad.end()});
     FillCampaignsTable();

--- a/libs/s25main/desktops/dskCampaignSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignSelection.cpp
@@ -173,7 +173,7 @@ void dskCampaignSelection::Msg_Timer(unsigned ctrl_id)
     for(const auto& campaign : campaigns_)
     {
         if(campaign.image)
-            resourcesToLoad.insert(campaign.image->string());
+            resourcesToLoad.insert(*campaign.image);
     }
     LOADER.LoadFiles({resourcesToLoad.begin(), resourcesToLoad.end()});
     FillCampaignsTable();

--- a/libs/s25main/desktops/dskCampaignSelection.cpp
+++ b/libs/s25main/desktops/dskCampaignSelection.cpp
@@ -137,7 +137,7 @@ void dskCampaignSelection::Msg_TableSelectItem(const unsigned ctrl_id, const std
             mapSelection->setMissionsStatus(std::vector<MissionStatus>(campaign.getNumMaps(), {true, true}));
             mapSelection->setPreview(true);
         } else if(campaign.image)
-            campaignImage_ = LOADER.GetImageN(ResourceId::fromPath(*campaign.image), 0);
+            campaignImage_ = LOADER.GetImageN(ResourceId::make(*campaign.image), 0);
         else
             campaignImage_ = nullptr;
     }
@@ -173,7 +173,7 @@ void dskCampaignSelection::Msg_Timer(unsigned ctrl_id)
     for(const auto& campaign : campaigns_)
     {
         if(campaign.image)
-            resourcesToLoad.insert(*campaign.image);
+            resourcesToLoad.insert(campaign.image->string());
     }
     LOADER.LoadFiles({resourcesToLoad.begin(), resourcesToLoad.end()});
     FillCampaignsTable();

--- a/libs/s25main/lua/LuaInterfaceGameBase.cpp
+++ b/libs/s25main/lua/LuaInterfaceGameBase.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -16,7 +16,7 @@ unsigned LuaInterfaceGameBase::GetVersion()
 
 unsigned LuaInterfaceGameBase::GetFeatureLevel()
 {
-    return 6;
+    return 7;
 }
 
 LuaInterfaceGameBase::LuaInterfaceGameBase(const ILocalGameState& localGameState) : localGameState(localGameState)

--- a/tests/libGameData/testCampaignLuaFile.cpp
+++ b/tests/libGameData/testCampaignLuaFile.cpp
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(LoadCampaignDescriptionWithoutTranslation)
     BOOST_TEST(desc.name == "My campaign");
     BOOST_TEST(desc.shortDescription == "Very short description");
     BOOST_TEST(desc.longDescription == "This is the long description");
-    BOOST_TEST(desc.image == RTTRCONFIG.ExpandPath("<RTTR_GAME>/GFX/PICS/WORLD.LBM"));
+    BOOST_TEST(desc.image == "<RTTR_GAME>/GFX/PICS/WORLD.LBM");
     BOOST_TEST(desc.maxHumanPlayers == 1u);
     BOOST_TEST(desc.difficulty == "easy");
 

--- a/tests/s25Main/UI/testMapSelection.cpp
+++ b/tests/s25Main/UI/testMapSelection.cpp
@@ -104,11 +104,11 @@ SelectionMapInputData createInputForSelectionMap(rttr::test::TmpFolder const& tm
     storeBitmap(conqueredPath, createBitmapWithOneColor(overlaySize, red));
 
     SelectionMapInputData selectionMapInputData;
-    selectionMapInputData.background = {backgroundPath, 0};
-    selectionMapInputData.map = {mapPath, 0};
-    selectionMapInputData.missionMapMask = {missionmapmaskPath, 0};
-    selectionMapInputData.marker = {markerPath, 0};
-    selectionMapInputData.conquered = {conqueredPath, 0};
+    selectionMapInputData.background = {backgroundPath.string(), 0};
+    selectionMapInputData.map = {mapPath.string(), 0};
+    selectionMapInputData.missionMapMask = {missionmapmaskPath.string(), 0};
+    selectionMapInputData.marker = {markerPath.string(), 0};
+    selectionMapInputData.conquered = {conqueredPath.string(), 0};
     selectionMapInputData.mapOffsetInBackground = mapOffsetInBackground;
     selectionMapInputData.disabledColor = disabledColor;
     selectionMapInputData.missionSelectionInfos = {{red, {Position((mapSize.x * 3) / 4, mapSize.y / 4)}},


### PR DESCRIPTION
Custom campaigns are not in `<RTTR_RTTR>` but in the user-data folder.
Hence it would be impossible to refer to custom images as shown in the example.

Allow a single subfolder level for images and adapt the docs