### PR TITLE
Add support for borderless Windows

### DIFF
--- a/data/RTTR/texte/de/keyboardlayout.txt
+++ b/data/RTTR/texte/de/keyboardlayout.txt
@@ -28,6 +28,7 @@ F1:................... (Spiel laden)
 F2:................... Spiel speichern
 F8:................... Tastaturbelegung anzeigen
 F9:................... ReadMe-Datei anzeigen
+F10:.................. Einstellungen (UI, ...)
 F11:.................. Musik-Spieler
 F12:.................. Kontrollfenster
 
@@ -47,6 +48,6 @@ P:.................... Pause/Fortsetzen (Auch nach GF Sprung)
 1-7:.................. Spielerwechsel
 
 ------------------------------------------------------------------------
-https://www.siedler25.org        Copyright (C) 2005-2022 Settlers Freaks
+https://www.siedler25.org        Copyright (C) 2005-2026 Settlers Freaks
 ------------------------------------------------------------------------
 

--- a/data/RTTR/texte/keyboardlayout.txt
+++ b/data/RTTR/texte/keyboardlayout.txt
@@ -28,6 +28,7 @@ F1:................... (Load game)
 F2:................... Save game
 F8:................... Readme "Keyboard layout"
 F9:................... Readme
+F10:.................. Settings (UI, ...)
 F11:.................. Musicplayer
 F12:.................. Options window
 
@@ -46,5 +47,5 @@ J:.................... Go to specific GF
 P:.................... Pause/Resume (also after GF jump)
 1-7:.................. Change to other player
 ------------------------------------------------------------------------
-https://www.siedler25.org        Copyright (C) 2005-2022 Settlers Freaks
+https://www.siedler25.org        Copyright (C) 2005-2026 Settlers Freaks
 ------------------------------------------------------------------------

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -32,11 +32,17 @@
 #    include <gl4esinit.h>
 #endif
 
+namespace {
+
 /// Check that the (SDL) call returns success or print the error
 /// Can be used in conditions: if(CHECK_SDL(SDL_Foo()))
-#define CHECK_SDL(call) ((call) >= 0 || (PrintError(), false))
-
-namespace {
+bool CHECK_SDL(int sdlResult)
+{
+    if(sdlResult >= 0)
+        return true;
+    VideoSDL2::PrintError();
+    return false;
+}
 
 template<typename T>
 struct SDLMemoryDeleter

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -540,11 +540,12 @@ unsigned long VideoSDL2::GetTickCount() const
     return SDL_GetTicks();
 }
 
-void VideoSDL2::ListVideoModes(std::vector<VideoMode>& video_modes) const
+std::vector<VideoMode> VideoSDL2::ListVideoModes() const
 {
     int display = SDL_GetWindowDisplayIndex(window);
     if(display < 0)
         display = 0;
+    std::vector<VideoMode> video_modes;
     for(int i = SDL_GetNumDisplayModes(display) - 1; i >= 0; --i)
     {
         SDL_DisplayMode mode;
@@ -557,6 +558,7 @@ void VideoSDL2::ListVideoModes(std::vector<VideoMode>& video_modes) const
                 video_modes.push_back(vm);
         }
     }
+    return video_modes;
 }
 
 OpenGL_Loader_Proc VideoSDL2::GetLoaderFunction() const

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -142,7 +142,7 @@ static VideoMode getDesktopSize(VideoMode fallback)
     return fallback;
 }
 
-bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, DisplayMode displayMode)
+bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode size, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
@@ -228,7 +228,7 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, Di
     return true;
 }
 
-bool VideoSDL2::ResizeScreen(const VideoMode& reqSize, DisplayMode displayMode)
+bool VideoSDL2::ResizeScreen(VideoMode reqSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -1,8 +1,9 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "VideoSDL2.h"
+#include "RTTR_Assert.h"
 #include "driver/Interface.h"
 #include "driver/VideoDriverLoaderInterface.h"
 #include "driver/VideoInterface.h"
@@ -31,17 +32,12 @@
 #    include <gl4esinit.h>
 #endif
 
-#define CHECK_SDL(call)                 \
-    ([&]() -> bool {                    \
-        if((call) < 0)                  \
-        {                               \
-            PrintError(SDL_GetError()); \
-            return false;               \
-        }                               \
-        return true;                    \
-    })()
+/// Check that the (SDL) call returns success or print the error
+/// Can be used in conditions: if(CHECK_SDL(SDL_Foo()))
+#define CHECK_SDL(call) ((call) >= 0 || (PrintError(), false))
 
 namespace {
+
 template<typename T>
 struct SDLMemoryDeleter
 {
@@ -102,7 +98,7 @@ bool VideoSDL2::Initialize()
     SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
     if(SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
     {
-        PrintError(SDL_GetError());
+        PrintError();
         return false;
     }
 
@@ -156,37 +152,53 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, Di
     CHECK_SDL(SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1));
 
     const int wndPos = SDL_WINDOWPOS_CENTERED;
-    const auto fullscreen = (displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
-    const auto resizable = (displayMode & DisplayMode::Resizable) != DisplayMode::None;
+    const auto fullscreen = displayMode == DisplayMode::Fullscreen;
     const auto requestedSize = fullscreen ? FindClosestVideoMode(size) : size;
-    const unsigned commonFlags = SDL_WINDOW_OPENGL | (resizable ? SDL_WINDOW_RESIZABLE : 0);
-    const unsigned fullscreenFlag = (fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
+    const unsigned commonFlags = SDL_WINDOW_OPENGL;
     // TODO: Fix GUI scaling with High DPI support enabled.
     // See https://github.com/Return-To-The-Roots/s25client/issues/1621
     // commonFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
-    window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
-                              commonFlags | fullscreenFlag);
+    const unsigned windowTypeFlag =
+      fullscreen ? SDL_WINDOW_FULLSCREEN :
+                   (displayMode == DisplayMode::BorderlessWindow ? SDL_WINDOW_BORDERLESS : SDL_WINDOW_RESIZABLE);
 
-    // Fallback to non-fullscreen
-    if(!window && fullscreen)
+    window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
+                              commonFlags | windowTypeFlag);
+
+    if(!window)
     {
-        window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
-                                  commonFlags | SDL_WINDOW_RESIZABLE);
+        PrintError();
+        // Fallback to borderless fullscreen
+        if(fullscreen)
+        {
+            SDL_DisplayMode dskSize;
+            if(!CHECK_SDL(SDL_GetDesktopDisplayMode(0, &dskSize)))
+            {
+                dskSize.w = size.width;
+                dskSize.h = size.height;
+            }
+            window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, dskSize.w, dskSize.h,
+                                      commonFlags | SDL_WINDOW_BORDERLESS);
+        }
+        // No borderless -> Resizable
+        if(!window)
+        {
+            window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, size.width, size.height,
+                                      commonFlags | SDL_WINDOW_RESIZABLE);
+        }
     }
 
     if(!window)
     {
-        PrintError(SDL_GetError());
+        PrintError();
         return false;
     }
 
-    const auto flags = SDL_GetWindowFlags(window);
-    SetFullscreenFlag((flags & SDL_WINDOW_FULLSCREEN) != 0);
-    SetResizableFlag((flags & SDL_WINDOW_RESIZABLE) != 0);
+    UpdateCurrentDisplayMode();
     UpdateCurrentSizes();
 
-    if(!IsFullscreen())
+    if(displayMode_ != DisplayMode::Fullscreen)
         MoveWindowToCenter();
 
     SDL_Surface* iconSurf =
@@ -196,7 +208,7 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, Di
         SDL_SetWindowIcon(window, iconSurf);
         SDL_FreeSurface(iconSurf);
     } else
-        PrintError(SDL_GetError());
+        PrintError();
 
     context = SDL_GL_CreateContext(window);
 
@@ -216,27 +228,27 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
     if(!initialized)
         return false;
 
-    const auto fullscreen = (displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
-    const auto resizable = (displayMode & DisplayMode::Resizable) != DisplayMode::None;
-
-    if(IsFullscreen() != fullscreen)
-    {
-        SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
-        SetFullscreenFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0);
-        if(!IsFullscreen())
-            MoveWindowToCenter();
-    }
-
     if(displayMode_ != displayMode)
     {
-        if(!IsFullscreen())
-            SDL_SetWindowResizable(window, static_cast<SDL_bool>(resizable));
-        SetResizableFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_RESIZABLE) != 0);
-    }
+        if(displayMode_ == DisplayMode::Fullscreen || displayMode == DisplayMode::Fullscreen)
+        {
+            if(!CHECK_SDL(
+                 SDL_SetWindowFullscreen(window, (displayMode == DisplayMode::Fullscreen) ? SDL_WINDOW_FULLSCREEN : 0)))
+            {
+                if(displayMode == DisplayMode::Fullscreen)
+                    displayMode = DisplayMode::BorderlessWindow;
+            }
+        }
+        SDL_SetWindowResizable(window, static_cast<SDL_bool>(displayMode == DisplayMode::Windowed));
+        SDL_SetWindowBordered(window, static_cast<SDL_bool>(displayMode != DisplayMode::BorderlessWindow));
 
+        UpdateCurrentDisplayMode();
+        if(displayMode_ != DisplayMode::Fullscreen)
+            MoveWindowToCenter();
+    }
     if(newSize != GetWindowSize())
     {
-        if(IsFullscreen())
+        if(displayMode_ == DisplayMode::Fullscreen)
         {
             auto const targetMode = FindClosestVideoMode(newSize);
             SDL_DisplayMode target;
@@ -247,22 +259,22 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
             target.driverdata = nullptr; // initialize to 0
             // Explicitly change the window size to avoid a bug with SDL reporting the wrong size until alt+tab
             SDL_SetWindowSize(window, target.w, target.h);
-            if(SDL_SetWindowDisplayMode(window, &target) < 0)
-            {
-                PrintError(SDL_GetError());
+            if(!CHECK_SDL(SDL_SetWindowDisplayMode(window, &target)))
                 return false;
-            }
         } else
-        {
             SDL_SetWindowSize(window, newSize.width, newSize.height);
-        }
         UpdateCurrentSizes();
     }
 
     return true;
 }
 
-void VideoSDL2::PrintError(const std::string& msg) const
+void VideoSDL2::PrintError()
+{
+    PrintError(SDL_GetError());
+}
+
+void VideoSDL2::PrintError(const std::string& msg)
 {
     boost::nowide::cerr << msg << std::endl;
 }
@@ -320,7 +332,7 @@ bool VideoSDL2::MessageLoop()
                 {
                     case SDL_WINDOWEVENT_RESIZED:
                     {
-                        SetFullscreenFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0);
+                        UpdateCurrentDisplayMode();
                         VideoMode newSize(ev.window.data1, ev.window.data2);
                         if(newSize != GetWindowSize())
                         {
@@ -529,7 +541,7 @@ void VideoSDL2::ListVideoModes(std::vector<VideoMode>& video_modes) const
     {
         SDL_DisplayMode mode;
         if(SDL_GetDisplayMode(display, i, &mode) != 0)
-            PrintError(SDL_GetError());
+            PrintError();
         else
         {
             VideoMode vm(mode.w, mode.h);
@@ -590,4 +602,16 @@ void VideoSDL2::MoveWindowToCenter()
         UpdateCurrentSizes();
     }
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+}
+
+void VideoSDL2::UpdateCurrentDisplayMode()
+{
+    RTTR_Assert(window);
+    const auto flags = SDL_GetWindowFlags(window);
+    if(flags & SDL_WINDOW_FULLSCREEN)
+        displayMode_ = DisplayMode::Fullscreen;
+    else if((flags & SDL_WINDOW_BORDERLESS) != 0)
+        displayMode_ = DisplayMode::BorderlessWindow;
+    else
+        displayMode_ = DisplayMode::Windowed;
 }

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -134,6 +134,14 @@ void VideoSDL2::UpdateCurrentSizes()
     SetNewSize(VideoMode(w, h), Extent(w2, h2));
 }
 
+static VideoMode getDesktopSize(VideoMode fallback)
+{
+    SDL_DisplayMode dskSize;
+    if(CHECK_SDL(SDL_GetDesktopDisplayMode(0, &dskSize)))
+        return VideoMode(dskSize.w, dskSize.h);
+    return fallback;
+}
+
 bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, DisplayMode displayMode)
 {
     if(!initialized)
@@ -158,16 +166,23 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, Di
     CHECK_SDL(SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1));
 
     const int wndPos = SDL_WINDOWPOS_CENTERED;
-    const auto fullscreen = displayMode == DisplayMode::Fullscreen;
-    const auto requestedSize = fullscreen ? FindClosestVideoMode(size) : size;
     const unsigned commonFlags = SDL_WINDOW_OPENGL;
     // TODO: Fix GUI scaling with High DPI support enabled.
     // See https://github.com/Return-To-The-Roots/s25client/issues/1621
     // commonFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
-    const unsigned windowTypeFlag =
-      fullscreen ? SDL_WINDOW_FULLSCREEN :
-                   (displayMode == DisplayMode::BorderlessWindow ? SDL_WINDOW_BORDERLESS : SDL_WINDOW_RESIZABLE);
+    unsigned windowTypeFlag = 0;
+    auto requestedSize = size;
+    if(displayMode == DisplayMode::Fullscreen)
+    {
+        windowTypeFlag = SDL_WINDOW_FULLSCREEN;
+        requestedSize = FindClosestVideoMode(size);
+    } else if(displayMode == DisplayMode::BorderlessWindow)
+    {
+        windowTypeFlag = SDL_WINDOW_BORDERLESS;
+        requestedSize = getDesktopSize(size);
+    } else if(displayMode.resizeable)
+        windowTypeFlag = SDL_WINDOW_RESIZABLE;
 
     window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
                               commonFlags | windowTypeFlag);
@@ -175,28 +190,12 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, Di
     if(!window)
     {
         PrintError();
-        // Fallback to borderless fullscreen
-        if(fullscreen)
-        {
-            SDL_DisplayMode dskSize;
-            if(!CHECK_SDL(SDL_GetDesktopDisplayMode(0, &dskSize)))
-            {
-                dskSize.w = size.width;
-                dskSize.h = size.height;
-            }
-            window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, dskSize.w, dskSize.h,
-                                      commonFlags | SDL_WINDOW_BORDERLESS);
-        }
-        // No borderless -> Resizable
-        if(!window)
-        {
-            window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, size.width, size.height,
-                                      commonFlags | SDL_WINDOW_RESIZABLE);
-        }
-    }
-
-    if(!window)
-    {
+        // Fallback to borderless fullscreen if unable to set resolution
+        if(displayMode == DisplayMode::Fullscreen)
+            return CreateScreen(title, size, DisplayMode::BorderlessWindow);
+        // No borderless -> Resizable window as last fallback to at least show something
+        if(displayMode == DisplayMode::BorderlessWindow)
+            return CreateScreen(title, size, DisplayMode::Windowed);
         PrintError();
         return false;
     }
@@ -204,7 +203,7 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, Di
     UpdateCurrentDisplayMode();
     UpdateCurrentSizes();
 
-    if(displayMode_ != DisplayMode::Fullscreen)
+    if(displayMode != DisplayMode::Fullscreen)
         MoveWindowToCenter();
 
     SDL_Surface* iconSurf =
@@ -229,7 +228,7 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, Di
     return true;
 }
 
-bool VideoSDL2::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
+bool VideoSDL2::ResizeScreen(const VideoMode& reqSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
@@ -245,13 +244,15 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
                     displayMode = DisplayMode::BorderlessWindow;
             }
         }
-        SDL_SetWindowResizable(window, static_cast<SDL_bool>(displayMode == DisplayMode::Windowed));
-        SDL_SetWindowBordered(window, static_cast<SDL_bool>(displayMode != DisplayMode::BorderlessWindow));
+        SDL_SetWindowResizable(window,
+                               static_cast<SDL_bool>(displayMode == DisplayMode::Windowed && displayMode.resizeable));
+        SDL_SetWindowBordered(window, static_cast<SDL_bool>(displayMode == DisplayMode::Windowed));
 
         UpdateCurrentDisplayMode();
         if(displayMode_ != DisplayMode::Fullscreen)
             MoveWindowToCenter();
     }
+    const VideoMode newSize = displayMode_ == DisplayMode::BorderlessWindow ? getDesktopSize(reqSize) : reqSize;
     if(newSize != GetWindowSize())
     {
         if(displayMode_ == DisplayMode::Fullscreen)
@@ -260,9 +261,9 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
             SDL_DisplayMode target;
             target.w = targetMode.width;
             target.h = targetMode.height;
-            target.format = 0;           // don't care
-            target.refresh_rate = 0;     // don't care
-            target.driverdata = nullptr; // initialize to 0
+            target.format = 0;       // don't care
+            target.refresh_rate = 0; // don't care
+            target.driverdata = nullptr;
             // Explicitly change the window size to avoid a bug with SDL reporting the wrong size until alt+tab
             SDL_SetWindowSize(window, target.w, target.h);
             if(!CHECK_SDL(SDL_SetWindowDisplayMode(window, &target)))
@@ -598,7 +599,7 @@ void VideoSDL2::MoveWindowToCenter()
     SDL_Rect usableBounds;
     CHECK_SDL(SDL_GetDisplayUsableBounds(SDL_GetWindowDisplayIndex(window), &usableBounds));
     int top, left, bottom, right;
-    if(CHECK_SDL(SDL_GetWindowBordersSize(window, &top, &left, &bottom, &right)) != 0)
+    if(!CHECK_SDL(SDL_GetWindowBordersSize(window, &top, &left, &bottom, &right)))
         top = left = bottom = right = 0;
     usableBounds.w -= left + right;
     usableBounds.h -= top + bottom;
@@ -620,4 +621,5 @@ void VideoSDL2::UpdateCurrentDisplayMode()
         displayMode_ = DisplayMode::BorderlessWindow;
     else
         displayMode_ = DisplayMode::Windowed;
+    displayMode_.resizeable = (flags & SDL_WINDOW_RESIZABLE) != 0;
 }

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -134,10 +134,11 @@ void VideoSDL2::UpdateCurrentSizes()
     SetNewSize(VideoMode(w, h), Extent(w2, h2));
 }
 
-static VideoMode getDesktopSize(VideoMode fallback)
+static VideoMode getDesktopSize(SDL_Window* window, VideoMode fallback)
 {
+    const int display = window ? std::max(0, SDL_GetWindowDisplayIndex(window)) : 0;
     SDL_DisplayMode dskSize;
-    if(CHECK_SDL(SDL_GetDesktopDisplayMode(0, &dskSize)))
+    if(CHECK_SDL(SDL_GetDesktopDisplayMode(display, &dskSize)))
         return VideoMode(dskSize.w, dskSize.h);
     return fallback;
 }
@@ -180,7 +181,7 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode size, Dis
     } else if(displayMode == DisplayMode::BorderlessWindow)
     {
         windowTypeFlag = SDL_WINDOW_BORDERLESS;
-        requestedSize = getDesktopSize(size);
+        requestedSize = getDesktopSize(nullptr, size);
     } else if(displayMode.resizeable)
         windowTypeFlag = SDL_WINDOW_RESIZABLE;
 
@@ -233,6 +234,8 @@ bool VideoSDL2::ResizeScreen(VideoMode newSize, DisplayMode displayMode)
     if(!initialized)
         return false;
 
+    bool centerWindow = false;
+
     if(displayMode_ != displayMode)
     {
         if(displayMode_ == DisplayMode::Fullscreen || displayMode == DisplayMode::Fullscreen)
@@ -249,11 +252,10 @@ bool VideoSDL2::ResizeScreen(VideoMode newSize, DisplayMode displayMode)
         SDL_SetWindowBordered(window, static_cast<SDL_bool>(displayMode == DisplayMode::Windowed));
 
         UpdateCurrentDisplayMode();
-        if(displayMode_ != DisplayMode::Fullscreen)
-            MoveWindowToCenter();
+        centerWindow = true;
     }
     if(displayMode_ == DisplayMode::BorderlessWindow)
-        newSize = getDesktopSize(newSize);
+        newSize = getDesktopSize(nullptr, newSize);
     if(newSize != GetWindowSize())
     {
         if(displayMode_ == DisplayMode::Fullscreen)
@@ -270,9 +272,14 @@ bool VideoSDL2::ResizeScreen(VideoMode newSize, DisplayMode displayMode)
             if(!CHECK_SDL(SDL_SetWindowDisplayMode(window, &target)))
                 return false;
         } else
+        {
             SDL_SetWindowSize(window, newSize.width, newSize.height);
+            centerWindow = true;
+        }
         UpdateCurrentSizes();
     }
+    if(centerWindow)
+        MoveWindowToCenter();
 
     return true;
 }
@@ -599,19 +606,27 @@ void* VideoSDL2::GetMapPointer() const
 
 void VideoSDL2::MoveWindowToCenter()
 {
+    SDL_PumpEvents(); // Let window system run update events/initialization
+    const int display = window ? std::max(0, SDL_GetWindowDisplayIndex(window)) : 0;
+
     SDL_Rect usableBounds;
-    CHECK_SDL(SDL_GetDisplayUsableBounds(SDL_GetWindowDisplayIndex(window), &usableBounds));
+    CHECK_SDL(SDL_GetDisplayUsableBounds(display, &usableBounds));
     int top, left, bottom, right;
     if(!CHECK_SDL(SDL_GetWindowBordersSize(window, &top, &left, &bottom, &right)))
         top = left = bottom = right = 0;
-    usableBounds.w -= left + right;
-    usableBounds.h -= top + bottom;
-    if(usableBounds.w < GetWindowSize().width || usableBounds.h < GetWindowSize().height)
+    auto wndOuterSize = GetWindowSize();
+    wndOuterSize.width += left + right;
+    wndOuterSize.height += top + bottom;
+    if(usableBounds.w < wndOuterSize.width || usableBounds.h < wndOuterSize.height)
     {
-        SDL_SetWindowSize(window, usableBounds.w, usableBounds.h);
+        SDL_SetWindowSize(window, usableBounds.w - left - right, usableBounds.h - top - bottom);
         UpdateCurrentSizes();
+        wndOuterSize.width = usableBounds.w;
+        wndOuterSize.height = usableBounds.h;
     }
-    SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    const int x = usableBounds.x + (usableBounds.w - wndOuterSize.width) / 2 + left;
+    const int y = usableBounds.y + (usableBounds.h - wndOuterSize.height) / 2 + top;
+    SDL_SetWindowPosition(window, x, y);
 }
 
 void VideoSDL2::UpdateCurrentDisplayMode()

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -132,7 +132,7 @@ void VideoSDL2::UpdateCurrentSizes()
     SetNewSize(VideoMode(w, h), Extent(w2, h2));
 }
 
-bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bool fullscreen)
+bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
@@ -155,16 +155,18 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
     CHECK_SDL(SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8));
     CHECK_SDL(SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1));
 
-    int wndPos = SDL_WINDOWPOS_CENTERED;
-
+    const int wndPos = SDL_WINDOWPOS_CENTERED;
+    const auto fullscreen = (displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
+    const auto resizable = (displayMode & DisplayMode::Resizable) != DisplayMode::None;
     const auto requestedSize = fullscreen ? FindClosestVideoMode(size) : size;
-    unsigned commonFlags = SDL_WINDOW_OPENGL;
+    const unsigned commonFlags = SDL_WINDOW_OPENGL | (resizable ? SDL_WINDOW_RESIZABLE : 0);
+    const unsigned fullscreenFlag = (fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
     // TODO: Fix GUI scaling with High DPI support enabled.
     // See https://github.com/Return-To-The-Roots/s25client/issues/1621
     // commonFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
     window = SDL_CreateWindow(title.c_str(), wndPos, wndPos, requestedSize.width, requestedSize.height,
-                              commonFlags | (fullscreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE));
+                              commonFlags | fullscreenFlag);
 
     // Fallback to non-fullscreen
     if(!window && fullscreen)
@@ -179,10 +181,12 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
         return false;
     }
 
-    isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
+    const auto flags = SDL_GetWindowFlags(window);
+    SetFullscreenFlag((flags & SDL_WINDOW_FULLSCREEN) != 0);
+    SetResizableFlag((flags & SDL_WINDOW_RESIZABLE) != 0);
     UpdateCurrentSizes();
 
-    if(!isFullscreen_)
+    if(!IsFullscreen())
         MoveWindowToCenter();
 
     SDL_Surface* iconSurf =
@@ -207,25 +211,32 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode& size, bo
     return true;
 }
 
-bool VideoSDL2::ResizeScreen(const VideoMode& newSize, bool fullscreen)
+bool VideoSDL2::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
 
-    if(isFullscreen_ != fullscreen)
+    const auto fullscreen = (displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
+    const auto resizable = (displayMode & DisplayMode::Resizable) != DisplayMode::None;
+
+    if(IsFullscreen() != fullscreen)
     {
         SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
-        isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
-        if(!isFullscreen_)
-        {
-            SDL_SetWindowResizable(window, SDL_TRUE);
+        SetFullscreenFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0);
+        if(!IsFullscreen())
             MoveWindowToCenter();
-        }
+    }
+
+    if(displayMode_ != displayMode)
+    {
+        if(!IsFullscreen())
+            SDL_SetWindowResizable(window, static_cast<SDL_bool>(resizable));
+        SetResizableFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_RESIZABLE) != 0);
     }
 
     if(newSize != GetWindowSize())
     {
-        if(isFullscreen_)
+        if(IsFullscreen())
         {
             auto const targetMode = FindClosestVideoMode(newSize);
             SDL_DisplayMode target;
@@ -247,6 +258,7 @@ bool VideoSDL2::ResizeScreen(const VideoMode& newSize, bool fullscreen)
         }
         UpdateCurrentSizes();
     }
+
     return true;
 }
 
@@ -308,7 +320,7 @@ bool VideoSDL2::MessageLoop()
                 {
                     case SDL_WINDOWEVENT_RESIZED:
                     {
-                        isFullscreen_ = (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0;
+                        SetFullscreenFlag((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) != 0);
                         VideoMode newSize(ev.window.data1, ev.window.data2);
                         if(newSize != GetWindowSize())
                         {

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -102,13 +102,9 @@ bool VideoSDL2::Initialize()
     rttr::ScopedLeakDisabler _;
     // Do not emulate mouse events using touch
     SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
-    if(SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
-    {
-        PrintError();
-        return false;
-    }
+    if(CHECK_SDL(SDL_InitSubSystem(SDL_INIT_VIDEO)))
+        initialized = true;
 
-    initialized = true;
     return initialized;
 }
 

--- a/extras/videoDrivers/SDL2/VideoSDL2.cpp
+++ b/extras/videoDrivers/SDL2/VideoSDL2.cpp
@@ -228,7 +228,7 @@ bool VideoSDL2::CreateScreen(const std::string& title, const VideoMode size, Dis
     return true;
 }
 
-bool VideoSDL2::ResizeScreen(VideoMode reqSize, DisplayMode displayMode)
+bool VideoSDL2::ResizeScreen(VideoMode newSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
@@ -252,7 +252,8 @@ bool VideoSDL2::ResizeScreen(VideoMode reqSize, DisplayMode displayMode)
         if(displayMode_ != DisplayMode::Fullscreen)
             MoveWindowToCenter();
     }
-    const VideoMode newSize = displayMode_ == DisplayMode::BorderlessWindow ? getDesktopSize(reqSize) : reqSize;
+    if(displayMode_ == DisplayMode::BorderlessWindow)
+        newSize = getDesktopSize(newSize);
     if(newSize != GetWindowSize())
     {
         if(displayMode_ == DisplayMode::Fullscreen)

--- a/extras/videoDrivers/SDL2/VideoSDL2.h
+++ b/extras/videoDrivers/SDL2/VideoSDL2.h
@@ -24,8 +24,8 @@ public:
 
     bool Initialize() override;
 
-    bool CreateScreen(const std::string& title, const VideoMode& size, bool fullscreen) override;
-    bool ResizeScreen(const VideoMode& newSize, bool fullscreen) override;
+    bool CreateScreen(const std::string& title, const VideoMode& size, DisplayMode displayMode) override;
+    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
 
     void DestroyScreen() override;
 

--- a/extras/videoDrivers/SDL2/VideoSDL2.h
+++ b/extras/videoDrivers/SDL2/VideoSDL2.h
@@ -53,9 +53,10 @@ public:
     /// Get (device-dependent!) window pointer, HWND in Windows
     void* GetMapPointer() const override;
 
-private:
     static void PrintError();
     static void PrintError(const std::string& msg);
+
+private:
     void HandlePaste();
     void UpdateCurrentSizes();
     void MoveWindowToCenter();

--- a/extras/videoDrivers/SDL2/VideoSDL2.h
+++ b/extras/videoDrivers/SDL2/VideoSDL2.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -54,10 +54,12 @@ public:
     void* GetMapPointer() const override;
 
 private:
-    void PrintError(const std::string& msg) const;
+    static void PrintError();
+    static void PrintError(const std::string& msg);
     void HandlePaste();
     void UpdateCurrentSizes();
     void MoveWindowToCenter();
+    void UpdateCurrentDisplayMode();
 
     SDL_Window* window;
     SDL_GLContext context;

--- a/extras/videoDrivers/SDL2/VideoSDL2.h
+++ b/extras/videoDrivers/SDL2/VideoSDL2.h
@@ -24,8 +24,8 @@ public:
 
     bool Initialize() override;
 
-    bool CreateScreen(const std::string& title, const VideoMode& size, DisplayMode displayMode) override;
-    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
+    bool CreateScreen(const std::string& title, VideoMode size, DisplayMode displayMode) override;
+    bool ResizeScreen(VideoMode newSize, DisplayMode displayMode) override;
 
     void DestroyScreen() override;
 

--- a/extras/videoDrivers/SDL2/VideoSDL2.h
+++ b/extras/videoDrivers/SDL2/VideoSDL2.h
@@ -41,8 +41,8 @@ public:
 
     OpenGL_Loader_Proc GetLoaderFunction() const override;
 
-    /// Add supported video modes
-    void ListVideoModes(std::vector<VideoMode>& video_modes) const override;
+    /// Get supported video modes
+    std::vector<VideoMode> ListVideoModes() const override;
 
     /// Set mouse position
     void SetMousePos(Position pos) override;

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -139,26 +139,25 @@ void VideoWinAPI::CleanUp()
 /**
  *  Erstellt das Fenster mit entsprechenden Werten.
  *
- *  @param[in] width      Breite des Fensters
- *  @param[in] height     Höhe des Fensters
- *  @param[in] fullscreen Vollbildmodus ja oder nein
+ *  @param[in] width       Breite des Fensters
+ *  @param[in] height      Höhe des Fensters
+ *  @param[in] displayMode Fullscreen on/off, window resizable?
  *
  *  @return @p true bei Erfolg, @p false bei Fehler
  *
  *  @bug Hardwarecursor ist bei Fenstermodus sichtbar,
  *       Cursor deaktivieren ist fehlerhaft
  */
-bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSize, bool fullscreen)
+bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
 
-    if(!RegisterAndCreateWindow(title, newSize, fullscreen))
+    if(!RegisterAndCreateWindow(title, newSize, displayMode))
         return false;
 
-    if(fullscreen && !MakeFullscreen(GetWindowSize()))
+    if(bitset::isSet(displayMode, DisplayMode::Fullscreen) && !MakeFullscreen(GetWindowSize()))
         return false;
-    isFullscreen_ = fullscreen;
 
     if(!InitOGL())
         return false;
@@ -184,30 +183,31 @@ bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSiz
  *
  *  @todo Vollbildmodus ggf. wechseln
  */
-bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, bool fullscreen)
+bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
 {
     if(!initialized || !isWindowResizable)
         return false;
 
-    if(isFullscreen_ == fullscreen && newSize == GetWindowSize())
+    const auto fullscreen = bitset::isSet(displayMode, DisplayMode::Fullscreen);
+    if(IsFullscreen() == fullscreen && newSize == GetWindowSize())
         return true;
 
     ShowWindow(screen, SW_HIDE);
 
     VideoMode windowSize = fullscreen ? FindClosestVideoMode(newSize) : newSize;
     // Try to switch full screen first
-    if(isFullscreen_ && !fullscreen)
+    if(IsFullscreen() && !fullscreen)
     {
         if(ChangeDisplaySettings(nullptr, 0) != DISP_CHANGE_SUCCESSFUL)
             return false;
-    } else if(isFullscreen_ || fullscreen)
+    } else if(IsFullscreen() || fullscreen)
     {
         if(!MakeFullscreen(windowSize))
             return false;
     }
 
     // Fensterstyle ggf. ändern
-    std::pair<DWORD, DWORD> style = GetStyleFlags(isFullscreen_);
+    std::pair<DWORD, DWORD> style = GetStyleFlags(IsFullscreen());
     SetWindowLongPtr(screen, GWL_STYLE, style.first);
     SetWindowLongPtr(screen, GWL_EXSTYLE, style.second);
 
@@ -263,7 +263,7 @@ RECT VideoWinAPI::CalculateWindowRect(bool fullscreen, VideoMode& size) const
     return wRect;
 }
 
-bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, bool fullscreen)
+bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode)
 {
     std::wstring wTitle = boost::nowide::widen(title);
     windowClassName = wTitle.substr(0, wTitle.find(' '));
@@ -285,6 +285,7 @@ bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoM
         return false;
 
     // Create window
+    const auto fullscreen = bitset::isSet(displayMode, DisplayMode::Fullscreen);
     auto adjWindowSize = fullscreen ? FindClosestVideoMode(wndSize) : wndSize;
     RECT wRect = CalculateWindowRect(fullscreen, adjWindowSize);
 
@@ -415,7 +416,7 @@ void VideoWinAPI::DestroyScreen()
 
     UnregisterClassW(windowClassName.c_str(), GetModuleHandle(nullptr));
 
-    isFullscreen_ = false;
+    displayMode_ = bitset::set(displayMode_, DisplayMode::Fullscreen, false);
 }
 
 /**

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -419,18 +419,20 @@ OpenGL_Loader_Proc VideoWinAPI::GetLoaderFunction() const
     return wglGetProcAddress_Wrapper;
 }
 
-void VideoWinAPI::ListVideoModes(std::vector<VideoMode>& video_modes) const
+std::vector<VideoMode> VideoWinAPI::ListVideoModes() const
 {
     DEVMODE dm;
     memset(&dm, 0, sizeof(dm));
     dm.dmSize = sizeof(dm);
     unsigned m = 0;
+    std::vector<VideoMode> video_modes;
     while(EnumDisplaySettings(nullptr, m++, &dm))
     {
         VideoMode vm(static_cast<unsigned short>(dm.dmPelsWidth), static_cast<unsigned short>(dm.dmPelsHeight));
         if(!helpers::contains(video_modes, vm))
             video_modes.push_back(vm);
     }
+    return video_modes;
 }
 
 void VideoWinAPI::SetMousePos(Position pos)

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -119,12 +119,18 @@ bool VideoWinAPI::ResizeScreen(const VideoMode newSize, DisplayMode displayMode)
     {
         ShowWindow(screen, SW_HIDE);
         if(ChangeDisplaySettings(nullptr, 0) != DISP_CHANGE_SUCCESSFUL)
+        {
+            ShowWindow(screen, SW_SHOW);
             return false;
+        }
     } else if(displayMode == DisplayMode::Fullscreen)
     {
         ShowWindow(screen, SW_HIDE);
         if(!MakeFullscreen(windowSize))
+        {
+            ShowWindow(screen, SW_SHOW);
             return false;
+        }
     }
 
     // Adjust style

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -113,16 +113,16 @@ bool VideoWinAPI::ResizeScreen(const VideoMode newSize, DisplayMode displayMode)
     if(displayMode == displayMode_ && newSize == GetWindowSize())
         return true;
 
-    ShowWindow(screen, SW_HIDE);
-
     VideoMode windowSize = (displayMode == DisplayMode::Fullscreen) ? FindClosestVideoMode(newSize) : newSize;
     // Try to switch full screen first
     if(displayMode_ == DisplayMode::Fullscreen && displayMode != DisplayMode::Fullscreen)
     {
+        ShowWindow(screen, SW_HIDE);
         if(ChangeDisplaySettings(nullptr, 0) != DISP_CHANGE_SUCCESSFUL)
             return false;
     } else if(displayMode == DisplayMode::Fullscreen)
     {
+        ShowWindow(screen, SW_HIDE);
         if(!MakeFullscreen(windowSize))
             return false;
     }
@@ -141,6 +141,7 @@ bool VideoWinAPI::ResizeScreen(const VideoMode newSize, DisplayMode displayMode)
     SetNewSize(adjustedSize, Extent(adjustedSize.width, adjustedSize.height));
 
     ShowWindow(screen, SW_SHOW);
+    SetActiveWindow(screen);
     SetForegroundWindow(screen);
     SetFocus(screen);
 
@@ -197,6 +198,9 @@ std::pair<Rect, VideoMode> VideoWinAPI::CalculateWindowRect(const DisplayMode mo
             // Calculate real right/bottom based on the window style
             const auto [style, exStyle] = GetStyleFlags(mode);
             AdjustWindowRectEx(&wRect, style, false, exStyle);
+            // Make sure border/title bar is visible
+            wRect.left = std::max<LONG>(wRect.left, 0);
+            wRect.top = std::max<LONG>(wRect.top, 0);
             return std::make_pair(Rect(wRect.left, wRect.top, wRect.right - wRect.left, wRect.bottom - wRect.top),
                                   size);
         }

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -80,7 +80,7 @@ void VideoWinAPI::CleanUp()
     initialized = false;
 }
 
-bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode)
+bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode newSize, DisplayMode displayMode)
 {
     if(!initialized)
         return false;
@@ -105,7 +105,7 @@ bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSiz
     return true;
 }
 
-bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
+bool VideoWinAPI::ResizeScreen(const VideoMode newSize, DisplayMode displayMode)
 {
     if(!initialized || !isDisplayModeChangeable)
         return false;
@@ -205,7 +205,7 @@ std::pair<Rect, VideoMode> VideoWinAPI::CalculateWindowRect(const DisplayMode mo
     BOOST_UNREACHABLE_RETURN(std::make_pair(RECT{0, 0, requestedSize.width, requestedSize.height}, requestedSize));
 }
 
-bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode)
+bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoMode wndSize, DisplayMode displayMode)
 {
     std::wstring wTitle = boost::nowide::widen(title);
     windowClassName = wTitle.substr(0, wTitle.find(' '));
@@ -301,7 +301,7 @@ bool VideoWinAPI::InitOGL()
     return true;
 }
 
-bool VideoWinAPI::MakeFullscreen(const VideoMode& resolution)
+bool VideoWinAPI::MakeFullscreen(const VideoMode resolution)
 {
     DEVMODE dm;
     memset(&dm, 0, sizeof(dm));

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -117,7 +117,7 @@ bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode
 
     VideoMode windowSize = (displayMode == DisplayMode::Fullscreen) ? FindClosestVideoMode(newSize) : newSize;
     // Try to switch full screen first
-    if(displayMode_ == DisplayMode::Fullscreen)
+    if(displayMode_ == DisplayMode::Fullscreen && displayMode != DisplayMode::Fullscreen)
     {
         if(ChangeDisplaySettings(nullptr, 0) != DISP_CHANGE_SUCCESSFUL)
             return false;
@@ -133,12 +133,12 @@ bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode
     SetWindowLongPtr(screen, GWL_EXSTYLE, exStyle);
     displayMode_ = displayMode;
 
-    const RECT wRect = CalculateWindowRect(displayMode, windowSize);
+    const auto [wndArea, adjustedSize] = CalculateWindowRect(displayMode, windowSize);
 
-    // Sett size and position
+    // Set size and position
     UINT flags = SWP_SHOWWINDOW | SWP_DRAWFRAME | SWP_FRAMECHANGED;
-    SetWindowPos(screen, HWND_TOP, wRect.left, wRect.top, wRect.right - wRect.left, wRect.bottom - wRect.top, flags);
-    SetNewSize(windowSize, Extent(windowSize.width, windowSize.height));
+    SetWindowPos(screen, HWND_TOP, wndArea.left, wndArea.top, wndArea.getSize().x, wndArea.getSize().y, flags);
+    SetNewSize(adjustedSize, Extent(adjustedSize.width, adjustedSize.height));
 
     ShowWindow(screen, SW_SHOW);
     SetForegroundWindow(screen);
@@ -160,37 +160,49 @@ std::pair<DWORD, DWORD> VideoWinAPI::GetStyleFlags(const DisplayMode mode) const
         {
             result.first |= WS_OVERLAPPEDWINDOW;
             result.second |= WS_EX_WINDOWEDGE;
+            if(!mode.resizeable)
+                result.first &= ~WS_THICKFRAME;
         }
         return result;
     }
 }
 
-RECT VideoWinAPI::CalculateWindowRect(const DisplayMode mode, VideoMode size) const
+std::pair<Rect, VideoMode> VideoWinAPI::CalculateWindowRect(const DisplayMode mode, VideoMode requestedSize) const
 {
-    RECT wRect;
-    if(mode == DisplayMode::Fullscreen)
+    switch(mode.type)
     {
-        wRect.left = 0;
-        wRect.top = 0;
-    } else
-    {
-        RECT workArea;
-        SystemParametersInfo(SPI_GETWORKAREA, 0, &workArea, 0);
-        const unsigned waWidth = workArea.right - workArea.left;
-        const unsigned waHeight = workArea.bottom - workArea.top;
-        size.width = std::min<uint16_t>(size.width, waWidth);
-        size.height = std::min<uint16_t>(size.height, waHeight);
-        wRect.left = (waWidth - size.width) / 2;
-        wRect.top = (waHeight - size.height) / 2;
+        case DisplayMode::Fullscreen:
+        {
+            const auto size = FindClosestVideoMode(requestedSize);
+            return std::make_pair(Rect(Position::all(0), size.width, size.height), size);
+        };
+        case DisplayMode::BorderlessWindow:
+        {
+            const auto size = getDesktopSize(requestedSize);
+            return std::make_pair(Rect(Position::all(0), size.width, size.height), size);
+        }
+        case DisplayMode::Windowed:
+        {
+            RECT workArea;
+            SystemParametersInfo(SPI_GETWORKAREA, 0, &workArea, 0);
+            const unsigned waWidth = workArea.right - workArea.left;
+            const unsigned waHeight = workArea.bottom - workArea.top;
+            const VideoMode size(std::min<uint16_t>(requestedSize.width, waWidth),
+                                 std::min<uint16_t>(requestedSize.height, waHeight));
+            RECT wRect;
+            wRect.left = (waWidth - size.width) / 2;
+            wRect.top = (waHeight - size.height) / 2;
+            wRect.right = wRect.left + size.width;
+            wRect.bottom = wRect.top + size.height;
+            // Calculate real right/bottom based on the window style
+            const auto [style, exStyle] = GetStyleFlags(mode);
+            AdjustWindowRectEx(&wRect, style, false, exStyle);
+            return std::make_pair(Rect(wRect.left, wRect.top, wRect.right - wRect.left, wRect.bottom - wRect.top),
+                                  size);
+        }
     }
-    wRect.right = wRect.left + size.width;
-    wRect.bottom = wRect.top + size.height;
 
-    const auto [style, exStyle] = GetStyleFlags(mode);
-    // Calculate real right/bottom based on the window style
-    AdjustWindowRectEx(&wRect, style, false, exStyle);
-
-    return wRect;
+    BOOST_UNREACHABLE_RETURN(std::make_pair(RECT{0, 0, requestedSize.width, requestedSize.height}, requestedSize));
 }
 
 bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode)
@@ -215,19 +227,16 @@ bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoM
         return false;
 
     // Create window
-    const auto reqWindowSize = (displayMode == DisplayMode::Fullscreen) ? FindClosestVideoMode(wndSize) : wndSize;
-    const RECT wRect = CalculateWindowRect(displayMode, reqWindowSize);
-    const VideoMode adjWindowSize(static_cast<unsigned short>(wRect.right - wRect.left),
-                                  static_cast<unsigned short>(wRect.bottom - wRect.top));
+    const auto [wndArea, adjustedSize] = CalculateWindowRect(displayMode, wndSize);
     const auto [style, exStyle] = GetStyleFlags(displayMode);
     screen =
-      CreateWindowExW(exStyle, windowClassName.c_str(), wTitle.c_str(), style, wRect.left, wRect.top,
-                      adjWindowSize.width, adjWindowSize.height, nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
+      CreateWindowExW(exStyle, windowClassName.c_str(), wTitle.c_str(), style, wndArea.left, wndArea.top,
+                      wndArea.getSize().x, wndArea.getSize().y, nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
 
     if(screen == nullptr)
         return false;
 
-    SetNewSize(adjWindowSize, Extent(adjWindowSize.width, adjWindowSize.height));
+    SetNewSize(adjustedSize, Extent(adjustedSize.width, adjustedSize.height));
 
     SetClipboardViewer(screen);
 
@@ -310,6 +319,24 @@ bool VideoWinAPI::MakeFullscreen(const VideoMode& resolution)
         return false;
     }
     return true;
+}
+
+VideoMode VideoWinAPI::getDesktopSize(const VideoMode fallback) const
+{
+    HMONITOR monitor;
+    if(screen)
+        monitor = MonitorFromWindow(screen, MONITOR_DEFAULTTONEAREST);
+    else
+        monitor = MonitorFromPoint(POINT{0, 0}, MONITOR_DEFAULTTOPRIMARY);
+
+    MONITORINFO mi{};
+    mi.cbSize = sizeof(mi);
+    if(GetMonitorInfo(monitor, &mi) == TRUE)
+    {
+        return VideoMode(static_cast<unsigned short>(mi.rcMonitor.right - mi.rcMonitor.left),
+                         static_cast<unsigned short>(mi.rcMonitor.bottom - mi.rcMonitor.top));
+    } else
+        return fallback;
 }
 
 void VideoWinAPI::DestroyScreen()

--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -27,18 +27,8 @@ void setSpecialKeys(KeyEvent& ke, LPARAM lParam)
 }
 } // namespace
 
-/**
- *  Zeiger auf die aktuelle Instanz.
- */
 static VideoWinAPI* pVideoWinAPI = nullptr;
 
-/**
- *  Instanzierungsfunktion von @p VideoWinAPI.
- *
- *  @param[in] CallBack DriverCallback für Rückmeldungen.
- *
- *  @return liefert eine Instanz des jeweiligen Treibers
- */
 IVideoDriver* CreateVideoInstance(VideoDriverLoaderInterface* CallBack)
 {
     return new VideoWinAPI(CallBack);
@@ -54,39 +44,9 @@ const char* GetDriverName()
     return "(WinAPI) OpenGL via the glorious WinAPI";
 }
 
-/** @class VideoWinAPI
- *
- *  Klasse für den WinAPI Videotreiber.
- */
-
-/** @var VideoWinAPI::dm_prev
- *
- *  Bildschirmmodus.
- */
-
-/** @var VideoWinAPI::screen
- *
- *  Fensterhandle.
- */
-
-/** @var VideoWinAPI::screen_dc
- *
- *  Zeichenkontext des Fensters.
- */
-
-/** @var VideoWinAPI::screen_rc
- *
- *  OpenGL-Kontext des Fensters.
- */
-
-/**
- *  Konstruktor von @p VideoWinAPI.
- *
- *  @param[in] CallBack DriverCallback für Rückmeldungen.
- */
 VideoWinAPI::VideoWinAPI(VideoDriverLoaderInterface* CallBack)
     : VideoDriver(CallBack), mouse_z(0), screen(nullptr), screen_dc(nullptr), screen_rc(nullptr),
-      isWindowResizable(false), isMinimized(true)
+      isDisplayModeChangeable(false), isMinimized(true)
 {
     pVideoWinAPI = this;
 }
@@ -97,21 +57,11 @@ VideoWinAPI::~VideoWinAPI()
     pVideoWinAPI = nullptr;
 }
 
-/**
- *  Funktion zum Auslesen des Treibernamens.
- *
- *  @return liefert den Treibernamen zurück
- */
 const char* VideoWinAPI::GetName() const
 {
     return GetDriverName();
 }
 
-/**
- *  Treiberinitialisierungsfunktion.
- *
- *  @return @p true bei Erfolg, @p false bei Fehler
- */
 bool VideoWinAPI::Initialize()
 {
     screen = nullptr;
@@ -124,30 +74,12 @@ bool VideoWinAPI::Initialize()
     return initialized;
 }
 
-/**
- *  Treiberaufräumfunktion.
- */
 void VideoWinAPI::CleanUp()
 {
-    // Fenster zerstören
     DestroyScreen();
-
-    // nun sind wir nicht mehr initalisiert
     initialized = false;
 }
 
-/**
- *  Erstellt das Fenster mit entsprechenden Werten.
- *
- *  @param[in] width       Breite des Fensters
- *  @param[in] height      Höhe des Fensters
- *  @param[in] displayMode Fullscreen on/off, window resizable?
- *
- *  @return @p true bei Erfolg, @p false bei Fehler
- *
- *  @bug Hardwarecursor ist bei Fenstermodus sichtbar,
- *       Cursor deaktivieren ist fehlerhaft
- */
 bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode)
 {
     if(!initialized)
@@ -156,9 +88,10 @@ bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSiz
     if(!RegisterAndCreateWindow(title, newSize, displayMode))
         return false;
 
-    if(bitset::isSet(displayMode, DisplayMode::Fullscreen) && !MakeFullscreen(GetWindowSize()))
+    if(displayMode == DisplayMode::Fullscreen && !MakeFullscreen(GetWindowSize()))
         return false;
 
+    displayMode_ = displayMode;
     if(!InitOGL())
         return false;
 
@@ -172,48 +105,37 @@ bool VideoWinAPI::CreateScreen(const std::string& title, const VideoMode& newSiz
     return true;
 }
 
-/**
- *  Erstellt oder verändert das Fenster mit entsprechenden Werten.
- *
- *  @param[in] width      Breite des Fensters
- *  @param[in] height     Höhe des Fensters
- *  @param[in] fullscreen Vollbildmodus ja oder nein
- *
- *  @return @p true bei Erfolg, @p false bei Fehler
- *
- *  @todo Vollbildmodus ggf. wechseln
- */
 bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
 {
-    if(!initialized || !isWindowResizable)
+    if(!initialized || !isDisplayModeChangeable)
         return false;
 
-    const auto fullscreen = bitset::isSet(displayMode, DisplayMode::Fullscreen);
-    if(IsFullscreen() == fullscreen && newSize == GetWindowSize())
+    if(displayMode == displayMode_ && newSize == GetWindowSize())
         return true;
 
     ShowWindow(screen, SW_HIDE);
 
-    VideoMode windowSize = fullscreen ? FindClosestVideoMode(newSize) : newSize;
+    VideoMode windowSize = (displayMode == DisplayMode::Fullscreen) ? FindClosestVideoMode(newSize) : newSize;
     // Try to switch full screen first
-    if(IsFullscreen() && !fullscreen)
+    if(displayMode_ == DisplayMode::Fullscreen)
     {
         if(ChangeDisplaySettings(nullptr, 0) != DISP_CHANGE_SUCCESSFUL)
             return false;
-    } else if(IsFullscreen() || fullscreen)
+    } else if(displayMode == DisplayMode::Fullscreen)
     {
         if(!MakeFullscreen(windowSize))
             return false;
     }
 
-    // Fensterstyle ggf. ändern
-    std::pair<DWORD, DWORD> style = GetStyleFlags(IsFullscreen());
-    SetWindowLongPtr(screen, GWL_STYLE, style.first);
-    SetWindowLongPtr(screen, GWL_EXSTYLE, style.second);
+    // Adjust style
+    const auto [style, exStyle] = GetStyleFlags(displayMode);
+    SetWindowLongPtr(screen, GWL_STYLE, style);
+    SetWindowLongPtr(screen, GWL_EXSTYLE, exStyle);
+    displayMode_ = displayMode;
 
-    RECT wRect = CalculateWindowRect(isFullscreen_, windowSize);
+    const RECT wRect = CalculateWindowRect(displayMode, windowSize);
 
-    // Fenstergröße ändern
+    // Sett size and position
     UINT flags = SWP_SHOWWINDOW | SWP_DRAWFRAME | SWP_FRAMECHANGED;
     SetWindowPos(screen, HWND_TOP, wRect.left, wRect.top, wRect.right - wRect.left, wRect.bottom - wRect.top, flags);
     SetNewSize(windowSize, Extent(windowSize.width, windowSize.height));
@@ -225,20 +147,28 @@ bool VideoWinAPI::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode
     return true;
 }
 
-std::pair<DWORD, DWORD> VideoWinAPI::GetStyleFlags(bool fullscreen) const
+std::pair<DWORD, DWORD> VideoWinAPI::GetStyleFlags(const DisplayMode mode) const
 {
-    if(fullscreen)
+    if(mode == DisplayMode::Fullscreen)
         return std::make_pair(WS_POPUP, WS_EX_APPWINDOW);
     else
-        return std::make_pair(WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_OVERLAPPEDWINDOW | WS_SYSMENU | WS_MINIMIZEBOX
-                                | WS_CAPTION,
-                              WS_EX_APPWINDOW | WS_EX_WINDOWEDGE);
+    {
+        auto result = std::make_pair(WS_CLIPSIBLINGS | WS_CLIPCHILDREN, WS_EX_APPWINDOW);
+        if(mode == DisplayMode::BorderlessWindow)
+            result.first |= WS_POPUP;
+        else
+        {
+            result.first |= WS_OVERLAPPEDWINDOW;
+            result.second |= WS_EX_WINDOWEDGE;
+        }
+        return result;
+    }
 }
 
-RECT VideoWinAPI::CalculateWindowRect(bool fullscreen, VideoMode& size) const
+RECT VideoWinAPI::CalculateWindowRect(const DisplayMode mode, VideoMode size) const
 {
     RECT wRect;
-    if(fullscreen)
+    if(mode == DisplayMode::Fullscreen)
     {
         wRect.left = 0;
         wRect.top = 0;
@@ -246,8 +176,8 @@ RECT VideoWinAPI::CalculateWindowRect(bool fullscreen, VideoMode& size) const
     {
         RECT workArea;
         SystemParametersInfo(SPI_GETWORKAREA, 0, &workArea, 0);
-        unsigned waWidth = workArea.right - workArea.left;
-        unsigned waHeight = workArea.bottom - workArea.top;
+        const unsigned waWidth = workArea.right - workArea.left;
+        const unsigned waHeight = workArea.bottom - workArea.top;
         size.width = std::min<uint16_t>(size.width, waWidth);
         size.height = std::min<uint16_t>(size.height, waHeight);
         wRect.left = (waWidth - size.width) / 2;
@@ -256,9 +186,9 @@ RECT VideoWinAPI::CalculateWindowRect(bool fullscreen, VideoMode& size) const
     wRect.right = wRect.left + size.width;
     wRect.bottom = wRect.top + size.height;
 
-    std::pair<DWORD, DWORD> style = GetStyleFlags(fullscreen);
+    const auto [style, exStyle] = GetStyleFlags(mode);
     // Calculate real right/bottom based on the window style
-    AdjustWindowRectEx(&wRect, style.first, false, style.second);
+    AdjustWindowRectEx(&wRect, style, false, exStyle);
 
     return wRect;
 }
@@ -285,14 +215,14 @@ bool VideoWinAPI::RegisterAndCreateWindow(const std::string& title, const VideoM
         return false;
 
     // Create window
-    const auto fullscreen = bitset::isSet(displayMode, DisplayMode::Fullscreen);
-    auto adjWindowSize = fullscreen ? FindClosestVideoMode(wndSize) : wndSize;
-    RECT wRect = CalculateWindowRect(fullscreen, adjWindowSize);
-
-    std::pair<DWORD, DWORD> style = GetStyleFlags(fullscreen);
-    screen = CreateWindowExW(style.second, windowClassName.c_str(), wTitle.c_str(), style.first, wRect.left, wRect.top,
-                             wRect.right - wRect.left, wRect.bottom - wRect.top, nullptr, nullptr,
-                             GetModuleHandle(nullptr), nullptr);
+    const auto reqWindowSize = (displayMode == DisplayMode::Fullscreen) ? FindClosestVideoMode(wndSize) : wndSize;
+    const RECT wRect = CalculateWindowRect(displayMode, reqWindowSize);
+    const VideoMode adjWindowSize(static_cast<unsigned short>(wRect.right - wRect.left),
+                                  static_cast<unsigned short>(wRect.bottom - wRect.top));
+    const auto [style, exStyle] = GetStyleFlags(displayMode);
+    screen =
+      CreateWindowExW(exStyle, windowClassName.c_str(), wTitle.c_str(), style, wRect.left, wRect.top,
+                      adjWindowSize.width, adjWindowSize.height, nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
 
     if(screen == nullptr)
         return false;
@@ -382,12 +312,8 @@ bool VideoWinAPI::MakeFullscreen(const VideoMode& resolution)
     return true;
 }
 
-/**
- *  Schliesst das Fenster.
- */
 void VideoWinAPI::DestroyScreen()
 {
-    // Fenster schliessen
     EndDialog(screen, 0);
 
     // Reset display settings to defaults
@@ -415,31 +341,17 @@ void VideoWinAPI::DestroyScreen()
     screen = nullptr;
 
     UnregisterClassW(windowClassName.c_str(), GetModuleHandle(nullptr));
-
-    displayMode_ = bitset::set(displayMode_, DisplayMode::Fullscreen, false);
 }
 
-/**
- *  Wechselt die OpenGL-Puffer.
- *
- *  @return @p true bei Erfolg, @p false bei Fehler
- */
 bool VideoWinAPI::SwapBuffers()
 {
     if(!screen_dc)
         return false;
 
-    // Puffer wechseln
     ::SwapBuffers(screen_dc);
-
     return true;
 }
 
-/**
- *  Die Nachrichtenschleife.
- *
- *  @return @p true bei Erfolg, @p false bei Fehler
- */
 bool VideoWinAPI::MessageLoop()
 {
     MSG msg;
@@ -459,11 +371,6 @@ void VideoWinAPI::ShowErrorMessage(const std::string& title, const std::string& 
     MessageBoxA(nullptr, message.c_str(), title.c_str(), MB_OK | MB_ICONEXCLAMATION);
 }
 
-/**
- *  Funktion zum Auslesen des TickCounts.
- *
- *  @return liefert den TickCount
- */
 unsigned long VideoWinAPI::GetTickCount() const
 {
     return ::GetTickCount();
@@ -485,7 +392,6 @@ OpenGL_Loader_Proc VideoWinAPI::GetLoaderFunction() const
     return wglGetProcAddress_Wrapper;
 }
 
-/// Listet verfügbare Videomodi auf
 void VideoWinAPI::ListVideoModes(std::vector<VideoMode>& video_modes) const
 {
     DEVMODE dm;
@@ -500,12 +406,6 @@ void VideoWinAPI::ListVideoModes(std::vector<VideoMode>& video_modes) const
     }
 }
 
-/**
- *  Funktion zum Setzen der Mauskoordinaten.
- *
- *  @param[in] x X-Koordinate
- *  @param[in] y Y-Koordinate
- */
 void VideoWinAPI::SetMousePos(Position pos)
 {
     if(GetActiveWindow())
@@ -518,11 +418,6 @@ void VideoWinAPI::SetMousePos(Position pos)
     }
 }
 
-/**
- *  Funktion zum Senden einer gedrückten Taste.
- *
- *  @param[in] c Tastencode
- */
 void VideoWinAPI::OnWMChar(unsigned c, bool disablepaste, LPARAM lParam)
 {
     // Keine Leerzeichen als Extra-Zeichen senden!
@@ -544,11 +439,6 @@ void VideoWinAPI::OnWMChar(unsigned c, bool disablepaste, LPARAM lParam)
     CallBack->Msg_KeyDown(ke);
 }
 
-/**
- *  Funktion zum Senden einer gedrückten Taste.
- *
- *  @param[in] c Tastencode
- */
 void VideoWinAPI::OnWMKeyDown(unsigned c, LPARAM lParam)
 {
     KeyEvent ke;
@@ -590,9 +480,6 @@ void VideoWinAPI::OnWMKeyDown(unsigned c, LPARAM lParam)
         CallBack->Msg_KeyDown(ke);
 }
 
-/**
- *  Funktion zum Pasten von Text aus dem Clipboard.
- */
 void VideoWinAPI::OnWMPaste()
 {
     if(!IsClipboardFormatAvailable(CF_UNICODETEXT))
@@ -614,14 +501,6 @@ void VideoWinAPI::OnWMPaste()
     CloseClipboard();
 }
 
-/**
- *  Callbackfunktion der WinAPI.
- *
- *  @param[in] window Fensterhandle
- *  @param[in] msg    Fensternachricht
- *  @param[in] wParam Erster Nachrichtenparameter
- *  @param[in] wParam Zweiter Nachrichtenparameter
- */
 LRESULT CALLBACK VideoWinAPI::WindowProc(HWND window, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     switch(msg)
@@ -639,9 +518,9 @@ LRESULT CALLBACK VideoWinAPI::WindowProc(HWND window, UINT msg, WPARAM wParam, L
             {
                 pVideoWinAPI->SetNewSize(newSize, Extent(newSize.width, newSize.height));
 
-                pVideoWinAPI->isWindowResizable = false;
+                pVideoWinAPI->isDisplayModeChangeable = false;
                 pVideoWinAPI->CallBack->WindowResized();
-                pVideoWinAPI->isWindowResizable = true;
+                pVideoWinAPI->isDisplayModeChangeable = true;
             }
             pVideoWinAPI->isMinimized = false;
             break;
@@ -721,9 +600,6 @@ LRESULT CALLBACK VideoWinAPI::WindowProc(HWND window, UINT msg, WPARAM wParam, L
     return DefWindowProcW(window, msg, wParam, lParam);
 }
 
-/**
- *  Get state of the modifier keys
- */
 KeyEvent VideoWinAPI::GetModKeyState() const
 {
     KeyEvent ke;
@@ -733,7 +609,6 @@ KeyEvent VideoWinAPI::GetModKeyState() const
     return ke;
 }
 
-/// Gibt Pointer auf ein Fenster zurück (device-dependent!), HWND unter Windows
 void* VideoWinAPI::GetMapPointer() const
 {
     return (void*)this->screen;

--- a/extras/videoDrivers/WinAPI/WinAPI.h
+++ b/extras/videoDrivers/WinAPI/WinAPI.h
@@ -30,10 +30,10 @@ public:
     bool Initialize() override;
 
     /// Erstellt das Fenster mit entsprechenden Werten.
-    bool CreateScreen(const std::string& title, const VideoMode& newSize, bool fullscreen) override;
+    bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) override;
 
     /// Erstellt oder verändert das Fenster mit entsprechenden Werten.
-    bool ResizeScreen(const VideoMode& newSize, bool fullscreen) override;
+    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
 
     /// Schliesst das Fenster.
     void DestroyScreen() override;
@@ -69,7 +69,7 @@ private:
     std::pair<DWORD, DWORD> GetStyleFlags(bool fullscreen) const;
     /// Calculate the rect for the window and adjusts the (usable) size if required
     RECT CalculateWindowRect(bool fullscreen, VideoMode& size) const;
-    bool RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, bool fullscreen);
+    bool RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode);
     bool InitOGL();
     static bool MakeFullscreen(const VideoMode& resolution);
 

--- a/extras/videoDrivers/WinAPI/WinAPI.h
+++ b/extras/videoDrivers/WinAPI/WinAPI.h
@@ -29,10 +29,10 @@ public:
     bool Initialize() override;
 
     /// Create window/rendering context with given title, size and display mode, return true on success
-    bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) override;
+    bool CreateScreen(const std::string& title, const VideoMode newSize, DisplayMode displayMode) override;
 
     /// Change window/resolution, return true on success
-    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
+    bool ResizeScreen(VideoMode newSize, DisplayMode displayMode) override;
 
     /// Close window
     void DestroyScreen() override;
@@ -70,9 +70,9 @@ private:
     /// Calculate the rect for the window of the requested size at the display mode
     /// Returns the final rect (position&size) for the window and the possibly adjusted size of the render region
     std::pair<Rect, VideoMode> CalculateWindowRect(DisplayMode mode, VideoMode requestedSize) const;
-    bool RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode);
+    bool RegisterAndCreateWindow(const std::string& title, VideoMode wndSize, DisplayMode displayMode);
     bool InitOGL();
-    static bool MakeFullscreen(const VideoMode& resolution);
+    static bool MakeFullscreen(VideoMode resolution);
     VideoMode getDesktopSize(VideoMode fallback) const;
 
     /// Callback for pressed character keys

--- a/extras/videoDrivers/WinAPI/WinAPI.h
+++ b/extras/videoDrivers/WinAPI/WinAPI.h
@@ -12,57 +12,54 @@
 #include <string>
 #include <utility>
 
-/// Klasse für den WinAPI Videotreiber.
 class VideoWinAPI final : public VideoDriver
 {
-    /// Treiberaufräumfunktion.
     void CleanUp();
 
 public:
     VideoWinAPI(VideoDriverLoaderInterface* CallBack);
-
     ~VideoWinAPI();
 
-    /// Funktion zum Auslesen des Treibernamens.
+    /// Return name of driver
     const char* GetName() const override;
 
-    /// Treiberinitialisierungsfunktion.
+    /// Initialize the driver, return true on success
     bool Initialize() override;
 
-    /// Erstellt das Fenster mit entsprechenden Werten.
+    /// Create window/rendering context with given title, size and display mode, return true on success
     bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) override;
 
-    /// Erstellt oder verändert das Fenster mit entsprechenden Werten.
+    /// Change window/resolution, return true on success
     bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
 
-    /// Schliesst das Fenster.
+    /// Close window
     void DestroyScreen() override;
 
-    /// Wechselt die OpenGL-Puffer.
+    /// Swap OpenGL buffers
     bool SwapBuffers() override;
 
-    /// Die Nachrichtenschleife.
+    /// Process messages/events, return false when the application should quit
     bool MessageLoop() override;
 
     /// Popup Window
     void ShowErrorMessage(const std::string& title, const std::string& message) override;
 
-    /// Funktion zum Auslesen des TickCounts.
+    /// Return the current tick count (time since epoch in ms)
     unsigned long GetTickCount() const override;
 
-    /// Funktion zum Holen einer Subfunktion.
+    /// Get a pointer to an OpenGL function loader
     OpenGL_Loader_Proc GetLoaderFunction() const override;
 
-    /// Listet verfügbare Videomodi auf
+    /// Return supported resolutions
     void ListVideoModes(std::vector<VideoMode>& video_modes) const override;
 
-    /// Funktion zum Setzen der Mauskoordinaten.
+    /// Set position of the mouse cursor in screen coordinates
     void SetMousePos(Position pos) override;
 
     /// Get state of the modifier keys
     KeyEvent GetModKeyState() const override;
 
-    /// Gibt Pointer auf ein Fenster zurück (device-dependent!), HWND unter Windows
+    /// Get pointer to window (device-dependent!)
     void* GetMapPointer() const override;
 
 private:
@@ -74,21 +71,21 @@ private:
     bool InitOGL();
     static bool MakeFullscreen(const VideoMode& resolution);
 
-    /// Funktion zum Senden einer gedrückten Taste.
+    /// Callback for pressed character keys
     void OnWMChar(unsigned c, bool disablepaste = false, LPARAM lParam = 0);
     void OnWMKeyDown(unsigned c, LPARAM lParam = 0);
 
-    /// Funktion zum Pasten von Text aus dem Clipboard.
+    /// Handle paste from clipboard (CTRL+V)
     void OnWMPaste();
 
-    /// Callbackfunktion der WinAPI.
+    /// Window callback function
     static LRESULT CALLBACK WindowProc(HWND window, UINT msg, WPARAM wParam, LPARAM lParam);
 
 private:
-    int mouse_z;     /// Scrolling position for mousewheel.
-    HWND screen;     /// Fensterhandle.
-    HDC screen_dc;   /// Zeichenkontext des Fensters.
-    HGLRC screen_rc; /// OpenGL-Kontext des Fensters.
+    int mouse_z;     /// Scrolling position for mouse wheel.
+    HWND screen;     /// window handle
+    HDC screen_dc;   /// Draw context of the window.
+    HGLRC screen_rc; /// OpenGL-context of the window.
     bool isDisplayModeChangeable, isMinimized;
     std::wstring windowClassName;
 };

--- a/extras/videoDrivers/WinAPI/WinAPI.h
+++ b/extras/videoDrivers/WinAPI/WinAPI.h
@@ -53,7 +53,7 @@ public:
     OpenGL_Loader_Proc GetLoaderFunction() const override;
 
     /// Return supported resolutions
-    void ListVideoModes(std::vector<VideoMode>& video_modes) const override;
+    std::vector<VideoMode> ListVideoModes() const override;
 
     /// Set position of the mouse cursor in screen coordinates
     void SetMousePos(Position pos) override;

--- a/extras/videoDrivers/WinAPI/WinAPI.h
+++ b/extras/videoDrivers/WinAPI/WinAPI.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -66,9 +66,10 @@ public:
     void* GetMapPointer() const override;
 
 private:
-    std::pair<DWORD, DWORD> GetStyleFlags(bool fullscreen) const;
-    /// Calculate the rect for the window and adjusts the (usable) size if required
-    RECT CalculateWindowRect(bool fullscreen, VideoMode& size) const;
+    /// Get style and extended style flags
+    std::pair<DWORD, DWORD> GetStyleFlags(DisplayMode mode) const;
+    /// Calculate the rect for the window of the requested size
+    RECT CalculateWindowRect(DisplayMode mode, VideoMode size) const;
     bool RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode);
     bool InitOGL();
     static bool MakeFullscreen(const VideoMode& resolution);
@@ -88,6 +89,6 @@ private:
     HWND screen;     /// Fensterhandle.
     HDC screen_dc;   /// Zeichenkontext des Fensters.
     HGLRC screen_rc; /// OpenGL-Kontext des Fensters.
-    bool isWindowResizable, isMinimized;
+    bool isDisplayModeChangeable, isMinimized;
     std::wstring windowClassName;
 };

--- a/extras/videoDrivers/WinAPI/WinAPI.h
+++ b/extras/videoDrivers/WinAPI/WinAPI.h
@@ -8,6 +8,8 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
 #endif
+#include "Point.h"
+#include "Rect.h"
 #include <windows.h>
 #include <string>
 #include <utility>
@@ -65,11 +67,13 @@ public:
 private:
     /// Get style and extended style flags
     std::pair<DWORD, DWORD> GetStyleFlags(DisplayMode mode) const;
-    /// Calculate the rect for the window of the requested size
-    RECT CalculateWindowRect(DisplayMode mode, VideoMode size) const;
+    /// Calculate the rect for the window of the requested size at the display mode
+    /// Returns the final rect (position&size) for the window and the possibly adjusted size of the render region
+    std::pair<Rect, VideoMode> CalculateWindowRect(DisplayMode mode, VideoMode requestedSize) const;
     bool RegisterAndCreateWindow(const std::string& title, const VideoMode& wndSize, DisplayMode displayMode);
     bool InitOGL();
     static bool MakeFullscreen(const VideoMode& resolution);
+    VideoMode getDesktopSize(VideoMode fallback) const;
 
     /// Callback for pressed character keys
     void OnWMChar(unsigned c, bool disablepaste = false, LPARAM lParam = 0);

--- a/libs/common/include/helpers/containerUtils.h
+++ b/libs/common/include/helpers/containerUtils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -33,6 +33,16 @@ namespace detail {
     {};
     template<class T, class U>
     constexpr bool has_find_v = has_find<T, U>::value;
+
+    template<typename T, typename = void>
+    struct is_less_comparable : std::false_type
+    {};
+
+    template<typename T>
+    struct is_less_comparable<T, std::void_t<decltype(std::declval<const T&>() < std::declval<const T&>())>> :
+        std::true_type
+    {};
+
 } // namespace detail
 
 /// Removes an element from a container by its reverse iterator and returns an iterator to the next element
@@ -144,19 +154,6 @@ void makeUniqueSorted(T& container)
     const auto newEnd = std::unique(begin(container), end(container));
     container.erase(newEnd, end(container));
 }
-/// Remove duplicate values from the given container, sorts it first
-template<class T>
-void makeUnique(T& container)
-{
-    sort(container);
-    makeUniqueSorted(container);
-}
-template<class T, class T_Predicate>
-void makeUnique(T& container, T_Predicate&& predicate)
-{
-    sort(container, std::forward<T_Predicate>(predicate));
-    makeUniqueSorted(container);
-}
 /// Remove duplicate values from the given container without changing the order
 template<class T>
 void makeUniqueStable(T& container)
@@ -175,6 +172,24 @@ void makeUniqueStable(T& container)
             *(itInsert++) = std::move(*it);
     }
     container.erase(itInsert, end(container));
+}
+
+/// Remove duplicate values from the given container, sorts it first if possible
+template<class T>
+void makeUnique(T& container)
+{
+    if constexpr(detail::is_less_comparable<typename T::value_type>::value)
+    {
+        std::sort(begin(container), end(container));
+        makeUniqueSorted(container);
+    } else
+        makeUniqueStable(container);
+}
+template<class T, class T_Predicate>
+void makeUnique(T& container, T_Predicate&& predicate)
+{
+    std::sort(begin(container), end(container), std::forward<T_Predicate>(predicate));
+    makeUniqueSorted(container);
 }
 
 /// Returns the index of the given element in the container or -1 when not found

--- a/libs/driver/include/driver/DriverInterfaceVersion.h
+++ b/libs/driver/include/driver/DriverInterfaceVersion.h
@@ -1,7 +1,7 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
-#define DRIVERAPIVERSION 7
+#define DRIVERAPIVERSION 8

--- a/libs/driver/include/driver/VideoDriver.h
+++ b/libs/driver/include/driver/VideoDriver.h
@@ -32,7 +32,9 @@ public:
 
     VideoMode GetWindowSize() const override final { return windowSize_; }
     Extent GetRenderSize() const override final { return scaledRenderSize_; }
-    bool IsFullscreen() const override final { return isFullscreen_; }
+    DisplayMode GetDisplayMode() const override final { return displayMode_; }
+    bool IsFullscreen() const override final { return bitset::isSet(displayMode_, DisplayMode::Fullscreen); }
+    bool IsResizable() const override final { return bitset::isSet(displayMode_, DisplayMode::Fullscreen); }
 
     float getDpiScale() const override final { return dpiScale_; }
 
@@ -49,11 +51,16 @@ protected:
     VideoMode FindClosestVideoMode(const VideoMode& mode) const;
     void SetNewSize(VideoMode windowSize, Extent renderSize);
 
+    void SetResizableFlag(bool resizable)
+    {
+        displayMode_ = bitset::set(displayMode_, DisplayMode::Resizable, resizable);
+    }
+
     VideoDriverLoaderInterface* CallBack; /// DriverCallback to notify on player input
     bool initialized;
     MouseCoords mouse_xy;           /// Mouse state
     std::array<bool, 512> keyboard; /// Keyboard state
-    bool isFullscreen_;
+    DisplayMode displayMode_;       /// Fullscreen/resizable?
 
 private:
     // cached as possibly used often

--- a/libs/driver/include/driver/VideoDriver.h
+++ b/libs/driver/include/driver/VideoDriver.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -33,8 +33,6 @@ public:
     VideoMode GetWindowSize() const override final { return windowSize_; }
     Extent GetRenderSize() const override final { return scaledRenderSize_; }
     DisplayMode GetDisplayMode() const override final { return displayMode_; }
-    bool IsFullscreen() const override final { return bitset::isSet(displayMode_, DisplayMode::Fullscreen); }
-    bool IsResizable() const override final { return bitset::isSet(displayMode_, DisplayMode::Fullscreen); }
 
     float getDpiScale() const override final { return dpiScale_; }
 
@@ -50,11 +48,6 @@ public:
 protected:
     VideoMode FindClosestVideoMode(const VideoMode& mode) const;
     void SetNewSize(VideoMode windowSize, Extent renderSize);
-
-    void SetResizableFlag(bool resizable)
-    {
-        displayMode_ = bitset::set(displayMode_, DisplayMode::Resizable, resizable);
-    }
 
     VideoDriverLoaderInterface* CallBack; /// DriverCallback to notify on player input
     bool initialized;

--- a/libs/driver/include/driver/VideoDriver.h
+++ b/libs/driver/include/driver/VideoDriver.h
@@ -46,7 +46,7 @@ public:
     bool IsOpenGL() const override { return true; }
 
 protected:
-    VideoMode FindClosestVideoMode(const VideoMode& mode) const;
+    VideoMode FindClosestVideoMode(VideoMode mode) const;
     void SetNewSize(VideoMode windowSize, Extent renderSize);
 
     VideoDriverLoaderInterface* CallBack; /// DriverCallback to notify on player input

--- a/libs/driver/include/driver/VideoInterface.h
+++ b/libs/driver/include/driver/VideoInterface.h
@@ -27,9 +27,9 @@ public:
     virtual bool Initialize() = 0;
 
     /// Erstellt das Fenster mit entsprechenden Werten.
-    virtual bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) = 0;
+    virtual bool CreateScreen(const std::string& title, VideoMode newSize, DisplayMode displayMode) = 0;
 
-    virtual bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) = 0;
+    virtual bool ResizeScreen(VideoMode newSize, DisplayMode displayMode) = 0;
 
     /// Schliesst das Fenster.
     virtual void DestroyScreen() = 0;

--- a/libs/driver/include/driver/VideoInterface.h
+++ b/libs/driver/include/driver/VideoInterface.h
@@ -9,11 +9,95 @@
 #include "Point.h"
 #include "VideoMode.h"
 #include "exportImport.h"
+// #include "s25util/enumUtils.h"
 #include <string>
+#include <type_traits>
 #include <vector>
 
 /// Function type for loading OpenGL methods
 using OpenGL_Loader_Proc = void* (*)(const char*);
+
+template<typename Enum>
+struct IsBitset : std::false_type
+{};
+
+template<typename Enum>
+using IsValidBitset =
+  std::integral_constant<bool, IsBitset<Enum>::value && std::is_unsigned<std::underlying_type_t<Enum>>::value>;
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr auto operator~(Enum val) noexcept
+{
+    using T = std::underlying_type_t<Enum>;
+    return Enum(~static_cast<T>(val));
+}
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr auto operator&(Enum lhs, Enum rhs) noexcept
+{
+    using T = std::underlying_type_t<Enum>;
+    return Enum(static_cast<T>(lhs) & static_cast<T>(rhs));
+}
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr auto operator|(Enum lhs, Enum rhs) noexcept
+{
+    using T = std::underlying_type_t<Enum>;
+    return Enum(static_cast<T>(lhs) | static_cast<T>(rhs));
+}
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr auto operator^(Enum lhs, Enum rhs) noexcept
+{
+    using T = std::underlying_type_t<Enum>;
+    return Enum(static_cast<T>(lhs) ^ static_cast<T>(rhs));
+}
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr auto operator&=(Enum& lhs, Enum rhs) noexcept
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr auto operator|=(Enum& lhs, Enum rhs) noexcept
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr auto operator^=(Enum& lhs, Enum rhs) noexcept
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
+
+namespace bitset {
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+constexpr bool isSet(Enum val, Enum flag)
+{
+    return (val & flag) != Enum(0);
+}
+
+template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
+[[nodiscard]] constexpr Enum set(Enum val, Enum flag, bool state)
+{
+    return state ? (val | flag) : (val & ~flag);
+}
+} // namespace bitset
+
+enum class DisplayMode : unsigned
+{
+    None,
+    Fullscreen = (1 << 0),
+    Resizable = (1 << 1)
+};
+
+template<>
+struct IsBitset<DisplayMode> : std::true_type
+{};
 
 class BOOST_SYMBOL_VISIBLE IVideoDriver
 {
@@ -26,9 +110,9 @@ public:
     virtual bool Initialize() = 0;
 
     /// Erstellt das Fenster mit entsprechenden Werten.
-    virtual bool CreateScreen(const std::string& title, const VideoMode& newSize, bool fullscreen) = 0;
+    virtual bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) = 0;
 
-    virtual bool ResizeScreen(const VideoMode& newSize, bool fullscreen) = 0;
+    virtual bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) = 0;
 
     /// Schliesst das Fenster.
     virtual void DestroyScreen() = 0;
@@ -64,7 +148,9 @@ public:
     virtual VideoMode GetWindowSize() const = 0;
     /// Get the size of the render region in pixels
     virtual Extent GetRenderSize() const = 0;
+    virtual DisplayMode GetDisplayMode() const = 0;
     virtual bool IsFullscreen() const = 0;
+    virtual bool IsResizable() const = 0;
 
     /// Get the factor required to scale "normal" DPI to the display DPI
     virtual float getDpiScale() const = 0;

--- a/libs/driver/include/driver/VideoInterface.h
+++ b/libs/driver/include/driver/VideoInterface.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -9,95 +9,12 @@
 #include "Point.h"
 #include "VideoMode.h"
 #include "exportImport.h"
-// #include "s25util/enumUtils.h"
 #include <string>
 #include <type_traits>
 #include <vector>
 
 /// Function type for loading OpenGL methods
 using OpenGL_Loader_Proc = void* (*)(const char*);
-
-template<typename Enum>
-struct IsBitset : std::false_type
-{};
-
-template<typename Enum>
-using IsValidBitset =
-  std::integral_constant<bool, IsBitset<Enum>::value && std::is_unsigned<std::underlying_type_t<Enum>>::value>;
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr auto operator~(Enum val) noexcept
-{
-    using T = std::underlying_type_t<Enum>;
-    return Enum(~static_cast<T>(val));
-}
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr auto operator&(Enum lhs, Enum rhs) noexcept
-{
-    using T = std::underlying_type_t<Enum>;
-    return Enum(static_cast<T>(lhs) & static_cast<T>(rhs));
-}
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr auto operator|(Enum lhs, Enum rhs) noexcept
-{
-    using T = std::underlying_type_t<Enum>;
-    return Enum(static_cast<T>(lhs) | static_cast<T>(rhs));
-}
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr auto operator^(Enum lhs, Enum rhs) noexcept
-{
-    using T = std::underlying_type_t<Enum>;
-    return Enum(static_cast<T>(lhs) ^ static_cast<T>(rhs));
-}
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr auto operator&=(Enum& lhs, Enum rhs) noexcept
-{
-    lhs = lhs & rhs;
-    return lhs;
-}
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr auto operator|=(Enum& lhs, Enum rhs) noexcept
-{
-    lhs = lhs | rhs;
-    return lhs;
-}
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr auto operator^=(Enum& lhs, Enum rhs) noexcept
-{
-    lhs = lhs ^ rhs;
-    return lhs;
-}
-
-namespace bitset {
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-constexpr bool isSet(Enum val, Enum flag)
-{
-    return (val & flag) != Enum(0);
-}
-
-template<typename Enum, std::enable_if_t<IsValidBitset<Enum>::value, int> = 0>
-[[nodiscard]] constexpr Enum set(Enum val, Enum flag, bool state)
-{
-    return state ? (val | flag) : (val & ~flag);
-}
-} // namespace bitset
-
-enum class DisplayMode : unsigned
-{
-    None,
-    Fullscreen = (1 << 0),
-    Resizable = (1 << 1)
-};
-
-template<>
-struct IsBitset<DisplayMode> : std::true_type
-{};
 
 class BOOST_SYMBOL_VISIBLE IVideoDriver
 {
@@ -149,8 +66,6 @@ public:
     /// Get the size of the render region in pixels
     virtual Extent GetRenderSize() const = 0;
     virtual DisplayMode GetDisplayMode() const = 0;
-    virtual bool IsFullscreen() const = 0;
-    virtual bool IsResizable() const = 0;
 
     /// Get the factor required to scale "normal" DPI to the display DPI
     virtual float getDpiScale() const = 0;

--- a/libs/driver/include/driver/VideoInterface.h
+++ b/libs/driver/include/driver/VideoInterface.h
@@ -46,7 +46,7 @@ public:
     /// Funktion zum Holen einer Subfunktion.
     virtual OpenGL_Loader_Proc GetLoaderFunction() const = 0;
 
-    virtual void ListVideoModes(std::vector<VideoMode>& video_modes) const = 0;
+    virtual std::vector<VideoMode> ListVideoModes() const = 0;
 
     /// Funktion zum Auslesen der Mauskoordinaten.
     virtual Position GetMousePos() const = 0;

--- a/libs/driver/include/driver/VideoMode.h
+++ b/libs/driver/include/driver/VideoMode.h
@@ -16,13 +16,27 @@ struct VideoMode
     bool operator!=(const VideoMode& o) const { return !(*this == o); }
 };
 
-enum class DisplayMode
+// Enum like type with extra flag
+struct DisplayMode
 {
-    Windowed,
-    Fullscreen,
-    BorderlessWindow,
+    enum Type
+    {
+        Windowed,
+        Fullscreen,
+        BorderlessWindow,
+    } type = Windowed;
+    bool resizeable = true;
+
+    constexpr DisplayMode() = default;
+    constexpr DisplayMode(Type t) : type(t) {}
+    constexpr explicit DisplayMode(unsigned t) : type(Type(t)) {}
+    constexpr bool operator==(const Type& t) const { return type == t; }
+    constexpr bool operator!=(const Type& t) const { return type != t; }
+    constexpr bool operator==(const DisplayMode& o) const { return o.type == type && o.resizeable == resizeable; }
+    constexpr bool operator!=(const DisplayMode& o) const { return !(o == *this); }
 };
-constexpr auto maxEnumValue(DisplayMode)
+
+constexpr auto maxEnumValue(DisplayMode::Type)
 {
     return DisplayMode::BorderlessWindow;
 }

--- a/libs/driver/include/driver/VideoMode.h
+++ b/libs/driver/include/driver/VideoMode.h
@@ -16,10 +16,6 @@ struct VideoMode
     constexpr bool operator!=(const VideoMode& o) const { return !(*this == o); }
     constexpr bool operator<(const VideoMode& o) const
     {
-        const auto area = static_cast<unsigned>(width) * height;
-        const auto otherArea = static_cast<unsigned>(o.width) * o.height;
-        if(area != otherArea)
-            return area < otherArea;
         if(width != o.width)
             return width < o.width;
         return height < o.height;

--- a/libs/driver/include/driver/VideoMode.h
+++ b/libs/driver/include/driver/VideoMode.h
@@ -10,10 +10,10 @@ struct VideoMode
     unsigned short width;
     unsigned short height;
 
-    VideoMode() : width(0), height(0) {}
-    VideoMode(unsigned short width, unsigned short height) : width(width), height(height) {}
-    bool operator==(const VideoMode& o) const { return (width == o.width && height == o.height); }
-    bool operator!=(const VideoMode& o) const { return !(*this == o); }
+    constexpr VideoMode() : width(0), height(0) {}
+    constexpr VideoMode(unsigned short width, unsigned short height) : width(width), height(height) {}
+    constexpr bool operator==(const VideoMode& o) const { return (width == o.width && height == o.height); }
+    constexpr bool operator!=(const VideoMode& o) const { return !(*this == o); }
 };
 
 // Enum like type with extra flag

--- a/libs/driver/include/driver/VideoMode.h
+++ b/libs/driver/include/driver/VideoMode.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -15,3 +15,14 @@ struct VideoMode
     bool operator==(const VideoMode& o) const { return (width == o.width && height == o.height); }
     bool operator!=(const VideoMode& o) const { return !(*this == o); }
 };
+
+enum class DisplayMode
+{
+    Windowed,
+    Fullscreen,
+    BorderlessWindow,
+};
+constexpr auto maxEnumValue(DisplayMode)
+{
+    return DisplayMode::BorderlessWindow;
+}

--- a/libs/driver/include/driver/VideoMode.h
+++ b/libs/driver/include/driver/VideoMode.h
@@ -14,6 +14,16 @@ struct VideoMode
     constexpr VideoMode(unsigned short width, unsigned short height) : width(width), height(height) {}
     constexpr bool operator==(const VideoMode& o) const { return (width == o.width && height == o.height); }
     constexpr bool operator!=(const VideoMode& o) const { return !(*this == o); }
+    constexpr bool operator<(const VideoMode& o) const
+    {
+        const auto area = static_cast<unsigned>(width) * height;
+        const auto otherArea = static_cast<unsigned>(o.width) * o.height;
+        if(area != otherArea)
+            return area < otherArea;
+        if(width != o.width)
+            return width < o.width;
+        return height < o.height;
+    }
 };
 
 // Enum like type with extra flag

--- a/libs/driver/src/VideoDriver.cpp
+++ b/libs/driver/src/VideoDriver.cpp
@@ -62,8 +62,7 @@ bool VideoDriver::IsTouchEvent() const
 
 VideoMode VideoDriver::FindClosestVideoMode(const VideoMode mode) const
 {
-    std::vector<VideoMode> avModes;
-    ListVideoModes(avModes);
+    std::vector<VideoMode> avModes = ListVideoModes();
     if(avModes.empty())
         throw std::runtime_error("No supported video modes found!");
     unsigned minSizeDiff = std::numeric_limits<unsigned>::max();

--- a/libs/driver/src/VideoDriver.cpp
+++ b/libs/driver/src/VideoDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -19,7 +19,7 @@ IVideoDriver::~IVideoDriver() = default;
  *  @param[in] CallBack DriverCallback für Rückmeldungen.
  */
 VideoDriver::VideoDriver(VideoDriverLoaderInterface* CallBack)
-    : CallBack(CallBack), initialized(false), displayMode_(DisplayMode::Resizable), renderSize_(0, 0),
+    : CallBack(CallBack), initialized(false), displayMode_(DisplayMode::Windowed), renderSize_(0, 0),
       scaledRenderSize_(0, 0), dpiScale_(1.f), guiScale_(100), autoGuiScale_(false)
 {
     std::fill(keyboard.begin(), keyboard.end(), false);

--- a/libs/driver/src/VideoDriver.cpp
+++ b/libs/driver/src/VideoDriver.cpp
@@ -60,7 +60,7 @@ bool VideoDriver::IsTouchEvent() const
     return mouse_xy.num_tfingers > 0;
 }
 
-VideoMode VideoDriver::FindClosestVideoMode(const VideoMode& mode) const
+VideoMode VideoDriver::FindClosestVideoMode(const VideoMode mode) const
 {
     std::vector<VideoMode> avModes;
     ListVideoModes(avModes);

--- a/libs/driver/src/VideoDriver.cpp
+++ b/libs/driver/src/VideoDriver.cpp
@@ -19,8 +19,8 @@ IVideoDriver::~IVideoDriver() = default;
  *  @param[in] CallBack DriverCallback für Rückmeldungen.
  */
 VideoDriver::VideoDriver(VideoDriverLoaderInterface* CallBack)
-    : CallBack(CallBack), initialized(false), isFullscreen_(false), renderSize_(0, 0), scaledRenderSize_(0, 0),
-      dpiScale_(1.f), guiScale_(100), autoGuiScale_(false)
+    : CallBack(CallBack), initialized(false), displayMode_(DisplayMode::Resizable), renderSize_(0, 0),
+      scaledRenderSize_(0, 0), dpiScale_(1.f), guiScale_(100), autoGuiScale_(false)
 {
     std::fill(keyboard.begin(), keyboard.end(), false);
 }

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -140,7 +140,7 @@ bool askForDebugData()
 }
 bool shouldSendDebugData()
 {
-    return (SETTINGS.global.submit_debug_data == 1) || askForDebugData();
+    return (SETTINGS.global.submitDebugData == 1) || askForDebugData();
 }
 
 void showCrashMessage()

--- a/libs/s25client/s25client.cpp
+++ b/libs/s25client/s25client.cpp
@@ -140,7 +140,7 @@ bool askForDebugData()
 }
 bool shouldSendDebugData()
 {
-    return (SETTINGS.global.submitDebugData == 1) || askForDebugData();
+    return (SETTINGS.global.submitDebugData == SubmitDebugData::Yes) || askForDebugData();
 }
 
 void showCrashMessage()

--- a/libs/s25main/GameManager.cpp
+++ b/libs/s25main/GameManager.cpp
@@ -12,6 +12,7 @@
 #include "desktops/dskLobby.h"
 #include "desktops/dskMainMenu.h"
 #include "desktops/dskSplash.h"
+#include "driver/VideoInterface.h"
 #include "drivers/AudioDriverWrapper.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "files.h"
@@ -48,9 +49,10 @@ bool GameManager::Start()
     }
 
     // Fenster erstellen
-    const auto screenSize =
-      settings_.video.fullscreen ? settings_.video.fullscreenSize : settings_.video.windowedSize; //-V807
-    if(!videoDriver_.CreateScreen(screenSize, settings_.video.fullscreen))
+    const auto screenSize = (settings_.video.displayMode & DisplayMode::Fullscreen) != DisplayMode::None ?
+                              settings_.video.fullscreenSize :
+                              settings_.video.windowedSize; //-V807
+    if(!videoDriver_.CreateScreen(screenSize, settings_.video.displayMode))
         return false;
     videoDriver_.setTargetFramerate(settings_.video.framerate);
     videoDriver_.SetMouseWarping(settings_.global.smartCursor);

--- a/libs/s25main/GameManager.cpp
+++ b/libs/s25main/GameManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -49,9 +49,8 @@ bool GameManager::Start()
     }
 
     // Fenster erstellen
-    const auto screenSize = (settings_.video.displayMode & DisplayMode::Fullscreen) != DisplayMode::None ?
-                              settings_.video.fullscreenSize :
-                              settings_.video.windowedSize; //-V807
+    const auto screenSize = (settings_.video.displayMode == DisplayMode::Fullscreen) ? settings_.video.fullscreenSize :
+                                                                                       settings_.video.windowedSize;
     if(!videoDriver_.CreateScreen(screenSize, settings_.video.displayMode))
         return false;
     videoDriver_.setTargetFramerate(settings_.video.framerate);

--- a/libs/s25main/Loader.cpp
+++ b/libs/s25main/Loader.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -1009,7 +1009,7 @@ void Loader::fillCaches()
         }
     }
 
-    if(SETTINGS.video.shared_textures)
+    if(SETTINGS.video.sharedTextures)
     {
         // generate mega texture
         stp->pack();

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -85,8 +85,8 @@ void Settings::LoadDefaults()
     // global
     // {
     // 0 = ask user at start, 1 = enabled, 2 = always ask
-    global.submit_debug_data = 0;
-    global.use_upnp = false;
+    global.submitDebugData = 0;
+    global.useUPNP = false;
     global.smartCursor = true;
     global.debugMode = false;
     global.showGFInfo = false;
@@ -107,7 +107,7 @@ void Settings::LoadDefaults()
     }
     video.framerate = 0; // Special value for HW vsync
     video.vbo = true;
-    video.shared_textures = SHARED_TEXTURES_DEFAULT;
+    video.sharedTextures = SHARED_TEXTURES_DEFAULT;
     video.guiScale = 0; // special value indicating automatic selection
     // }
 
@@ -140,12 +140,12 @@ void Settings::LoadDefaults()
     lobby.name = System::getUserName();
     lobby.portraitIndex = 0;
     lobby.password.clear();
-    lobby.save_password = false;
+    lobby.savePassword = false;
     // }
 
     // server
     // {
-    server.last_ip.clear();
+    server.lastIP.clear();
     server.localPort = 3665;
     server.ipv6 = false;
     // }
@@ -155,7 +155,7 @@ void Settings::LoadDefaults()
 
     // interface
     // {
-    interface.autosave_interval = 0;
+    interface.autosaveInterval = 0;
     interface.mapScrollMode = MAP_SCROLL_MODE_DEFAULT;
     interface.enableWindowPinning = false;
     interface.windowSnapDistance = 8;
@@ -173,7 +173,7 @@ void Settings::LoadIngameDefaults()
 {
     // ingame
     // {
-    ingame.scale_statistics = false;
+    ingame.scaleStatistics = false;
     ingame.showBQ = false;
     ingame.showNames = false;
     ingame.showProductivity = false;
@@ -230,8 +230,8 @@ void Settings::Load()
         if(iniGlobal->getValue("gameversion") != rttr::version::GetRevision())
             s25util::warning("Your application version has changed - please recheck your settings!");
 
-        global.submit_debug_data = iniGlobal->getIntValue("submit_debug_data");
-        global.use_upnp = iniGlobal->getBoolValue("use_upnp");
+        global.submitDebugData = iniGlobal->getIntValue("submit_debug_data");
+        global.useUPNP = iniGlobal->getBoolValue("use_upnp");
         global.smartCursor = iniGlobal->getValue("smartCursor", true);
         global.debugMode = iniGlobal->getValue("debugMode", false);
         global.showGFInfo = iniGlobal->getValue("showGFInfo", false);
@@ -253,7 +253,7 @@ void Settings::Load()
         }
         video.framerate = iniVideo->getValue("framerate", 0);
         video.vbo = iniVideo->getBoolValue("vbo");
-        video.shared_textures = iniVideo->getBoolValue("shared_textures");
+        video.sharedTextures = iniVideo->getBoolValue("shared_textures");
         video.guiScale = iniVideo->getValue("gui_scale", 0);
         // };
 
@@ -289,7 +289,7 @@ void Settings::Load()
         lobby.name = iniLobby->getValue("name");
         lobby.portraitIndex = iniLobby->getIntValue("portrait_index");
         lobby.password = iniLobby->getValue("password");
-        lobby.save_password = iniLobby->getBoolValue("save_password");
+        lobby.savePassword = iniLobby->getBoolValue("save_password");
         // }
 
         if(lobby.name.empty())
@@ -302,7 +302,7 @@ void Settings::Load()
 
         // server
         // {
-        server.last_ip = iniServer->getValue("last_ip");
+        server.lastIP = iniServer->getValue("last_ip");
         boost::optional<uint16_t> port = validate::checkPort(iniServer->getValue("local_port"));
         server.localPort = port.value_or(3665);
         server.ipv6 = iniServer->getBoolValue("ipv6");
@@ -329,7 +329,7 @@ void Settings::Load()
 
         // interface
         // {
-        interface.autosave_interval = iniInterface->getIntValue("autosave_interval");
+        interface.autosaveInterval = iniInterface->getIntValue("autosave_interval");
         try
         {
             interface.mapScrollMode = static_cast<MapScrollMode>(iniInterface->getIntValue("map_scroll_mode"));
@@ -381,7 +381,7 @@ void Settings::LoadIngame()
             throw std::runtime_error("Missing section");
         // ingame
         // {
-        ingame.scale_statistics = iniIngame->getBoolValue("scale_statistics");
+        ingame.scaleStatistics = iniIngame->getBoolValue("scale_statistics");
         ingame.showBQ = iniIngame->getBoolValue("show_building_quality");
         ingame.showNames = iniIngame->getBoolValue("show_names");
         ingame.showProductivity = iniIngame->getBoolValue("show_productivity");
@@ -439,8 +439,8 @@ void Settings::Save()
     // {
     iniGlobal->setValue("version", VERSION);
     iniGlobal->setValue("gameversion", rttr::version::GetRevision());
-    iniGlobal->setValue("submit_debug_data", global.submit_debug_data);
-    iniGlobal->setValue("use_upnp", global.use_upnp);
+    iniGlobal->setValue("submit_debug_data", global.submitDebugData);
+    iniGlobal->setValue("use_upnp", global.useUPNP);
     iniGlobal->setValue("smartCursor", global.smartCursor);
     iniGlobal->setValue("debugMode", global.debugMode);
     iniGlobal->setValue("showGFInfo", global.showGFInfo);
@@ -455,7 +455,7 @@ void Settings::Save()
     iniVideo->setValue("displayMode", rttr::enum_cast(video.displayMode));
     iniVideo->setValue("framerate", video.framerate);
     iniVideo->setValue("vbo", video.vbo);
-    iniVideo->setValue("shared_textures", video.shared_textures);
+    iniVideo->setValue("shared_textures", video.sharedTextures);
     iniVideo->setValue("gui_scale", video.guiScale);
     // };
 
@@ -485,12 +485,12 @@ void Settings::Save()
     iniLobby->setValue("name", lobby.name);
     iniLobby->setValue("portrait_index", lobby.portraitIndex);
     iniLobby->setValue("password", lobby.password);
-    iniLobby->setValue("save_password", lobby.save_password);
+    iniLobby->setValue("save_password", lobby.savePassword);
     // }
 
     // server
     // {
-    iniServer->setValue("last_ip", server.last_ip);
+    iniServer->setValue("last_ip", server.lastIP);
     iniServer->setValue("local_port", server.localPort);
     iniServer->setValue("ipv6", server.ipv6);
     // }
@@ -504,7 +504,7 @@ void Settings::Save()
 
     // interface
     // {
-    iniInterface->setValue("autosave_interval", interface.autosave_interval);
+    iniInterface->setValue("autosave_interval", interface.autosaveInterval);
     iniInterface->setValue("map_scroll_mode", static_cast<int>(interface.mapScrollMode));
     iniInterface->setValue("enable_window_pinning", interface.enableWindowPinning);
     iniInterface->setValue("window_snap_distance", interface.windowSnapDistance);
@@ -542,7 +542,7 @@ void Settings::SaveIngame()
 
     // ingame
     // {
-    iniIngame->setValue("scale_statistics", ingame.scale_statistics);
+    iniIngame->setValue("scale_statistics", ingame.scaleStatistics);
     iniIngame->setValue("show_building_quality", ingame.showBQ);
     iniIngame->setValue("show_names", ingame.showNames);
     iniIngame->setValue("show_productivity", ingame.showProductivity);

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -84,8 +84,7 @@ void Settings::LoadDefaults()
 {
     // global
     // {
-    // 0 = ask user at start, 1 = enabled, 2 = always ask
-    global.submitDebugData = 0;
+    global.submitDebugData = SubmitDebugData::AskAtStart;
     global.useUPNP = false;
     global.smartCursor = true;
     global.debugMode = false;
@@ -231,7 +230,11 @@ void Settings::Load()
         if(iniGlobal->getValue("gameversion") != rttr::version::GetRevision())
             s25util::warning("Your application version has changed - please recheck your settings!");
 
-        global.submitDebugData = iniGlobal->getIntValue("submit_debug_data");
+        unsigned submitDebugData = iniGlobal->getIntValue("submit_debug_data");
+        if(submitDebugData <= helpers::MaxEnumValue_v<SubmitDebugData>)
+            global.submitDebugData = static_cast<SubmitDebugData>(submitDebugData);
+        else
+            global.submitDebugData = SubmitDebugData::AskAtStart;
         global.useUPNP = iniGlobal->getBoolValue("use_upnp");
         global.smartCursor = iniGlobal->getValue("smartCursor", true);
         global.debugMode = iniGlobal->getValue("debugMode", false);
@@ -441,7 +444,7 @@ void Settings::Save()
     // {
     iniGlobal->setValue("version", VERSION);
     iniGlobal->setValue("gameversion", rttr::version::GetRevision());
-    iniGlobal->setValue("submit_debug_data", global.submitDebugData);
+    iniGlobal->setValue("submit_debug_data", rttr::enum_cast(global.submitDebugData));
     iniGlobal->setValue("use_upnp", global.useUPNP);
     iniGlobal->setValue("smartCursor", global.smartCursor);
     iniGlobal->setValue("debugMode", global.debugMode);

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -6,6 +6,7 @@
 #include "DrawPoint.h"
 #include "RTTR_Version.h"
 #include "RttrConfig.h"
+#include "driver/VideoInterface.h"
 #include "drivers/AudioDriverWrapper.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "files.h"
@@ -95,11 +96,12 @@ void Settings::LoadDefaults()
     {
         video.fullscreenSize = VIDEODRIVER.GetWindowSize();
         video.windowedSize = VIDEODRIVER.IsFullscreen() ? VideoMode(800, 600) : video.fullscreenSize;
-        video.fullscreen = VIDEODRIVER.IsFullscreen();
+        video.displayMode = (VIDEODRIVER.IsFullscreen() ? DisplayMode::Fullscreen : DisplayMode::None)
+                            | (VIDEODRIVER.IsResizable() ? DisplayMode::Resizable : DisplayMode::None);
     } else
     {
         video.windowedSize = video.fullscreenSize = VideoMode(800, 600);
-        video.fullscreen = false;
+        video.displayMode = DisplayMode::Resizable;
     }
     video.framerate = 0; // Special value for HW vsync
     video.vbo = true;
@@ -239,7 +241,10 @@ void Settings::Load()
         video.windowedSize.height = iniVideo->getIntValue("windowed_height");
         video.fullscreenSize.width = iniVideo->getIntValue("fullscreen_width");
         video.fullscreenSize.height = iniVideo->getIntValue("fullscreen_height");
-        video.fullscreen = iniVideo->getBoolValue("fullscreen");
+        const auto fullscreen = iniVideo->getBoolValue("fullscreen");
+        const auto resizable = iniVideo->getValue("resizable", true);
+        video.displayMode = (fullscreen ? DisplayMode::Fullscreen : DisplayMode::None)
+                            | (resizable ? DisplayMode::Resizable : DisplayMode::None);
         video.framerate = iniVideo->getValue("framerate", 0);
         video.vbo = iniVideo->getBoolValue("vbo");
         video.shared_textures = iniVideo->getBoolValue("shared_textures");
@@ -441,7 +446,8 @@ void Settings::Save()
     iniVideo->setValue("fullscreen_height", video.fullscreenSize.height);
     iniVideo->setValue("windowed_width", video.windowedSize.width);
     iniVideo->setValue("windowed_height", video.windowedSize.height);
-    iniVideo->setValue("fullscreen", video.fullscreen);
+    iniVideo->setValue("fullscreen", (video.displayMode & DisplayMode::Fullscreen) != DisplayMode::None);
+    iniVideo->setValue("resizable", (video.displayMode & DisplayMode::Resizable) != DisplayMode::None);
     iniVideo->setValue("framerate", video.framerate);
     iniVideo->setValue("vbo", video.vbo);
     iniVideo->setValue("shared_textures", video.shared_textures);

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -9,7 +9,9 @@
 #include "driver/VideoInterface.h"
 #include "drivers/AudioDriverWrapper.h"
 #include "drivers/VideoDriverWrapper.h"
+#include "enum_cast.hpp"
 #include "files.h"
+#include "helpers/MaxEnumValue.h"
 #include "helpers/strUtils.h"
 #include "languages.h"
 #include "gameData/PortraitConsts.h"
@@ -95,13 +97,13 @@ void Settings::LoadDefaults()
     if(VIDEODRIVER.IsLoaded())
     {
         video.fullscreenSize = VIDEODRIVER.GetWindowSize();
-        video.windowedSize = VIDEODRIVER.IsFullscreen() ? VideoMode(800, 600) : video.fullscreenSize;
-        video.displayMode = (VIDEODRIVER.IsFullscreen() ? DisplayMode::Fullscreen : DisplayMode::None)
-                            | (VIDEODRIVER.IsResizable() ? DisplayMode::Resizable : DisplayMode::None);
+        video.windowedSize =
+          (VIDEODRIVER.GetDisplayMode() == DisplayMode::Fullscreen) ? video.fullscreenSize : VideoMode(800, 600);
+        video.displayMode = VIDEODRIVER.GetDisplayMode();
     } else
     {
         video.windowedSize = video.fullscreenSize = VideoMode(800, 600);
-        video.displayMode = DisplayMode::Resizable;
+        video.displayMode = DisplayMode::Windowed;
     }
     video.framerate = 0; // Special value for HW vsync
     video.vbo = true;
@@ -241,10 +243,14 @@ void Settings::Load()
         video.windowedSize.height = iniVideo->getIntValue("windowed_height");
         video.fullscreenSize.width = iniVideo->getIntValue("fullscreen_width");
         video.fullscreenSize.height = iniVideo->getIntValue("fullscreen_height");
-        const auto fullscreen = iniVideo->getBoolValue("fullscreen");
-        const auto resizable = iniVideo->getValue("resizable", true);
-        video.displayMode = (fullscreen ? DisplayMode::Fullscreen : DisplayMode::None)
-                            | (resizable ? DisplayMode::Resizable : DisplayMode::None);
+        const auto displayMode = iniVideo->getValue("displayMode", -1);
+        if(displayMode >= 0 && static_cast<unsigned>(displayMode) <= helpers::MaxEnumValue_v<DisplayMode>)
+            video.displayMode = DisplayMode(displayMode);
+        else
+        {
+            video.displayMode =
+              iniVideo->getValue("fullscreen", false) ? DisplayMode::Fullscreen : DisplayMode::Windowed;
+        }
         video.framerate = iniVideo->getValue("framerate", 0);
         video.vbo = iniVideo->getBoolValue("vbo");
         video.shared_textures = iniVideo->getBoolValue("shared_textures");
@@ -446,8 +452,7 @@ void Settings::Save()
     iniVideo->setValue("fullscreen_height", video.fullscreenSize.height);
     iniVideo->setValue("windowed_width", video.windowedSize.width);
     iniVideo->setValue("windowed_height", video.windowedSize.height);
-    iniVideo->setValue("fullscreen", (video.displayMode & DisplayMode::Fullscreen) != DisplayMode::None);
-    iniVideo->setValue("resizable", (video.displayMode & DisplayMode::Resizable) != DisplayMode::None);
+    iniVideo->setValue("displayMode", rttr::enum_cast(video.displayMode));
     iniVideo->setValue("framerate", video.framerate);
     iniVideo->setValue("vbo", video.vbo);
     iniVideo->setValue("shared_textures", video.shared_textures);

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -244,13 +244,14 @@ void Settings::Load()
         video.fullscreenSize.width = iniVideo->getIntValue("fullscreen_width");
         video.fullscreenSize.height = iniVideo->getIntValue("fullscreen_height");
         const auto displayMode = iniVideo->getValue("displayMode", -1);
-        if(displayMode >= 0 && static_cast<unsigned>(displayMode) <= helpers::MaxEnumValue_v<DisplayMode>)
+        if(displayMode >= 0 && static_cast<unsigned>(displayMode) <= helpers::MaxEnumValue_v<DisplayMode::Type>)
             video.displayMode = DisplayMode(displayMode);
         else
         {
             video.displayMode =
               iniVideo->getValue("fullscreen", false) ? DisplayMode::Fullscreen : DisplayMode::Windowed;
         }
+        video.displayMode.resizeable = !iniVideo->getValue("lock_window_size", false);
         video.framerate = iniVideo->getValue("framerate", 0);
         video.vbo = iniVideo->getBoolValue("vbo");
         video.sharedTextures = iniVideo->getBoolValue("shared_textures");
@@ -452,7 +453,8 @@ void Settings::Save()
     iniVideo->setValue("fullscreen_height", video.fullscreenSize.height);
     iniVideo->setValue("windowed_width", video.windowedSize.width);
     iniVideo->setValue("windowed_height", video.windowedSize.height);
-    iniVideo->setValue("displayMode", rttr::enum_cast(video.displayMode));
+    iniVideo->setValue("displayMode", rttr::enum_cast(video.displayMode.type));
+    iniVideo->setValue("lock_window_size", !video.displayMode.resizeable);
     iniVideo->setValue("framerate", video.framerate);
     iniVideo->setValue("vbo", video.vbo);
     iniVideo->setValue("shared_textures", video.sharedTextures);

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -252,6 +252,7 @@ void Settings::Load()
             video.displayMode = DisplayMode(displayMode);
         else
         {
+            // Compatibility with prior settings format
             video.displayMode =
               iniVideo->getValue("fullscreen", false) ? DisplayMode::Fullscreen : DisplayMode::Windowed;
         }

--- a/libs/s25main/Settings.cpp
+++ b/libs/s25main/Settings.cpp
@@ -96,13 +96,14 @@ void Settings::LoadDefaults()
     // {
     if(VIDEODRIVER.IsLoaded())
     {
-        video.fullscreenSize = VIDEODRIVER.GetWindowSize();
-        video.windowedSize =
-          (VIDEODRIVER.GetDisplayMode() == DisplayMode::Fullscreen) ? video.fullscreenSize : VideoMode(800, 600);
+        video.fullscreenSize = (VIDEODRIVER.GetDisplayMode() == DisplayMode::Fullscreen) ? VIDEODRIVER.GetWindowSize() :
+                                                                                           VIDEODRIVER.MinWindowSize;
+        video.windowedSize = (VIDEODRIVER.GetDisplayMode() == DisplayMode::Windowed) ? VIDEODRIVER.GetWindowSize() :
+                                                                                       VIDEODRIVER.MinWindowSize;
         video.displayMode = VIDEODRIVER.GetDisplayMode();
     } else
     {
-        video.windowedSize = video.fullscreenSize = VideoMode(800, 600);
+        video.windowedSize = video.fullscreenSize = VIDEODRIVER.MinWindowSize;
         video.displayMode = DisplayMode::Windowed;
     }
     video.framerate = 0; // Special value for HW vsync

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -39,6 +39,17 @@ enum class MapScrollMode
     GrabAndDrag
 };
 
+enum class SubmitDebugData : uint8_t
+{
+    AskAtStart = 0, // I.e. undecided
+    Yes = 1,
+    AlwaysAsk = 2
+};
+constexpr auto maxEnumValue(SubmitDebugData)
+{
+    return SubmitDebugData::AlwaysAsk;
+}
+
 /// Configuration class
 class Settings : public Singleton<Settings, SingletonPolicies::WithLongevity>
 {
@@ -60,7 +71,7 @@ protected:
 public:
     struct
     {
-        uint8_t submitDebugData;
+        SubmitDebugData submitDebugData;
         bool useUPNP, smartCursor, debugMode, showGFInfo;
     } global;
 

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -60,8 +60,8 @@ protected:
 public:
     struct
     {
-        uint8_t submit_debug_data;
-        bool use_upnp, smartCursor, debugMode, showGFInfo;
+        uint8_t submitDebugData;
+        bool useUPNP, smartCursor, debugMode, showGFInfo;
     } global;
 
     struct
@@ -70,7 +70,7 @@ public:
         signed short framerate; // <0 for unlimited, 0 for HW Vsync
         DisplayMode displayMode;
         bool vbo;
-        bool shared_textures;
+        bool sharedTextures;
         unsigned guiScale; ///< UI scaling in percent; 0 indicates automatic selection
     } video;
 
@@ -100,12 +100,12 @@ public:
         std::string name;
         unsigned portraitIndex;
         std::string password;
-        bool save_password;
+        bool savePassword;
     } lobby;
 
     struct
     {
-        std::string last_ip; /// last entered ip or hostname
+        std::string lastIP; /// last entered ip or hostname
         uint16_t localPort;
         bool ipv6; /// listen/connect on ipv6 as default or not
     } server;
@@ -114,7 +114,7 @@ public:
 
     struct
     {
-        unsigned autosave_interval;
+        unsigned autosaveInterval;
         MapScrollMode mapScrollMode;
         bool enableWindowPinning;
         unsigned windowSnapDistance;
@@ -122,7 +122,7 @@ public:
 
     struct
     {
-        bool scale_statistics;
+        bool scaleStatistics;
         bool showNames;
         bool showProductivity;
         bool showBQ;

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/libs/s25main/Settings.h
+++ b/libs/s25main/Settings.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "DrawPoint.h"
+#include "driver/VideoInterface.h"
 #include "driver/VideoMode.h"
 #include "s25util/ProxySettings.h"
 #include "s25util/Singleton.h"
@@ -67,7 +68,7 @@ public:
     {
         VideoMode fullscreenSize, windowedSize;
         signed short framerate; // <0 for unlimited, 0 for HW Vsync
-        bool fullscreen;
+        DisplayMode displayMode;
         bool vbo;
         bool shared_textures;
         unsigned guiScale; ///< UI scaling in percent; 0 indicates automatic selection

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -25,9 +25,6 @@ Window::Window(Window* parent, unsigned id, const DrawPoint& pos, const Extent& 
 Window::~Window()
 {
     RTTR_Assert(!isInMouseRelay);
-    // Steuerelemente aufräumen
-    for(Window* ctrl : childIdToWnd_ | boost::adaptors::map_values)
-        delete ctrl;
 }
 
 void Window::Draw()
@@ -79,9 +76,7 @@ bool Window::RelayKeyboardMessage(KeyboardMsgHandler msg, const KeyEvent& ke)
     if(!IsMessageRelayAllowed())
         return false;
 
-    // Alle Controls durchgehen
-    // Falls das Fenster dann plötzlich nich mehr aktiv ist (z.b. neues Fenster geöffnet, sofort abbrechen!)
-    for(Window* wnd : childIdToWnd_ | boost::adaptors::map_values)
+    for(auto& wnd : childIdToWnd_ | boost::adaptors::map_values)
     {
         if(wnd->visible_ && wnd->active_ && CALL_MEMBER_FN(*wnd, msg)(ke))
             return true;
@@ -100,7 +95,7 @@ bool Window::RelayMouseMessage(MouseMsgHandler msg, const MouseCoords& mc)
     isInMouseRelay = true;
 
     // Use reverse iterator because the topmost (=last elements) should receive the messages first!
-    for(Window* wnd : childIdToWnd_ | boost::adaptors::map_values | boost::adaptors::reversed)
+    for(auto& wnd : childIdToWnd_ | boost::adaptors::map_values | boost::adaptors::reversed)
     {
         if(!lockedAreas_.empty() && IsInLockedRegion(mc.pos, wnd.get()))
             continue;
@@ -187,38 +182,32 @@ bool Window::IsMessageRelayAllowed() const
 
 void Window::DeleteCtrl(unsigned id)
 {
-    auto it = childIdToWnd_.find(id);
-
-    if(it == childIdToWnd_.end())
-        return;
-
-    delete it->second;
-
-    childIdToWnd_.erase(it);
+    childIdToWnd_.erase(id);
 }
 
 ctrlBuildingIcon* Window::AddBuildingIcon(unsigned id, const DrawPoint& pos, BuildingType type, const Nation nation,
                                           unsigned short size, const std::string& tooltip)
 {
-    return AddCtrl(new ctrlBuildingIcon(this, id, ScaleIf(pos), type, nation, ScaleIf(Extent(size, 0)).x, tooltip));
+    return AddCtrl(
+      std::make_unique<ctrlBuildingIcon>(this, id, ScaleIf(pos), type, nation, ScaleIf(Extent(size, 0)).x, tooltip));
 }
 
 ctrlButton* Window::AddTextButton(unsigned id, const DrawPoint& pos, const Extent& size, const TextureColor tc,
                                   const std::string& text, const glFont* font, const std::string& tooltip)
 {
-    return AddCtrl(new ctrlTextButton(this, id, ScaleIf(pos), ScaleIf(size), tc, text, font, tooltip));
+    return AddCtrl(std::make_unique<ctrlTextButton>(this, id, ScaleIf(pos), ScaleIf(size), tc, text, font, tooltip));
 }
 
 ctrlButton* Window::AddColorButton(unsigned id, const DrawPoint& pos, const Extent& size, const TextureColor tc,
                                    const unsigned fillColor, const std::string& tooltip)
 {
-    return AddCtrl(new ctrlColorButton(this, id, ScaleIf(pos), ScaleIf(size), tc, fillColor, tooltip));
+    return AddCtrl(std::make_unique<ctrlColorButton>(this, id, ScaleIf(pos), ScaleIf(size), tc, fillColor, tooltip));
 }
 
 ctrlButton* Window::AddImageButton(unsigned id, const DrawPoint& pos, const Extent& size, const TextureColor tc,
                                    ITexture* const image, const std::string& tooltip)
 {
-    return AddCtrl(new ctrlImageButton(this, id, ScaleIf(pos), ScaleIf(size), tc, image, tooltip));
+    return AddCtrl(std::make_unique<ctrlImageButton>(this, id, ScaleIf(pos), ScaleIf(size), tc, image, tooltip));
 }
 
 ctrlButton* Window::AddImageButton(unsigned id, const DrawPoint& pos, const Extent& size, const TextureColor tc,
@@ -230,37 +219,39 @@ ctrlButton* Window::AddImageButton(unsigned id, const DrawPoint& pos, const Exte
 ctrlChat* Window::AddChatCtrl(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                               const glFont* font)
 {
-    return AddCtrl(new ctrlChat(this, id, ScaleIf(pos), ScaleIf(size), tc, font));
+    return AddCtrl(std::make_unique<ctrlChat>(this, id, ScaleIf(pos), ScaleIf(size), tc, font));
 }
 
 ctrlCheck* Window::AddCheckBox(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                const std::string& text, const glFont* font, bool readonly)
 {
-    return AddCtrl(new ctrlCheck(this, id, ScaleIf(pos), ScaleIf(size), tc, text, font, readonly));
+    return AddCtrl(std::make_unique<ctrlCheck>(this, id, ScaleIf(pos), ScaleIf(size), tc, text, font, readonly));
 }
 
 ctrlComboBox* Window::AddComboBox(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                   const glFont* font, unsigned short max_list_height, bool readonly)
 {
-    return AddCtrl(new ctrlComboBox(this, id, ScaleIf(pos), ScaleIf(size), tc, font, max_list_height, readonly));
+    return AddCtrl(
+      std::make_unique<ctrlComboBox>(this, id, ScaleIf(pos), ScaleIf(size), tc, font, max_list_height, readonly));
 }
 
 ctrlDeepening* Window::AddTextDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                         const std::string& text, const glFont* font, unsigned color, FontStyle style)
 {
-    return AddCtrl(new ctrlTextDeepening(this, id, ScaleIf(pos), ScaleIf(size), tc, text, font, color, style));
+    return AddCtrl(
+      std::make_unique<ctrlTextDeepening>(this, id, ScaleIf(pos), ScaleIf(size), tc, text, font, color, style));
 }
 
 ctrlDeepening* Window::AddColorDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                          unsigned fillColor)
 {
-    return AddCtrl(new ctrlColorDeepening(this, id, ScaleIf(pos), ScaleIf(size), tc, fillColor));
+    return AddCtrl(std::make_unique<ctrlColorDeepening>(this, id, ScaleIf(pos), ScaleIf(size), tc, fillColor));
 }
 
 ctrlDeepening* Window::AddImageDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                          ITexture* image)
 {
-    return AddCtrl(new ctrlImageDeepening(this, id, ScaleIf(pos), ScaleIf(size), tc, image));
+    return AddCtrl(std::make_unique<ctrlImageDeepening>(this, id, ScaleIf(pos), ScaleIf(size), tc, image));
 }
 
 ctrlDeepening* Window::AddImageDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
@@ -272,18 +263,18 @@ ctrlDeepening* Window::AddImageDeepening(unsigned id, const DrawPoint& pos, cons
 ctrlEdit* Window::AddEdit(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font,
                           unsigned short maxlength, bool password, bool disabled, bool notify)
 {
-    return AddCtrl(
-      new ctrlEdit(this, id, ScaleIf(pos), ScaleIf(size), tc, font, maxlength, password, disabled, notify));
+    return AddCtrl(std::make_unique<ctrlEdit>(this, id, ScaleIf(pos), ScaleIf(size), tc, font, maxlength, password,
+                                              disabled, notify));
 }
 
 ctrlGroup* Window::AddGroup(unsigned id)
 {
-    return AddCtrl(new ctrlGroup(this, id));
+    return AddCtrl(std::make_unique<ctrlGroup>(this, id));
 }
 
 ctrlImage* Window::AddImage(unsigned id, const DrawPoint& pos, ITexture* image, const std::string& tooltip)
 {
-    return AddCtrl(new ctrlImage(this, id, ScaleIf(pos), image, tooltip));
+    return AddCtrl(std::make_unique<ctrlImage>(this, id, ScaleIf(pos), image, tooltip));
 }
 
 ctrlImage* Window::AddImage(unsigned id, const DrawPoint& pos, glArchivItem_Bitmap* image, const std::string& tooltip)
@@ -293,45 +284,30 @@ ctrlImage* Window::AddImage(unsigned id, const DrawPoint& pos, glArchivItem_Bitm
 
 ctrlList* Window::AddList(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font)
 {
-    return AddCtrl(new ctrlList(this, id, ScaleIf(pos), ScaleIf(size), tc, font));
+    return AddCtrl(std::make_unique<ctrlList>(this, id, ScaleIf(pos), ScaleIf(size), tc, font));
 }
 
 ctrlMultiline* Window::AddMultiline(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                     const glFont* font, FontStyle format)
 {
-    return AddCtrl(new ctrlMultiline(this, id, ScaleIf(pos), ScaleIf(size), tc, font, format));
+    return AddCtrl(std::make_unique<ctrlMultiline>(this, id, ScaleIf(pos), ScaleIf(size), tc, font, format));
 }
 
-/**
- *  fügt ein OptionenGruppe hinzu.
- *
- *  @param[in] id          ID des Steuerelements
- *  @param[in] select_type Typ der Auswahl
- *
- *  @return Instanz das Steuerelement.
- */
 ctrlOptionGroup* Window::AddOptionGroup(unsigned id, GroupSelectType select_type)
 {
-    return AddCtrl(new ctrlOptionGroup(this, id, select_type));
+    return AddCtrl(std::make_unique<ctrlOptionGroup>(this, id, select_type));
 }
 
-/**
- *  fügt ein MultiSelectGruppe hinzu.
- *
- *  @param[in] id          ID des Steuerelements
- *  @param[in] select_type Typ der Auswahl
- *
- *  @return Instanz das Steuerelement.
- */
 ctrlMultiSelectGroup* Window::AddMultiSelectGroup(unsigned id, GroupSelectType select_type)
 {
-    return AddCtrl(new ctrlMultiSelectGroup(this, id, select_type));
+    return AddCtrl(std::make_unique<ctrlMultiSelectGroup>(this, id, select_type));
 }
 
 ctrlPercent* Window::AddPercent(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                 unsigned text_color, const glFont* font, const unsigned short* percentage)
 {
-    return AddCtrl(new ctrlPercent(this, id, ScaleIf(pos), ScaleIf(size), tc, text_color, font, percentage));
+    return AddCtrl(
+      std::make_unique<ctrlPercent>(this, id, ScaleIf(pos), ScaleIf(size), tc, text_color, font, percentage));
 }
 
 ctrlProgress* Window::AddProgress(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
@@ -339,8 +315,9 @@ ctrlProgress* Window::AddProgress(unsigned id, const DrawPoint& pos, const Exten
                                   const std::string& tooltip, const Extent& padding, unsigned force_color,
                                   const std::string& button_minus_tooltip, const std::string& button_plus_tooltip)
 {
-    return AddCtrl(new ctrlProgress(this, id, ScaleIf(pos), ScaleIf(size), tc, button_minus, button_plus, maximum,
-                                    padding, force_color, tooltip, button_minus_tooltip, button_plus_tooltip));
+    return AddCtrl(std::make_unique<ctrlProgress>(this, id, ScaleIf(pos), ScaleIf(size), tc, button_minus, button_plus,
+                                                  maximum, padding, force_color, tooltip, button_minus_tooltip,
+                                                  button_plus_tooltip));
 }
 
 ctrlScrollBar* Window::AddScrollBar(unsigned id, const DrawPoint& pos, const Extent& size, unsigned short button_height,
@@ -348,55 +325,36 @@ ctrlScrollBar* Window::AddScrollBar(unsigned id, const DrawPoint& pos, const Ext
 {
     button_height = ScaleIf(Extent(0, button_height)).y;
 
-    return AddCtrl(new ctrlScrollBar(this, id, ScaleIf(pos), ScaleIf(size), button_height, tc, page_size));
+    return AddCtrl(
+      std::make_unique<ctrlScrollBar>(this, id, ScaleIf(pos), ScaleIf(size), button_height, tc, page_size));
 }
 
 ctrlTab* Window::AddTabCtrl(unsigned id, const DrawPoint& pos, unsigned short width)
 {
-    return AddCtrl(new ctrlTab(this, id, ScaleIf(pos), ScaleIf(Extent(width, 0)).x));
+    return AddCtrl(std::make_unique<ctrlTab>(this, id, ScaleIf(pos), ScaleIf(Extent(width, 0)).x));
 }
 
-/**
- *  fügt eine Tabelle hinzu.
- *  ... sollte eine Menge von const char*, int und SortType sein
- */
 ctrlTable* Window::AddTable(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font,
                             std::vector<TableColumn> columns)
 {
-    return AddCtrl(new ctrlTable(this, id, ScaleIf(pos), ScaleIf(size), tc, font, std::move(columns)));
+    return AddCtrl(std::make_unique<ctrlTable>(this, id, ScaleIf(pos), ScaleIf(size), tc, font, std::move(columns)));
 }
 
 ctrlTimer* Window::AddTimer(unsigned id, std::chrono::milliseconds timeout)
 {
-    return AddCtrl(new ctrlTimer(this, id, timeout));
+    return AddCtrl(std::make_unique<ctrlTimer>(this, id, timeout));
 }
 
-/**
- *  fügt ein TextCtrl hinzu.
- *
- *  @param[in] x      X-Koordinate des Steuerelements
- *  @param[in] y      Y-Koordinate des Steuerelements
- *  @param[in] text   Text
- *  @param[in] color  Textfarbe
- *  @param[in] format Formatierung des Textes
- *                      @p FontStyle::LEFT    - Text links ( standard )
- *                      @p FontStyle::CENTER  - Text mittig
- *                      @p FontStyle::RIGHT   - Text rechts
- *                      @p FontStyle::TOP     - Text oben ( standard )
- *                      @p FontStyle::VCENTER - Text vertikal zentriert
- *                      @p FontStyle::BOTTOM  - Text unten
- *  @param[in] font   Schriftart
- */
 ctrlText* Window::AddText(unsigned id, const DrawPoint& pos, const std::string& text, unsigned color, FontStyle format,
                           const glFont* font)
 {
-    return AddCtrl(new ctrlText(this, id, ScaleIf(pos), text, color, format, font));
+    return AddCtrl(std::make_unique<ctrlText>(this, id, ScaleIf(pos), text, color, format, font));
 }
 
 ctrlMapSelection* Window::AddMapSelection(unsigned id, const DrawPoint& pos, const Extent& size,
                                           const SelectionMapInputData& inputData)
 {
-    return AddCtrl(new ctrlMapSelection(this, id, ScaleIf(pos), ScaleIf(size), inputData));
+    return AddCtrl(std::make_unique<ctrlMapSelection>(this, id, ScaleIf(pos), ScaleIf(size), inputData));
 }
 
 TextFormatSetter Window::AddFormattedText(unsigned id, const DrawPoint& pos, const std::string& text, unsigned color,
@@ -412,49 +370,32 @@ ctrlVarDeepening* Window::AddVarDeepening(unsigned id, const DrawPoint& pos, con
     va_list liste;
     va_start(liste, parameters);
 
-    auto* ctrl =
-      new ctrlVarDeepening(this, id, ScaleIf(pos), ScaleIf(size), tc, formatstr, font, color, parameters, liste);
+    auto ctrl = std::make_unique<ctrlVarDeepening>(this, id, ScaleIf(pos), ScaleIf(size), tc, formatstr, font, color,
+                                                   parameters, liste);
 
     va_end(liste);
 
-    return AddCtrl(ctrl);
+    return AddCtrl(std::move(ctrl));
 }
 
-/**
- *  fügt ein variables TextCtrl hinzu.
- *
- *  @param[in] x          X-Koordinate des Steuerelements
- *  @param[in] y          Y-Koordinate des Steuerelements
- *  @param[in] formatstr  Der Formatstring des Steuerelements
- *  @param[in] color      Textfarbe
- *  @param[in] format     Formatierung des Textes
- *                          @p FontStyle::LEFT    - Text links ( standard )
- *                          @p FontStyle::CENTER  - Text mittig
- *                          @p FontStyle::RIGHT   - Text rechts
- *                          @p FontStyle::TOP     - Text oben ( standard )
- *                          @p FontStyle::VCENTER - Text vertikal zentriert
- *                          @p FontStyle::BOTTOM  - Text unten
- *  @param[in] font       Schriftart
- *  @param[in] parameters Anzahl der nachfolgenden Parameter
- *  @param[in] ...        die variablen Parameter
- */
 ctrlVarText* Window::AddVarText(unsigned id, const DrawPoint& pos, const std::string& formatstr, unsigned color,
                                 FontStyle format, const glFont* font, unsigned parameters, ...)
 {
     va_list liste;
     va_start(liste, parameters);
 
-    auto* ctrl = new ctrlVarText(this, id, ScaleIf(pos), formatstr, color, format, font, parameters, liste);
+    auto ctrl =
+      std::make_unique<ctrlVarText>(this, id, ScaleIf(pos), formatstr, color, format, font, parameters, liste);
 
     va_end(liste);
 
-    return AddCtrl(ctrl);
+    return AddCtrl(std::move(ctrl));
 }
 
 ctrlPreviewMinimap* Window::AddPreviewMinimap(const unsigned id, const DrawPoint& pos, const Extent& size,
                                               libsiedler2::ArchivItem_Map* const map)
 {
-    return AddCtrl(new ctrlPreviewMinimap(this, id, ScaleIf(pos), ScaleIf(size), map));
+    return AddCtrl(std::make_unique<ctrlPreviewMinimap>(this, id, ScaleIf(pos), ScaleIf(size), map));
 }
 
 void Window::Draw3D(const Rect& rect, TextureColor tc, bool elevated, bool highlighted, bool illuminated,
@@ -499,19 +440,19 @@ void Window::DrawLine(DrawPoint pt1, DrawPoint pt2, unsigned short width, unsign
 void Window::Msg_PaintBefore()
 {
     animations_.update(VIDEODRIVER.GetTickCount());
-    for(Window* control : childIdToWnd_ | boost::adaptors::map_values)
+    for(auto& control : childIdToWnd_ | boost::adaptors::map_values)
         control->Msg_PaintBefore();
 }
 
 void Window::Msg_PaintAfter()
 {
-    for(Window* control : childIdToWnd_ | boost::adaptors::map_values)
+    for(auto& control : childIdToWnd_ | boost::adaptors::map_values)
         control->Msg_PaintAfter();
 }
 
 void Window::Draw_()
 {
-    for(Window* control : childIdToWnd_ | boost::adaptors::map_values)
+    for(auto& control : childIdToWnd_ | boost::adaptors::map_values)
         control->Draw();
 }
 
@@ -521,10 +462,8 @@ void Window::Msg_ScreenResize(const ScreenResizeEvent& sr)
     if(!scale_)
         return;
     RescaleWindowProp rescale(sr.oldSize, sr.newSize);
-    for(Window* ctrl : childIdToWnd_ | boost::adaptors::map_values)
+    for(auto& ctrl : childIdToWnd_ | boost::adaptors::map_values)
     {
-        if(!ctrl)
-            continue;
         // Save new size (could otherwise be changed(?) in Msg_ScreenResize)
         Extent newSize = rescale(ctrl->GetSize());
         ctrl->SetPos(rescale(ctrl->GetPos()));

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -30,9 +30,6 @@ Window::~Window()
         delete ctrl;
 }
 
-/**
- *  zeichnet das Fenster.
- */
 void Window::Draw()
 {
     if(visible_)
@@ -49,8 +46,7 @@ DrawPoint Window::GetDrawPos() const
     DrawPoint result = pos_;
     const Window* temp = this;
 
-    // Relative Koordinaten in absolute umrechnen
-    // ( d.h. Koordinaten von allen Eltern zusammenaddieren )
+    // Convert relative to absolute coordinates, i.e. sum positions of parents
     while(temp->parent_)
     {
         temp = temp->parent_;
@@ -76,17 +72,10 @@ Rect Window::GetBoundaryRect() const
     return GetDrawRect();
 }
 
-/**
- *  Sendet eine Fensternachricht an die Steuerelemente.
- *
- *  @param[in] msg   Die Nachricht.
- *  @param[in] id    Die ID des Quellsteuerelements.
- *  @param[in] param Ein nachrichtenspezifischer Parameter.
- */
 bool Window::RelayKeyboardMessage(KeyboardMsgHandler msg, const KeyEvent& ke)
 {
-    // Abgeleitete Klassen fragen, ob das Weiterleiten von Nachrichten erlaubt ist
-    // (IngameFenster könnten ja z.B. minimiert sein)
+    // Ask derived classes whether relaying messages is allowed
+    // (For example, ingame windows might not want to receive keyboard messages when they are minimized)
     if(!IsMessageRelayAllowed())
         return false;
 
@@ -103,19 +92,17 @@ bool Window::RelayKeyboardMessage(KeyboardMsgHandler msg, const KeyEvent& ke)
 
 bool Window::RelayMouseMessage(MouseMsgHandler msg, const MouseCoords& mc)
 {
-    // Abgeleitete Klassen fragen, ob das Weiterleiten von Mausnachrichten erlaubt ist
-    // (IngameFenster könnten ja z.B. minimiert sein)
+    // Ask derived classes whether relaying messages is allowed
     if(!IsMessageRelayAllowed())
         return false;
 
     bool processed = false;
     isInMouseRelay = true;
 
-    // Alle Controls durchgehen
     // Use reverse iterator because the topmost (=last elements) should receive the messages first!
     for(Window* wnd : childIdToWnd_ | boost::adaptors::map_values | boost::adaptors::reversed)
     {
-        if(!lockedAreas_.empty() && IsInLockedRegion(mc.pos, wnd))
+        if(!lockedAreas_.empty() && IsInLockedRegion(mc.pos, wnd.get()))
             continue;
 
         if(wnd->visible_ && wnd->active_ && CALL_MEMBER_FN(*wnd, msg)(mc))
@@ -137,7 +124,7 @@ bool Window::RelayMouseMessage(MouseMsgHandler msg, const MouseCoords& mc)
  */
 void Window::SetActive(bool activate)
 {
-    this->active_ = activate;
+    active_ = activate;
     ActivateControls(activate);
 }
 
@@ -193,7 +180,6 @@ void Window::SetPos(const DrawPoint& newPos)
     pos_ = newPos;
 }
 
-/// Weiterleitung von Nachrichten von abgeleiteten Klassen erlaubt oder nicht?
 bool Window::IsMessageRelayAllowed() const
 {
     return true;

--- a/libs/s25main/Window.cpp
+++ b/libs/s25main/Window.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -560,7 +560,9 @@ T_Pt Window::ScaleIf(const T_Pt& pt) const
     return scale_ ? Scale(pt) : pt;
 }
 
-// Inlining removes those. so add it here
+// Explicit template instantiations for the used types to avoid linker errors
+template DrawPoint Window::Scale(const DrawPoint&);
+template Extent Window::Scale(const Extent&);
 template DrawPoint Window::ScaleIf(const DrawPoint&) const;
 template Extent Window::ScaleIf(const Extent&) const;
 

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -18,6 +18,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <chrono>
 #include <map>
+#include <memory>
 #include <vector>
 
 class ctrlBuildingIcon;
@@ -135,7 +136,7 @@ public:
     AnimationManager& GetAnimationManager() { return animations_; }
 
     template<typename T>
-    T* AddCtrl(T* ctrl);
+    T* AddCtrl(std::unique_ptr<T> ctrl);
 
     ctrlBuildingIcon* AddBuildingIcon(unsigned id, const DrawPoint& pos, BuildingType type, Nation nation,
                                       unsigned short size = 36, const std::string& tooltip = "");
@@ -287,7 +288,7 @@ protected:
         Pressed
     };
     friend constexpr auto maxEnumValue(ButtonState) { return ButtonState::Pressed; }
-    using ControlMap = std::map<unsigned, Window*>;
+    using ControlMap = std::map<unsigned, std::unique_ptr<Window>>;
 
     /// Scale the value from the reference coordinates to current render size
     template<class T_Pt>
@@ -323,44 +324,42 @@ private:
 };
 
 template<typename T>
-inline T* Window::AddCtrl(T* ctrl)
+T* Window::AddCtrl(std::unique_ptr<T> ctrl)
 {
+    RTTR_Assert(ctrl);
     RTTR_Assert(childIdToWnd_.find(ctrl->GetID()) == childIdToWnd_.end());
-    childIdToWnd_.insert(std::make_pair(ctrl->GetID(), ctrl));
 
+    T* ctrlPtr = ctrl.get();
     ctrl->scale_ = scale_;
-    ctrl->SetActive(active_);
+    childIdToWnd_.emplace(ctrl->GetID(), std::move(ctrl));
 
-    return ctrl;
+    ctrlPtr->SetActive(active_);
+    return ctrlPtr;
 }
 
 template<typename T>
-inline T* Window::GetCtrl(unsigned id)
+T* Window::GetCtrl(unsigned id)
+{
+    return const_cast<T*>(static_cast<const Window&>(*this).GetCtrl<T>(id));
+}
+
+template<typename T>
+const T* Window::GetCtrl(unsigned id) const
 {
     auto it = childIdToWnd_.find(id);
     if(it == childIdToWnd_.end())
         return nullptr;
 
-    return dynamic_cast<T*>(it->second);
+    return dynamic_cast<T*>(it->second.get());
 }
 
 template<typename T>
-inline const T* Window::GetCtrl(unsigned id) const
-{
-    auto it = childIdToWnd_.find(id);
-    if(it == childIdToWnd_.end())
-        return nullptr;
-
-    return dynamic_cast<T*>(it->second);
-}
-
-template<typename T>
-inline std::vector<T*> Window::GetCtrls()
+std::vector<T*> Window::GetCtrls()
 {
     std::vector<T*> result;
-    for(auto* wnd : childIdToWnd_ | boost::adaptors::map_values)
+    for(const auto& wnd : childIdToWnd_ | boost::adaptors::map_values)
     {
-        T* ctrl = dynamic_cast<T*>(wnd);
+        T* ctrl = dynamic_cast<T*>(wnd.get());
         if(ctrl)
             result.push_back(ctrl);
     }
@@ -368,12 +367,12 @@ inline std::vector<T*> Window::GetCtrls()
 }
 
 template<typename T>
-inline std::vector<const T*> Window::GetCtrls() const
+std::vector<const T*> Window::GetCtrls() const
 {
     std::vector<const T*> result;
-    for(auto* const wnd : childIdToWnd_ | boost::adaptors::map_values)
+    for(const auto& wnd : childIdToWnd_ | boost::adaptors::map_values)
     {
-        const T* ctrl = dynamic_cast<const T*>(wnd);
+        const T* ctrl = dynamic_cast<const T*>(wnd.get());
         if(ctrl)
             result.push_back(ctrl);
     }

--- a/libs/s25main/Window.h
+++ b/libs/s25main/Window.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -58,7 +58,7 @@ namespace libsiedler2 {
 class ArchivItem_Map;
 }
 
-/// Die Basisklasse der Fenster.
+/// Base class for windows and controls
 class Window
 {
 public:
@@ -67,36 +67,37 @@ public:
 
     Window(Window* parent, unsigned id, const DrawPoint& pos, const Extent& size = Extent(0, 0));
     virtual ~Window();
-    /// zeichnet das Fenster.
+    /// Draw all contained controls if the window is visible
     void Draw();
-    /// Get the current position
+    /// Get the current position relative to the parent window
     DrawPoint GetPos() const;
-    /// Get the absolute (X,Y) position as when calling GetX/GetY for drawing
+    /// Get the absolute position for drawing
     DrawPoint GetDrawPos() const;
     /// Get the size of the window
     Extent GetSize() const;
-    /// gets the extent of the window in absolute coordinates
+    /// Get the extent of the window in absolute coordinates
     Rect GetDrawRect() const;
-    /// Get the actual extents of the rect (might be different to the draw rect if the window resizes according to
-    /// content)
+    /// Get the actual extents of the rect
+    /// (might be different to the draw rect if the window resizes according to content)
     virtual Rect GetBoundaryRect() const;
-    /// setzt die Größe des Fensters
+    /// Change the size
     virtual void Resize(const Extent& newSize) { size_ = newSize; }
-    /// setzt die Breite des Fensters
+    /// Change only the width
     void SetWidth(unsigned width) { Resize(Extent(width, size_.y)); }
-    /// setzt die Höhe des Fensters
+    /// Change only the height
     void SetHeight(unsigned height) { Resize(Extent(size_.x, height)); }
-    /// Sendet eine Tastaturnachricht an die Steuerelemente.
+    /// Send a keyboard message to all controls, return true if handled
     bool RelayKeyboardMessage(KeyboardMsgHandler msg, const KeyEvent& ke);
-    /// Sendet eine Mausnachricht weiter an alle Steuerelemente
+    /// Send a mouse message to all controls, return true if handled
     bool RelayMouseMessage(MouseMsgHandler msg, const MouseCoords& mc);
-    /// aktiviert das Fenster.
+    /// Make the window active or inactive. Inactive controls e.g. don't react to events
     virtual void SetActive(bool activate = true);
-    /// aktiviert die Steuerelemente des Fensters.
+    /// Activate/deactivate only the elements of the window
     void ActivateControls(bool activate = true);
-    /// Sperrt eine bestimmte Region für Mausereignisse.
+    /// Lock a region which won't react to mouse events anymore except for the given window/control.
+    /// Only a single region can be locked per window.
     void LockRegion(Window* window, const Rect& rect);
-    /// Gibt eine gesperrte Region wieder frei.
+    /// Release the region locked for the given window/control.
     void FreeRegion(Window* window);
     /// Check if the given point is in a region locked by any window other than exception
     bool IsInLockedRegion(const Position& pos, const Window* exception = nullptr) const;
@@ -108,13 +109,11 @@ public:
     /// Set the position for the window
     void SetPos(const DrawPoint& newPos);
 
-    // macht das Fenster sichtbar oder blendet es aus
-    virtual void SetVisible(bool visible) { this->visible_ = visible; }
-    /// Ist das Fenster sichtbar?
+    // Make the window visible or hide it
+    virtual void SetVisible(bool visible) { visible_ = visible; }
     bool IsVisible() const { return visible_; }
-    /// Ist das Fenster aktiv?
     bool IsActive() const { return active_; }
-    /// liefert das übergeordnete Fenster
+    /// Get the parent window (containing this) or nullptr if this is a top-level window
     Window* GetParent() const { return parent_; }
     unsigned GetID() const { return id_; }
     /// Get control with given ID of given type or nullptr if not found or other type
@@ -185,6 +184,11 @@ public:
     ctrlTab* AddTabCtrl(unsigned id, const DrawPoint& pos, unsigned short width);
     ctrlTable* AddTable(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc, const glFont* font,
                         std::vector<TableColumn> columns);
+    /// Add text
+    /// @param color    Text color (ARGB)
+    /// @param format   can be a combination of FontStyle::LEFT/CENTER/RIGHT and FontStyle::TOP/VCENTER/BOTTOM and
+    /// FontStyle::OUTLINE/NO_OUTLINE
+    ///                 Alignment specifies how the position is treated, i.e. where relative to the text it will be.
     ctrlText* AddText(unsigned id, const DrawPoint& pos, const std::string& text, unsigned color, FontStyle format,
                       const glFont* font);
     ctrlMapSelection* AddMapSelection(unsigned id, const DrawPoint& pos, const Extent& size,
@@ -192,13 +196,13 @@ public:
     TextFormatSetter AddFormattedText(unsigned id, const DrawPoint& pos, const std::string& text, unsigned color,
                                       FontStyle format, const glFont* font);
     ctrlTimer* AddTimer(unsigned id, std::chrono::milliseconds timeout);
-    /// fügt ein vertieftes variables TextCtrl hinzu.
-    /// var parameters are pointers to int, unsigned or const char and must be valid for the lifetime of the var text!
+    /// Add a 3D text control with a variable text. The text is formatted like printf but with pointers
+    /// to int (%d), unsigned (%u) or const char (%s) which must be valid for the lifetime of the var text!
     ctrlVarDeepening* AddVarDeepening(unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                                       const std::string& formatstr, const glFont* font, unsigned color,
                                       unsigned parameters, ...);
-    /// fügt ein variables TextCtrl hinzu.
-    /// var parameters are pointers to int, unsigned or const char and must be valid for the lifetime of the var text!
+    /// Add a text control with a variable text. The text is formatted like printf but with pointers
+    /// to int (%d), unsigned (%u) or const char (%s) which must be valid for the lifetime of the var text!
     ctrlVarText* AddVarText(unsigned id, const DrawPoint& pos, const std::string& formatstr, unsigned color,
                             FontStyle format, const glFont* font, unsigned parameters, ...);
     ctrlPreviewMinimap* AddPreviewMinimap(unsigned id, const DrawPoint& pos, const Extent& size,
@@ -210,14 +214,13 @@ public:
     static void Draw3DBorder(const Rect& rect, TextureColor tc, bool elevated);
     static void Draw3DContent(const Rect& rect, TextureColor tc, bool elevated, bool highlighted = false,
                               bool illuminated = false, unsigned contentColor = COLOR_WHITE);
-    /// Zeichnet ein Rechteck
     static void DrawRectangle(const Rect& rect, unsigned color);
-    /// Zeichnet eine Linie
     static void DrawLine(DrawPoint pt1, DrawPoint pt2, unsigned short width, unsigned color);
 
     // GUI-Notify-Messages
 
-    // Nachrichten, die von oben (WindowManager) nach unten (zu Controls) gereicht werden
+    // These messages get passed downwards (WindowManager to controls)
+    // Return true if the message was handled
     virtual void Msg_PaintBefore();
     virtual void Msg_PaintAfter();
     virtual bool Msg_LeftDown(const MouseCoords&) { return false; }
@@ -232,7 +235,7 @@ public:
     virtual bool Msg_KeyDown(const KeyEvent&) { return false; }
     virtual void Msg_ScreenResize(const ScreenResizeEvent& sr);
 
-    // Nachrichten, die von unten (Controls) nach oben (Fenster) gereicht werden
+    // Callback messages that are passed upwards (from controls to window)
     virtual void Msg_ButtonClick(unsigned /*ctrl_id*/) {}
     virtual void Msg_EditEnter(unsigned /*ctrl_id*/) {}
     virtual void Msg_EditChange(unsigned /*ctrl_id*/) {}
@@ -251,10 +254,10 @@ public:
     virtual void Msg_TableRightButton(unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
     virtual void Msg_TableLeftButton(unsigned /*ctrl_id*/, const boost::optional<unsigned>& /*selection*/) {}
 
-    // Sonstiges
+    /// Callback of a message box when closed
     virtual void Msg_MsgBoxResult(unsigned /*msgbox_id*/, MsgboxResult /*mbr*/) {}
 
-    // Nachrichten, die von Controls von ctrlGroup weitergeleitet werden
+    // Callbacks triggered by controls of ctrlGroup
     virtual void Msg_Group_ButtonClick(unsigned /*group_id*/, unsigned /*ctrl_id*/) {}
     virtual void Msg_Group_EditEnter(unsigned /*group_id*/, unsigned /*ctrl_id*/) {}
     virtual void Msg_Group_EditChange(unsigned /*group_id*/, unsigned /*ctrl_id*/) {}
@@ -286,32 +289,36 @@ protected:
     friend constexpr auto maxEnumValue(ButtonState) { return ButtonState::Pressed; }
     using ControlMap = std::map<unsigned, Window*>;
 
-    /// scales X- und Y values to fit the screen
+    /// Scale the value from the reference coordinates to current render size
     template<class T_Pt>
     static T_Pt Scale(const T_Pt& pt);
-    /// Scales the value when scale_ is true, else returns the value
+    /// Scales the value when scale_ is true, else returns the value unchanged
     template<class T_Pt>
     T_Pt ScaleIf(const T_Pt& pt) const;
-    /// setzt Scale-Wert, ob neue Controls skaliert werden sollen oder nicht.
-    void SetScale(bool scale = true) { this->scale_ = scale; }
-    /// zeichnet das Fenster.
+    /// Set whether controls of this window shall be scaled
+    void SetScale(bool scale = true) { scale_ = scale; }
+    /// Implementation of drawing the window, derived classes can override this to draw custom backgrounds or similar
     virtual void Draw_();
-    /// Weiterleitung von Nachrichten von abgeleiteten Klassen erlaubt oder nicht?
+    /// Shall messages be relayed to the controls of this window?
     virtual bool IsMessageRelayAllowed() const;
 
 private:
-    Window* const parent_; /// Handle auf das Parentfenster.
-    unsigned id_;          /// ID des Fensters.
-    DrawPoint pos_;        /// Position des Fensters.
-    Extent size_;          /// Höhe des Fensters.
-    bool active_;          /// Fenster aktiv?
-    bool visible_;         /// Fenster sichtbar?
-    bool scale_;           /// Sollen Controls an Fenstergröße angepasst werden?
+    Window* const parent_; /// Handle to parent window
+    unsigned id_;          /// ID of the window, must be unique among siblings
+    DrawPoint pos_;        /// Position relative to parent window.
+    Extent size_;          /// Size of the window
+    bool active_;          /// Window active?
+    bool visible_;         /// Window visible?
+    bool scale_;           /// Shall the controls of this window be scaled according to the render size?
 
-    std::map<Window*, Rect> lockedAreas_; /// gesperrte Regionen des Fensters.
+    /// Locked areas for mouse events.
+    /// The key is the window/control for which the area is locked, i.e. which control is the only one getting mouse
+    /// events from this region, the value is the locked area relative to this window. Only a single area can be locked
+    /// per window/control.
+    std::map<Window*, Rect> lockedAreas_;
     std::vector<Window*> tofreeAreas_;
     bool isInMouseRelay;
-    ControlMap childIdToWnd_; /// Die Steuerelemente des Fensters.
+    ControlMap childIdToWnd_; /// Controls contained in this window, mapped by their ID
     AnimationManager animations_;
 };
 

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -12,6 +12,7 @@
 #include "commonDefines.h"
 #include "desktops/Desktop.h"
 #include "driver/MouseCoords.h"
+#include "driver/VideoInterface.h"
 #include "drivers/ScreenResizeEvent.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "files.h"
@@ -380,10 +381,10 @@ void WindowManager::Msg_KeyDown(const KeyEvent& ke)
     if(ke.alt && (ke.kt == KeyType::Return))
     {
         // Switch Fullscreen/Windowed
-        const auto newScreenSize =
-          !SETTINGS.video.fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize; //-V807
-        VIDEODRIVER.ResizeScreen(newScreenSize, !SETTINGS.video.fullscreen);
-        SETTINGS.video.fullscreen = VIDEODRIVER.IsFullscreen();
+        SETTINGS.video.displayMode ^= DisplayMode::Fullscreen;
+        const auto isFullscreen = (SETTINGS.video.displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
+        const auto newScreenSize = isFullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize; //-V807
+        VIDEODRIVER.ResizeScreen(newScreenSize, SETTINGS.video.displayMode);
     } else if(ke.kt == KeyType::Print)
         TakeScreenshot();
     else
@@ -412,7 +413,7 @@ void WindowManager::Msg_ScreenResize(const Extent& newSize)
     curRenderSize = sr.newSize;
 
     // Don't change fullscreen size (only in menu)
-    if(!SETTINGS.video.fullscreen)
+    if(!bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen))
         SETTINGS.video.windowedSize = VIDEODRIVER.GetWindowSize();
 
     // ist unser Desktop gültig?

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -416,7 +416,7 @@ void WindowManager::Msg_ScreenResize(const Extent& newSize)
     curRenderSize = sr.newSize;
 
     // Don't change fullscreen size (only in menu)
-    if(SETTINGS.video.displayMode != DisplayMode::Fullscreen)
+    if(SETTINGS.video.displayMode == DisplayMode::Windowed)
         SETTINGS.video.windowedSize = VIDEODRIVER.GetWindowSize();
 
     // Desktop (still) valid?

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -431,6 +431,7 @@ void WindowManager::Msg_ScreenResize(const Extent& newSize)
         DrawPoint delta = window->GetPos() + DrawPoint(window->GetSize()) - DrawPoint(sr.newSize);
         if(delta.x > 0 || delta.y > 0)
             window->SetPos(window->GetPos() - elMax(delta, DrawPoint(0, 0)));
+        window->Msg_ScreenResize(sr);
     }
 }
 

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -412,7 +412,8 @@ void WindowManager::Msg_ScreenResize(const Extent& newSize)
     if(newSize == curRenderSize)
         return;
 
-    ScreenResizeEvent sr(curRenderSize, elMax(Extent(800, 600), newSize));
+    constexpr Extent minSize(VideoDriverWrapper::MinWindowSize.width, VideoDriverWrapper::MinWindowSize.height);
+    ScreenResizeEvent sr(curRenderSize, elMax(minSize, newSize));
     curRenderSize = sr.newSize;
 
     // Don't change fullscreen size (only in menu)

--- a/libs/s25main/WindowManager.cpp
+++ b/libs/s25main/WindowManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -381,10 +381,13 @@ void WindowManager::Msg_KeyDown(const KeyEvent& ke)
     if(ke.alt && (ke.kt == KeyType::Return))
     {
         // Switch Fullscreen/Windowed
-        SETTINGS.video.displayMode ^= DisplayMode::Fullscreen;
-        const auto isFullscreen = (SETTINGS.video.displayMode & DisplayMode::Fullscreen) != DisplayMode::None;
-        const auto newScreenSize = isFullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize; //-V807
-        VIDEODRIVER.ResizeScreen(newScreenSize, SETTINGS.video.displayMode);
+        const auto newMode =
+          (SETTINGS.video.displayMode == DisplayMode::Fullscreen) ? DisplayMode::Windowed : DisplayMode::Fullscreen;
+        const auto newScreenSize =
+          (newMode == DisplayMode::Fullscreen) ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
+        VIDEODRIVER.ResizeScreen(newScreenSize, newMode);
+
+        SETTINGS.video.displayMode = VIDEODRIVER.GetDisplayMode();
     } else if(ke.kt == KeyType::Print)
         TakeScreenshot();
     else
@@ -413,16 +416,16 @@ void WindowManager::Msg_ScreenResize(const Extent& newSize)
     curRenderSize = sr.newSize;
 
     // Don't change fullscreen size (only in menu)
-    if(!bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen))
+    if(SETTINGS.video.displayMode != DisplayMode::Fullscreen)
         SETTINGS.video.windowedSize = VIDEODRIVER.GetWindowSize();
 
-    // ist unser Desktop gültig?
+    // Desktop (still) valid?
     if(!curDesktop)
         return;
 
     curDesktop->Msg_ScreenResize(sr);
 
-    // IngameWindow verschieben falls nötig, so dass sie komplett sichtbar sind
+    // Move IngameWindows so they are completely visible
     for(const auto& window : windows)
     {
         DrawPoint delta = window->GetPos() + DrawPoint(window->GetSize()) - DrawPoint(sr.newSize);

--- a/libs/s25main/addons/AddonList.cpp
+++ b/libs/s25main/addons/AddonList.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -32,7 +32,7 @@ AddonList::Gui::Gui(const AddonList& addon, Window& window, bool readonly) : Add
 
     auto* cb = window.AddComboBox(2, cbPos, Extent(220, 20), TextureColor::Grey, NormalFont, 100, readonly);
     for(const auto& option : addon.options)
-        cb->AddString(option);
+        cb->AddItem(option);
     if(readonly)
         window.AddImage(3, cbPos - DrawPoint(1, 0), LOADER.GetImageN("io_new", 14), _("Locked"));
 }

--- a/libs/s25main/controls/ctrlBaseVarText.h
+++ b/libs/s25main/controls/ctrlBaseVarText.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -11,11 +11,12 @@
 
 class glFont;
 
-/// Base class for controls containing a text
+/// Base class for controls containing a text with format specifies
 class ctrlBaseVarText : public ctrlBaseText
 {
 public:
-    /// fmtArgs contains pointers to int, unsigned or const char and must be valid for the lifetime of the var text!
+    /// fmtArgs contains pointers to int (%d), unsigned (%u) or const char (%s)
+    /// which must be valid for the lifetime of the var text!
     ctrlBaseVarText(const std::string& fmtString, unsigned color, const glFont* font, unsigned count, va_list fmtArgs);
 
 protected:

--- a/libs/s25main/controls/ctrlComboBox.cpp
+++ b/libs/s25main/controls/ctrlComboBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -17,10 +17,7 @@ ctrlComboBox::ctrlComboBox(Window* parent, unsigned id, const DrawPoint& pos, co
     : Window(parent, id, pos, size), tc(tc), font(font), max_list_height(max_list_height), readonly(readonly),
       suppressSelectEvent(false)
 {
-    ctrlList* liste = AddList(0, DrawPoint(0, size.y), Extent(size.x, 4), tc, font);
-
-    // Liste am Anfang nicht anzeigen
-    liste->SetVisible(false);
+    AddList(0, DrawPoint(0, size.y), Extent(size.x, 4), tc, font)->SetVisible(false);
 
     if(!readonly)
         AddImageButton(1, DrawPoint(size.x - size.y, 0), Extent(size.y, size.y), tc, LOADER.GetImageN("io", 34));
@@ -28,9 +25,6 @@ ctrlComboBox::ctrlComboBox(Window* parent, unsigned id, const DrawPoint& pos, co
     Resize(size);
 }
 
-/**
- *  Größe verändern
- */
 void ctrlComboBox::Resize(const Extent& newSize)
 {
     Window::Resize(newSize);
@@ -76,13 +70,6 @@ boost::optional<std::string> ctrlComboBox::GetSelectedText() const
         return GetText(*selection);
     else
         return boost::none;
-}
-
-void ctrlComboBox::Msg_PaintAfter()
-{
-    // Liste erst jetzt malen, damit sie den Rest überdeckt
-    GetCtrl<ctrlList>(0)->Draw();
-    Window::Msg_PaintAfter();
 }
 
 bool ctrlComboBox::Msg_MouseMove(const MouseCoords& mc)
@@ -200,28 +187,19 @@ void ctrlComboBox::Msg_ListSelectItem(unsigned, const int selection)
     }
 }
 
-/**
- *  fügt einen String zur Liste hinzu.
- */
-void ctrlComboBox::AddString(const std::string& text)
+void ctrlComboBox::AddItem(const std::string& text)
 {
-    GetCtrl<ctrlList>(0)->AddString(text);
+    GetCtrl<ctrlList>(0)->AddItem(text);
     Resize(GetSize());
 }
 
-/**
- *  löscht alle Items der Liste.
- */
 void ctrlComboBox::DeleteAllItems()
 {
     GetCtrl<ctrlList>(0)->DeleteAllItems();
     Resize(GetSize());
 }
 
-/**
- *  wählt ein Item aus
- */
-void ctrlComboBox::SetSelection(unsigned short selection)
+void ctrlComboBox::SetSelection(unsigned selection)
 {
     // Avoid sending the change method when this is invoked intentionally
     suppressSelectEvent = true;
@@ -229,46 +207,46 @@ void ctrlComboBox::SetSelection(unsigned short selection)
     suppressSelectEvent = false;
 }
 
-/**
- *  zeichnet das Fenster.
- */
 void ctrlComboBox::Draw_()
 {
     auto* liste = GetCtrl<ctrlList>(0);
 
-    // Box
     Draw3D(Rect(GetDrawPos(), GetSize()), tc, false);
 
-    // Namen des selektierten Strings in der Box anzeigen
+    // Show selected item in the box
     if(liste->GetNumLines() > 0)
+    {
         font->Draw(GetDrawPos() + DrawPoint(2, GetSize().y / 2), liste->GetSelItemText(), FontStyle::VCENTER,
                    COLOR_YELLOW, GetSize().x - 2 - GetSize().y, "");
+    }
 
-    // Male restliche Controls per Hand, denn ein einfaches DrawControls() würde
-    // auch die Liste malen, die bei Msg_PaintAfter() sowieso gemalt wird.
+    // Draw button manually as we can't use DrawControls which would draw the list we do in Msg_PaintAfter
     auto* button = GetCtrl<ctrlButton>(1);
     if(button)
         button->Draw();
 }
 
-/**
- *  blendet die Liste ein oder aus.
- */
+void ctrlComboBox::Msg_PaintAfter()
+{
+    // Draw list now so it is on top of everything
+    GetCtrl<ctrlList>(0)->Draw();
+    Window::Msg_PaintAfter();
+}
+
 void ctrlComboBox::ShowList(bool show)
 {
-    auto* liste = GetCtrl<ctrlList>(0);
-    if(liste->IsVisible() == show)
+    auto* list = GetCtrl<ctrlList>(0);
+    if(list->IsVisible() == show)
         return;
 
-    // Liste entsprechend
-    liste->SetVisible(show);
-
-    // Pfeilbutton entsprechend
+    // list field
+    list->SetVisible(show);
+    // Arrow button
     GetCtrl<ctrlButton>(1)->SetChecked(show);
 
-    // Region sperren für die Liste, oder freigeben
+    // Lock/unlock region of extended list
     if(show)
-        GetParent()->LockRegion(this, liste->GetDrawRect());
+        GetParent()->LockRegion(this, list->GetDrawRect());
     else
         GetParent()->FreeRegion(this);
 

--- a/libs/s25main/controls/ctrlComboBox.h
+++ b/libs/s25main/controls/ctrlComboBox.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -19,13 +19,14 @@ public:
 
     bool isReadOnly() const { return readonly; }
 
-    void AddString(const std::string& text);
+    void AddItem(const std::string& text);
     void DeleteAllItems();
-
-    void SetSelection(unsigned short selection);
+    /// Set selection to an item if within bounds. Does not trigger a notification.
+    void SetSelection(unsigned selection);
     const boost::optional<unsigned>& GetSelection() const { return GetCtrl<ctrlList>(0)->GetSelection(); };
-    unsigned short GetNumItems() const { return GetCtrl<ctrlList>(0)->GetNumLines(); }
-    const std::string& GetText(unsigned short item) const { return GetCtrl<ctrlList>(0)->GetItemText(item); }
+    unsigned GetNumItems() const { return GetCtrl<ctrlList>(0)->GetNumLines(); }
+    const std::string& GetText(unsigned item) const { return GetCtrl<ctrlList>(0)->GetItemText(item); }
+    void SetText(unsigned item, const std::string& text) { GetCtrl<ctrlList>(0)->SetItemText(item, text); }
     boost::optional<std::string> GetSelectedText() const;
 
     void Msg_PaintAfter() override;
@@ -40,6 +41,7 @@ public:
 
 protected:
     void Draw_() override;
+    /// Show or hide the list.
     void ShowList(bool show);
     Rect GetFullDrawRect(const ctrlList* list);
 

--- a/libs/s25main/controls/ctrlList.cpp
+++ b/libs/s25main/controls/ctrlList.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -127,11 +127,6 @@ bool ctrlList::Msg_WheelDown(const MouseCoords& mc)
     return false;
 }
 
-/**
- *  Zeichenmethode.
- *
- *  @return @p true bei Erfolg, @p false bei Fehler
- */
 void ctrlList::Draw_()
 {
     if(lines.empty())
@@ -162,10 +157,7 @@ void ctrlList::Draw_()
     }
 }
 
-/**
- *  fügt eine Zeile hinzu.
- */
-void ctrlList::AddString(const std::string& text)
+void ctrlList::AddItem(const std::string& text)
 {
     // lines-Array ggf vergrößern
     lines.push_back(text);
@@ -173,31 +165,18 @@ void ctrlList::AddString(const std::string& text)
     GetCtrl<ctrlScrollBar>(0)->SetRange(static_cast<unsigned short>(lines.size()));
 }
 
-/**
- *  Verändert einen String
- */
-void ctrlList::SetString(const std::string& text, const unsigned id)
+void ctrlList::SetItemText(const unsigned id, const std::string& text)
 {
-    lines[id] = text;
+    lines.at(id) = text;
 }
 
-/**
- *  löscht alle Items.
- */
 void ctrlList::DeleteAllItems()
 {
     lines.clear();
     selection_ = boost::none;
 }
 
-/**
- *  liefert den Wert einer Zeile.
- *
- *  @param[in] line Die Zeile
- *
- *  @return Text der Zeile
- */
-const std::string& ctrlList::GetItemText(unsigned short line) const
+const std::string& ctrlList::GetItemText(unsigned line) const
 {
     RTTR_Assert(line < lines.size());
     return lines[line];
@@ -212,12 +191,6 @@ const std::string& ctrlList::GetSelItemText() const
         return EMPTY;
 }
 
-/**
- *  Größe ändern.
- *
- *  @param[in] width  Neue Breite
- *  @param[in] height Neue Höhe
- */
 void ctrlList::Resize(const Extent& newSize)
 {
     auto* scrollbar = GetCtrl<ctrlScrollBar>(0);
@@ -237,9 +210,6 @@ void ctrlList::Resize(const Extent& newSize)
     Window::Resize(newSize);
 }
 
-/**
- *  vertauscht zwei Zeilen
- */
 void ctrlList::Swap(unsigned first, unsigned second)
 {
     // Evtl Selection auf das jeweilige Element beibehalten?
@@ -252,10 +222,7 @@ void ctrlList::Swap(unsigned first, unsigned second)
     std::swap(lines[first], lines[second]);
 }
 
-/**
- *  entfernt eine Zeile
- */
-void ctrlList::Remove(const unsigned short index)
+void ctrlList::Remove(const unsigned index)
 {
     if(index < lines.size())
     {

--- a/libs/s25main/controls/ctrlList.h
+++ b/libs/s25main/controls/ctrlList.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -20,25 +20,23 @@ public:
              const glFont* font);
     ~ctrlList() override;
 
-    /// Größe verändern
+    /// Change size
     void Resize(const Extent& newSize) override;
 
-    /// Neuen String zur Listbox hinzufügen.
-    void AddString(const std::string& text);
-    /// Verändert einen String
-    void SetString(const std::string& text, unsigned id);
-    /// Listbox leeren.
+    /// Add item to listbox.
+    void AddItem(const std::string& text);
+    /// Change text of an item.
+    void SetItemText(unsigned id, const std::string& text);
     void DeleteAllItems();
-    /// liefert den Wert einer Zeile.
-    const std::string& GetItemText(unsigned short line) const;
-    /// liefert den Wert der aktuell gewählten Zeile.
+    const std::string& GetItemText(unsigned line) const;
+    /// Get the value of the currently selected item
     const std::string& GetSelItemText() const;
-    /// Vertauscht zwei Zeilen.
+    /// Exchange the text of 2 items
     void Swap(unsigned first, unsigned second);
-    /// Löscht ein Element
-    void Remove(unsigned short index);
+    /// Deletes an item. If the deleted item is selected then the selection is cleared.
+    void Remove(unsigned index);
 
-    unsigned short GetNumLines() const { return static_cast<unsigned short>(lines.size()); }
+    unsigned GetNumLines() const { return static_cast<unsigned>(lines.size()); }
     const boost::optional<unsigned>& GetSelection() const { return selection_; };
     void SetSelection(const boost::optional<unsigned>& selection);
 
@@ -50,7 +48,6 @@ public:
     bool Msg_WheelDown(const MouseCoords& mc) override;
 
 protected:
-    /// Zeichenmethode.
     void Draw_() override;
 
 private:

--- a/libs/s25main/controls/ctrlVarDeepening.h
+++ b/libs/s25main/controls/ctrlVarDeepening.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -13,7 +13,8 @@ class glFont;
 class ctrlVarDeepening : public ctrlDeepening, public ctrlBaseVarText
 {
 public:
-    /// fmtArgs contains pointers to int, unsigned or const char and must be valid for the lifetime of the var text!
+    /// fmtArgs contains pointers to int (%d), unsigned (%u) or const char (%s)
+    /// which must be valid for the lifetime of the var text!
     ctrlVarDeepening(Window* parent, unsigned id, const DrawPoint& pos, const Extent& size, TextureColor tc,
                      const std::string& fmtString, const glFont* font, unsigned color, unsigned count, va_list fmtArgs);
 

--- a/libs/s25main/desktops/Desktop.cpp
+++ b/libs/s25main/desktops/Desktop.cpp
@@ -11,16 +11,13 @@
 #include "helpers/toString.h"
 #include "ogl/FontStyle.h"
 #include "ogl/glArchivItem_Bitmap.h"
+#include <RescaleWindowProp.h>
 #include <limits>
 
 // Set to highest possible so it is drawn last
 const unsigned Desktop::fpsDisplayId = std::numeric_limits<unsigned>::max();
+constexpr DrawPoint fpsDisplayPos(800, 0);
 
-/**
- *  Konstruktor für einen Spieldesktop
- *
- *  @param[in] background Hintergrund des Desktops
- */
 Desktop::Desktop(glArchivItem_Bitmap* background)
     : Window(nullptr, 0, DrawPoint::all(0), VIDEODRIVER.GetRenderSize()), background(background), lastFPS_(0)
 {
@@ -36,12 +33,6 @@ Desktop::Desktop(glArchivItem_Bitmap* background)
 
 Desktop::~Desktop() = default;
 
-/**
- *  Zeichenmethode zum Zeichnen des Desktops
- *  und der ggf. enthaltenen Steuerelemente.
- *
- *  @return @p true bei Erfolg, @p false bei Fehler
- */
 void Desktop::Draw_()
 {
     unsigned curFPS = VIDEODRIVER.GetFPS();
@@ -54,14 +45,14 @@ void Desktop::Draw_()
     Window::Draw_();
 }
 
-/**
- *  Reagiert auf Spielfenstergrößenänderung
- */
 void Desktop::Msg_ScreenResize(const ScreenResizeEvent& sr)
 {
     Window::Msg_ScreenResize(sr);
     // Resize to new screen size
     Resize(sr.newSize);
+    auto* fpsDisplay = GetCtrl<ctrlText>(fpsDisplayId);
+    if(fpsDisplay)
+        fpsDisplay->SetPos(Scale(fpsDisplayPos));
 }
 
 void Desktop::SetFpsDisplay(bool show)
@@ -70,7 +61,7 @@ void Desktop::SetFpsDisplay(bool show)
         DeleteCtrl(fpsDisplayId);
     else if(!GetCtrl<ctrlText>(fpsDisplayId) && SmallFont)
     {
-        AddText(fpsDisplayId, DrawPoint(800, 0), helpers::toString(lastFPS_) + " fps", COLOR_YELLOW, FontStyle::RIGHT,
+        AddText(fpsDisplayId, fpsDisplayPos, helpers::toString(lastFPS_) + " fps", COLOR_YELLOW, FontStyle::RIGHT,
                 SmallFont);
     }
 }

--- a/libs/s25main/desktops/dskBenchmark.cpp
+++ b/libs/s25main/desktops/dskBenchmark.cpp
@@ -131,7 +131,7 @@ void dskBenchmark::Msg_PaintAfter()
 void dskBenchmark::SetActive(bool activate)
 {
     if(!IsActive() && activate)
-        VIDEODRIVER.ResizeScreen(VideoMode(1600, 900), false);
+        VIDEODRIVER.ResizeScreen(VideoMode(1600, 900), DisplayMode::Resizable);
     dskMenuBase::SetActive(activate);
 }
 

--- a/libs/s25main/desktops/dskBenchmark.cpp
+++ b/libs/s25main/desktops/dskBenchmark.cpp
@@ -131,7 +131,7 @@ void dskBenchmark::Msg_PaintAfter()
 void dskBenchmark::SetActive(bool activate)
 {
     if(!IsActive() && activate)
-        VIDEODRIVER.ResizeScreen(VideoMode(1600, 900), DisplayMode::Resizable);
+        VIDEODRIVER.ResizeScreen(VideoMode(1600, 900), DisplayMode::Windowed);
     dskMenuBase::SetActive(activate);
 }
 

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -99,6 +99,11 @@ enum
     ID_txtNumMsg
 };
 
+/// Size of buttons on lower bar
+constexpr Extent btSize = Extent(37, 32);
+/// Offsets of the buttons relative to the "border" graphics on the lower bar
+constexpr DrawPoint btOffset(44, 4);
+
 float getNextZoomLevel(const float currentZoom)
 {
     // Get first level bigger than current zoom
@@ -130,10 +135,11 @@ dskGameInterface::dskGameInterface(std::shared_ptr<Game> game, std::shared_ptr<c
 
     SetScale(false);
 
-    DrawPoint barPos((GetSize().x - LOADER.GetImageN("resource", 29)->getWidth()) / 2 + 44,
-                     GetSize().y - LOADER.GetImageN("resource", 29)->getHeight() + 4);
+    const glArchivItem_Bitmap& imgButtonBar = *LOADER.GetImageN("resource", 29);
 
-    Extent btSize = Extent(37, 32);
+    auto barPos =
+      DrawPoint((GetSize().x - imgButtonBar.getWidth()) / 2, GetSize().y - imgButtonBar.getHeight()) + btOffset;
+
     AddImageButton(ID_btMap, barPos, btSize, TextureColor::Green1, LOADER.GetImageN("io", 50), _("Map"))
       ->SetBorder(false);
     barPos.x += btSize.x;
@@ -303,8 +309,9 @@ void dskGameInterface::Resize(const Extent& newSize)
     // move buttons
     // Get real renderer size as newSize may get capped but we want to keep the manually drawn borders intact
     const Extent realNewSize = VIDEODRIVER.GetRenderSize();
-    DrawPoint barPos = DrawPoint((realNewSize.x - LOADER.GetImageN("resource", 29)->getWidth()) / 2 + 44,
-                                 realNewSize.y - LOADER.GetImageN("resource", 29)->getHeight() + 4);
+    const glArchivItem_Bitmap& imgButtonBar = *LOADER.GetImageN("resource", 29);
+    DrawPoint barPos =
+      DrawPoint((realNewSize.x - imgButtonBar.getWidth()) / 2, realNewSize.y - imgButtonBar.getHeight()) + btOffset;
 
     auto* button = GetCtrl<ctrlButton>(ID_btMap);
     button->SetPos(barPos);
@@ -698,10 +705,11 @@ bool dskGameInterface::ContextClick(const MouseCoords& mc)
 
 bool dskGameInterface::Msg_LeftDown(const MouseCoords& mc)
 {
-    DrawPoint btOrig(VIDEODRIVER.GetRenderSize().x / 2 - LOADER.GetImageN("resource", 29)->getWidth() / 2 + 44,
-                     VIDEODRIVER.GetRenderSize().y - LOADER.GetImageN("resource", 29)->getHeight() + 4);
-    Extent btSize = Extent(37, 32) * 4u;
-    if(IsPointInRect(mc.pos, Rect(btOrig, btSize)))
+    const glArchivItem_Bitmap& imgButtonBar = *LOADER.GetImageN("resource", 29);
+    const auto btOrig = DrawPoint(VIDEODRIVER.GetRenderSize().x / 2 - imgButtonBar.getWidth() / 2,
+                                  VIDEODRIVER.GetRenderSize().y - imgButtonBar.getHeight())
+                        + btOffset;
+    if(IsPointInRect(mc.pos, Rect(btOrig, btSize * 4u)))
         return false;
 
     if(!VIDEODRIVER.IsTouch())

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -53,6 +53,7 @@
 #include "ingameWindows/iwPostWindow.h"
 #include "ingameWindows/iwRoadWindow.h"
 #include "ingameWindows/iwSave.h"
+#include "ingameWindows/iwSettings.h"
 #include "ingameWindows/iwShip.h"
 #include "ingameWindows/iwSkipGFs.h"
 #include "ingameWindows/iwStatistics.h"
@@ -826,6 +827,7 @@ bool dskGameInterface::Msg_KeyDown(const KeyEvent& ke)
         case KeyType::F9:
             WINDOWMANAGER.ToggleWindow(std::make_unique<iwTextfile>("readme.txt", _("Readme!")));
             return true;
+        case KeyType::F10: WINDOWMANAGER.ToggleWindow(std::make_unique<iwSettings>()); return true;
         case KeyType::F11: // Music player (midi files)
             WINDOWMANAGER.ToggleWindow(std::make_unique<iwMusicPlayer>());
             return true;

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -301,8 +301,10 @@ void dskGameInterface::Resize(const Extent& newSize)
     cbb.buildBorder(newSize, borders);
 
     // move buttons
-    DrawPoint barPos((newSize.x - LOADER.GetImageN("resource", 29)->getWidth()) / 2 + 44,
-                     newSize.y - LOADER.GetImageN("resource", 29)->getHeight() + 4);
+    // Get real renderer size as newSize may get capped but we want to keep the manually drawn borders intact
+    const Extent realNewSize = VIDEODRIVER.GetRenderSize();
+    DrawPoint barPos = DrawPoint((realNewSize.x - LOADER.GetImageN("resource", 29)->getWidth()) / 2 + 44,
+                                 realNewSize.y - LOADER.GetImageN("resource", 29)->getHeight() + 4);
 
     auto* button = GetCtrl<ctrlButton>(ID_btMap);
     button->SetPos(barPos);

--- a/libs/s25main/desktops/dskGameLobby.cpp
+++ b/libs/s25main/desktops/dskGameLobby.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -233,43 +233,43 @@ dskGameLobby::dskGameLobby(ServerType serverType, std::shared_ptr<GameLobby> gam
     AddText(ID_txtExploration, DrawPoint(400, 405), _("Exploration:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     combo = AddComboBox(ID_cbExploration, DrawPoint(600, 400), Extent(180, 20), TextureColor::Grey, NormalFont, 100,
                         readonlySettings);
-    combo->AddString(_("Off (all visible)"));
-    combo->AddString(_("Classic (Settlers 2)"));
-    combo->AddString(_("Fog of War"));
-    combo->AddString(_("FoW - all explored"));
+    combo->AddItem(_("Off (all visible)"));
+    combo->AddItem(_("Classic (Settlers 2)"));
+    combo->AddItem(_("Fog of War"));
+    combo->AddItem(_("FoW - all explored"));
 
     AddText(ID_txtGoods, DrawPoint(400, 375), _("Goods at start:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     combo = AddComboBox(ID_cbGoods, DrawPoint(600, 370), Extent(180, 20), TextureColor::Grey, NormalFont, 100,
                         readonlySettings);
-    combo->AddString(_("Very Low"));
-    combo->AddString(_("Low"));
-    combo->AddString(_("Normal"));
-    combo->AddString(_("A lot"));
+    combo->AddItem(_("Very Low"));
+    combo->AddItem(_("Low"));
+    combo->AddItem(_("Normal"));
+    combo->AddItem(_("A lot"));
 
     AddText(ID_txtGoals, DrawPoint(400, 345), _("Goals:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     combo = AddComboBox(ID_cbGoals, DrawPoint(600, 340), Extent(180, 20), TextureColor::Grey, NormalFont, 100,
                         readonlySettings);
-    combo->AddString(_("None"));
-    combo->AddString(_("Conquer 3/4 of map"));
-    combo->AddString(_("Total domination"));
-    combo->AddString(_("Economy mode"));
+    combo->AddItem(_("None"));
+    combo->AddItem(_("Conquer 3/4 of map"));
+    combo->AddItem(_("Total domination"));
+    combo->AddItem(_("Economy mode"));
 
     // Lobby game?
     if(lobbyClient_ && lobbyClient_->IsLoggedIn())
     {
         // Then add tournament modes as possible "objectives"
         for(const auto duration : TOURNAMENT_MODES_DURATION)
-            combo->AddString(helpers::format(_("Tournament: %u minutes"), duration / 1min));
+            combo->AddItem(helpers::format(_("Tournament: %u minutes"), duration / 1min));
     }
 
     AddText(ID_txtSpeed, DrawPoint(400, 315), _("Speed:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     combo = AddComboBox(ID_cbSpeed, DrawPoint(600, 310), Extent(180, 20), TextureColor::Grey, NormalFont, 100,
                         !gameLobby_->isHost());
-    combo->AddString(_("Very slow"));
-    combo->AddString(_("Slow"));
-    combo->AddString(_("Normal"));
-    combo->AddString(_("Fast"));
-    combo->AddString(_("Very fast"));
+    combo->AddItem(_("Very slow"));
+    combo->AddItem(_("Slow"));
+    combo->AddItem(_("Normal"));
+    combo->AddItem(_("Fast"));
+    combo->AddItem(_("Very fast"));
 
     // Karte laden, um Kartenvorschau anzuzeigen
     if(!gameLobby_->isSavegame())
@@ -518,7 +518,7 @@ void dskGameLobby::UpdatePlayerRow(const unsigned row)
             {
                 if(!gameLobby_->getPlayer(i).originName.empty())
                 {
-                    combo->AddString(gameLobby_->getPlayer(i).originName);
+                    combo->AddItem(gameLobby_->getPlayer(i).originName);
                     if(i == row)
                         combo->SetSelection(combo->GetNumItems() - 1u);
                 }

--- a/libs/s25main/desktops/dskMainMenu.cpp
+++ b/libs/s25main/desktops/dskMainMenu.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -50,7 +50,7 @@ dskMainMenu::dskMainMenu()
     AddImage(ID_logo, DrawPoint(20, 20), LOADER.GetImageN("logo", 0));
 
     using namespace std::chrono_literals;
-    if(SETTINGS.global.submit_debug_data == 0)
+    if(SETTINGS.global.submitDebugData == 0)
         AddTimer(ID_tmrDebugData, 250ms);
 
     /*AddText(20, DrawPoint(50, 450), _("Font Test"), COLOR_YELLOW, FontStyle::LEFT, SmallFont);
@@ -73,9 +73,9 @@ void dskMainMenu::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult 
     if(msgbox_id == 100)
     {
         if(mbr == MsgboxResult::Yes)
-            SETTINGS.global.submit_debug_data = 1;
+            SETTINGS.global.submitDebugData = 1;
         else
-            SETTINGS.global.submit_debug_data = 2;
+            SETTINGS.global.submitDebugData = 2;
 
         SETTINGS.Save();
     }

--- a/libs/s25main/desktops/dskMainMenu.cpp
+++ b/libs/s25main/desktops/dskMainMenu.cpp
@@ -50,7 +50,7 @@ dskMainMenu::dskMainMenu()
     AddImage(ID_logo, DrawPoint(20, 20), LOADER.GetImageN("logo", 0));
 
     using namespace std::chrono_literals;
-    if(SETTINGS.global.submitDebugData == 0)
+    if(SETTINGS.global.submitDebugData == SubmitDebugData::AskAtStart)
         AddTimer(ID_tmrDebugData, 250ms);
 
     /*AddText(20, DrawPoint(50, 450), _("Font Test"), COLOR_YELLOW, FontStyle::LEFT, SmallFont);
@@ -73,9 +73,9 @@ void dskMainMenu::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult 
     if(msgbox_id == 100)
     {
         if(mbr == MsgboxResult::Yes)
-            SETTINGS.global.submitDebugData = 1;
+            SETTINGS.global.submitDebugData = SubmitDebugData::Yes;
         else
-            SETTINGS.global.submitDebugData = 2;
+            SETTINGS.global.submitDebugData = SubmitDebugData::AlwaysAsk;
 
         SETTINGS.Save();
     }

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -14,6 +14,7 @@
 #include "controls/ctrlImageButton.h"
 #include "controls/ctrlOptionGroup.h"
 #include "controls/ctrlProgress.h"
+#include "controls/ctrlTextButton.h"
 #include "driver/VideoDriver.h"
 #include "drivers/AudioDriverWrapper.h"
 #include "drivers/VideoDriverWrapper.h"
@@ -66,15 +67,11 @@ enum
     ID_cbProxyType,
     ID_txtDebugData,
     ID_grpDebugData,
-    ID_txtUPNP,
     ID_grpUPNP,
     ID_txtMapScrollMode,
     ID_cbMapScrollMode,
-    ID_txtSmartCursor,
     ID_grpSmartCursor,
-    ID_txtWindowPinning,
     ID_grpWindowPinning,
-    ID_txtGFInfo,
     ID_grpGFInfo,
     ID_txtResolution,
     ID_cbResolution,
@@ -82,28 +79,24 @@ enum
     ID_cbDisplayMode,
     ID_txtFramerate,
     ID_cbFramerate,
-    ID_txtVBO,
     ID_grpVBO,
     ID_txtVideoDriver,
     ID_cbVideoDriver,
-    ID_txtOptTextures,
     ID_grpOptTextures,
     ID_txtGuiScale,
     ID_cbGuiScale,
     ID_txtAudioDriver,
     ID_cbAudioDriver,
-    ID_txtMusic,
     ID_grpMusic,
     ID_pgMusicVol,
-    ID_txtEffects,
     ID_grpEffects,
     ID_pgEffectsVol,
     ID_btMusicPlayer,
     ID_txtCommonPortrait,
     ID_btCommonPortrait,
     ID_cbCommonPortrait,
-    ID_txtBirdSounds,
     ID_grpBirdSounds,
+    ID_txtsStart, // First ID for texts used by options (ID of option is used as offset on top)
 };
 // Use these as IDs in dedicated groups
 constexpr auto ID_btOn = 1;
@@ -122,9 +115,8 @@ constexpr Offset ctrlOffset(200, -5);                       // Offset of control
 constexpr Offset ctrlOffset2 = ctrlOffset + Offset(200, 0); // Offset of 2nd control to its description text
 constexpr Extent ctrlSize(190, 22);
 constexpr Extent ctrlSizeLarge = ctrlSize + Extent(ctrlOffset2 - ctrlOffset);
-} // namespace
 
-static VideoMode getAspectRatio(const VideoMode& vm)
+VideoMode getAspectRatio(const VideoMode& vm)
 {
     // First some a bit off values where the aspect ratio is defined by convention
     if(vm == VideoMode(1360, 1024))
@@ -143,6 +135,32 @@ static VideoMode getAspectRatio(const VideoMode& vm)
     else
         return ratio;
 }
+
+enum class ButtonSize
+{
+    Normal,
+    Half /// Both buttons take up the same space as a single button
+};
+
+ctrlOptionGroup& addOnOffOption(ctrlGroup& parentGroup, DrawPoint pos, unsigned id, const std::string& title,
+                                bool value, ButtonSize btSize = ButtonSize::Normal)
+{
+    constexpr auto spacing = 10;
+    auto size = ctrlSize;
+    if(btSize == ButtonSize::Half)
+        size.x = (ctrlSize.x - spacing) / 2;
+
+    parentGroup.AddText(ID_txtsStart + id, pos, title, COLOR_YELLOW, FontStyle{}, NormalFont);
+    auto* option = parentGroup.AddOptionGroup(id, GroupSelectType::Check);
+    pos += ctrlOffset;
+    option->AddTextButton(ID_btOn, pos, size, TextureColor::Grey, _("On"), NormalFont);
+    pos.x += size.x + spacing;
+    option->AddTextButton(ID_btOff, pos, size, TextureColor::Grey, _("Off"), NormalFont);
+    option->SetSelection(value);
+    return *option;
+}
+
+} // namespace
 
 dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 {
@@ -229,14 +247,11 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     curPos.y += rowHeight;
 
     // IPv4/6
-    groupCommon->AddText(ID_txtIpv6, curPos, _("Use IPv6:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-
-    ctrlOptionGroup* ipv6 = groupCommon->AddOptionGroup(ID_grpIpv6, GroupSelectType::Check);
-    ipv6->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("IPv6"), NormalFont);
-    ipv6->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("IPv4"), NormalFont);
-    ipv6->SetSelection(SETTINGS.server.ipv6);
+    auto& grpIPv6 = addOnOffOption(*groupCommon, curPos, ID_grpIpv6, _("Use IPv6:"), SETTINGS.server.ipv6);
+    grpIPv6.GetCtrl<ctrlTextButton>(ID_btOn)->SetText(_("IPv6"));
+    grpIPv6.GetCtrl<ctrlTextButton>(ID_btOff)->SetText(_("IPv4"));
     // Enable/disable the IPv6 field if necessary
-    ipv6->GetCtrl<ctrlButton>(1)->SetEnabled(SETTINGS.proxy.type != ProxyType::Socks5); //-V807
+    grpIPv6.GetCtrl<ctrlButton>(ID_btOn)->SetEnabled(SETTINGS.proxy.type != ProxyType::Socks5); //-V807
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacingCommon;
@@ -250,11 +265,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     proxy->SetText(SETTINGS.proxy.port);
     curPos.y += rowHeight;
 
-    groupCommon->AddText(ID_txtUPNP, curPos, _("Use UPnP"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    ctrlOptionGroup* upnp = groupCommon->AddOptionGroup(ID_grpUPNP, GroupSelectType::Check);
-    upnp->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("On"), NormalFont);
-    upnp->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Off"), NormalFont);
-    upnp->SetSelection(SETTINGS.global.useUPNP);
+    addOnOffOption(*groupCommon, curPos, ID_grpUPNP, _("Use UPnP"), SETTINGS.global.useUPNP);
     curPos.y += rowHeight;
 
     // Proxy type
@@ -285,23 +296,19 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     combo->SetSelection(static_cast<int>(SETTINGS.interface.mapScrollMode));
     curPos.y += rowHeight;
 
-    groupCommon->AddText(ID_txtSmartCursor, curPos, _("Smart Cursor"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    ctrlOptionGroup* smartCursor = groupCommon->AddOptionGroup(ID_grpSmartCursor, GroupSelectType::Check);
-    smartCursor->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("On"), NormalFont,
-                               _("Place cursor on default button for new dialogs / action windows (default)"));
-    smartCursor->AddTextButton(
-      ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Off"), NormalFont,
+    auto& grpSmartCursor =
+      addOnOffOption(*groupCommon, curPos, ID_grpSmartCursor, _("Smart Cursor"), SETTINGS.global.smartCursor);
+    grpSmartCursor.GetCtrl<ctrlButton>(ID_btOn)->SetTooltip(
+      _("Place cursor on default button for new dialogs / action windows (default)"));
+    grpSmartCursor.GetCtrl<ctrlButton>(ID_btOff)->SetTooltip(
       _("Don't move cursor automatically\nUseful e.g. for split-screen / dual-mice multiplayer (see wiki)"));
-    smartCursor->SetSelection(SETTINGS.global.smartCursor);
     curPos.y += rowHeight;
 
-    groupCommon->AddText(ID_txtWindowPinning, curPos, _("Window pinning"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    ctrlOptionGroup* windowPinning = groupCommon->AddOptionGroup(ID_grpWindowPinning, GroupSelectType::Check);
-    windowPinning->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("On"), NormalFont,
-                                 _("Replace minimize button on windows by pin button avoiding closing the window with "
-                                   "ESC.\nMinimize by double-clicking the title bar."));
-    windowPinning->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Off"), NormalFont);
-    windowPinning->SetSelection(SETTINGS.interface.enableWindowPinning);
+    auto& grpWindowPinning = addOnOffOption(*groupCommon, curPos, ID_grpWindowPinning, _("Window pinning"),
+                                            SETTINGS.interface.enableWindowPinning);
+    grpWindowPinning.GetCtrl<ctrlButton>(ID_btOn)->SetTooltip(
+      _("Replace minimize button on windows by pin button avoiding closing the window with "
+        "ESC.\nMinimize by double-clicking the title bar."));
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacingCommon;
@@ -315,12 +322,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     mainGroup->SetSelection((SETTINGS.global.submitDebugData == 1) ? ID_btSubmitDebugOn : ID_btSubmitDebugAsk); //-V807
     curPos.y += rowHeight;
 
-    groupCommon->AddText(ID_txtGFInfo, curPos, _("Show GameFrame Info:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    mainGroup = groupCommon->AddOptionGroup(ID_grpGFInfo, GroupSelectType::Check);
-    mainGroup->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("On"), NormalFont);
-    mainGroup->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Off"), NormalFont);
-
-    mainGroup->SetSelection(SETTINGS.global.showGFInfo);
+    addOnOffOption(*groupCommon, curPos, ID_grpGFInfo, _("Show GameFrame Info:"), SETTINGS.global.showGFInfo);
 
     curPos = optionRowsStartPosition;
     groupGraphics->AddText(ID_txtResolution, curPos, _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{},
@@ -344,10 +346,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
-    groupGraphics->AddText(ID_txtVBO, curPos, _("Vertex Buffer Objects:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    mainGroup = groupGraphics->AddOptionGroup(ID_grpVBO, GroupSelectType::Check);
-    mainGroup->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("On"), NormalFont);
-    mainGroup->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Off"), NormalFont);
+    addOnOffOption(*groupGraphics, curPos, ID_grpVBO, _("Vertex Buffer Objects:"), SETTINGS.video.vbo);
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
@@ -366,11 +365,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
-    groupGraphics->AddText(ID_txtOptTextures, curPos, _("Optimized Textures:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    mainGroup = groupGraphics->AddOptionGroup(ID_grpOptTextures, GroupSelectType::Check);
-
-    mainGroup->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("On"), NormalFont);
-    mainGroup->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Off"), NormalFont);
+    addOnOffOption(*groupGraphics, curPos, ID_grpOptTextures, _("Optimized Textures:"), SETTINGS.video.sharedTextures);
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
@@ -379,36 +374,24 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     updateGuiScale();
 
     curPos = optionRowsStartPosition;
-    constexpr Offset bt1Offset(200, -5);
-    constexpr Offset bt2Offset(300, -5);
-    constexpr Offset volOffset(400, -5);
-    constexpr Extent ctrlSizeSmall(90, ctrlSize.y);
 
-    groupSound->AddText(ID_txtEffects, curPos, _("Effects"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    mainGroup = groupSound->AddOptionGroup(ID_grpEffects, GroupSelectType::Check);
-    mainGroup->AddTextButton(ID_btOn, curPos + bt1Offset, ctrlSizeSmall, TextureColor::Grey, _("On"), NormalFont);
-    mainGroup->AddTextButton(ID_btOff, curPos + bt2Offset, ctrlSizeSmall, TextureColor::Grey, _("Off"), NormalFont);
+    addOnOffOption(*groupSound, curPos, ID_grpEffects, _("Effects"), SETTINGS.sound.effectsEnabled, ButtonSize::Half);
 
     ctrlProgress* FXvolume =
-      groupSound->AddProgress(ID_pgEffectsVol, curPos + volOffset, ctrlSize, TextureColor::Grey, 139, 138, 100);
+      groupSound->AddProgress(ID_pgEffectsVol, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, 139, 138, 100);
     FXvolume->SetPosition((SETTINGS.sound.effectsVolume * 100) / 255);
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
-    groupSound->AddText(ID_txtBirdSounds, curPos, _("Bird sounds"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    mainGroup = groupSound->AddOptionGroup(ID_grpBirdSounds, GroupSelectType::Check);
-    mainGroup->AddTextButton(ID_btOn, curPos + bt1Offset, ctrlSizeSmall, TextureColor::Grey, _("On"), NormalFont);
-    mainGroup->AddTextButton(ID_btOff, curPos + bt2Offset, ctrlSizeSmall, TextureColor::Grey, _("Off"), NormalFont);
+    addOnOffOption(*groupSound, curPos, ID_grpBirdSounds, _("Bird sounds"), SETTINGS.sound.birdsEnabled,
+                   ButtonSize::Half);
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
-    groupSound->AddText(ID_txtMusic, curPos, _("Music"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    mainGroup = groupSound->AddOptionGroup(ID_grpMusic, GroupSelectType::Check);
-    mainGroup->AddTextButton(ID_btOn, curPos + bt1Offset, ctrlSizeSmall, TextureColor::Grey, _("On"), NormalFont);
-    mainGroup->AddTextButton(ID_btOff, curPos + bt2Offset, ctrlSizeSmall, TextureColor::Grey, _("Off"), NormalFont);
+    addOnOffOption(*groupSound, curPos, ID_grpMusic, _("Music"), SETTINGS.sound.musicEnabled, ButtonSize::Half);
 
     ctrlProgress* Mvolume =
-      groupSound->AddProgress(ID_pgMusicVol, curPos + volOffset, ctrlSize, TextureColor::Grey, 139, 138, 100);
+      groupSound->AddProgress(ID_pgMusicVol, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, 139, 138, 100);
     Mvolume->SetPosition((SETTINGS.sound.musicVolume * 100) / 255); //-V807
     curPos.y += rowHeight;
 
@@ -476,9 +459,6 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     if(!cbFrameRate->GetSelection())
         cbFrameRate->SetSelection(0);
 
-    groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpVBO)->SetSelection(SETTINGS.video.vbo);
-
-    groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpOptTextures)->SetSelection(SETTINGS.video.sharedTextures);
     // }
 
     // Sound
@@ -614,6 +594,7 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
             break;
         case ID_grpWindowPinning: SETTINGS.interface.enableWindowPinning = enabled; break;
         case ID_grpGFInfo: SETTINGS.global.showGFInfo = enabled; break;
+        default: RTTR_Assert(false);
     }
 }
 

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -644,9 +644,12 @@ void dskOptions::Msg_ButtonClick(const unsigned ctrl_id)
 
             // Is the selected backend required to support GUI scaling to fulfill the user's choice?
             // If so, warn the user if the backend is unable to support GUI scaling.
-            if(VIDEODRIVER.getGuiScale().percent() == 100
-               && (SETTINGS.video.guiScale != 100
-                   || (SETTINGS.video.guiScale == 0 && VIDEODRIVER.getGuiScaleRange().recommendedPercent != 100)))
+            const auto requestedGuiScale = SETTINGS.video.guiScale;
+            const bool autoGuiScale = requestedGuiScale == 0;
+            if((!autoGuiScale && requestedGuiScale != VIDEODRIVER.getGuiScale().percent())
+               || (autoGuiScale
+                   && VIDEODRIVER.getGuiScaleRange().recommendedPercent != VIDEODRIVER.getGuiScale().percent()))
+
             {
                 WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
                   _("Sorry!"), _("The selected video driver does not support GUI scaling! Setting won't be used."),

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -79,7 +79,7 @@ enum
     ID_txtResolution,
     ID_cbResolution,
     ID_txtFullscreen,
-    ID_grpFullscreen,
+    ID_cbDisplayMode,
     ID_txtFramerate,
     ID_cbFramerate,
     ID_txtVBO,
@@ -331,9 +331,12 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 
     curPos.y += sectionSpacing;
     groupGraphics->AddText(ID_txtFullscreen, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    mainGroup = groupGraphics->AddOptionGroup(ID_grpFullscreen, GroupSelectType::Check);
-    mainGroup->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("Fullscreen"), NormalFont);
-    mainGroup->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Windowed"), NormalFont);
+    ctrlComboBox* cbDisplayMode = groupGraphics->AddComboBox(ID_cbDisplayMode, curPos + ctrlOffset, ctrlSizeLarge,
+                                                             TextureColor::Grey, NormalFont, 100);
+    cbDisplayMode->AddString(_("Windowed"));
+    cbDisplayMode->AddString(_("Fullscreen"));
+    cbDisplayMode->AddString(_("Borderless window"));
+    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode));
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
@@ -458,10 +461,6 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
             cbVideoModes.SetSelection(cbVideoModes.GetNumItems() - 1);
     }
 
-    // Set "Fullscreen"
-    groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpFullscreen)
-      ->SetSelection(bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen)); //-V807
-
     // Fill "Limit Framerate"
     auto* cbFrameRate = groupGraphics->GetCtrl<ctrlComboBox>(ID_cbFramerate);
     if(VIDEODRIVER.HasVSync())
@@ -583,6 +582,7 @@ void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsign
             VIDEODRIVER.setGuiScalePercent(SETTINGS.video.guiScale);
             break;
         case ID_cbAudioDriver: SETTINGS.driver.audio = combo->GetText(selection); break;
+        case ID_cbDisplayMode: SETTINGS.video.displayMode = DisplayMode(selection); break;
     }
 }
 
@@ -593,9 +593,6 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
     switch(ctrl_id)
     {
         case ID_grpIpv6: SETTINGS.server.ipv6 = enabled; break;
-        case ID_grpFullscreen:
-            SETTINGS.video.displayMode = bitset::set(SETTINGS.video.displayMode, DisplayMode::Fullscreen, enabled);
-            break;
         case ID_grpVBO: SETTINGS.video.vbo = enabled; break;
         case ID_grpOptTextures: SETTINGS.video.shared_textures = enabled; break;
         case ID_grpEffects: SETTINGS.sound.effectsEnabled = enabled; break;
@@ -665,7 +662,7 @@ void dskOptions::Msg_ButtonClick(const unsigned ctrl_id)
 
             SETTINGS.Save();
 
-            // Is the selected backend required to support GUI scaling to fullfill the user's choice?
+            // Is the selected backend required to support GUI scaling to fulfill the user's choice?
             // If so, warn the user if the backend is unable to support GUI scaling.
             if(VIDEODRIVER.getGuiScale().percent() == 100
                && (SETTINGS.video.guiScale != 100
@@ -676,9 +673,9 @@ void dskOptions::Msg_ButtonClick(const unsigned ctrl_id)
                   this, MsgboxButton::Ok, MsgboxIcon::ExclamationGreen, 1));
             }
 
-            const auto fullscreen = bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen);
+            const auto fullscreen = SETTINGS.video.displayMode == DisplayMode::Fullscreen;
             if((fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize()) //-V807
-               || fullscreen != VIDEODRIVER.IsFullscreen())
+               || VIDEODRIVER.GetDisplayMode() != SETTINGS.video.displayMode)
             {
                 const auto screenSize = fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
                 if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -73,8 +73,12 @@ enum
     ID_grpSmartCursor,
     ID_grpWindowPinning,
     ID_grpGFInfo,
+    ID_grpResolution,
     ID_txtResolution,
     ID_cbResolution,
+    ID_grpWindowSize,
+    ID_txtWindowSize,
+    ID_cbWindowSize,
     ID_txtDisplayMode,
     ID_cbDisplayMode,
     ID_grpLockWindowSize,
@@ -326,12 +330,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     addOnOffOption(*groupCommon, curPos, ID_grpGFInfo, _("Show GameFrame Info:"), SETTINGS.global.showGFInfo);
 
     curPos = optionRowsStartPosition;
-    groupGraphics->AddText(ID_txtResolution, curPos, _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{},
-                           NormalFont);
-    groupGraphics->AddComboBox(ID_cbResolution, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, NormalFont, 150);
-    curPos.y += rowHeight;
 
-    curPos.y += sectionSpacing;
     groupGraphics->AddText(ID_txtDisplayMode, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     ctrlComboBox* cbDisplayMode = groupGraphics->AddComboBox(ID_cbDisplayMode, curPos + ctrlOffset, ctrlSizeLarge,
                                                              TextureColor::Grey, NormalFont, 100);
@@ -341,7 +340,16 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode.type));
     curPos.y += rowHeight;
 
-    addOnOffOption(*groupGraphics, curPos, ID_grpLockWindowSize, _("Lock window size:"),
+    auto* grpResolution = groupGraphics->AddGroup(ID_grpResolution);
+    grpResolution->AddText(ID_txtResolution, curPos, _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{},
+                           NormalFont);
+    grpResolution->AddComboBox(ID_cbResolution, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, NormalFont, 150);
+    auto* grpWindowSize = groupGraphics->AddGroup(ID_grpWindowSize);
+    grpWindowSize->AddText(ID_txtWindowSize, curPos, _("Window size:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    grpWindowSize->AddComboBox(ID_cbWindowSize, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, NormalFont, 150);
+    curPos.y += rowHeight;
+
+    addOnOffOption(*grpWindowSize, curPos, ID_grpLockWindowSize, _("Lock window size:"),
                    !SETTINGS.video.displayMode.resizeable);
     curPos.y += rowHeight;
 
@@ -429,7 +437,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     loadVideoModes();
 
     // and add to the combo box
-    ctrlComboBox& cbVideoModes = *groupGraphics->GetCtrl<ctrlComboBox>(ID_cbResolution);
+    ctrlComboBox& cbVideoModes = *grpResolution->GetCtrl<ctrlComboBox>(ID_cbResolution);
     for(const auto& videoMode : videoModes_)
     {
         VideoMode ratio = getAspectRatio(videoMode);
@@ -447,6 +455,16 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
         if(videoMode == SETTINGS.video.fullscreenSize) //-V807
             cbVideoModes.SetSelection(cbVideoModes.GetNumItems() - 1);
     }
+    ctrlComboBox& cbWindowSize = *grpWindowSize->GetCtrl<ctrlComboBox>(ID_cbWindowSize);
+    cbWindowSize.AddItem(""); // Placeholder for current window size
+    for(const auto& size : windowSizes_)
+    {
+        s25util::ClassicImbuedStream<std::ostringstream> str;
+        str << size.width << "x" << size.height;
+        cbWindowSize.AddItem(str.str());
+    }
+    updateWindowSizeComboBox();
+    updateResolutionGroups();
 
     // Fill "Limit Framerate"
     auto* cbFrameRate = groupGraphics->GetCtrl<ctrlComboBox>(ID_cbFramerate);
@@ -548,6 +566,15 @@ void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsign
             break;
         case ID_cbMapScrollMode: SETTINGS.interface.mapScrollMode = static_cast<MapScrollMode>(selection); break;
         case ID_cbResolution: SETTINGS.video.fullscreenSize = videoModes_[selection]; break;
+        case ID_cbWindowSize:
+            if(selection > 0)
+            {
+                SETTINGS.video.windowedSize = windowSizes_[selection - 1];
+                if(SETTINGS.video.displayMode == DisplayMode::Windowed
+                   && VIDEODRIVER.GetDisplayMode() == DisplayMode::Windowed)
+                    VIDEODRIVER.ResizeScreen(SETTINGS.video.windowedSize, DisplayMode::Windowed);
+            }
+            break;
         case ID_cbFramerate:
             if(VIDEODRIVER.HasVSync())
             {
@@ -566,7 +593,10 @@ void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsign
             VIDEODRIVER.setGuiScalePercent(SETTINGS.video.guiScale);
             break;
         case ID_cbAudioDriver: SETTINGS.driver.audio = combo->GetText(selection); break;
-        case ID_cbDisplayMode: SETTINGS.video.displayMode = DisplayMode(selection); break;
+        case ID_cbDisplayMode:
+            SETTINGS.video.displayMode = DisplayMode(selection);
+            updateResolutionGroups();
+            break;
     }
 }
 
@@ -740,12 +770,15 @@ void dskOptions::loadVideoModes()
     helpers::erase_if(videoModes_, [](const auto& it) { return it.width < 800 && it.height < 600; });
     // Sort by aspect ratio
     helpers::sort(videoModes_, cmpVideoModes);
+    windowSizes_ = VIDEODRIVER.GetDefaultWindowSizes();
+    std::sort(windowSizes_.begin(), windowSizes_.end(), cmpVideoModes);
 }
 
 void dskOptions::Msg_ScreenResize(const ScreenResizeEvent& sr)
 {
     Desktop::Msg_ScreenResize(sr);
     updateGuiScale();
+    updateWindowSizeComboBox();
 }
 
 bool dskOptions::Msg_WheelUp(const MouseCoords& mc)
@@ -837,4 +870,26 @@ void dskOptions::updatePortraitControls()
 
     auto* portraitCombo = groupCommon->GetCtrl<ctrlComboBox>(ID_cbCommonPortrait);
     portraitCombo->SetSelection(SETTINGS.lobby.portraitIndex);
+}
+
+void dskOptions::updateWindowSizeComboBox()
+{
+    auto* cbWindowSize =
+      GetCtrl<ctrlGroup>(ID_grpGraphics)->GetCtrl<ctrlGroup>(ID_grpWindowSize)->GetCtrl<ctrlComboBox>(ID_cbWindowSize);
+
+    const VideoMode currentSize =
+      VIDEODRIVER.GetDisplayMode() == DisplayMode::Windowed ? VIDEODRIVER.GetWindowSize() : SETTINGS.video.windowedSize;
+    s25util::ClassicImbuedStream<std::ostringstream> curStr;
+    curStr << currentSize.width << "x" << currentSize.height;
+    cbWindowSize->SetText(0, curStr.str());
+    // Not found == -1 -> First entry selected
+    cbWindowSize->SetSelection(static_cast<unsigned>(helpers::indexOf(windowSizes_, currentSize) + 1));
+}
+
+void dskOptions::updateResolutionGroups()
+{
+    const auto currentDisplayMode = SETTINGS.video.displayMode;
+    auto& grpGraphics = *GetCtrl<ctrlGroup>(ID_grpGraphics);
+    grpGraphics.GetCtrl<ctrlGroup>(ID_grpResolution)->SetVisible(currentDisplayMode == DisplayMode::Fullscreen);
+    grpGraphics.GetCtrl<ctrlGroup>(ID_grpWindowSize)->SetVisible(currentDisplayMode == DisplayMode::Windowed);
 }

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -766,8 +766,6 @@ void dskOptions::loadVideoModes()
 {
     // Get available modes
     videoModes_ = VIDEODRIVER.ListVideoModes();
-    // Remove everything below 800x600
-    helpers::erase_if(videoModes_, [](const auto& it) { return it.width < 800 && it.height < 600; });
     // Sort by aspect ratio
     helpers::sort(videoModes_, cmpVideoModes);
     windowSizes_ = VIDEODRIVER.GetDefaultWindowSizes();

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -755,22 +755,14 @@ void dskOptions::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult /
     }
 }
 
-static bool cmpVideoModes(const VideoMode& left, const VideoMode& right)
-{
-    if(left.width == right.width)
-        return left.height > right.height;
-    else
-        return left.width > right.width;
-}
-
 void dskOptions::loadVideoModes()
 {
     // Get available modes
-    videoModes_ = VIDEODRIVER.ListVideoModes();
-    // Sort by aspect ratio
-    helpers::sort(videoModes_, cmpVideoModes);
-    windowSizes_ = VIDEODRIVER.GetDefaultWindowSizes();
-    std::sort(windowSizes_.begin(), windowSizes_.end(), cmpVideoModes);
+    const auto videoModes = VIDEODRIVER.ListVideoModes();
+    // random access is need for selection
+    videoModes_.assign(videoModes.begin(), videoModes.end());
+    const auto windowSizes = VIDEODRIVER.GetDefaultWindowSizes();
+    windowSizes_.assign(windowSizes.begin(), windowSizes.end());
 }
 
 void dskOptions::Msg_ScreenResize(const ScreenResizeEvent& sr)

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -117,7 +117,7 @@ constexpr Offset ctrlOffset2 = ctrlOffset + Offset(200, 0); // Offset of 2nd con
 constexpr Extent ctrlSize(190, 22);
 constexpr Extent ctrlSizeLarge = ctrlSize + Extent(ctrlOffset2 - ctrlOffset);
 
-VideoMode getAspectRatio(const VideoMode& vm)
+VideoMode getAspectRatio(const VideoMode vm)
 {
     // First some a bit off values where the aspect ratio is defined by convention
     if(vm == VideoMode(1360, 1024))

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -430,7 +430,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 
     // and add to the combo box
     ctrlComboBox& cbVideoModes = *groupGraphics->GetCtrl<ctrlComboBox>(ID_cbResolution);
-    for(const auto& videoMode : video_modes)
+    for(const auto& videoMode : videoModes_)
     {
         VideoMode ratio = getAspectRatio(videoMode);
         s25util::ClassicImbuedStream<std::ostringstream> str;
@@ -547,7 +547,7 @@ void dskOptions::Msg_Group_ComboSelectItem(const unsigned group_id, const unsign
                   ->SetEnabled(true);
             break;
         case ID_cbMapScrollMode: SETTINGS.interface.mapScrollMode = static_cast<MapScrollMode>(selection); break;
-        case ID_cbResolution: SETTINGS.video.fullscreenSize = video_modes[selection]; break;
+        case ID_cbResolution: SETTINGS.video.fullscreenSize = videoModes_[selection]; break;
         case ID_cbFramerate:
             if(VIDEODRIVER.HasVSync())
             {
@@ -735,11 +735,11 @@ static bool cmpVideoModes(const VideoMode& left, const VideoMode& right)
 void dskOptions::loadVideoModes()
 {
     // Get available modes
-    VIDEODRIVER.ListVideoModes(video_modes);
+    videoModes_ = VIDEODRIVER.ListVideoModes();
     // Remove everything below 800x600
-    helpers::erase_if(video_modes, [](const auto& it) { return it.width < 800 && it.height < 600; });
+    helpers::erase_if(videoModes_, [](const auto& it) { return it.width < 800 && it.height < 600; });
     // Sort by aspect ratio
-    helpers::sort(video_modes, cmpVideoModes);
+    helpers::sort(videoModes_, cmpVideoModes);
 }
 
 void dskOptions::Msg_ScreenResize(const ScreenResizeEvent& sr)

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -254,7 +254,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     ctrlOptionGroup* upnp = groupCommon->AddOptionGroup(ID_grpUPNP, GroupSelectType::Check);
     upnp->AddTextButton(ID_btOn, curPos + ctrlOffset, ctrlSize, TextureColor::Grey, _("On"), NormalFont);
     upnp->AddTextButton(ID_btOff, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Off"), NormalFont);
-    upnp->SetSelection(SETTINGS.global.use_upnp);
+    upnp->SetSelection(SETTINGS.global.useUPNP);
     curPos.y += rowHeight;
 
     // Proxy type
@@ -312,8 +312,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     mainGroup->AddTextButton(ID_btSubmitDebugAsk, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Ask always"),
                              NormalFont);
 
-    mainGroup->SetSelection((SETTINGS.global.submit_debug_data == 1) ? ID_btSubmitDebugOn :
-                                                                       ID_btSubmitDebugAsk); //-V807
+    mainGroup->SetSelection((SETTINGS.global.submitDebugData == 1) ? ID_btSubmitDebugOn : ID_btSubmitDebugAsk); //-V807
     curPos.y += rowHeight;
 
     groupCommon->AddText(ID_txtGFInfo, curPos, _("Show GameFrame Info:"), COLOR_YELLOW, FontStyle{}, NormalFont);
@@ -479,7 +478,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 
     groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpVBO)->SetSelection(SETTINGS.video.vbo);
 
-    groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpOptTextures)->SetSelection(SETTINGS.video.shared_textures);
+    groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpOptTextures)->SetSelection(SETTINGS.video.sharedTextures);
     // }
 
     // Sound
@@ -594,7 +593,7 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
     {
         case ID_grpIpv6: SETTINGS.server.ipv6 = enabled; break;
         case ID_grpVBO: SETTINGS.video.vbo = enabled; break;
-        case ID_grpOptTextures: SETTINGS.video.shared_textures = enabled; break;
+        case ID_grpOptTextures: SETTINGS.video.sharedTextures = enabled; break;
         case ID_grpEffects: SETTINGS.sound.effectsEnabled = enabled; break;
         case ID_grpBirdSounds: SETTINGS.sound.birdsEnabled = enabled; break;
         case ID_grpMusic:
@@ -606,9 +605,9 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
             break;
         case ID_grpDebugData:
             // Special case: Uses e.g. ID_btSubmitDebugOn directly
-            SETTINGS.global.submit_debug_data = selection;
+            SETTINGS.global.submitDebugData = selection;
             break;
-        case ID_grpUPNP: SETTINGS.global.use_upnp = enabled; break;
+        case ID_grpUPNP: SETTINGS.global.useUPNP = enabled; break;
         case ID_grpSmartCursor:
             SETTINGS.global.smartCursor = enabled;
             VIDEODRIVER.SetMouseWarping(enabled);

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -210,7 +210,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 
     for(unsigned i = 0; i < Portraits.size(); ++i)
     {
-        combo->AddString(_(Portraits[i].name));
+        combo->AddItem(_(Portraits[i].name));
         if(SETTINGS.lobby.portraitIndex == i)
             combo->SetSelection(i);
     }
@@ -224,7 +224,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     {
         const Language& l = LANGUAGES.getLanguage(i);
 
-        combo->AddString(_(l.name));
+        combo->AddItem(_(l.name));
         if(SETTINGS.language.language == l.code)
         {
             combo->SetSelection(static_cast<unsigned short>(i));
@@ -273,8 +273,8 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     groupCommon->AddText(ID_txtProxyType, curPos, _("Proxytyp:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     combo =
       groupCommon->AddComboBox(ID_cbProxyType, curPos + ctrlOffset, ctrlSizeLarge, TextureColor::Grey, NormalFont, 100);
-    combo->AddString(_("No Proxy"));
-    combo->AddString(_("Socks v4"));
+    combo->AddItem(_("No Proxy"));
+    combo->AddItem(_("Socks v4"));
     // TODO: not implemented
     // combo->AddString(_("Socks v5"));
 
@@ -290,10 +290,10 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     groupCommon->AddText(ID_txtMapScrollMode, curPos, _("Map scroll mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     combo = groupCommon->AddComboBox(ID_cbMapScrollMode, curPos + ctrlOffset, ctrlSizeLarge, TextureColor::Grey,
                                      NormalFont, 100);
-    combo->AddString(_("Scroll same (Map moves in the same direction the mouse is moved when scrolling/panning.)"));
-    combo->AddString(
+    combo->AddItem(_("Scroll same (Map moves in the same direction the mouse is moved when scrolling/panning.)"));
+    combo->AddItem(
       _("Scroll opposite (Map moves in the opposite direction the mouse is moved when scrolling/panning.)"));
-    combo->AddString(_("Grab and drag (Map moves with your cursor when scrolling/panning.)"));
+    combo->AddItem(_("Grab and drag (Map moves with your cursor when scrolling/panning.)"));
     combo->SetSelection(static_cast<int>(SETTINGS.interface.mapScrollMode));
     curPos.y += rowHeight;
 
@@ -335,9 +335,9 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     groupGraphics->AddText(ID_txtDisplayMode, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     ctrlComboBox* cbDisplayMode = groupGraphics->AddComboBox(ID_cbDisplayMode, curPos + ctrlOffset, ctrlSizeLarge,
                                                              TextureColor::Grey, NormalFont, 100);
-    cbDisplayMode->AddString(_("Windowed"));
-    cbDisplayMode->AddString(_("Fullscreen"));
-    cbDisplayMode->AddString(_("Borderless window"));
+    cbDisplayMode->AddItem(_("Windowed"));
+    cbDisplayMode->AddItem(_("Fullscreen"));
+    cbDisplayMode->AddItem(_("Borderless window"));
     cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode.type));
     curPos.y += rowHeight;
 
@@ -363,7 +363,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 
     for(const auto& video_driver : video_drivers)
     {
-        combo->AddString(video_driver.GetName());
+        combo->AddItem(video_driver.GetName());
         if(video_driver.GetName() == SETTINGS.driver.video)
             combo->SetSelection(combo->GetNumItems() - 1);
     }
@@ -414,7 +414,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
 
     for(const auto& audio_driver : audio_drivers)
     {
-        combo->AddString(audio_driver.GetName());
+        combo->AddItem(audio_driver.GetName());
         if(audio_driver.GetName() == SETTINGS.driver.audio)
             combo->SetSelection(combo->GetNumItems() - 1);
     }
@@ -441,7 +441,7 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
             str << " ";
         str << " (" << ratio.width << ":" << ratio.height << ")";
 
-        cbVideoModes.AddString(str.str());
+        cbVideoModes.AddItem(str.str());
 
         // Select, if this is the current resolution
         if(videoMode == SETTINGS.video.fullscreenSize) //-V807
@@ -451,13 +451,13 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     // Fill "Limit Framerate"
     auto* cbFrameRate = groupGraphics->GetCtrl<ctrlComboBox>(ID_cbFramerate);
     if(VIDEODRIVER.HasVSync())
-        cbFrameRate->AddString(_("Dynamic (Limits to display refresh rate, works with most drivers)"));
+        cbFrameRate->AddItem(_("Dynamic (Limits to display refresh rate, works with most drivers)"));
     for(int framerate : Settings::SCREEN_REFRESH_RATES)
     {
         if(framerate == -1)
-            cbFrameRate->AddString(_("Disabled"));
+            cbFrameRate->AddItem(_("Disabled"));
         else
-            cbFrameRate->AddString(helpers::toString(framerate) + " FPS");
+            cbFrameRate->AddItem(helpers::toString(framerate) + " FPS");
         if(SETTINGS.video.framerate == framerate)
             cbFrameRate->SetSelection(cbFrameRate->GetNumItems() - 1);
     }
@@ -784,7 +784,7 @@ void dskOptions::updateGuiScale()
     combo->DeleteAllItems();
 
     guiScales_.push_back(0);
-    combo->AddString(helpers::format(_("Auto (%u%%)"), range.recommendedPercent));
+    combo->AddItem(helpers::format(_("Auto (%u%%)"), range.recommendedPercent));
     if(SETTINGS.video.guiScale == 0)
         combo->SetSelection(0);
 
@@ -794,7 +794,7 @@ void dskOptions::updateGuiScale()
             recommendedGuiScaleIndex_ = guiScales_.size();
         guiScales_.push_back(percent);
 
-        combo->AddString(helpers::toString(percent) + "%");
+        combo->AddItem(helpers::toString(percent) + "%");
         if(percent == SETTINGS.video.guiScale)
             combo->SetSelection(combo->GetNumItems() - 1);
     }

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -75,8 +75,9 @@ enum
     ID_grpGFInfo,
     ID_txtResolution,
     ID_cbResolution,
-    ID_txtFullscreen,
+    ID_txtDisplayMode,
     ID_cbDisplayMode,
+    ID_grpLockWindowSize,
     ID_txtFramerate,
     ID_cbFramerate,
     ID_grpVBO,
@@ -331,13 +332,17 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
-    groupGraphics->AddText(ID_txtFullscreen, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    groupGraphics->AddText(ID_txtDisplayMode, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     ctrlComboBox* cbDisplayMode = groupGraphics->AddComboBox(ID_cbDisplayMode, curPos + ctrlOffset, ctrlSizeLarge,
                                                              TextureColor::Grey, NormalFont, 100);
     cbDisplayMode->AddString(_("Windowed"));
     cbDisplayMode->AddString(_("Fullscreen"));
     cbDisplayMode->AddString(_("Borderless window"));
-    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode));
+    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode.type));
+    curPos.y += rowHeight;
+
+    addOnOffOption(*groupGraphics, curPos, ID_grpLockWindowSize, _("Lock window size:"),
+                   !SETTINGS.video.displayMode.resizeable);
     curPos.y += rowHeight;
 
     curPos.y += sectionSpacing;
@@ -572,6 +577,14 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
     switch(ctrl_id)
     {
         case ID_grpIpv6: SETTINGS.server.ipv6 = enabled; break;
+        case ID_grpLockWindowSize:
+        {
+            SETTINGS.video.displayMode.resizeable = !enabled;
+            const auto newDisplayMode = SETTINGS.video.displayMode;
+            if(newDisplayMode == DisplayMode::Windowed && VIDEODRIVER.GetDisplayMode() == DisplayMode::Windowed)
+                VIDEODRIVER.ResizeScreen(VIDEODRIVER.GetWindowSize(), newDisplayMode);
+        }
+        break;
         case ID_grpVBO: SETTINGS.video.vbo = enabled; break;
         case ID_grpOptTextures: SETTINGS.video.sharedTextures = enabled; break;
         case ID_grpEffects: SETTINGS.sound.effectsEnabled = enabled; break;

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -459,7 +459,8 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     }
 
     // Set "Fullscreen"
-    groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpFullscreen)->SetSelection(SETTINGS.video.fullscreen); //-V807
+    groupGraphics->GetCtrl<ctrlOptionGroup>(ID_grpFullscreen)
+      ->SetSelection(bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen)); //-V807
 
     // Fill "Limit Framerate"
     auto* cbFrameRate = groupGraphics->GetCtrl<ctrlComboBox>(ID_cbFramerate);
@@ -592,7 +593,9 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
     switch(ctrl_id)
     {
         case ID_grpIpv6: SETTINGS.server.ipv6 = enabled; break;
-        case ID_grpFullscreen: SETTINGS.video.fullscreen = enabled; break;
+        case ID_grpFullscreen:
+            SETTINGS.video.displayMode = bitset::set(SETTINGS.video.displayMode, DisplayMode::Fullscreen, enabled);
+            break;
         case ID_grpVBO: SETTINGS.video.vbo = enabled; break;
         case ID_grpOptTextures: SETTINGS.video.shared_textures = enabled; break;
         case ID_grpEffects: SETTINGS.sound.effectsEnabled = enabled; break;
@@ -673,12 +676,12 @@ void dskOptions::Msg_ButtonClick(const unsigned ctrl_id)
                   this, MsgboxButton::Ok, MsgboxIcon::ExclamationGreen, 1));
             }
 
-            if((SETTINGS.video.fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize()) //-V807
-               || SETTINGS.video.fullscreen != VIDEODRIVER.IsFullscreen())
+            const auto fullscreen = bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen);
+            if((fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize()) //-V807
+               || fullscreen != VIDEODRIVER.IsFullscreen())
             {
-                const auto screenSize =
-                  SETTINGS.video.fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
-                if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.fullscreen))
+                const auto screenSize = fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
+                if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
                 {
                     WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
                       _("Sorry!"), _("You need to restart your game to change the screen resolution!"), this,

--- a/libs/s25main/desktops/dskOptions.cpp
+++ b/libs/s25main/desktops/dskOptions.cpp
@@ -324,7 +324,8 @@ dskOptions::dskOptions() : Desktop(LOADER.GetImageN("setup013", 0))
     mainGroup->AddTextButton(ID_btSubmitDebugAsk, curPos + ctrlOffset2, ctrlSize, TextureColor::Grey, _("Ask always"),
                              NormalFont);
 
-    mainGroup->SetSelection((SETTINGS.global.submitDebugData == 1) ? ID_btSubmitDebugOn : ID_btSubmitDebugAsk); //-V807
+    mainGroup->SetSelection((SETTINGS.global.submitDebugData == SubmitDebugData::Yes) ? ID_btSubmitDebugOn :
+                                                                                        ID_btSubmitDebugAsk); //-V807
     curPos.y += rowHeight;
 
     addOnOffOption(*groupCommon, curPos, ID_grpGFInfo, _("Show GameFrame Info:"), SETTINGS.global.showGFInfo);
@@ -628,7 +629,7 @@ void dskOptions::Msg_Group_OptionGroupChange(const unsigned /*group_id*/, const 
             break;
         case ID_grpDebugData:
             // Special case: Uses e.g. ID_btSubmitDebugOn directly
-            SETTINGS.global.submitDebugData = selection;
+            SETTINGS.global.submitDebugData = SubmitDebugData(selection);
             break;
         case ID_grpUPNP: SETTINGS.global.useUPNP = enabled; break;
         case ID_grpSmartCursor:

--- a/libs/s25main/desktops/dskOptions.h
+++ b/libs/s25main/desktops/dskOptions.h
@@ -31,6 +31,8 @@ private:
 
     void updateGuiScale();
     void scrollGuiScale(bool up);
+    void updateWindowSizeComboBox();
+    void updateResolutionGroups();
 
     GlobalGameSettings ggs;
     std::vector<VideoMode> videoModes_;    ///< Sorted list of filtered video modes

--- a/libs/s25main/desktops/dskOptions.h
+++ b/libs/s25main/desktops/dskOptions.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -33,7 +33,8 @@ private:
     void scrollGuiScale(bool up);
 
     GlobalGameSettings ggs;
-    std::vector<VideoMode> video_modes;    ///< Sorted list of filtered video modes
+    std::vector<VideoMode> videoModes_;    ///< Sorted list of filtered video modes
+    std::vector<VideoMode> windowSizes_;   ///< Sorted list of default window sizes
     std::vector<unsigned> guiScales_;      ///< Generated GUI scale percentages
     std::size_t recommendedGuiScaleIndex_; ///< Index of the recommended GUI scale percentage
 

--- a/libs/s25main/desktops/dskTest.cpp
+++ b/libs/s25main/desktops/dskTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -83,9 +83,9 @@ dskTest::dskTest() : curBGIdx(LOAD_SCREENS.size())
     AddEdit(ID_edtTest, btPos, Extent(150, 22), TextureColor::Green2, NormalFont, 0, false, false, true);
     btPos.x += 170;
     ctrlComboBox* cb = AddComboBox(ID_cbTxtSize, btPos, Extent(100, 22), TextureColor::Green2, NormalFont, 100);
-    cb->AddString("Small Font");
-    cb->AddString("Medium Font");
-    cb->AddString("Large Font");
+    cb->AddItem("Small Font");
+    cb->AddItem("Medium Font");
+    cb->AddItem("Large Font");
     cb->SetSelection(0);
     btPos.x += 110;
     btPos.y += 11;

--- a/libs/s25main/desktops/dskTextureTest.cpp
+++ b/libs/s25main/desktops/dskTextureTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -53,7 +53,7 @@ void dskTextureTest::Load()
     const unsigned selection = cb->GetSelection().value_or(0);
     cb->DeleteAllItems();
     for(const auto& t : desc.terrain)
-        cb->AddString(t.name);
+        cb->AddItem(t.name);
     cb->SetSelection(selection);
     Msg_ComboSelectItem(ID_cbTexture, selection);
 }

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -433,7 +433,10 @@ std::vector<VideoMode> VideoDriverWrapper::ListVideoModes() const
     if(!videodriver)
         return {};
 
-    return videodriver->ListVideoModes();
+    auto videoModes = videodriver->ListVideoModes();
+    // Remove everything below 800x600
+    helpers::erase_if(videoModes, [](const auto& m) { return m.width < 800 && m.height < 600; });
+    return videoModes;
 }
 
 std::vector<VideoMode> VideoDriverWrapper::GetDefaultWindowSizes() const

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -92,7 +92,7 @@ void VideoDriverWrapper::UnloadDriver()
  *
  *  @return Bei Erfolg @p true ansonsten @p false
  */
-bool VideoDriverWrapper::CreateScreen(const VideoMode size, const bool fullscreen)
+bool VideoDriverWrapper::CreateScreen(const VideoMode size, const DisplayMode displayMode)
 {
     if(!videodriver)
     {
@@ -100,7 +100,7 @@ bool VideoDriverWrapper::CreateScreen(const VideoMode size, const bool fullscree
         return false;
     }
 
-    if(!videodriver->CreateScreen(rttr::version::GetTitle(), size, fullscreen))
+    if(!videodriver->CreateScreen(rttr::version::GetTitle(), size, displayMode))
     {
         s25util::fatal_error("Could not create window!");
         return false;
@@ -134,7 +134,7 @@ bool VideoDriverWrapper::CreateScreen(const VideoMode size, const bool fullscree
  *
  *  @return Bei Erfolg @p true ansonsten @p false
  */
-bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const bool fullscreen)
+bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const DisplayMode displayMode)
 {
     if(!videodriver)
     {
@@ -142,7 +142,7 @@ bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const bool fullscree
         return false;
     }
 
-    const bool result = videodriver->ResizeScreen(size, fullscreen);
+    const bool result = videodriver->ResizeScreen(size, displayMode);
 #ifdef _WIN32
     if(!videodriver->IsFullscreen())
     {
@@ -497,6 +497,11 @@ Extent VideoDriverWrapper::GetRenderSize() const
     return videodriver->GetRenderSize();
 }
 
+DisplayMode VideoDriverWrapper::GetDisplayMode() const
+{
+    return videodriver->GetDisplayMode();
+}
+
 bool VideoDriverWrapper::IsFullscreen() const
 {
     return videodriver->IsFullscreen();
@@ -520,4 +525,9 @@ void VideoDriverWrapper::setGuiScalePercent(unsigned percent)
 GuiScaleRange VideoDriverWrapper::getGuiScaleRange() const
 {
     return videodriver->getGuiScaleRange();
+}
+
+bool VideoDriverWrapper::IsResizable() const
+{
+    return videodriver->IsResizable();
 }

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -428,22 +428,23 @@ void VideoDriverWrapper::SetMousePos(const Position& newPos)
     videodriver->SetMousePos(newPos);
 }
 
-std::vector<VideoMode> VideoDriverWrapper::ListVideoModes() const
+std::set<VideoMode> VideoDriverWrapper::ListVideoModes() const
 {
     if(!videodriver)
         return {};
 
-    auto videoModes = videodriver->ListVideoModes();
-    // Remove everything below 800x600
-    helpers::erase_if(videoModes,
-                      [](const auto& m) { return m.width < MinWindowSize.width && m.height < MinWindowSize.height; });
-    return videoModes;
+    const auto videoModes = videodriver->ListVideoModes();
+    std::set<VideoMode> result;
+    // Keep only modes larger than the minimum
+    std::copy_if(videoModes.begin(), videoModes.end(), std::inserter(result, result.end()),
+                 [](const auto& m) { return m.width >= MinWindowSize.width || m.height >= MinWindowSize.height; });
+    return result;
 }
 
-std::vector<VideoMode> VideoDriverWrapper::GetDefaultWindowSizes() const
+std::set<VideoMode> VideoDriverWrapper::GetDefaultWindowSizes() const
 {
     // clang-format off
-    std::vector<VideoMode> defaultWindowSizes = {
+    std::array defaultWindowSizes = {
       VideoMode(800, 600),
       VideoMode(1024, 768),
       VideoMode(1152, 648),
@@ -456,9 +457,8 @@ std::vector<VideoMode> VideoDriverWrapper::GetDefaultWindowSizes() const
       VideoMode(1920, 1080)
     };
     // clang-format on
-    std::vector<VideoMode> windowSizes = ListVideoModes();
-    windowSizes.insert(windowSizes.end(), defaultWindowSizes.begin(), defaultWindowSizes.end());
-    helpers::makeUnique(windowSizes);
+    std::set<VideoMode> windowSizes = ListVideoModes();
+    windowSizes.insert(defaultWindowSizes.begin(), defaultWindowSizes.end());
     return windowSizes;
 }
 

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -436,6 +436,17 @@ std::vector<VideoMode> VideoDriverWrapper::ListVideoModes() const
     return videodriver->ListVideoModes();
 }
 
+std::vector<VideoMode> VideoDriverWrapper::GetDefaultWindowSizes() const
+{
+    std::vector<VideoMode> defaultWindowSizes = {
+      VideoMode(800, 600),  VideoMode(1024, 768), VideoMode(1152, 648), VideoMode(1280, 720),  VideoMode(1280, 800),
+      VideoMode(1366, 768), VideoMode(1440, 810), VideoMode(1600, 900), VideoMode(1680, 1050), VideoMode(1920, 1080)};
+    std::vector<VideoMode> windowSizes = ListVideoModes();
+    windowSizes.insert(windowSizes.end(), defaultWindowSizes.begin(), defaultWindowSizes.end());
+    helpers::makeUnique(windowSizes);
+    return windowSizes;
+}
+
 bool VideoDriverWrapper::HasVSync() const
 {
     return wglSwapIntervalEXT != nullptr;

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -435,7 +435,8 @@ std::vector<VideoMode> VideoDriverWrapper::ListVideoModes() const
 
     auto videoModes = videodriver->ListVideoModes();
     // Remove everything below 800x600
-    helpers::erase_if(videoModes, [](const auto& m) { return m.width < 800 && m.height < 600; });
+    helpers::erase_if(videoModes,
+                      [](const auto& m) { return m.width < MinWindowSize.width && m.height < MinWindowSize.height; });
     return videoModes;
 }
 
@@ -465,10 +466,10 @@ void* VideoDriverWrapper::GetMapPointer() const
 
 VideoMode VideoDriverWrapper::GetWindowSize() const
 {
-    // Always return at least 800x600 even if real window is smaller
+    // Always return at least MinWindowSize even if real window is smaller
     VideoMode windowSize = videodriver->GetWindowSize();
-    windowSize.width = std::max<unsigned>(800, windowSize.width);
-    windowSize.height = std::max<unsigned>(600, windowSize.height);
+    windowSize.width = std::max(MinWindowSize.width, windowSize.width);
+    windowSize.height = std::max(MinWindowSize.height, windowSize.height);
     return windowSize;
 }
 

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -16,6 +16,7 @@
 #include "s25util/Log.h"
 #include "s25util/error.h"
 #include <glad/glad.h>
+#include <array>
 #include <ctime>
 #if !defined(NDEBUG) && defined(HAVE_MEMCHECK_H)
 #    include <valgrind/memcheck.h>
@@ -84,14 +85,6 @@ void VideoDriverWrapper::UnloadDriver()
     renderer_.reset();
 }
 
-/**
- *  Erstellt das Fenster.
- *
- *  @param[in] width  Breite des Fensters
- *  @param[in] height Höhe des Fensters
- *
- *  @return Bei Erfolg @p true ansonsten @p false
- */
 bool VideoDriverWrapper::CreateScreen(const VideoMode size, const DisplayMode displayMode)
 {
     if(!videodriver)
@@ -125,15 +118,6 @@ bool VideoDriverWrapper::CreateScreen(const VideoMode size, const DisplayMode di
     return true;
 }
 
-/**
- *  Verändert Auflösung, Fenster/Fullscreen
- *
- *  @param[in] screenWidth neue Breite des Fensters
- *  @param[in] screenHeight neue Höhe des Fensters
- *  @param[in] fullscreen Vollbild oder nicht
- *
- *  @return Bei Erfolg @p true ansonsten @p false
- */
 bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const DisplayMode displayMode)
 {
     if(!videodriver)
@@ -158,9 +142,6 @@ bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const DisplayMode di
     return result;
 }
 
-/**
- *  Zerstört den DriverWrapper-Bildschirm.
- */
 bool VideoDriverWrapper::DestroyScreen()
 {
     if(!videodriver)
@@ -198,9 +179,6 @@ unsigned VideoDriverWrapper::GetFPS() const
     return frameCtr_->getFrameRate();
 }
 
-/**
- *  Löscht alle herausgegebenen Texturen aus dem Speicher.
- */
 void VideoDriverWrapper::CleanUp()
 {
     if(!texture_list.empty())
@@ -296,9 +274,6 @@ bool VideoDriverWrapper::setHwVSync(bool enabled)
     return wglSwapIntervalEXT(enabled ? 1 : 0) != 0;
 }
 
-/**
- *  Viewport (neu) setzen
- */
 void VideoDriverWrapper::RenewViewport()
 {
     if(!videodriver->IsOpenGL() || !renderer_)
@@ -356,9 +331,6 @@ void VideoDriverWrapper::RenewViewport()
     ClearScreen();
 }
 
-/**
- *  lädt die driverwrapper-extensions.
- */
 bool VideoDriverWrapper::LoadAllExtensions()
 {
     if(videodriver->IsOpenGL())
@@ -456,15 +428,12 @@ void VideoDriverWrapper::SetMousePos(const Position& newPos)
     videodriver->SetMousePos(newPos);
 }
 
-/**
- *  Listet verfügbare Videomodi auf.
- */
-void VideoDriverWrapper::ListVideoModes(std::vector<VideoMode>& video_modes) const
+std::vector<VideoMode> VideoDriverWrapper::ListVideoModes() const
 {
     if(!videodriver)
-        return;
+        return {};
 
-    videodriver->ListVideoModes(video_modes);
+    return videodriver->ListVideoModes();
 }
 
 bool VideoDriverWrapper::HasVSync() const
@@ -472,9 +441,6 @@ bool VideoDriverWrapper::HasVSync() const
     return wglSwapIntervalEXT != nullptr;
 }
 
-/**
- *  Gibt Pointer auf ein Fenster zurück (device-dependent!), HWND unter Windows.
- */
 void* VideoDriverWrapper::GetMapPointer() const
 {
     if(!videodriver)

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -144,7 +144,7 @@ bool VideoDriverWrapper::ResizeScreen(const VideoMode size, const DisplayMode di
 
     const bool result = videodriver->ResizeScreen(size, displayMode);
 #ifdef _WIN32
-    if(!videodriver->IsFullscreen())
+    if(videodriver->GetDisplayMode() != DisplayMode::Fullscreen)
     {
         // We cannot change the size of a maximized window. So restore it here
         WINDOWPLACEMENT wp;
@@ -502,11 +502,6 @@ DisplayMode VideoDriverWrapper::GetDisplayMode() const
     return videodriver->GetDisplayMode();
 }
 
-bool VideoDriverWrapper::IsFullscreen() const
-{
-    return videodriver->IsFullscreen();
-}
-
 float VideoDriverWrapper::getDpiScale() const
 {
     return videodriver->getDpiScale();
@@ -525,9 +520,4 @@ void VideoDriverWrapper::setGuiScalePercent(unsigned percent)
 GuiScaleRange VideoDriverWrapper::getGuiScaleRange() const
 {
     return videodriver->getGuiScaleRange();
-}
-
-bool VideoDriverWrapper::IsResizable() const
-{
-    return videodriver->IsResizable();
 }

--- a/libs/s25main/drivers/VideoDriverWrapper.cpp
+++ b/libs/s25main/drivers/VideoDriverWrapper.cpp
@@ -442,9 +442,20 @@ std::vector<VideoMode> VideoDriverWrapper::ListVideoModes() const
 
 std::vector<VideoMode> VideoDriverWrapper::GetDefaultWindowSizes() const
 {
+    // clang-format off
     std::vector<VideoMode> defaultWindowSizes = {
-      VideoMode(800, 600),  VideoMode(1024, 768), VideoMode(1152, 648), VideoMode(1280, 720),  VideoMode(1280, 800),
-      VideoMode(1366, 768), VideoMode(1440, 810), VideoMode(1600, 900), VideoMode(1680, 1050), VideoMode(1920, 1080)};
+      VideoMode(800, 600),
+      VideoMode(1024, 768),
+      VideoMode(1152, 648),
+      VideoMode(1280, 720),
+      VideoMode(1280, 800),
+      VideoMode(1366, 768),
+      VideoMode(1440, 810),
+      VideoMode(1600, 900),
+      VideoMode(1680, 1050),
+      VideoMode(1920, 1080)
+    };
+    // clang-format on
     std::vector<VideoMode> windowSizes = ListVideoModes();
     windowSizes.insert(windowSizes.end(), defaultWindowSizes.begin(), defaultWindowSizes.end());
     helpers::makeUnique(windowSizes);

--- a/libs/s25main/drivers/VideoDriverWrapper.h
+++ b/libs/s25main/drivers/VideoDriverWrapper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -71,8 +71,6 @@ public:
     /// Get the renderer size in pixels
     Extent GetRenderSize() const;
     DisplayMode GetDisplayMode() const;
-    bool IsFullscreen() const;
-    bool IsResizable() const;
 
     /// Get the factor required to scale "normal" DPI to the display DPI
     float getDpiScale() const;

--- a/libs/s25main/drivers/VideoDriverWrapper.h
+++ b/libs/s25main/drivers/VideoDriverWrapper.h
@@ -111,6 +111,8 @@ public:
     /// Calculate the size of the texture which is optimal for the driver and at least minSize
     Extent calcPreferredTextureSize(const Extent& minSize) const;
 
+    static constexpr VideoMode MinWindowSize{800, 600};
+
 private:
     bool Initialize();
     bool setHwVSync(bool enabled);

--- a/libs/s25main/drivers/VideoDriverWrapper.h
+++ b/libs/s25main/drivers/VideoDriverWrapper.h
@@ -12,7 +12,9 @@
 #include "driver/VideoMode.h"
 #include "s25util/Singleton.h"
 #include <memory>
+#include <set>
 #include <string>
+#include <vector>
 
 class IVideoDriver;
 class IRenderer;
@@ -61,8 +63,8 @@ public:
     Position GetMousePos() const;
 
     /// Get supported resolutions
-    std::vector<VideoMode> ListVideoModes() const;
-    std::vector<VideoMode> GetDefaultWindowSizes() const;
+    std::set<VideoMode> ListVideoModes() const;
+    std::set<VideoMode> GetDefaultWindowSizes() const;
     bool HasVSync() const;
 
     /// Gibt Pointer auf ein Fenster zurück (device-dependent!), HWND unter Windows

--- a/libs/s25main/drivers/VideoDriverWrapper.h
+++ b/libs/s25main/drivers/VideoDriverWrapper.h
@@ -8,6 +8,7 @@
 #include "Point.h"
 #include "driver/GuiScale.h"
 #include "driver/KeyEvent.h"
+#include "driver/VideoInterface.h"
 #include "driver/VideoMode.h"
 #include "s25util/Singleton.h"
 #include <memory>
@@ -36,9 +37,9 @@ public:
     IVideoDriver* GetDriver() const { return videodriver.get(); }
 
     /// Erstellt das Fenster.
-    bool CreateScreen(VideoMode size, bool fullscreen);
+    bool CreateScreen(VideoMode size, DisplayMode displayMode);
     /// Verändert Auflösung, Fenster/Fullscreen
-    bool ResizeScreen(VideoMode size, bool fullscreen);
+    bool ResizeScreen(VideoMode size, DisplayMode displayMode);
     /// Viewport (neu) setzen
     void RenewViewport();
     /// zerstört das Fenster.
@@ -69,7 +70,9 @@ public:
     VideoMode GetWindowSize() const;
     /// Get the renderer size in pixels
     Extent GetRenderSize() const;
+    DisplayMode GetDisplayMode() const;
     bool IsFullscreen() const;
+    bool IsResizable() const;
 
     /// Get the factor required to scale "normal" DPI to the display DPI
     float getDpiScale() const;

--- a/libs/s25main/drivers/VideoDriverWrapper.h
+++ b/libs/s25main/drivers/VideoDriverWrapper.h
@@ -60,8 +60,9 @@ public:
     // Should only be used to draw the mouse. For everything else use the events
     Position GetMousePos() const;
 
-    /// Listet verfügbare Videomodi auf
-    void ListVideoModes(std::vector<VideoMode>& video_modes) const;
+    /// Get supported resolutions
+    std::vector<VideoMode> ListVideoModes() const;
+    std::vector<VideoMode> GetDefaultWindowSizes() const;
     bool HasVSync() const;
 
     /// Gibt Pointer auf ein Fenster zurück (device-dependent!), HWND unter Windows

--- a/libs/s25main/ingameWindows/IngameWindow.cpp
+++ b/libs/s25main/ingameWindows/IngameWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -36,8 +36,8 @@ const Extent IngameWindow::borderSize(1, 1);
 IngameWindow::IngameWindow(unsigned id, const DrawPoint& pos, const Extent& size, std::string title,
                            glArchivItem_Bitmap* background, bool modal, CloseBehavior closeBehavior, Window* parent)
     : Window(parent, id, pos, size), title_(std::move(title)), background(background), lastMousePos(0, 0),
-      isModal_(modal), closeme(false), isPinned_(false), isMinimized_(false), isMoving(false),
-      closeBehavior_(closeBehavior)
+      closeBehavior_(closeBehavior), isModal_(modal), closeme(false), isPinned_(false), isMinimized_(false),
+      isMoving(false)
 {
     std::fill(buttonStates_.begin(), buttonStates_.end(), ButtonState::Up);
     contentOffset.x = LOADER.GetImageN("resource", 38)->getWidth();     // left border

--- a/libs/s25main/ingameWindows/IngameWindow.h
+++ b/libs/s25main/ingameWindows/IngameWindow.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -136,6 +136,7 @@ protected:
     Extent contentOffset;
     /// Offset from content to right and bottom boundary
     Extent contentOffsetEnd;
+    CloseBehavior closeBehavior_;
 
 private:
     /// Get bounds of given button
@@ -147,7 +148,6 @@ private:
     bool isMinimized_;
     bool isMoving;
     SnapOffset snapOffset_;
-    CloseBehavior closeBehavior_;
     helpers::EnumArray<ButtonState, IwButton> buttonStates_;
     PersistentWindowSettings* windowSettings_;
     DrawPoint restorePos_;

--- a/libs/s25main/ingameWindows/iwAIDebug.cpp
+++ b/libs/s25main/ingameWindows/iwAIDebug.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -93,24 +93,24 @@ iwAIDebug::iwAIDebug(GameWorldView& gwv, const std::vector<const AIPlayer*>& ais
       AddComboBox(ID_CbPlayer, DrawPoint(15, 30), Extent(250, 20), TextureColor::Grey, NormalFont, 100);
     for(const AIJH::AIPlayerJH* ai : ais_)
     {
-        players->AddString(ai->GetPlayerName());
+        players->AddItem(ai->GetPlayerName());
     }
 
     ctrlComboBox* overlays =
       AddComboBox(ID_CbOverlay, DrawPoint(15, 60), Extent(250, 20), TextureColor::Grey, NormalFont, 100);
-    overlays->AddString("None");
-    overlays->AddString("BuildingQuality");
-    overlays->AddString("Reachability");
-    overlays->AddString("Farmed");
-    overlays->AddString("Gold");
-    overlays->AddString("Ironore");
-    overlays->AddString("Coal");
-    overlays->AddString("Granite");
-    overlays->AddString("Fish");
-    overlays->AddString("Wood");
-    overlays->AddString("Stones");
-    overlays->AddString("Plantspace");
-    overlays->AddString("Borderland");
+    overlays->AddItem("None");
+    overlays->AddItem("BuildingQuality");
+    overlays->AddItem("Reachability");
+    overlays->AddItem("Farmed");
+    overlays->AddItem("Gold");
+    overlays->AddItem("Ironore");
+    overlays->AddItem("Coal");
+    overlays->AddItem("Granite");
+    overlays->AddItem("Fish");
+    overlays->AddItem("Wood");
+    overlays->AddItem("Stones");
+    overlays->AddItem("Plantspace");
+    overlays->AddItem("Borderland");
 
     // Show 7 lines of text and 1 empty line
     text = AddMultiline(ID_Text, DrawPoint(15, 120), Extent(250, 8 * NormalFont->getHeight()), TextureColor::Grey,

--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -148,7 +148,7 @@ void iwAddons::UpdateView(const AddonGroup selection)
     for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
     {
         const Addon* addon = ggs.getAddon(i);
-        const bool isVisible = (addon->getGroups() & selection) != AddonGroup(0);
+        const bool isVisible = bitset::any(addon->getGroups(), selection);
         auto* group = GetCtrl<ctrlGroup>(ID_grpAddonsStart + i);
 
         // Don't show addon's gui if addon is beyond selected group or is beyond current page scope

--- a/libs/s25main/ingameWindows/iwBuildOrder.cpp
+++ b/libs/s25main/ingameWindows/iwBuildOrder.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -36,7 +36,7 @@ iwBuildOrder::iwBuildOrder(const GameWorldViewer& gwv)
     fillBuildOrder(GAMECLIENT.visual_settings.build_order);
 
     for(const auto buildOrder : pendingBuildOrder)
-        list->AddString(_(BUILDING_NAMES[buildOrder])); //-V807
+        list->AddItem(_(BUILDING_NAMES[buildOrder])); //-V807
 
     // Nach ganz oben
     AddImageButton(1, DrawPoint(250, 194), Extent(48, 20), TextureColor::Grey, LOADER.GetImageN("io", 215), _("Top"));
@@ -52,8 +52,8 @@ iwBuildOrder::iwBuildOrder(const GameWorldViewer& gwv)
     AddImage(5, DrawPoint(240, 150), LOADER.GetBuildingTex(gwv.GetPlayer().nation, pendingBuildOrder[0]));
 
     ctrlComboBox* combo = AddComboBox(6, DrawPoint(15, 30), Extent(290, 20), TextureColor::Grey, NormalFont, 100);
-    combo->AddString(_("Sequence of given order"));   // "Reihenfolge der Auftraggebung"
-    combo->AddString(_("After the following order")); // "Nach folgender Reihenfolge"
+    combo->AddItem(_("Sequence of given order"));   // "Reihenfolge der Auftraggebung"
+    combo->AddItem(_("After the following order")); // "Nach folgender Reihenfolge"
 
     // Eintrag in Combobox auswählen
     useCustomBuildOrder = GAMECLIENT.visual_settings.useCustomBuildOrder;
@@ -205,7 +205,7 @@ void iwBuildOrder::Msg_ButtonClick(const unsigned ctrl_id)
 
             // Liste füllen
             for(unsigned char i = 0; i < 31; ++i)
-                list->AddString(_(BUILDING_NAMES[pendingBuildOrder[i]]));
+                list->AddItem(_(BUILDING_NAMES[pendingBuildOrder[i]]));
             list->SetSelection(0);
 
             GetCtrl<ctrlImage>(5)->SetImage(LOADER.GetBuildingTex(gwv.GetPlayer().nation, pendingBuildOrder[0]));
@@ -226,5 +226,5 @@ void iwBuildOrder::UpdateSettings()
     }
     GetCtrl<ctrlComboBox>(6)->SetSelection(useCustomBuildOrder ? 1 : 0);
     for(unsigned char i = 0; i < pendingBuildOrder.size(); ++i)
-        GetCtrl<ctrlList>(0)->SetString(_(BUILDING_NAMES[pendingBuildOrder[i]]), i);
+        GetCtrl<ctrlList>(0)->SetItemText(i, _(BUILDING_NAMES[pendingBuildOrder[i]]));
 }

--- a/libs/s25main/ingameWindows/iwDiplomacy.cpp
+++ b/libs/s25main/ingameWindows/iwDiplomacy.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -229,13 +229,13 @@ iwSuggestPact::iwSuggestPact(const PactType pt, const GamePlayer& player, GameCo
     // Zeiten zur Combobox hinzufügen
     for(unsigned i = 0; i < NUM_DURATIONS; ++i)
     {
-        combo->AddString(helpers::format("%s  (%s)", DURATION_NAMES[i], GAMECLIENT.FormatGFTime(DURATIONS[i])));
+        combo->AddItem(helpers::format("%s  (%s)", DURATION_NAMES[i], GAMECLIENT.FormatGFTime(DURATIONS[i])));
     }
     // Erstes Item in der Combobox vorerst auswählen
     combo->SetSelection(0);
 
     // Option "ewig" noch hinzufügen
-    combo->AddString(_("Eternal"));
+    combo->AddItem(_("Eternal"));
 
     AddTextButton(7, DrawPoint(110, 170), Extent(100, 22), TextureColor::Green2, _("Confirm"), NormalFont);
 }

--- a/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPConnect.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -65,7 +65,7 @@ iwDirectIPConnect::iwDirectIPConnect(ServerType serverType)
     AddTextButton(ID_btBack, DrawPoint(155, 240), Extent(125, 22), TextureColor::Red1, _("Back"), NormalFont);
 
     host->SetFocus();
-    host->SetText(SETTINGS.server.last_ip);
+    host->SetText(SETTINGS.server.lastIP);
     port->SetText(SETTINGS.server.localPort);
 }
 
@@ -105,7 +105,7 @@ void iwDirectIPConnect::Msg_ButtonClick(const unsigned ctrl_id)
             }
 
             // save settings
-            SETTINGS.server.last_ip = edtHost->GetText();
+            SETTINGS.server.lastIP = edtHost->GetText();
 
             if(!GAMECLIENT.Connect(edtHost->GetText(), edtPw->GetText(), serverType_, *port, false,
                                    SETTINGS.server.ipv6))

--- a/libs/s25main/ingameWindows/iwDirectIPCreate.cpp
+++ b/libs/s25main/ingameWindows/iwDirectIPCreate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -143,7 +143,7 @@ void iwDirectIPCreate::Msg_ButtonClick(const unsigned ctrl_id)
             }
 
             CreateServerInfo csi(server_type, *port, edtName->GetText(), edtPw->GetText(), SETTINGS.server.ipv6,
-                                 SETTINGS.global.use_upnp);
+                                 SETTINGS.global.useUPNP);
 
             // Map auswählen
             WINDOWMANAGER.Switch(std::make_unique<dskSelectMap>(csi));

--- a/libs/s25main/ingameWindows/iwLobbyConnect.cpp
+++ b/libs/s25main/ingameWindows/iwLobbyConnect.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -75,7 +75,7 @@ iwLobbyConnect::iwLobbyConnect()
                                 NormalFont);
     savepassword->AddTextButton(1, DrawPoint(secCtrlStartPos, curLblPos.y), btSize, TextureColor::Green2, _("Yes"),
                                 NormalFont);
-    savepassword->SetSelection((SETTINGS.lobby.save_password ? 1 : 0));
+    savepassword->SetSelection((SETTINGS.lobby.savePassword ? 1 : 0));
     curLblPos.y += 30;
 
     AddText(ID_txtProtocol, curLblPos, _("Use IPv6:"), COLOR_YELLOW, FontStyle{}, NormalFont);
@@ -123,7 +123,7 @@ void iwLobbyConnect::ReadFromEditAndSaveLobbyData(std::string& user, std::string
 
     // Save name and password if requested
     SETTINGS.lobby.name = user; //-V807
-    if(SETTINGS.lobby.save_password)
+    if(SETTINGS.lobby.savePassword)
         SETTINGS.lobby.password = "md5:" + pass;
     else
         SETTINGS.lobby.password.clear();
@@ -183,7 +183,7 @@ void iwLobbyConnect::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigne
 {
     switch(ctrl_id)
     {
-        case ID_optSavePw: SETTINGS.lobby.save_password = (selection == 1); break;
+        case ID_optSavePw: SETTINGS.lobby.savePassword = (selection == 1); break;
         case ID_optProtocol: // IPv6 yes/no
             SETTINGS.server.ipv6 = (selection == 1);
             break;

--- a/libs/s25main/ingameWindows/iwMapDebug.cpp
+++ b/libs/s25main/ingameWindows/iwMapDebug.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -174,10 +174,10 @@ iwMapDebug::iwMapDebug(GameWorldView& gwv, bool allowCheating)
     ctrlComboBox* cbCheckEvents =
       AddComboBox(ID_cbCheckEventForPlayer, curPos, ctrlSize, TextureColor::Grey, NormalFont, 100);
     curPos.y += spaceY;
-    cbCheckEvents->AddString(_("BQ check disabled"));
+    cbCheckEvents->AddItem(_("BQ check disabled"));
     for(const std::chrono::milliseconds ms : BQ_CHECK_INTERVALS)
     {
-        cbCheckEvents->AddString((boost::format(_("BQ check every %1%ms")) % ms.count()).str());
+        cbCheckEvents->AddItem((boost::format(_("BQ check every %1%ms")) % ms.count()).str());
     }
     cbCheckEvents->SetSelection(0);
     using namespace std::chrono_literals;
@@ -187,13 +187,13 @@ iwMapDebug::iwMapDebug(GameWorldView& gwv, bool allowCheating)
     {
         ctrlComboBox* data = AddComboBox(ID_cbShowWhat, curPos, ctrlSize, TextureColor::Grey, NormalFont, 100);
         curPos.y += spaceY;
-        data->AddString(_("Nothing"));
-        data->AddString(_("Reserved"));
-        data->AddString(_("Altitude"));
-        data->AddString(_("Resources"));
-        data->AddString(_("Sea Id"));
-        data->AddString(_("Owner"));
-        data->AddString(_("Restricted area"));
+        data->AddItem(_("Nothing"));
+        data->AddItem(_("Reserved"));
+        data->AddItem(_("Altitude"));
+        data->AddItem(_("Resources"));
+        data->AddItem(_("Sea Id"));
+        data->AddItem(_("Owner"));
+        data->AddItem(_("Restricted area"));
         data->SetSelection(1);
         ctrlComboBox* players = AddComboBox(ID_cbShowForPlayer, curPos, ctrlSize, TextureColor::Grey, NormalFont, 100);
         curPos.y += spaceY;
@@ -201,9 +201,9 @@ iwMapDebug::iwMapDebug(GameWorldView& gwv, bool allowCheating)
         {
             const GamePlayer& p = gwv.GetWorld().GetPlayer(pIdx);
             if(!p.isUsed())
-                players->AddString((boost::format(_("Player %1%")) % pIdx).str());
+                players->AddItem((boost::format(_("Player %1%")) % pIdx).str());
             else
-                players->AddString(p.name);
+                players->AddItem(p.name);
         }
         players->SetSelection(0);
         printer->showDataIdx = data->GetSelection().get();

--- a/libs/s25main/ingameWindows/iwMapGenerator.cpp
+++ b/libs/s25main/ingameWindows/iwMapGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -41,15 +41,15 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
     curPos.y += 30;
     ctrlComboBox* combo = AddComboBox(ID_cbNumPlayers, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     for(unsigned n = 2; n <= MAX_PLAYERS; n++)
-        combo->AddString(helpers::format(_("%1% players"), n));
+        combo->AddItem(helpers::format(_("%1% players"), n));
 
     curPos.y += 30;
     AddText(ID_txtMapStyle, curPos, _("Style"), COLOR_YELLOW, FontStyle{}, NormalFont);
     combo =
       AddComboBox(ID_cbMapStyle, curPos + DrawPoint(100, -5), comboSizeSmall, TextureColor::Grey, NormalFont, 100);
-    combo->AddString(_("Water"));
-    combo->AddString(_("Land"));
-    combo->AddString(_("Mixed"));
+    combo->AddItem(_("Water"));
+    combo->AddItem(_("Land"));
+    combo->AddItem(_("Mixed"));
 
     curPos.y += 30;
     AddText(ID_txtMapSize, curPos, _("Size"), COLOR_YELLOW, FontStyle{}, NormalFont);
@@ -61,8 +61,8 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
     for(unsigned size = 32; size <= 320; size += 32)
     {
         const auto strSize = s25util::toStringClassic(size);
-        cbSizeX->AddString(strSize);
-        cbSizeY->AddString(strSize);
+        cbSizeX->AddItem(strSize);
+        cbSizeY->AddItem(strSize);
     }
 
     curPos.y += 30;
@@ -70,24 +70,24 @@ iwMapGenerator::iwMapGenerator(MapSettings& settings)
     curPos.y += 20;
     combo = AddComboBox(ID_cbMapType, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
     for(unsigned i = 0; i < desc.landscapes.size(); i++)
-        combo->AddString(_(desc.get(DescIdx<LandscapeDesc>(i)).name));
+        combo->AddItem(_(desc.get(DescIdx<LandscapeDesc>(i)).name));
 
     curPos.y += 30;
     AddText(ID_txtMountainDist, curPos, _("HQ distance to mountain"), COLOR_YELLOW, FontStyle{}, NormalFont);
     curPos.y += 20;
     combo = AddComboBox(ID_cbMountainDist, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
-    combo->AddString(_("Close"));
-    combo->AddString(_("Normal"));
-    combo->AddString(_("Far"));
-    combo->AddString(_("Very far"));
+    combo->AddItem(_("Close"));
+    combo->AddItem(_("Normal"));
+    combo->AddItem(_("Far"));
+    combo->AddItem(_("Very far"));
 
     curPos.y += 30;
     AddText(ID_txtIslands, curPos, _("Islands"), COLOR_YELLOW, FontStyle{}, NormalFont);
     curPos.y += 20;
     combo = AddComboBox(ID_cbIslands, curPos, comboSize, TextureColor::Grey, NormalFont, 100);
-    combo->AddString(_("Few"));
-    combo->AddString(_("Medium"));
-    combo->AddString(_("Many"));
+    combo->AddItem(_("Few"));
+    combo->AddItem(_("Medium"));
+    combo->AddItem(_("Many"));
 
     constexpr int pgrOffset = 120;
     curPos.y += 35;

--- a/libs/s25main/ingameWindows/iwMinimap.cpp
+++ b/libs/s25main/ingameWindows/iwMinimap.cpp
@@ -30,8 +30,8 @@ iwMinimap::iwMinimap(IngameMinimap& minimap, GameWorldView& gwv)
                    LOADER.GetImageN("resource", 41)),
       extended(SETTINGS.ingame.minimapExtended)
 {
-    AddCtrl(new ctrlIngameMinimap(this, 0, DrawPoint(contentOffset), Extent::all(WINDOW_MAP_SPACE),
-                                  Extent::all(WINDOW_MAP_SPACE), minimap, gwv));
+    AddCtrl(std::make_unique<ctrlIngameMinimap>(this, 0, DrawPoint(contentOffset), Extent::all(WINDOW_MAP_SPACE),
+                                                Extent::all(WINDOW_MAP_SPACE), minimap, gwv));
 
     // Land, Häuser, Straßen an/aus
     DrawPoint curPos(contentOffset.x + WINDOW_MAP_SPACE, 0);

--- a/libs/s25main/ingameWindows/iwMusicPlayer.cpp
+++ b/libs/s25main/ingameWindows/iwMusicPlayer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -215,7 +215,7 @@ void iwMusicPlayer::UpdateFromPlaylist(const Playlist& playlist)
     lstSongs->DeleteAllItems();
 
     for(const auto& song : playlist.getSongs())
-        lstSongs->AddString(song);
+        lstSongs->AddItem(song);
 
     const auto& currentSong = playlist.getCurrentSong();
     if(!currentSong.empty())
@@ -370,7 +370,7 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
 
             if(valid)
             {
-                GetCtrl<ctrlList>(ID_lstSongs)->AddString(msg);
+                GetCtrl<ctrlList>(ID_lstSongs)->AddItem(msg);
                 changed = true;
             } else
                 WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Error"), _("The specified file couldn't be opened!"),
@@ -398,7 +398,7 @@ void iwMusicPlayer::Msg_Input(const unsigned win_id, const std::string& msg)
             std::vector<boost::filesystem::path> oggFiles = ListDir(msg, "ogg");
 
             for(const auto& oggFile : oggFiles)
-                GetCtrl<ctrlList>(ID_lstSongs)->AddString(oggFile.string());
+                GetCtrl<ctrlList>(ID_lstSongs)->AddItem(oggFile.string());
 
             changed = true;
         }
@@ -442,7 +442,7 @@ void iwMusicPlayer::UpdatePlaylistCombo(const std::string& highlight_entry)
     for(const auto& playlistPath : playlists)
     {
         // Reduce to pure filename
-        cbPlaylist->AddString(playlistPath.stem().string());
+        cbPlaylist->AddItem(playlistPath.stem().string());
         if(playlistPath == currentPath)
             cbPlaylist->SetSelection(i);
         ++i;

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -137,12 +137,12 @@ iwSave::iwSave() : iwSaveLoad(_("Save game!"), LOADER.GetTextureN("io", 47), 30)
     AddText(ID_txtAutoSave, pos, _("Auto-Save every:"), 0xFFFFFF00, FontStyle::RIGHT | FontStyle::VCENTER, NormalFont);
 
     // Add intervals
-    combo->AddString(_("Disabled"));
+    combo->AddItem(_("Disabled"));
     for(const std::chrono::minutes interval : AUTO_SAVE_INTERVALS)
-        combo->AddString((boost::format(_("%1% min")) % interval.count()).str());
+        combo->AddItem((boost::format(_("%1% min")) % interval.count()).str());
     // Last entry is only for debugging
     if(SETTINGS.global.debugMode)
-        combo->AddString(_("Every GF"));
+        combo->AddItem(_("Every GF"));
 
     // Select interval
     combo->SetSelection(0); // Use disabled by default and change if possible

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -51,7 +51,7 @@ iwSaveLoad::iwSaveLoad(const std::string& window_title, ITexture* btImg, const u
              ctrlTable::Columns{{_("Filename"), 270, SRT::String},
                                 {_("Map"), 250, SRT::String},
                                 {_("Time"), 250, SRT::Date},
-                                {_("Game Time"), 320, SRT::Time},
+                                {_("Game Time"), 2026, SRT::Time},
                                 {}});
 
     AddText(ID_txtSaveFolder, DrawPoint(20, 333), RTTRCONFIG.ExpandPath(s25::folders::save).string(), COLOR_YELLOW,
@@ -146,14 +146,14 @@ iwSave::iwSave() : iwSaveLoad(_("Save game!"), LOADER.GetTextureN("io", 47), 30)
 
     // Select interval
     combo->SetSelection(0); // Use disabled by default and change if possible
-    if(SETTINGS.interface.autosave_interval == 1)
+    if(SETTINGS.interface.autosaveInterval == 1)
         combo->SetSelection(AUTO_SAVE_INTERVALS.size() + 1);
     else
     {
         // Start selection index at 1, 0 is "disabled"
         for(const auto& i : AUTO_SAVE_INTERVALS | boost::adaptors::indexed(1))
         {
-            if(SETTINGS.interface.autosave_interval == duration_to_gfs(i.value()))
+            if(SETTINGS.interface.autosaveInterval == duration_to_gfs(i.value()))
             {
                 combo->SetSelection(static_cast<unsigned>(i.index()));
                 break;
@@ -165,14 +165,14 @@ iwSave::iwSave() : iwSaveLoad(_("Save game!"), LOADER.GetTextureN("io", 47), 30)
 void iwSave::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsigned selection)
 {
     if(selection == 0) // First entry is "disabled"
-        SETTINGS.interface.autosave_interval = 0;
+        SETTINGS.interface.autosaveInterval = 0;
     else if(selection > AUTO_SAVE_INTERVALS.size()) // Last entry is "every GF" (in debug mode)
-        SETTINGS.interface.autosave_interval = 1;
+        SETTINGS.interface.autosaveInterval = 1;
     else
     {
         // selection is the index into the array ignoring the first ("disabled") entry
         RTTR_Assert(selection >= 1 && selection <= AUTO_SAVE_INTERVALS.size());
-        SETTINGS.interface.autosave_interval = duration_to_gfs(AUTO_SAVE_INTERVALS[selection - 1]);
+        SETTINGS.interface.autosaveInterval = duration_to_gfs(AUTO_SAVE_INTERVALS[selection - 1]);
     }
 }
 

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -23,43 +23,50 @@ enum
     ID_txtResolution,
     ID_txtFullScreen,
     ID_cbDisplayMode,
+    ID_cbLockWindowSize,
     ID_cbResolution,
     ID_txtMapScrollMode,
     ID_cbMapScrollMode,
     ID_cbSmartCursor,
     ID_cbStatisticScale,
+    ID_btApply,
+    ID_btAbort,
 };
 } // namespace
 
 iwSettings::iwSettings()
-    : IngameWindow(CGI_SETTINGS, IngameWindow::posLastOrCenter, Extent(370, 228), _("Settings"),
-                   LOADER.GetImageN("resource", 41))
+    : IngameWindow(CGI_SETTINGS, IngameWindow::posLastOrCenter, Extent(370, 254), _("Settings"),
+                   LOADER.GetImageN("resource", 41), false)
 {
     // Controls are in 2 columns, the left might be the label for the control on the right
     constexpr auto rowWidth = 350;
-    constexpr auto leftColOffset = 15u;   // X-position of the left column
+    constexpr auto leftColOffset = 17u;   // X-position of the left column
     constexpr auto rightColOffset = 180u; // X-position of the right column
     constexpr Extent ctrlSize(rowWidth - rightColOffset, 22);
     constexpr Extent cbSize = Extent(rowWidth - leftColOffset, 26);
+    // 2 buttons evenly spaced
+    constexpr Extent btSize = Extent(rowWidth / 3, 22);
+    constexpr auto btSpacing = btSize.x / 3;
 
-    DrawPoint curPos(leftColOffset, 40);
+    DrawPoint curPos(leftColOffset, 30);
     AddText(ID_txtResolution, curPos, _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     auto* cbResolution = AddComboBox(ID_cbResolution, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
                                      TextureColor::Grey, NormalFont, 110);
     curPos.y += ctrlSize.y + 5;
 
-    VIDEODRIVER.ListVideoModes(video_modes);
-    for(unsigned i = 0; i < video_modes.size(); ++i)
+    VIDEODRIVER.ListVideoModes(supportedVideoModes);
+    for(unsigned i = 0; i < supportedVideoModes.size(); ++i)
     {
         // >=800x600, alles andere macht keinen Sinn
-        if(video_modes[i].width >= 800 && video_modes[i].height >= 600)
+        if(supportedVideoModes[i].width >= 800 && supportedVideoModes[i].height >= 600)
         {
-            cbResolution->AddString(helpers::format("%ux%u", video_modes[i].width, video_modes[i].height));
-            if(video_modes[i] == SETTINGS.video.fullscreenSize)
+            cbResolution->AddString(
+              helpers::format("%ux%u", supportedVideoModes[i].width, supportedVideoModes[i].height));
+            if(supportedVideoModes[i] == SETTINGS.video.fullscreenSize)
                 cbResolution->SetSelection(i);
         } else
         {
-            video_modes.erase(video_modes.begin() + i);
+            supportedVideoModes.erase(supportedVideoModes.begin() + i);
             --i;
         }
     }
@@ -70,8 +77,13 @@ iwSettings::iwSettings()
     cbDisplayMode->AddString(_("Windowed"));
     cbDisplayMode->AddString(_("Fullscreen"));
     cbDisplayMode->AddString(_("Borderless window"));
-    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode));
-    curPos.y += ctrlSize.y + 10;
+    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode.type));
+
+    curPos.y += ctrlSize.y + 1;
+    AddCheckBox(ID_cbLockWindowSize, curPos, cbSize, TextureColor::Grey, _("Lock window size:"), NormalFont, false)
+      ->setChecked(!SETTINGS.video.displayMode.resizeable);
+
+    curPos.y += cbSize.y + 15;
 
     AddText(ID_txtMapScrollMode, curPos, _("Map scroll mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     ctrlComboBox* cbMapScrollMode = AddComboBox(ID_cbMapScrollMode, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
@@ -90,50 +102,57 @@ iwSettings::iwSettings()
     curPos.y += cbSize.y + 3;
     AddCheckBox(ID_cbStatisticScale, curPos, cbSize, TextureColor::Grey, _("Statistics Scale"), NormalFont, false)
       ->setChecked(SETTINGS.ingame.scaleStatistics);
+
+    curPos = DrawPoint(leftColOffset + btSpacing, GetSize().y - 40);
+    AddTextButton(ID_btApply, curPos, btSize, TextureColor::Green2, _("Apply"), NormalFont, _("Apply Changes"));
+    curPos.x += btSize.x + btSpacing;
+    AddTextButton(ID_btAbort, curPos, btSize, TextureColor::Red1, _("Abort"), NormalFont, _("Close Without Saving"));
 }
 
-iwSettings::~iwSettings()
-{
-    try
-    {
-        auto* MouseMdCombo = GetCtrl<ctrlComboBox>(ID_cbMapScrollMode);
-        SETTINGS.interface.mapScrollMode = static_cast<MapScrollMode>(MouseMdCombo->GetSelection().get());
-
-        auto* SizeCombo = GetCtrl<ctrlComboBox>(ID_cbResolution);
-        SETTINGS.video.fullscreenSize = video_modes[SizeCombo->GetSelection().get()];
-
-        const auto fullscreen = SETTINGS.video.displayMode == DisplayMode::Fullscreen;
-        if((fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize())
-           || SETTINGS.video.displayMode != VIDEODRIVER.GetDisplayMode())
-        {
-            const auto screenSize = fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
-            if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
-            {
-                WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
-                  _("Sorry!"), _("You need to restart your game to change the screen resolution!"), this,
-                  MsgboxButton::Ok, MsgboxIcon::ExclamationGreen, 1));
-            }
-        }
-    } catch(...)
-    {
-        // ignored
-    }
-}
-
-void iwSettings::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selection)
-{
-    RTTR_Assert(ctrl_id == ID_cbDisplayMode);
-    SETTINGS.video.displayMode = DisplayMode(selection);
-}
-
-void iwSettings::Msg_CheckboxChange(const unsigned ctrl_id, const bool checked)
+void iwSettings::Msg_ButtonClick(unsigned ctrl_id)
 {
     switch(ctrl_id)
     {
-        case ID_cbSmartCursor:
-            SETTINGS.global.smartCursor = checked;
-            VIDEODRIVER.SetMouseWarping(checked);
-            break;
-        case ID_cbStatisticScale: SETTINGS.ingame.scaleStatistics = checked; break;
+        case ID_btApply:
+        {
+            SETTINGS.global.smartCursor = GetCtrl<ctrlCheck>(ID_cbSmartCursor)->isChecked();
+            VIDEODRIVER.SetMouseWarping(SETTINGS.global.smartCursor);
+            SETTINGS.ingame.scaleStatistics = GetCtrl<ctrlCheck>(ID_cbStatisticScale)->isChecked();
+            SETTINGS.video.displayMode = DisplayMode(*GetCtrl<ctrlComboBox>(ID_cbDisplayMode)->GetSelection());
+            SETTINGS.video.displayMode.resizeable = !GetCtrl<ctrlCheck>(ID_cbLockWindowSize)->isChecked();
+            SETTINGS.interface.mapScrollMode =
+              static_cast<MapScrollMode>(GetCtrl<ctrlComboBox>(ID_cbMapScrollMode)->GetSelection().get());
+            SETTINGS.video.fullscreenSize =
+              supportedVideoModes[GetCtrl<ctrlComboBox>(ID_cbResolution)->GetSelection().get()];
+            closeBehavior_ = CloseBehavior::Regular;
+
+            const auto screenSize = SETTINGS.video.displayMode == DisplayMode::Fullscreen ?
+                                      SETTINGS.video.fullscreenSize :
+                                      SETTINGS.video.windowedSize;
+            if(VIDEODRIVER.GetWindowSize() != screenSize || SETTINGS.video.displayMode != VIDEODRIVER.GetDisplayMode())
+            {
+                if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
+                {
+                    WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
+                      _("Sorry!"), _("You need to restart your game to change the screen resolution!"), this,
+                      MsgboxButton::Ok, MsgboxIcon::ExclamationGreen, 1));
+                }
+            }
+        }
+        break;
+        case ID_btAbort: Close(); break;
+        default: RTTR_Assert(false);
     }
+}
+
+void iwSettings::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsigned /*selection*/)
+{
+    // Handle on apply and just disable closing the window without the buttons (apply/discard)
+    closeBehavior_ = CloseBehavior::Custom;
+}
+
+void iwSettings::Msg_CheckboxChange(const unsigned /*ctrl_id*/, const bool /*checked*/)
+{
+    // Handle on apply and just disable closing the window without the buttons (apply/discard)
+    closeBehavior_ = CloseBehavior::Custom;
 }

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -78,8 +78,6 @@ iwSettings::iwSettings()
       ->setChecked(!SETTINGS.video.displayMode.resizeable);
 
     supportedResolutions_ = VIDEODRIVER.ListVideoModes();
-    // Remove everything below 800x600
-    helpers::erase_if(supportedResolutions_, [](const auto& it) { return it.width < 800 && it.height < 600; });
     for(const auto& videoMode : supportedResolutions_)
     {
         cbResolution->AddItem(helpers::format("%ux%u", videoMode.width, videoMode.height));

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -11,6 +11,7 @@
 #include "controls/ctrlOptionGroup.h"
 #include "driver/VideoInterface.h"
 #include "drivers/VideoDriverWrapper.h"
+#include "enum_cast.hpp"
 #include "helpers/format.hpp"
 #include "iwMsgbox.h"
 #include "gameData/const_gui_ids.h"
@@ -21,15 +22,13 @@ enum
 {
     ID_txtResolution,
     ID_txtFullScreen,
-    ID_grpFullscreen,
+    ID_cbDisplayMode,
     ID_cbResolution,
     ID_txtMapScrollMode,
     ID_cbMapScrollMode,
     ID_cbSmartCursor,
     ID_cbStatisticScale,
 };
-constexpr auto ID_btOn = 1;
-constexpr auto ID_btOff = 0;
 } // namespace
 
 iwSettings::iwSettings()
@@ -37,15 +36,17 @@ iwSettings::iwSettings()
                    LOADER.GetImageN("resource", 41))
 {
     // Controls are in 2 columns, the left might be the label for the control on the right
+    constexpr auto rowWidth = 350;
     constexpr auto leftColOffset = 15u;   // X-position of the left column
-    constexpr auto rightColOffset = 200u; // X-position of the right column
-    constexpr Extent ctrlSize(150, 22);
-    constexpr auto rowWidth = rightColOffset + ctrlSize.x;
+    constexpr auto rightColOffset = 180u; // X-position of the right column
+    constexpr Extent ctrlSize(rowWidth - rightColOffset, 22);
+    constexpr Extent cbSize = Extent(rowWidth - leftColOffset, 26);
 
-    AddText(ID_txtResolution, DrawPoint(leftColOffset, 40), _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{},
-            NormalFont);
-    auto* cbResolution =
-      AddComboBox(ID_cbResolution, DrawPoint(rightColOffset, 35), ctrlSize, TextureColor::Grey, NormalFont, 110);
+    DrawPoint curPos(leftColOffset, 40);
+    AddText(ID_txtResolution, curPos, _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    auto* cbResolution = AddComboBox(ID_cbResolution, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
+                                     TextureColor::Grey, NormalFont, 110);
+    curPos.y += ctrlSize.y + 5;
 
     VIDEODRIVER.ListVideoModes(video_modes);
     for(unsigned i = 0; i < video_modes.size(); ++i)
@@ -62,20 +63,18 @@ iwSettings::iwSettings()
             --i;
         }
     }
-    AddText(ID_txtFullScreen, DrawPoint(leftColOffset, 85), _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    ctrlOptionGroup* optiongroup = AddOptionGroup(ID_grpFullscreen, GroupSelectType::Check);
-    DrawPoint curPos(rightColOffset, 70);
-    optiongroup->AddTextButton(ID_btOn, curPos, ctrlSize, TextureColor::Grey, _("Fullscreen"), NormalFont);
-    curPos.y += ctrlSize.y + 3;
-    optiongroup->AddTextButton(ID_btOff, curPos, ctrlSize, TextureColor::Grey, _("Windowed"), NormalFont);
-    optiongroup->SetSelection((bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen) ? 1 : 2)); //-V807
 
-    curPos = DrawPoint(leftColOffset, curPos.y + ctrlSize.y + 5);
-    const auto cbSize = Extent(rowWidth - curPos.x, 26);
+    AddText(ID_txtFullScreen, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    ctrlComboBox* cbDisplayMode = AddComboBox(ID_cbDisplayMode, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
+                                              TextureColor::Grey, NormalFont, 100);
+    cbDisplayMode->AddString(_("Windowed"));
+    cbDisplayMode->AddString(_("Fullscreen"));
+    cbDisplayMode->AddString(_("Borderless window"));
+    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode));
+    curPos.y += ctrlSize.y + 10;
 
-    AddText(ID_txtMapScrollMode, DrawPoint(leftColOffset, curPos.y + 5), _("Map scroll mode:"), COLOR_YELLOW,
-            FontStyle{}, NormalFont);
-    ctrlComboBox* cbMapScrollMode = AddComboBox(ID_cbMapScrollMode, DrawPoint(rightColOffset, curPos.y), ctrlSize,
+    AddText(ID_txtMapScrollMode, curPos, _("Map scroll mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    ctrlComboBox* cbMapScrollMode = AddComboBox(ID_cbMapScrollMode, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
                                                 TextureColor::Grey, NormalFont, 100);
     cbMapScrollMode->AddString(
       _("Scroll same (Map moves in the same direction the mouse is moved when scrolling/panning.)"));
@@ -84,7 +83,7 @@ iwSettings::iwSettings()
     cbMapScrollMode->AddString(_("Grab and drag (Map moves with your cursor when scrolling/panning.)"));
     cbMapScrollMode->SetSelection(static_cast<int>(SETTINGS.interface.mapScrollMode));
 
-    curPos.y += cbSize.y + 3;
+    curPos.y += ctrlSize.y + 10;
     AddCheckBox(ID_cbSmartCursor, curPos, cbSize, TextureColor::Grey, _("Smart Cursor"), NormalFont, false)
       ->setChecked(SETTINGS.global.smartCursor)
       ->SetTooltip(_("Place cursor on default button for new dialogs / action windows (default)"));
@@ -103,9 +102,9 @@ iwSettings::~iwSettings()
         auto* SizeCombo = GetCtrl<ctrlComboBox>(ID_cbResolution);
         SETTINGS.video.fullscreenSize = video_modes[SizeCombo->GetSelection().get()];
 
-        const auto fullscreen = bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen);
+        const auto fullscreen = SETTINGS.video.displayMode == DisplayMode::Fullscreen;
         if((fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize())
-           || fullscreen != VIDEODRIVER.IsFullscreen())
+           || SETTINGS.video.displayMode != VIDEODRIVER.GetDisplayMode())
         {
             const auto screenSize = fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
             if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
@@ -121,15 +120,10 @@ iwSettings::~iwSettings()
     }
 }
 
-void iwSettings::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned selection)
+void iwSettings::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selection)
 {
-    switch(ctrl_id)
-    {
-        case ID_grpFullscreen:
-            SETTINGS.video.displayMode =
-              bitset::set(SETTINGS.video.displayMode, DisplayMode::Fullscreen, (selection == ID_btOn));
-            break;
-    }
+    RTTR_Assert(ctrl_id == ID_cbDisplayMode);
+    SETTINGS.video.displayMode = DisplayMode(selection);
 }
 
 void iwSettings::Msg_CheckboxChange(const unsigned ctrl_id, const bool checked)

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -77,14 +77,16 @@ iwSettings::iwSettings()
       ->AddCheckBox(ID_cbLockWindowSize, curPos, cbSize, TextureColor::Grey, _("Lock window size:"), NormalFont, false)
       ->setChecked(!SETTINGS.video.displayMode.resizeable);
 
-    supportedResolutions_ = VIDEODRIVER.ListVideoModes();
+    const auto supportedResolutions = VIDEODRIVER.ListVideoModes();
+    supportedResolutions_.assign(supportedResolutions.begin(), supportedResolutions.end());
     for(const auto& videoMode : supportedResolutions_)
     {
         cbResolution->AddItem(helpers::format("%ux%u", videoMode.width, videoMode.height));
         if(videoMode == SETTINGS.video.fullscreenSize)
             cbResolution->SetSelection(cbResolution->GetNumItems() - 1);
     }
-    windowSizes_ = VIDEODRIVER.GetDefaultWindowSizes();
+    const auto windowSizes = VIDEODRIVER.GetDefaultWindowSizes();
+    windowSizes_.assign(windowSizes.begin(), windowSizes.end());
     cbWindowSize.AddItem(""); // Placeholder for current window size
     for(const auto& size : windowSizes_)
         cbWindowSize.AddItem(helpers::format("%ux%u", size.width, size.height));

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -89,7 +89,7 @@ iwSettings::iwSettings()
       ->SetTooltip(_("Place cursor on default button for new dialogs / action windows (default)"));
     curPos.y += cbSize.y + 3;
     AddCheckBox(ID_cbStatisticScale, curPos, cbSize, TextureColor::Grey, _("Statistics Scale"), NormalFont, false)
-      ->setChecked(SETTINGS.ingame.scale_statistics);
+      ->setChecked(SETTINGS.ingame.scaleStatistics);
 }
 
 iwSettings::~iwSettings()
@@ -134,6 +134,6 @@ void iwSettings::Msg_CheckboxChange(const unsigned ctrl_id, const bool checked)
             SETTINGS.global.smartCursor = checked;
             VIDEODRIVER.SetMouseWarping(checked);
             break;
-        case ID_cbStatisticScale: SETTINGS.ingame.scale_statistics = checked; break;
+        case ID_cbStatisticScale: SETTINGS.ingame.scaleStatistics = checked; break;
     }
 }

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -12,6 +12,7 @@
 #include "driver/VideoInterface.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "enum_cast.hpp"
+#include "helpers/containerUtils.h"
 #include "helpers/format.hpp"
 #include "iwMsgbox.h"
 #include "gameData/const_gui_ids.h"
@@ -54,21 +55,14 @@ iwSettings::iwSettings()
                                      TextureColor::Grey, NormalFont, 110);
     curPos.y += ctrlSize.y + 5;
 
-    VIDEODRIVER.ListVideoModes(supportedVideoModes);
-    for(unsigned i = 0; i < supportedVideoModes.size(); ++i)
+    supportedVideoModes = VIDEODRIVER.ListVideoModes();
+    // Remove everything below 800x600
+    helpers::erase_if(supportedVideoModes, [](const auto& it) { return it.width < 800 && it.height < 600; });
+    for(const auto& videoMode : supportedVideoModes)
     {
-        // >=800x600, alles andere macht keinen Sinn
-        if(supportedVideoModes[i].width >= 800 && supportedVideoModes[i].height >= 600)
-        {
-            cbResolution->AddString(
-              helpers::format("%ux%u", supportedVideoModes[i].width, supportedVideoModes[i].height));
-            if(supportedVideoModes[i] == SETTINGS.video.fullscreenSize)
-                cbResolution->SetSelection(i);
-        } else
-        {
-            supportedVideoModes.erase(supportedVideoModes.begin() + i);
-            --i;
-        }
+        cbResolution->AddString(helpers::format("%ux%u", videoMode.width, videoMode.height));
+        if(videoMode == SETTINGS.video.fullscreenSize)
+            cbResolution->SetSelection(cbResolution->GetNumItems() - 1);
     }
 
     AddText(ID_txtFullScreen, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -9,6 +9,7 @@
 #include "controls/ctrlCheck.h"
 #include "controls/ctrlComboBox.h"
 #include "controls/ctrlOptionGroup.h"
+#include "driver/VideoInterface.h"
 #include "drivers/VideoDriverWrapper.h"
 #include "helpers/format.hpp"
 #include "iwMsgbox.h"
@@ -67,7 +68,7 @@ iwSettings::iwSettings()
     optiongroup->AddTextButton(ID_btOn, curPos, ctrlSize, TextureColor::Grey, _("Fullscreen"), NormalFont);
     curPos.y += ctrlSize.y + 3;
     optiongroup->AddTextButton(ID_btOff, curPos, ctrlSize, TextureColor::Grey, _("Windowed"), NormalFont);
-    optiongroup->SetSelection(SETTINGS.video.fullscreen); //-V807
+    optiongroup->SetSelection((bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen) ? 1 : 2)); //-V807
 
     curPos = DrawPoint(leftColOffset, curPos.y + ctrlSize.y + 5);
     const auto cbSize = Extent(rowWidth - curPos.x, 26);
@@ -102,12 +103,12 @@ iwSettings::~iwSettings()
         auto* SizeCombo = GetCtrl<ctrlComboBox>(ID_cbResolution);
         SETTINGS.video.fullscreenSize = video_modes[SizeCombo->GetSelection().get()];
 
-        if((SETTINGS.video.fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize())
-           || SETTINGS.video.fullscreen != VIDEODRIVER.IsFullscreen())
+        const auto fullscreen = bitset::isSet(SETTINGS.video.displayMode, DisplayMode::Fullscreen);
+        if((fullscreen && SETTINGS.video.fullscreenSize != VIDEODRIVER.GetWindowSize())
+           || fullscreen != VIDEODRIVER.IsFullscreen())
         {
-            const auto screenSize =
-              SETTINGS.video.fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
-            if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.fullscreen))
+            const auto screenSize = fullscreen ? SETTINGS.video.fullscreenSize : SETTINGS.video.windowedSize;
+            if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
             {
                 WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
                   _("Sorry!"), _("You need to restart your game to change the screen resolution!"), this,
@@ -124,7 +125,10 @@ void iwSettings::Msg_OptionGroupChange(const unsigned ctrl_id, const unsigned se
 {
     switch(ctrl_id)
     {
-        case ID_grpFullscreen: SETTINGS.video.fullscreen = selection == ID_btOn; break;
+        case ID_grpFullscreen:
+            SETTINGS.video.displayMode =
+              bitset::set(SETTINGS.video.displayMode, DisplayMode::Fullscreen, (selection == ID_btOn));
+            break;
     }
 }
 

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -60,7 +60,7 @@ iwSettings::iwSettings()
     helpers::erase_if(supportedVideoModes, [](const auto& it) { return it.width < 800 && it.height < 600; });
     for(const auto& videoMode : supportedVideoModes)
     {
-        cbResolution->AddString(helpers::format("%ux%u", videoMode.width, videoMode.height));
+        cbResolution->AddItem(helpers::format("%ux%u", videoMode.width, videoMode.height));
         if(videoMode == SETTINGS.video.fullscreenSize)
             cbResolution->SetSelection(cbResolution->GetNumItems() - 1);
     }
@@ -68,9 +68,9 @@ iwSettings::iwSettings()
     AddText(ID_txtFullScreen, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     ctrlComboBox* cbDisplayMode = AddComboBox(ID_cbDisplayMode, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
                                               TextureColor::Grey, NormalFont, 100);
-    cbDisplayMode->AddString(_("Windowed"));
-    cbDisplayMode->AddString(_("Fullscreen"));
-    cbDisplayMode->AddString(_("Borderless window"));
+    cbDisplayMode->AddItem(_("Windowed"));
+    cbDisplayMode->AddItem(_("Fullscreen"));
+    cbDisplayMode->AddItem(_("Borderless window"));
     cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode.type));
 
     curPos.y += ctrlSize.y + 1;
@@ -82,11 +82,11 @@ iwSettings::iwSettings()
     AddText(ID_txtMapScrollMode, curPos, _("Map scroll mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
     ctrlComboBox* cbMapScrollMode = AddComboBox(ID_cbMapScrollMode, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
                                                 TextureColor::Grey, NormalFont, 100);
-    cbMapScrollMode->AddString(
+    cbMapScrollMode->AddItem(
       _("Scroll same (Map moves in the same direction the mouse is moved when scrolling/panning.)"));
-    cbMapScrollMode->AddString(
+    cbMapScrollMode->AddItem(
       _("Scroll opposite (Map moves in the opposite direction the mouse is moved when scrolling/panning.)"));
-    cbMapScrollMode->AddString(_("Grab and drag (Map moves with your cursor when scrolling/panning.)"));
+    cbMapScrollMode->AddItem(_("Grab and drag (Map moves with your cursor when scrolling/panning.)"));
     cbMapScrollMode->SetSelection(static_cast<int>(SETTINGS.interface.mapScrollMode));
 
     curPos.y += ctrlSize.y + 10;

--- a/libs/s25main/ingameWindows/iwSettings.cpp
+++ b/libs/s25main/ingameWindows/iwSettings.cpp
@@ -21,11 +21,15 @@
 namespace {
 enum
 {
-    ID_txtResolution,
-    ID_txtFullScreen,
+    ID_txtDisplayMode,
     ID_cbDisplayMode,
     ID_cbLockWindowSize,
+    ID_grpResolution,
+    ID_txtResolution,
     ID_cbResolution,
+    ID_grpWindowSize,
+    ID_txtWindowSize,
+    ID_cbWindowSize,
     ID_txtMapScrollMode,
     ID_cbMapScrollMode,
     ID_cbSmartCursor,
@@ -41,47 +45,57 @@ iwSettings::iwSettings()
 {
     // Controls are in 2 columns, the left might be the label for the control on the right
     constexpr auto rowWidth = 350;
-    constexpr auto leftColOffset = 17u;   // X-position of the left column
-    constexpr auto rightColOffset = 180u; // X-position of the right column
-    constexpr Extent ctrlSize(rowWidth - rightColOffset, 22);
+    constexpr auto leftColOffset = 17u;                           // X-position of the left column
+    constexpr DrawPoint rightColOffset(170u - leftColOffset, -1); // Offset from left column to right column
+    constexpr Extent ctrlSize(rowWidth - rightColOffset.x - leftColOffset, 22);
     constexpr Extent cbSize = Extent(rowWidth - leftColOffset, 26);
     // 2 buttons evenly spaced
     constexpr Extent btSize = Extent(rowWidth / 3, 22);
     constexpr auto btSpacing = btSize.x / 3;
 
     DrawPoint curPos(leftColOffset, 30);
-    AddText(ID_txtResolution, curPos, _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    auto* cbResolution = AddComboBox(ID_cbResolution, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
-                                     TextureColor::Grey, NormalFont, 110);
+    AddText(ID_txtDisplayMode, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    ctrlComboBox* cbDisplayMode =
+      AddComboBox(ID_cbDisplayMode, curPos + rightColOffset, ctrlSize, TextureColor::Grey, NormalFont, 100);
+    cbDisplayMode->AddItem(_("Windowed"));
+    cbDisplayMode->AddItem(_("Fullscreen"));
+    cbDisplayMode->AddItem(_("Borderless window"));
+    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode.type));
     curPos.y += ctrlSize.y + 5;
 
-    supportedVideoModes = VIDEODRIVER.ListVideoModes();
+    auto* grpResolution = AddGroup(ID_grpResolution);
+    grpResolution->AddText(ID_txtResolution, curPos, _("Fullscreen resolution:"), COLOR_YELLOW, FontStyle{},
+                           NormalFont);
+    auto* cbResolution = grpResolution->AddComboBox(ID_cbResolution, curPos + rightColOffset, ctrlSize,
+                                                    TextureColor::Grey, NormalFont, 110);
+    auto* grpWindowSize = AddGroup(ID_grpWindowSize);
+    grpWindowSize->AddText(ID_txtWindowSize, curPos, _("Window size:"), COLOR_YELLOW, FontStyle{}, NormalFont);
+    auto& cbWindowSize = *grpWindowSize->AddComboBox(ID_cbWindowSize, curPos + rightColOffset, ctrlSize,
+                                                     TextureColor::Grey, NormalFont, 150);
+    curPos.y += ctrlSize.y + 1;
+    grpWindowSize
+      ->AddCheckBox(ID_cbLockWindowSize, curPos, cbSize, TextureColor::Grey, _("Lock window size:"), NormalFont, false)
+      ->setChecked(!SETTINGS.video.displayMode.resizeable);
+
+    supportedResolutions_ = VIDEODRIVER.ListVideoModes();
     // Remove everything below 800x600
-    helpers::erase_if(supportedVideoModes, [](const auto& it) { return it.width < 800 && it.height < 600; });
-    for(const auto& videoMode : supportedVideoModes)
+    helpers::erase_if(supportedResolutions_, [](const auto& it) { return it.width < 800 && it.height < 600; });
+    for(const auto& videoMode : supportedResolutions_)
     {
         cbResolution->AddItem(helpers::format("%ux%u", videoMode.width, videoMode.height));
         if(videoMode == SETTINGS.video.fullscreenSize)
             cbResolution->SetSelection(cbResolution->GetNumItems() - 1);
     }
-
-    AddText(ID_txtFullScreen, curPos, _("Mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    ctrlComboBox* cbDisplayMode = AddComboBox(ID_cbDisplayMode, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
-                                              TextureColor::Grey, NormalFont, 100);
-    cbDisplayMode->AddItem(_("Windowed"));
-    cbDisplayMode->AddItem(_("Fullscreen"));
-    cbDisplayMode->AddItem(_("Borderless window"));
-    cbDisplayMode->SetSelection(rttr::enum_cast(SETTINGS.video.displayMode.type));
-
-    curPos.y += ctrlSize.y + 1;
-    AddCheckBox(ID_cbLockWindowSize, curPos, cbSize, TextureColor::Grey, _("Lock window size:"), NormalFont, false)
-      ->setChecked(!SETTINGS.video.displayMode.resizeable);
+    windowSizes_ = VIDEODRIVER.GetDefaultWindowSizes();
+    cbWindowSize.AddItem(""); // Placeholder for current window size
+    for(const auto& size : windowSizes_)
+        cbWindowSize.AddItem(helpers::format("%ux%u", size.width, size.height));
 
     curPos.y += cbSize.y + 15;
 
     AddText(ID_txtMapScrollMode, curPos, _("Map scroll mode:"), COLOR_YELLOW, FontStyle{}, NormalFont);
-    ctrlComboBox* cbMapScrollMode = AddComboBox(ID_cbMapScrollMode, DrawPoint(rightColOffset, curPos.y - 5), ctrlSize,
-                                                TextureColor::Grey, NormalFont, 100);
+    ctrlComboBox* cbMapScrollMode =
+      AddComboBox(ID_cbMapScrollMode, curPos + rightColOffset, ctrlSize, TextureColor::Grey, NormalFont, 100);
     cbMapScrollMode->AddItem(
       _("Scroll same (Map moves in the same direction the mouse is moved when scrolling/panning.)"));
     cbMapScrollMode->AddItem(
@@ -101,6 +115,9 @@ iwSettings::iwSettings()
     AddTextButton(ID_btApply, curPos, btSize, TextureColor::Green2, _("Apply"), NormalFont, _("Apply Changes"));
     curPos.x += btSize.x + btSpacing;
     AddTextButton(ID_btAbort, curPos, btSize, TextureColor::Red1, _("Abort"), NormalFont, _("Close Without Saving"));
+
+    updateWindowSizeComboBox();
+    updateResolutionGroups();
 }
 
 void iwSettings::Msg_ButtonClick(unsigned ctrl_id)
@@ -109,21 +126,30 @@ void iwSettings::Msg_ButtonClick(unsigned ctrl_id)
     {
         case ID_btApply:
         {
+            auto& grpWindowSize = *GetCtrl<ctrlGroup>(ID_grpWindowSize);
             SETTINGS.global.smartCursor = GetCtrl<ctrlCheck>(ID_cbSmartCursor)->isChecked();
             VIDEODRIVER.SetMouseWarping(SETTINGS.global.smartCursor);
             SETTINGS.ingame.scaleStatistics = GetCtrl<ctrlCheck>(ID_cbStatisticScale)->isChecked();
             SETTINGS.video.displayMode = DisplayMode(*GetCtrl<ctrlComboBox>(ID_cbDisplayMode)->GetSelection());
-            SETTINGS.video.displayMode.resizeable = !GetCtrl<ctrlCheck>(ID_cbLockWindowSize)->isChecked();
+            SETTINGS.video.displayMode.resizeable = !grpWindowSize.GetCtrl<ctrlCheck>(ID_cbLockWindowSize)->isChecked();
             SETTINGS.interface.mapScrollMode =
               static_cast<MapScrollMode>(GetCtrl<ctrlComboBox>(ID_cbMapScrollMode)->GetSelection().get());
-            SETTINGS.video.fullscreenSize =
-              supportedVideoModes[GetCtrl<ctrlComboBox>(ID_cbResolution)->GetSelection().get()];
+            SETTINGS.video.fullscreenSize = supportedResolutions_
+              [GetCtrl<ctrlGroup>(ID_grpResolution)->GetCtrl<ctrlComboBox>(ID_cbResolution)->GetSelection().get()];
+            const unsigned windowSizeSelection =
+              grpWindowSize.GetCtrl<ctrlComboBox>(ID_cbWindowSize)->GetSelection().get();
+            if(windowSizeSelection > 0)
+                SETTINGS.video.windowedSize = windowSizes_[windowSizeSelection - 1];
+            else if(VIDEODRIVER.GetDisplayMode() == DisplayMode::Windowed)
+                SETTINGS.video.windowedSize = VIDEODRIVER.GetWindowSize();
             closeBehavior_ = CloseBehavior::Regular;
 
             const auto screenSize = SETTINGS.video.displayMode == DisplayMode::Fullscreen ?
                                       SETTINGS.video.fullscreenSize :
                                       SETTINGS.video.windowedSize;
-            if(VIDEODRIVER.GetWindowSize() != screenSize || SETTINGS.video.displayMode != VIDEODRIVER.GetDisplayMode())
+            if((SETTINGS.video.displayMode != DisplayMode::BorderlessWindow
+                && VIDEODRIVER.GetWindowSize() != screenSize)
+               || SETTINGS.video.displayMode != VIDEODRIVER.GetDisplayMode())
             {
                 if(!VIDEODRIVER.ResizeScreen(screenSize, SETTINGS.video.displayMode))
                 {
@@ -132,6 +158,7 @@ void iwSettings::Msg_ButtonClick(unsigned ctrl_id)
                       MsgboxButton::Ok, MsgboxIcon::ExclamationGreen, 1));
                 }
             }
+            SETTINGS.Save();
         }
         break;
         case ID_btAbort: Close(); break;
@@ -139,14 +166,60 @@ void iwSettings::Msg_ButtonClick(unsigned ctrl_id)
     }
 }
 
-void iwSettings::Msg_ComboSelectItem(const unsigned /*ctrl_id*/, const unsigned /*selection*/)
+void iwSettings::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned /*selection*/)
 {
     // Handle on apply and just disable closing the window without the buttons (apply/discard)
     closeBehavior_ = CloseBehavior::Custom;
+    if(ctrl_id == ID_cbDisplayMode)
+        updateResolutionGroups();
 }
 
 void iwSettings::Msg_CheckboxChange(const unsigned /*ctrl_id*/, const bool /*checked*/)
 {
     // Handle on apply and just disable closing the window without the buttons (apply/discard)
     closeBehavior_ = CloseBehavior::Custom;
+}
+
+void iwSettings::Msg_Group_ComboSelectItem(unsigned /*group_id*/, unsigned ctrl_id, unsigned selection)
+{
+    if(ctrl_id == ID_cbWindowSize && selection > 0)
+    {
+        const DisplayMode currentDisplayMode = getDisplayModeSelection();
+        // Directly apply new window size
+        if(currentDisplayMode == DisplayMode::Windowed && VIDEODRIVER.GetDisplayMode() == DisplayMode::Windowed)
+        {
+            VIDEODRIVER.ResizeScreen(windowSizes_[selection - 1], DisplayMode::Windowed);
+        } else
+            closeBehavior_ = CloseBehavior::Custom;
+    } else
+        closeBehavior_ = CloseBehavior::Custom;
+}
+
+void iwSettings::Msg_ScreenResize(const ScreenResizeEvent& sr)
+{
+    IngameWindow::Msg_ScreenResize(sr);
+    updateWindowSizeComboBox();
+}
+
+void iwSettings::updateWindowSizeComboBox()
+{
+    auto* cbWindowSize = GetCtrl<ctrlGroup>(ID_grpWindowSize)->GetCtrl<ctrlComboBox>(ID_cbWindowSize);
+
+    const VideoMode currentSize =
+      VIDEODRIVER.GetDisplayMode() == DisplayMode::Windowed ? VIDEODRIVER.GetWindowSize() : SETTINGS.video.windowedSize;
+    cbWindowSize->SetText(0, helpers::format("%ux%u", currentSize.width, currentSize.height));
+    // Not found == -1 -> First entry selected
+    cbWindowSize->SetSelection(static_cast<unsigned>(helpers::indexOf(windowSizes_, currentSize) + 1));
+}
+
+void iwSettings::updateResolutionGroups()
+{
+    const DisplayMode currentDisplayMode = getDisplayModeSelection();
+    GetCtrl<ctrlGroup>(ID_grpResolution)->SetVisible(currentDisplayMode == DisplayMode::Fullscreen);
+    GetCtrl<ctrlGroup>(ID_grpWindowSize)->SetVisible(currentDisplayMode == DisplayMode::Windowed);
+}
+
+DisplayMode iwSettings::getDisplayModeSelection() const
+{
+    return DisplayMode(*GetCtrl<ctrlComboBox>(ID_cbDisplayMode)->GetSelection());
 }

--- a/libs/s25main/ingameWindows/iwSettings.h
+++ b/libs/s25main/ingameWindows/iwSettings.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -16,6 +16,6 @@ public:
 
 private:
     std::vector<VideoMode> video_modes; /// Vector für die Auflösungen
-    void Msg_OptionGroupChange(unsigned ctrl_id, unsigned selection) override;
+    void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
 };

--- a/libs/s25main/ingameWindows/iwSettings.h
+++ b/libs/s25main/ingameWindows/iwSettings.h
@@ -12,10 +12,12 @@ class iwSettings : public IngameWindow
 {
 public:
     iwSettings();
-    ~iwSettings() override;
 
-private:
-    std::vector<VideoMode> video_modes; /// Vector für die Auflösungen
+protected:
+    void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
+
+private:
+    std::vector<VideoMode> supportedVideoModes;
 };

--- a/libs/s25main/ingameWindows/iwSettings.h
+++ b/libs/s25main/ingameWindows/iwSettings.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include "IngameWindow.h"
-
-struct VideoMode;
+#include "driver/VideoMode.h"
 
 class iwSettings : public IngameWindow
 {
@@ -17,7 +16,12 @@ protected:
     void Msg_ButtonClick(unsigned ctrl_id) override;
     void Msg_ComboSelectItem(unsigned ctrl_id, unsigned selection) override;
     void Msg_CheckboxChange(unsigned ctrl_id, bool checked) override;
+    void Msg_Group_ComboSelectItem(unsigned group_id, unsigned ctrl_id, unsigned selection) override;
+    void Msg_ScreenResize(const ScreenResizeEvent& sr) override;
 
 private:
-    std::vector<VideoMode> supportedVideoModes;
+    std::vector<VideoMode> supportedResolutions_, windowSizes_;
+    void updateWindowSizeComboBox();
+    void updateResolutionGroups();
+    DisplayMode getDisplayModeSelection() const;
 };

--- a/libs/s25main/ingameWindows/iwStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwStatistics.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -183,7 +183,7 @@ iwStatistics::iwStatistics(const GameWorldViewer& gwv)
     timeChanger->SetSelection(ID_time15m, true);
     currentTime = StatisticTime::T15Minutes;
 
-    if(!SETTINGS.ingame.scale_statistics)
+    if(!SETTINGS.ingame.scaleStatistics)
         txtMinValueY->SetVisible(false);
 }
 
@@ -334,7 +334,7 @@ void iwStatistics::DrawStatistic(StatisticType type)
         {
             const auto idx = (currentIndex >= i) ? (currentIndex - i) : (NUM_STAT_STEPS - i + currentIndex);
             max = std::max(max, stat.data[type][idx]);
-            if(SETTINGS.ingame.scale_statistics) //-V807
+            if(SETTINGS.ingame.scaleStatistics) //-V807
                 min = std::min(min, stat.data[type][idx]);
         }
     }
@@ -346,7 +346,7 @@ void iwStatistics::DrawStatistic(StatisticType type)
     }
     // Add values to axis
     txtMaxValueY->SetText(std::to_string(max));
-    if(SETTINGS.ingame.scale_statistics)
+    if(SETTINGS.ingame.scaleStatistics)
         txtMinValueY->SetText(std::to_string(min));
 
     // Draw the line diagram
@@ -366,7 +366,7 @@ void iwStatistics::DrawStatistic(StatisticType type)
             DrawPoint curPos = topLeft + DrawPoint((NUM_STAT_STEPS - i) * stepX, diagramSize.y);
             unsigned curStatVal =
               stat.data[type][(currentIndex >= i) ? (currentIndex - i) : (NUM_STAT_STEPS - i + currentIndex)];
-            if(SETTINGS.ingame.scale_statistics)
+            if(SETTINGS.ingame.scaleStatistics)
                 curPos.y -= ((curStatVal - min) * diagramSize.y) / (max - min);
             else
                 curPos.y -= (curStatVal * diagramSize.y) / max;

--- a/libs/s25main/ingameWindows/iwTrade.cpp
+++ b/libs/s25main/ingameWindows/iwTrade.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -40,8 +40,8 @@ iwTrade::iwTrade(const nobBaseWarehouse& wh, const GameWorldViewer& gwv, GameCom
     AddText(1, DrawPoint(left_column, 30), "Deal in:", COLOR_YELLOW, FontStyle::LEFT, NormalFont);
     ctrlComboBox* box = this->AddComboBox(2, DrawPoint(left_column, 44), Extent(160, 18), TextureColor::Grey,
                                           NormalFont, 200); // Ware or figure?
-    box->AddString(_("Wares"));
-    box->AddString(_("Settlers"));
+    box->AddItem(_("Wares"));
+    box->AddItem(_("Settlers"));
     AddText(3, DrawPoint(left_column, 70), "Type:", COLOR_YELLOW, FontStyle::LEFT, NormalFont);
 
     // Create possible wares, figures
@@ -108,13 +108,13 @@ void iwTrade::Msg_ComboSelectItem(const unsigned ctrl_id, const unsigned selecti
             {
                 // Add ware names
                 for(GoodType ware : wares)
-                    names->AddString(_(WARE_NAMES[ware]));
+                    names->AddItem(_(WARE_NAMES[ware]));
 
             } else
             {
                 // Add job names
                 for(Job job : jobs)
-                    names->AddString(_(JOB_NAMES[job]));
+                    names->AddItem(_(JOB_NAMES[job]));
             }
             names->SetSelection(0);
             Msg_ComboSelectItem(4, 0);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1389,11 +1389,11 @@ void GameClient::ExecuteGameFrame()
 void GameClient::HandleAutosave()
 {
     // If inactive or during replay -> no autosave
-    if(!SETTINGS.interface.autosave_interval || replayMode)
+    if(!SETTINGS.interface.autosaveInterval || replayMode)
         return;
 
     // Alle .... GF
-    if(GetGFNumber() % SETTINGS.interface.autosave_interval == 0)
+    if(GetGFNumber() % SETTINGS.interface.autosaveInterval == 0)
     {
         std::string filename;
         if(mapinfo.title.empty())

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -1571,7 +1571,7 @@ bfs::path GameServer::SaveAsyncLog()
 
 void GameServer::SendAsyncLog(const bfs::path& asyncLogFilePath)
 {
-    if(SETTINGS.global.submitDebugData == 1
+    if(SETTINGS.global.submitDebugData == SubmitDebugData::Yes
 #ifdef _WIN32
        || (MessageBoxW(nullptr,
                        boost::nowide::widen(_("The game clients are out of sync. Would you like to send debug "

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -1571,7 +1571,7 @@ bfs::path GameServer::SaveAsyncLog()
 
 void GameServer::SendAsyncLog(const bfs::path& asyncLogFilePath)
 {
-    if(SETTINGS.global.submit_debug_data == 1
+    if(SETTINGS.global.submitDebugData == 1
 #ifdef _WIN32
        || (MessageBoxW(nullptr,
                        boost::nowide::widen(_("The game clients are out of sync. Would you like to send debug "

--- a/tests/mockupDrivers/MockupVideoDriver.cpp
+++ b/tests/mockupDrivers/MockupVideoDriver.cpp
@@ -31,16 +31,16 @@ bool MockupVideoDriver::Initialize()
     return true;
 }
 
-bool MockupVideoDriver::CreateScreen(const std::string&, const VideoMode& newSize, bool fullscreen)
+bool MockupVideoDriver::CreateScreen(const std::string&, const VideoMode& newSize, DisplayMode displayMode)
 {
-    ResizeScreen(newSize, fullscreen);
+    ResizeScreen(newSize, displayMode);
     return true;
 }
 
-bool MockupVideoDriver::ResizeScreen(const VideoMode& newSize, bool fullscreen)
+bool MockupVideoDriver::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
 {
     SetNewSize(newSize, Extent(newSize.width, newSize.height));
-    isFullscreen_ = fullscreen;
+    displayMode_ = displayMode;
     return true;
 }
 

--- a/tests/mockupDrivers/MockupVideoDriver.cpp
+++ b/tests/mockupDrivers/MockupVideoDriver.cpp
@@ -31,13 +31,13 @@ bool MockupVideoDriver::Initialize()
     return true;
 }
 
-bool MockupVideoDriver::CreateScreen(const std::string&, const VideoMode& newSize, DisplayMode displayMode)
+bool MockupVideoDriver::CreateScreen(const std::string&, const VideoMode newSize, DisplayMode displayMode)
 {
     ResizeScreen(newSize, displayMode);
     return true;
 }
 
-bool MockupVideoDriver::ResizeScreen(const VideoMode& newSize, DisplayMode displayMode)
+bool MockupVideoDriver::ResizeScreen(const VideoMode newSize, DisplayMode displayMode)
 {
     SetNewSize(newSize, Extent(newSize.width, newSize.height));
     displayMode_ = displayMode;

--- a/tests/mockupDrivers/MockupVideoDriver.cpp
+++ b/tests/mockupDrivers/MockupVideoDriver.cpp
@@ -64,9 +64,9 @@ OpenGL_Loader_Proc MockupVideoDriver::GetLoaderFunction() const
     return dummyLoader;
 }
 
-void MockupVideoDriver::ListVideoModes(std::vector<VideoMode>& video_modes) const
+std::vector<VideoMode> MockupVideoDriver::ListVideoModes() const
 {
-    video_modes = video_modes_;
+    return video_modes_;
 }
 
 void MockupVideoDriver::SetMousePos(Position pos)

--- a/tests/mockupDrivers/MockupVideoDriver.cpp
+++ b/tests/mockupDrivers/MockupVideoDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/tests/mockupDrivers/MockupVideoDriver.h
+++ b/tests/mockupDrivers/MockupVideoDriver.h
@@ -13,8 +13,8 @@ public:
     ~MockupVideoDriver() override;
     const char* GetName() const override;
     bool Initialize() override;
-    bool CreateScreen(const std::string& title, const VideoMode& newSize, bool fullscreen) override;
-    bool ResizeScreen(const VideoMode& newSize, bool fullscreen) override;
+    bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) override;
+    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
     void DestroyScreen() override {}
     bool SwapBuffers() override { return true; }
     bool MessageLoop() override;

--- a/tests/mockupDrivers/MockupVideoDriver.h
+++ b/tests/mockupDrivers/MockupVideoDriver.h
@@ -13,8 +13,8 @@ public:
     ~MockupVideoDriver() override;
     const char* GetName() const override;
     bool Initialize() override;
-    bool CreateScreen(const std::string& title, const VideoMode& newSize, DisplayMode displayMode) override;
-    bool ResizeScreen(const VideoMode& newSize, DisplayMode displayMode) override;
+    bool CreateScreen(const std::string& title, VideoMode newSize, DisplayMode displayMode) override;
+    bool ResizeScreen(VideoMode newSize, DisplayMode displayMode) override;
     void DestroyScreen() override {}
     bool SwapBuffers() override { return true; }
     bool MessageLoop() override;

--- a/tests/mockupDrivers/MockupVideoDriver.h
+++ b/tests/mockupDrivers/MockupVideoDriver.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/tests/mockupDrivers/MockupVideoDriver.h
+++ b/tests/mockupDrivers/MockupVideoDriver.h
@@ -20,7 +20,7 @@ public:
     bool MessageLoop() override;
     unsigned long GetTickCount() const override;
     OpenGL_Loader_Proc GetLoaderFunction() const override;
-    void ListVideoModes(std::vector<VideoMode>& video_modes) const override;
+    std::vector<VideoMode> ListVideoModes() const override;
     void SetMousePos(Position pos) override;
     KeyEvent GetModKeyState() const override;
     void* GetMapPointer() const override;

--- a/tests/s25Main/UI/testAnimations.cpp
+++ b/tests/s25Main/UI/testAnimations.cpp
@@ -681,7 +681,7 @@ BOOST_AUTO_TEST_CASE(MoveAniScale)
     video->tickCount_ += 1;
     dsk->Msg_PaintBefore();
     // Resize the screen and test that the final position got updated too
-    VIDEODRIVER.ResizeScreen(VideoMode(1024, 768), false);
+    VIDEODRIVER.ResizeScreen(VideoMode(1024, 768), DisplayMode::Resizable);
     // Pass the animation
     video->tickCount_ += 1100;
     dsk->Msg_PaintBefore();

--- a/tests/s25Main/UI/testAnimations.cpp
+++ b/tests/s25Main/UI/testAnimations.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -681,7 +681,7 @@ BOOST_AUTO_TEST_CASE(MoveAniScale)
     video->tickCount_ += 1;
     dsk->Msg_PaintBefore();
     // Resize the screen and test that the final position got updated too
-    VIDEODRIVER.ResizeScreen(VideoMode(1024, 768), DisplayMode::Resizable);
+    VIDEODRIVER.ResizeScreen(VideoMode(1024, 768), DisplayMode::Windowed);
     // Pass the animation
     video->tickCount_ += 1100;
     dsk->Msg_PaintBefore();

--- a/tests/s25Main/UI/testComboBox.cpp
+++ b/tests/s25Main/UI/testComboBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(ItemHandling)
     REQUIRE(cb->GetNumItems() == 0);
     REQUIRE(!cb->GetSelection());
 
-    cb->AddString("text");
+    cb->AddItem("text");
     REQUIRE(cb->GetNumItems() == 1);
     REQUIRE(!cb->GetSelection());
     REQUIRE(cb->GetText(0) == "text");
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(ItemHandling)
     for(int i = 0; i < 10; i++)
     {
         lines.emplace_back(randString());
-        cb->AddString(lines.back());
+        cb->AddItem(lines.back());
         REQUIRE(cb->GetNumItems() == lines.size());
         REQUIRE(cb->GetSelection() == 0u);
     }
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(ControlWithScrollWheel)
 
     for(int i = 0; i < 3; i++)
     {
-        cb->AddString(randString());
+        cb->AddItem(randString());
     }
     REQUIRE(!cb->GetSelection());
     mock::sequence s;
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(ListRemove)
     for(int i = 0; i < 10; i++)
     {
         lines.emplace_back(randString());
-        list->AddString(lines.back());
+        list->AddItem(lines.back());
         REQUIRE(list->GetNumLines() == lines.size());
         REQUIRE(!list->GetSelection());
     }

--- a/tests/s25Main/UI/testIngameWindow.cpp
+++ b/tests/s25Main/UI/testIngameWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -453,7 +453,7 @@ void WindowPositioning_testOne(IngameWindow& wnd, const char* context, const std
 
 BOOST_AUTO_TEST_CASE(WindowPositioning)
 {
-    VIDEODRIVER.ResizeScreen(VideoMode(800, 600), false);
+    VIDEODRIVER.ResizeScreen(VideoMode(800, 600), DisplayMode::Windowed);
 
     const auto renderSize = VIDEODRIVER.GetRenderSize();
 
@@ -598,7 +598,7 @@ BOOST_AUTO_TEST_CASE(WindowSnapping)
 {
     SETTINGS.interface.windowSnapDistance = 10;
 
-    VIDEODRIVER.ResizeScreen(VideoMode(800, 600), false);
+    VIDEODRIVER.ResizeScreen(VideoMode(800, 600), DisplayMode::Windowed);
 
     auto& wnd1 = static_cast<IngameWindow&>(WINDOWMANAGER.Show(
       std::make_unique<IngameWindow>(0, DrawPoint(0, 500), Extent(100, 100), "Test Window 1", nullptr)));

--- a/tests/s25Main/UI/testVideoDriver.cpp
+++ b/tests/s25Main/UI/testVideoDriver.cpp
@@ -68,7 +68,7 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
     {
         rttr::test::LogAccessor logAcc;
         VIDEODRIVER.DestroyScreen();
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
         logAcc.clearLog();
     }
 
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
 
     {
         rttr::test::LogAccessor logAcc;
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
         logAcc.clearLog();
     }
     glGenTextures = rttrOglMock2::glGenTextures;

--- a/tests/s25Main/UI/testVideoDriver.cpp
+++ b/tests/s25Main/UI/testVideoDriver.cpp
@@ -15,7 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 // LCOV_EXCL_START
-static std::ostream& operator<<(std::ostream& os, const VideoMode& mode)
+static std::ostream& operator<<(std::ostream& os, const VideoMode mode)
 {
     return os << mode.width << "x" << mode.height;
 }

--- a/tests/s25Main/UI/testVideoDriver.cpp
+++ b/tests/s25Main/UI/testVideoDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -68,7 +68,7 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
     {
         rttr::test::LogAccessor logAcc;
         VIDEODRIVER.DestroyScreen();
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Windowed);
         logAcc.clearLog();
     }
 
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
 
     {
         rttr::test::LogAccessor logAcc;
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Windowed);
         logAcc.clearLog();
     }
     glGenTextures = rttrOglMock2::glGenTextures;
@@ -106,7 +106,7 @@ BOOST_FIXTURE_TEST_CASE(CreateAndDestroyTextures, uiHelper::Fixture)
 BOOST_AUTO_TEST_CASE(TranslateDimensionsBetweenScreenAndViewSpace)
 {
     auto* driver = uiHelper::GetVideoDriver();
-    driver->CreateScreen("", VideoMode(800 * 2, 600 * 2), false);
+    driver->CreateScreen("", VideoMode(800 * 2, 600 * 2), DisplayMode::Windowed);
 
     {
         // GUI scale 100%; translations are no-ops
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(GuiScaleRangeCalculation)
 {
     GuiScaleRange range;
     auto* driver = uiHelper::GetVideoDriver();
-    driver->CreateScreen("", VideoMode(800 * 3, 600 * 3), false);
+    driver->CreateScreen("", VideoMode(800 * 3, 600 * 3), DisplayMode::Windowed);
 
     // Regular DPI configuration
     range = driver->getGuiScaleRange();
@@ -203,15 +203,15 @@ BOOST_AUTO_TEST_CASE(GuiScaleRangeCalculation)
     BOOST_TEST(range.recommendedPercent == 100u);
 
     // Maximum is constrained by width
-    driver->ResizeScreen(VideoMode(800 * 2, 600 * 3), false);
+    driver->ResizeScreen(VideoMode(800 * 2, 600 * 3), DisplayMode::Windowed);
     BOOST_TEST(driver->getGuiScaleRange().maxPercent == 200u);
 
     // Maximum is constrained by height
-    driver->ResizeScreen(VideoMode(800 * 3, 600 * 2), false);
+    driver->ResizeScreen(VideoMode(800 * 3, 600 * 2), DisplayMode::Windowed);
     BOOST_TEST(driver->getGuiScaleRange().maxPercent == 200u);
 
     // HighDPI configuration (50% larger render size than window size)
-    driver->ResizeScreen(VideoMode(800 * 2, 600 * 2), false);
+    driver->ResizeScreen(VideoMode(800 * 2, 600 * 2), DisplayMode::Windowed);
     driver->SetNewSize(driver->GetWindowSize(), Extent(800 * 3, 600 * 3));
     range = driver->getGuiScaleRange();
     BOOST_TEST(range.minPercent == 100u);

--- a/tests/s25Main/UI/testWindows.cpp
+++ b/tests/s25Main/UI/testWindows.cpp
@@ -115,11 +115,12 @@ BOOST_AUTO_TEST_CASE(DrawOrder)
 {
     Desktop* dsk = WINDOWMANAGER.GetCurrentDesktop();
     std::vector<TestWindow*> wnds;
+    wnds.reserve(6);
     // Top level controls
     for(int i = 0; i < 3; i++)
     {
-        wnds.push_back(new TestWindow(dsk, static_cast<unsigned>(wnds.size()), DrawPoint(0, 0)));
-        dsk->AddCtrl(wnds.back());
+        wnds.push_back(
+          dsk->AddCtrl(std::make_unique<TestWindow>(dsk, static_cast<unsigned>(wnds.size()), DrawPoint(0, 0))));
     }
     // Some groups with own controls
     for(int i = 0; i < 3; i++)
@@ -127,8 +128,8 @@ BOOST_AUTO_TEST_CASE(DrawOrder)
         ctrlGroup* grp = dsk->AddGroup(100 + i);
         for(int i = 0; i < 3; i++)
         {
-            wnds.push_back(new TestWindow(dsk, static_cast<unsigned>(wnds.size()), DrawPoint(0, 0)));
-            grp->AddCtrl(wnds.back());
+            wnds.push_back(
+              grp->AddCtrl(std::make_unique<TestWindow>(dsk, static_cast<unsigned>(wnds.size()), DrawPoint(0, 0))));
         }
     }
     mock::sequence s;

--- a/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
+++ b/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
@@ -29,7 +29,7 @@ void initGUITests()
         rttr::test::LogAccessor logAcc;
         VIDEODRIVER.LoadDriver(new MockupVideoDriver(&WINDOWMANAGER));
         RTTR_REQUIRE_LOG_CONTAINS("Mockup Video Driver", false);
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), false);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
         BOOST_TEST_CHECKPOINT("Load dummy files");
         LOADER.LoadDummyGUIFiles();
         LOADER.LoadDummySoundFiles();

--- a/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
+++ b/tests/s25Main/UI/uiHelper/uiHelper/uiHelpers.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -29,7 +29,7 @@ void initGUITests()
         rttr::test::LogAccessor logAcc;
         VIDEODRIVER.LoadDriver(new MockupVideoDriver(&WINDOWMANAGER));
         RTTR_REQUIRE_LOG_CONTAINS("Mockup Video Driver", false);
-        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Resizable);
+        VIDEODRIVER.CreateScreen(VideoMode(800, 600), DisplayMode::Windowed);
         BOOST_TEST_CHECKPOINT("Load dummy files");
         LOADER.LoadDummyGUIFiles();
         LOADER.LoadDummySoundFiles();


### PR DESCRIPTION
Continuation of #1602 to add a 3rd mode:
- Fullscreen
- Windowed
- **Borderless window**

Additionally adds an option to disable window resizing

The window size controls will only be visible when windowed mode is selected.
 Similar for fullscreen resolution.
The window size and resize lock change is directly applied if windowed mode is active

This is how it looks like now

<img width="640" height="2545" alt="windowsize" src="https://github.com/user-attachments/assets/07d7e16d-b717-41fa-aca4-018ab61dced5" />


Closes #1602 Fixes #1512


In the options screen I added a similar drop-down.

As an extension I would change "Fullscreen resolution" to "Window size" when selecting a windowed option in both settings. There all resolution options and the current window size will be added. Shall I? @Spikeone 