### PR TITLE
Fix save crash for skinner

### DIFF
--- a/libs/s25main/figures/nofSkinner.h
+++ b/libs/s25main/figures/nofSkinner.h
@@ -13,7 +13,7 @@ class noAnimal;
 class nofSkinner : public nofWorkman
 {
     /// animal, which is skinned
-    noAnimal* animal;
+    noAnimal* animal = nullptr;
 
     /// Draw worker at work
     void DrawWorking(DrawPoint drawPt) override;


### PR DESCRIPTION
Reproduce:

- Build a skinner in an area without animals
- Save game
- Crash happens because animal is not initialized
