### PR TITLE
Fix failures in UI tests

### DIFF
--- a/tests/s25Main/UI/testWindowManager.cpp
+++ b/tests/s25Main/UI/testWindowManager.cpp
@@ -48,7 +48,20 @@ struct WMFixture : mock::cleanup
     {
         dsk = static_cast<TestDesktop*>(WINDOWMANAGER.Switch(std::make_unique<TestDesktop>()));
         MOCK_EXPECT(dsk->Msg_MouseMove).once().returns(true);
+        MOCK_EXPECT(dsk->Msg_LeftDown).once().returns(true);
+        MOCK_EXPECT(dsk->Msg_LeftUp).once().returns(true);
         WINDOWMANAGER.Draw();
+
+        // Ensure next click in test won't be registered as double-click
+        // by doing a fake click outside of any relevant space and time
+        MouseCoords mc1(-100, -100);
+        mc1.ldown = true;
+        MouseCoords mc1_u(mc1.pos);
+        video->tickCount_ = DOUBLE_CLICK_INTERVAL * 100;
+        WINDOWMANAGER.Msg_LeftDown(mc1);
+        WINDOWMANAGER.Msg_LeftUp(mc1);
+        video->tickCount_ = 0;
+
         mock::verify(*dsk);
         mock::reset(*dsk);
     }

--- a/tests/s25Main/UI/testWindows.cpp
+++ b/tests/s25Main/UI/testWindows.cpp
@@ -88,6 +88,7 @@ BOOST_AUTO_TEST_CASE(AddonWindow)
 
 BOOST_FIXTURE_TEST_CASE(JumpWindow, SmallWorldFixture)
 {
+    uiHelper::Fixture f;
     // Test if it is constructible only, accesses GameClient for buttons
     GameWorldViewer gwv(0, world);
     GameWorldView view(gwv, Position(0, 0), Extent(100, 100));


### PR DESCRIPTION
`BOOST_FIXTURE_TEST_CASE` resets the fixture of the test suite so we have to add that manually when required.

In the double click tests a double click could be registered too early as the last left click time and position are initially zeroes. Do a fake click to initialize them to something that isn't relevant to the tests.