### PR TITLE
change planer algorithms to match the original

### DIFF
--- a/libs/s25main/buildings/noBuildingSite.cpp
+++ b/libs/s25main/buildings/noBuildingSite.cpp
@@ -29,7 +29,10 @@ noBuildingSite::noBuildingSite(const BuildingType type, const MapPoint pos, cons
        || GetSize() == BuildingQuality::Harbor)
     {
         // Höhe auf dem Punkt, wo die Baustelle steht
-        int altitude = world->GetNode(pos).altitude;
+        int altitude = world->GetNode(this->GetFlagPos()).altitude;
+
+        if(altitude - world->GetNode(pos).altitude != 0)
+	    state = BuildingSiteState::Planing;
 
         for(const auto dir : helpers::EnumRange<Direction>{})
         {
@@ -376,6 +379,8 @@ void noBuildingSite::PlaningFinished()
     /// Normale Baustelle
     state = BuildingSiteState::Building;
     planer = nullptr;
+
+    world->ChangeAltitude(pos, world->GetNode(this->GetFlagPos()).altitude);
 
     // Wir hätten gerne einen Bauarbeiter...
     world->GetPlayer(player).AddJobWanted(Job::Builder, this);

--- a/libs/s25main/figures/nofPlaner.cpp
+++ b/libs/s25main/figures/nofPlaner.cpp
@@ -158,7 +158,7 @@ void nofPlaner::HandleDerivedEvent(const unsigned id)
     {
         // Planieren (falls Baustelle noch existiert)
         if(building_site)
-            world->ChangeAltitude(pos, world->GetNode(building_site->GetPos()).altitude);
+            world->ChangeAltitude(pos, world->GetNode(building_site->GetFlagPos()).altitude);
         /// Sounds abmelden
         world->GetSoundMgr().stopSounds(*this);
 


### PR DESCRIPTION
S2 planes the area to match the altitude of the flag, not the altitude of the building tile. This means both a difference in what altitude is being planed to, and also changes the calculation for deciding to plane or not. S2 changes the height of the building tile to match the flag when the planer has done his round and returns to the central building tile.