### PR TITLE
Fixed clang 22 error with overloaded operator

### DIFF
--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -12,6 +12,7 @@
 #include "gameData/const_gui_ids.h"
 #include "s25util/colors.h"
 #include <utility>
+#include <bitset>
 
 namespace {
 enum
@@ -148,7 +149,7 @@ void iwAddons::UpdateView(const AddonGroup selection)
     for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
     {
         const Addon* addon = ggs.getAddon(i);
-        const bool isVisible = (addon->getGroups() & selection) != AddonGroup(0);
+        const bool isVisible = bitset::any(addon->getGroups(), selection);
         auto* group = GetCtrl<ctrlGroup>(ID_grpAddonsStart + i);
 
         // Don't show addon's gui if addon is beyond selected group or is beyond current page scope


### PR DESCRIPTION
Error:

```
s25client/libs/s25main/ingameWindows/iwAddons.cpp:151:65: error: use of overloaded operator '!=' is ambiguous (with operand types 'AddonGroup' and 'AddonGroup')
  151 |         const bool isVisible = (addon->getGroups() & selection) != AddonGroup(0);
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~
s25client/libs/s25main/addons/const_addons.h:90:1: note: candidate function has been explicitly deleted
   90 | MAKE_BITSET_STRONG(AddonGroup);
      | ^
s25client/external/libutil/libs/common/include/s25util/enumUtils.h:91:10: note: expanded from macro 'MAKE_BITSET_STRONG'
   91 |     bool operator!=(const Type& lhs, const Type& rhs) = delete;     \
      |          ^
s25client/libs/s25main/ingameWindows/iwAddons.cpp:151:65: note: built-in candidate operator!=(enum AddonGroup, enum AddonGroup)
  151 |         const bool isVisible = (addon->getGroups() & selection) != AddonGroup(0);
      |                                                                 ^
1 error generated.
```