### PR TITLE
Fix updater error on Windows

### DIFF
--- a/extras/videoDrivers/WinAPI/WinAPI.cpp
+++ b/extras/videoDrivers/WinAPI/WinAPI.cpp
@@ -459,10 +459,6 @@ void VideoWinAPI::SetMousePos(Position pos)
 
 void VideoWinAPI::OnWMChar(unsigned c, bool disablepaste, LPARAM lParam)
 {
-    // Keine Leerzeichen als Extra-Zeichen senden!
-    if(c == ' ')
-        return;
-
     KeyEvent ke(c);
     setSpecialKeys(ke, lParam);
 


### PR DESCRIPTION
Fix removal of bz2 file
The file handle wasn't closed yet so removing it failed on Windows as it was still "in use".

Fixes #1914