### PR TITLE
Fix inexhaustible granite mine production

### DIFF
--- a/libs/s25main/figures/nofMiner.cpp
+++ b/libs/s25main/figures/nofMiner.cpp
@@ -71,21 +71,30 @@ helpers::OptionalEnum<GoodType> nofMiner::ProduceWare()
 
 bool nofMiner::AreWaresAvailable() const
 {
-    return nofWorkman::AreWaresAvailable() && FindPointWithResource(GetRequiredResType()).isValid();
+    return nofWorkman::AreWaresAvailable()
+           && (CanMineWithoutResource() || FindPointWithResource(GetRequiredResType()).isValid());
 }
 
 bool nofMiner::StartWorking()
 {
-    MapPoint resPt = FindPointWithResource(GetRequiredResType());
-    if(!resPt.isValid())
-        return false;
     const GlobalGameSettings& settings = world->GetGGS();
-    bool inexhaustibleRes = settings.isEnabled(AddonId::INEXHAUSTIBLE_MINES)
-                            || (workplace->GetBuildingType() == BuildingType::GraniteMine
-                                && settings.isEnabled(AddonId::INEXHAUSTIBLE_GRANITEMINES));
-    if(!inexhaustibleRes)
-        world->ReduceResource(resPt);
+    const bool canMineWithoutResource = CanMineWithoutResource();
+    const bool inexhaustibleRes = settings.isEnabled(AddonId::INEXHAUSTIBLE_MINES) || canMineWithoutResource;
+    if(!canMineWithoutResource)
+    {
+        MapPoint resPt = FindPointWithResource(GetRequiredResType());
+        if(!resPt.isValid())
+            return false;
+        if(!inexhaustibleRes)
+            world->ReduceResource(resPt);
+    }
     return nofWorkman::StartWorking();
+}
+
+bool nofMiner::CanMineWithoutResource() const
+{
+    return workplace->GetBuildingType() == BuildingType::GraniteMine
+           && world->GetGGS().isEnabled(AddonId::INEXHAUSTIBLE_GRANITEMINES);
 }
 
 ResourceType nofMiner::GetRequiredResType() const

--- a/libs/s25main/figures/nofMiner.h
+++ b/libs/s25main/figures/nofMiner.h
@@ -23,6 +23,7 @@ protected:
     bool AreWaresAvailable() const override;
     bool StartWorking() override;
     ResourceType GetRequiredResType() const;
+    bool CanMineWithoutResource() const;
 
 public:
     nofMiner(MapPoint pos, unsigned char player, nobUsual* workplace);

--- a/tests/s25Main/integration/testProduction.cpp
+++ b/tests/s25Main/integration/testProduction.cpp
@@ -102,4 +102,46 @@ BOOST_FIXTURE_TEST_CASE(MetalWorkerOrders, WorldWithGCExecution1P)
     RTTR_EXEC_TILL(1300, mw->is_working);
 }
 
+BOOST_FIXTURE_TEST_CASE(GraniteMineWithoutResourcesNeedsAddon, WorldWithGCExecution1P)
+{
+    GoodsAndPeopleCounts inv;
+    inv[GoodType::Fish] = 10;
+    inv[GoodType::PickAxe] = 1;
+    inv[Job::Miner] = 1;
+    world.GetSpecObj<nobBaseWarehouse>(hqPos)->AddToInventory(inv, true);
+
+    MapPoint minePos = hqPos + MapPoint(2, 0);
+    const auto* mine = static_cast<nobUsual*>(
+      BuildingFactory::CreateBuilding(world, BuildingType::GraniteMine, minePos, curPlayer, Nation::Romans));
+    this->BuildRoad(world.GetNeighbour(minePos, Direction::SouthEast), false,
+                    std::vector<Direction>(2, Direction::West));
+
+    const Inventory& curInventory = world.GetPlayer(curPlayer).GetInventory();
+    const unsigned initialStones = curInventory[GoodType::Stones];
+    RTTR_EXEC_TILL(500, mine->HasWorker());
+    RTTR_SKIP_GFS(2000);
+
+    BOOST_TEST(curInventory[GoodType::Stones] == initialStones);
+}
+
+BOOST_FIXTURE_TEST_CASE(InexhaustibleGraniteMineWorksWithoutResources, WorldWithGCExecution1P)
+{
+    ggs.setSelection(AddonId::INEXHAUSTIBLE_GRANITEMINES, 1);
+
+    GoodsAndPeopleCounts inv;
+    inv[GoodType::Fish] = 10;
+    inv[GoodType::PickAxe] = 1;
+    inv[Job::Miner] = 1;
+    world.GetSpecObj<nobBaseWarehouse>(hqPos)->AddToInventory(inv, true);
+
+    MapPoint minePos = hqPos + MapPoint(2, 0);
+    BuildingFactory::CreateBuilding(world, BuildingType::GraniteMine, minePos, curPlayer, Nation::Romans);
+    this->BuildRoad(world.GetNeighbour(minePos, Direction::SouthEast), false,
+                    std::vector<Direction>(2, Direction::West));
+
+    const Inventory& curInventory = world.GetPlayer(curPlayer).GetInventory();
+    const unsigned initialStones = curInventory[GoodType::Stones];
+    RTTR_EXEC_TILL(3000, curInventory[GoodType::Stones] > initialStones);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- allow granite mines to produce without a granite resource spot when `INEXHAUSTIBLE_GRANITEMINES` is enabled
- keep the existing resource requirement when the addon is disabled
- add regression coverage for both addon-disabled and addon-enabled behavior

## Root cause
The addon prevented granite resource depletion, but production still required `FindPointWithResource(ResourceType::Granite)` to find an existing resource spot. On mountain positions without granite resources, the mine therefore never started producing even with the addon enabled.

## Validation
- `Test_integration.exe --run_test=Production --report_level=short`
- `ctest --test-dir C:\dev\s25client\build-vs-x64-debug -C Debug --output-on-failure`

Fixes #918