### PR TITLE
Add military warehouse focus

### DIFF
--- a/libs/s25main/GameCommand.cpp
+++ b/libs/s25main/GameCommand.cpp
@@ -15,7 +15,8 @@ unsigned Deserializer::getCurrentVersion()
     // 1: Add wine addon --> 3 new values in distribution
     // 2: Add leather addon --> 3 new values in distribution, 1 new value in transport order and transport order default
     // values changed, 3 new values in custom build order, 3 new jobs/wares in setAllInventory settings
-    return 2;
+    // 3: Add SetMilitaryWarehouse command
+    return 3;
 }
 
 GameCommandPtr GameCommand::Deserialize(Deserializer& ser)
@@ -59,6 +60,7 @@ GameCommandPtr GameCommand::Deserialize(Deserializer& ser)
         case GCType::UpgradeRoad: gc = new UpgradeRoad(ser); break;
         case GCType::SetTroopLimit: gc = new SetTroopLimit(ser); break;
         case GCType::NotifyAlliesOfLocation: gc = new NotifyAlliesOfLocation(ser); break;
+        case GCType::SetMilitaryWarehouse: gc = new SetMilitaryWarehouse(ser); break;
         default: throw std::logic_error("Invalid GC Type: " + helpers::toString(rttr::enum_cast(gcType)));
     }
     RTTR_Assert(gc->gcType == gcType);

--- a/libs/s25main/GameCommand.h
+++ b/libs/s25main/GameCommand.h
@@ -63,10 +63,11 @@ enum class GCType : uint8_t
     NotifyAlliesOfLocation,
     SetTempleProductionMode,
     SetArmorAllowed,
+    SetMilitaryWarehouse,
 };
 constexpr auto maxEnumValue(GCType)
 {
-    return GCType::SetArmorAllowed;
+    return GCType::SetMilitaryWarehouse;
 }
 
 class GameCommand

--- a/libs/s25main/GameCommands.cpp
+++ b/libs/s25main/GameCommands.cpp
@@ -277,6 +277,13 @@ void SetInventorySetting::Execute(GameWorld& world, uint8_t playerId)
         bld->SetInventorySetting(what, state);
 }
 
+void SetMilitaryWarehouse::Execute(GameWorld& world, uint8_t playerId)
+{
+    auto* const bld = world.GetSpecObj<nobBaseWarehouse>(pt_);
+    if(bld && bld->GetPlayer() == playerId)
+        world.GetPlayer(playerId).SetMilitaryWarehouse(pt_);
+}
+
 SetAllInventorySettings::SetAllInventorySettings(Deserializer& ser)
     : Coords(GCType::SetAllInventorySettings, ser), isJob(ser.PopBool())
 {

--- a/libs/s25main/GameCommands.h
+++ b/libs/s25main/GameCommands.h
@@ -487,6 +487,19 @@ public:
     void Execute(GameWorld& world, uint8_t playerId) override;
 };
 
+/// Mark a warehouse as the player's military production warehouse
+class SetMilitaryWarehouse : public Coords
+{
+    GC_FRIEND_DECL;
+
+protected:
+    SetMilitaryWarehouse(const MapPoint pt) : Coords(GCType::SetMilitaryWarehouse, pt) {}
+    SetMilitaryWarehouse(Serializer& ser) : Coords(GCType::SetMilitaryWarehouse, ser) {}
+
+public:
+    void Execute(GameWorld& world, uint8_t playerId) override;
+};
+
 /// Alle Einlagerungseinstellungen (für alle Menschen oder Waren) von einem Lagerhaus verändern
 class SetAllInventorySettings : public Coords
 {

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -50,8 +50,21 @@
 #include <limits>
 #include <numeric>
 
+namespace {
+constexpr std::array<GoodType, 3> MILITARY_WAREHOUSE_GOODS = {GoodType::Beer, GoodType::Sword,
+                                                              GoodType::ShieldRomans};
+
+bool IsMilitaryWarehouseGood(const GoodType good)
+{
+    const GoodType normalizedGood = ConvertShields(good);
+    return normalizedGood == GoodType::Beer || normalizedGood == GoodType::Sword
+           || normalizedGood == GoodType::ShieldRomans;
+}
+} // namespace
+
 GamePlayer::GamePlayer(unsigned playerId, const PlayerInfo& playerInfo, GameWorld& world)
-    : GamePlayerInfo(playerId, playerInfo), world(world), hqPos(MapPoint::Invalid()), emergency(false)
+    : GamePlayerInfo(playerId, playerInfo), world(world), hqPos(MapPoint::Invalid()),
+      militaryWarehousePos(MapPoint::Invalid()), emergency(false)
 {
     std::fill(building_enabled.begin(), building_enabled.end(), true);
 
@@ -187,6 +200,7 @@ void GamePlayer::Serialize(SerializedGameData& sgd) const
 
     helpers::pushContainer(sgd, shouldSendDefenderList);
     helpers::pushPoint(sgd, hqPos);
+    helpers::pushPoint(sgd, GetMilitaryWarehousePos());
 
     for(const Distribution& dist : distribution)
     {
@@ -265,6 +279,7 @@ void GamePlayer::Deserialize(SerializedGameData& sgd)
     sgd.PopContainer(shouldSendDefenderList);
 
     hqPos = sgd.PopMapPoint();
+    militaryWarehousePos = sgd.GetGameDataVersion() >= 15 ? sgd.PopMapPoint() : hqPos;
 
     for(const auto i : helpers::enumRange<GoodType>())
     {
@@ -519,6 +534,8 @@ void GamePlayer::RemoveBuilding(noBuilding* bld, BuildingType bldType)
             }
         }
     }
+    if(BuildingProperties::IsWareHouse(bldType) && bld->GetPos() == militaryWarehousePos)
+        militaryWarehousePos = hqPos;
     if(BuildingProperties::IsWareHouse(bldType) || BuildingProperties::IsMilitary(bldType))
         TestDefeat();
 }
@@ -1174,6 +1191,20 @@ noBaseBuilding* GamePlayer::FindClientForWare(const Ware& ware)
 
 nobBaseWarehouse* GamePlayer::FindWarehouseForWare(const Ware& ware) const
 {
+    if(IsMilitaryWarehouseGood(ware.type))
+    {
+        const nobBaseWarehouse* militaryWh = GetMilitaryWarehouse();
+        if(militaryWh && FW::AcceptsWare(ware.type)(*militaryWh))
+        {
+            if(ware.GetLocation()->GetPos() == militaryWh->GetPos())
+                return const_cast<nobBaseWarehouse*>(militaryWh);
+
+            unsigned pathCosts = 0;
+            if(world.FindPathForWareOnRoads(*ware.GetLocation(), *militaryWh, &pathCosts) != RoadPathDirection::None)
+                return const_cast<nobBaseWarehouse*>(militaryWh);
+        }
+    }
+
     // Check whs that collect this ware
     nobBaseWarehouse* wh = FindWarehouse(*ware.GetLocation(), FW::CollectsWare(ware.type), true, true);
     // If there is none, check those that accept it
@@ -1505,6 +1536,47 @@ const nobHQ* GamePlayer::GetHQ() const
 nobHQ* GamePlayer::GetHQ()
 {
     return const_cast<nobHQ*>(std::as_const(*this).GetHQ());
+}
+
+const nobBaseWarehouse* GamePlayer::GetMilitaryWarehouse() const
+{
+    const MapPoint whPos = GetMilitaryWarehousePos();
+    auto* wh = whPos.isValid() ? GetGameWorld().GetSpecObj<nobBaseWarehouse>(whPos) : nullptr;
+    if(wh && wh->GetPlayer() == GetPlayerId())
+        return wh;
+    return GetHQ();
+}
+
+bool GamePlayer::IsMilitaryWarehouse(const nobBaseWarehouse& wh) const
+{
+    const nobBaseWarehouse* militaryWh = GetMilitaryWarehouse();
+    return militaryWh && militaryWh->GetPos() == wh.GetPos();
+}
+
+void GamePlayer::SetMilitaryWarehouse(const MapPoint pt)
+{
+    auto* newMilitaryWh = GetGameWorld().GetSpecObj<nobBaseWarehouse>(pt);
+    if(!newMilitaryWh || newMilitaryWh->GetPlayer() != GetPlayerId())
+        return;
+
+    militaryWarehousePos = pt;
+    for(nobBaseWarehouse* wh : buildings.GetStorehouses())
+    {
+        const bool isMilitaryWh = wh->GetPos() == militaryWarehousePos;
+        for(const GoodType good : MILITARY_WAREHOUSE_GOODS)
+        {
+            InventorySetting desiredSetting = wh->GetInventorySetting(good);
+            if(isMilitaryWh)
+                desiredSetting = EInventorySetting::Collect;
+            else if(desiredSetting.IsSet(EInventorySetting::Collect))
+                desiredSetting = InventorySetting();
+
+            if(wh->GetInventorySetting(good) != desiredSetting)
+                wh->SetInventorySetting(good, desiredSetting);
+            if(wh->GetInventorySettingVisual(good) != desiredSetting)
+                wh->SetInventorySettingVisual(good, desiredSetting);
+        }
+    }
 }
 
 void GamePlayer::Surrender()

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -95,6 +95,13 @@ public:
     const MapPoint& GetHQPos() const { return hqPos; }
     const nobHQ* GetHQ() const;
     nobHQ* GetHQ();
+    const MapPoint& GetMilitaryWarehousePos() const
+    {
+        return militaryWarehousePos.isValid() ? militaryWarehousePos : hqPos;
+    }
+    const nobBaseWarehouse* GetMilitaryWarehouse() const;
+    bool IsMilitaryWarehouse(const nobBaseWarehouse& wh) const;
+    void SetMilitaryWarehouse(MapPoint pt);
     bool IsHQTent() const;
     void SetHQIsTent(bool isTent);
 
@@ -381,6 +388,8 @@ private:
 
     /// Koordinaten des HQs des Spielers
     MapPoint hqPos;
+    /// Warehouse that collects beer, swords and shields for recruitment. Defaults to HQ.
+    MapPoint militaryWarehousePos;
 
     helpers::EnumArray<Distribution, GoodType> distribution;
 

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -108,7 +108,8 @@
 /// 12: leatheraddon added, three new building types and three new goods
 /// 13: SeaId & HarborId: World::harborData w/o dummy entry at 0
 /// 14: Remove "age" field in nobBaseMilitary
-static const unsigned currentGameDataVersion = 14;
+/// 15: Store the player's military warehouse focus
+static const unsigned currentGameDataVersion = 15;
 // clang-format on
 
 std::unique_ptr<GameObject> SerializedGameData::Create_GameObject(const GO_Type got, const unsigned obj_id)

--- a/libs/s25main/buildings/nobBaseWarehouse.h
+++ b/libs/s25main/buildings/nobBaseWarehouse.h
@@ -15,6 +15,7 @@
 #include <memory>
 
 class nofCarrier;
+class GamePlayer;
 class noFigure;
 class Ware;
 class nobMilitary;
@@ -96,6 +97,7 @@ private:
 
     friend class gc::SetInventorySetting;
     friend class gc::SetAllInventorySettings;
+    friend class GamePlayer;
     /// Verändert Ein/Auslagerungseinstellungen
     void SetInventorySetting(const boost_variant2<GoodType, Job>& what, InventorySetting state);
 

--- a/libs/s25main/factories/GameCommandFactory.cpp
+++ b/libs/s25main/factories/GameCommandFactory.cpp
@@ -113,6 +113,11 @@ bool GameCommandFactory::SetInventorySetting(const MapPoint pt, const boost_vari
     return AddGC(new gc::SetInventorySetting(pt, what, state));
 }
 
+bool GameCommandFactory::SetMilitaryWarehouse(const MapPoint pt)
+{
+    return AddGC(new gc::SetMilitaryWarehouse(pt));
+}
+
 bool GameCommandFactory::SetAllInventorySettings(const MapPoint pt, bool isJob,
                                                  const std::vector<InventorySetting>& states)
 {

--- a/libs/s25main/factories/GameCommandFactory.h
+++ b/libs/s25main/factories/GameCommandFactory.h
@@ -60,6 +60,7 @@ public:
     bool NotifyAlliesOfLocation(MapPoint pt);
     /// Sets inventory settings for a warehouse
     bool SetInventorySetting(MapPoint pt, const boost_variant2<GoodType, Job>& what, InventorySetting state);
+    bool SetMilitaryWarehouse(MapPoint pt);
     bool SetAllInventorySettings(MapPoint pt, bool isJob, const std::vector<InventorySetting>& states);
     bool ChangeReserve(MapPoint pt, unsigned char rank, unsigned count);
     bool CheatArmageddon();

--- a/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
@@ -39,12 +39,19 @@ enum
     ID_SELECT_ALL,
     ID_GOTO,
     ID_GOTO_NEXT,
+    ID_MILITARY_WAREHOUSE,
     ID_DEMOLISH
 };
+
+constexpr unsigned BUTTON_SIZE = 32;
+constexpr unsigned BUTTON_SPACING = 4;
+constexpr unsigned STORAGE_ROW_OFFSET = 115;
+constexpr unsigned WAREHOUSE_ACTION_ROW_OFFSET = 81;
+constexpr unsigned WINDOW_ACTION_ROW_OFFSET = 47;
 }
 
 iwBaseWarehouse::iwBaseWarehouse(GameWorldView& gwv, GameCommandFactory& gcFactory, nobBaseWarehouse* wh)
-    : iwWares(CGI_BUILDING + MapBase::CreateGUIID(wh->GetPos()), IngameWindow::posAtMouse, 40,
+    : iwWares(CGI_BUILDING + MapBase::CreateGUIID(wh->GetPos()), IngameWindow::posAtMouse, 74,
               _(BUILDING_NAMES[wh->GetBuildingType()]), true, NormalFont, wh->GetInventory(),
               gwv.GetWorld().GetPlayer(wh->GetPlayer())),
       gwv(gwv), gcFactory(gcFactory), wh(wh)
@@ -57,37 +64,49 @@ iwBaseWarehouse::iwBaseWarehouse(GameWorldView& gwv, GameCommandFactory& gcFacto
     // Auswahl für Auslagern/Einlagern Verbieten-Knöpfe
     ctrlOptionGroup* group = AddOptionGroup(ID_STORE_SETTINGS_GROUP, GroupSelectType::Check);
     // Einlagern
-    group->AddImageButton(ID_COLLECT, DrawPoint(16, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    group->AddImageButton(ID_COLLECT, DrawPoint(16, GetFullSize().y - STORAGE_ROW_OFFSET),
+                          Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                           LOADER.GetImageN("io_new", 4), _("Collect"));
     // Auslagern
-    group->AddImageButton(ID_TAKEOUT, DrawPoint(52, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    group->AddImageButton(ID_TAKEOUT, DrawPoint(52, GetFullSize().y - STORAGE_ROW_OFFSET),
+                          Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                           LOADER.GetImageN("io", 211), _("Take out of store"));
     // Einlagern verbieten
-    group->AddImageButton(ID_STOP, DrawPoint(86, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    group->AddImageButton(ID_STOP, DrawPoint(86, GetFullSize().y - STORAGE_ROW_OFFSET),
+                          Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                           LOADER.GetImageN("io", 212), _("Stop storage"));
     // nix tun auswählen
     group->SetSelection(ID_COLLECT);
     // Alle auswählen bzw setzen!
-    AddImageButton(ID_SELECT_ALL, DrawPoint(122, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    AddImageButton(ID_SELECT_ALL, DrawPoint(122, GetFullSize().y - STORAGE_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                    LOADER.GetImageN("io", 223), _("Select all"));
 
     // "Gehe Zu Ort"
-    AddImageButton(ID_GOTO, DrawPoint(122, GetFullSize().y - 47), Extent(15, 32), TextureColor::Grey,
+    AddImageButton(ID_GOTO, DrawPoint(52, GetFullSize().y - WAREHOUSE_ACTION_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                    LOADER.GetImageN("io_new", 10), _("Go to place"));
     // Go to next warehouse
-    AddImageButton(ID_GOTO_NEXT, DrawPoint(139, GetFullSize().y - 47), Extent(15, 32), TextureColor::Grey,
+    AddImageButton(ID_GOTO_NEXT, DrawPoint(52 + BUTTON_SIZE + BUTTON_SPACING,
+                                           GetFullSize().y - WAREHOUSE_ACTION_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                    LOADER.GetImageN("io_new", 13), _("Go to next warehouse"));
+    AddImageButton(ID_MILITARY_WAREHOUSE, DrawPoint(122, GetFullSize().y - WAREHOUSE_ACTION_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
+                   LOADER.GetJobTex(Job::Private), _("Collect beer, swords and shields here"));
 
     UpdateOverlays();
+    UpdateMilitaryWarehouseButton();
 
     // Add demolish button if not HQ
     if(wh->GetGOT() != GO_Type::NobHq)
     {
         // Make paginate button smaller and move to make space for demolish button
-        GetCtrl<ctrlButton>(ID_PAGINATE)->SetWidth(32);
-        GetCtrl<ctrlButton>(ID_PAGINATE)->SetPos(DrawPoint(86, GetFullSize().y - 47));
+        GetCtrl<ctrlButton>(ID_PAGINATE)->SetWidth(BUTTON_SIZE);
+        GetCtrl<ctrlButton>(ID_PAGINATE)->SetPos(DrawPoint(86, GetFullSize().y - WINDOW_ACTION_ROW_OFFSET));
 
-        AddImageButton(ID_DEMOLISH, DrawPoint(52, GetFullSize().y - 47), Extent(32, 32), TextureColor::Grey,
+        AddImageButton(ID_DEMOLISH, DrawPoint(52, GetFullSize().y - WINDOW_ACTION_ROW_OFFSET),
+                       Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                        LOADER.GetImageN("io", 23), _("Demolish house"));
     }
 }
@@ -253,6 +272,14 @@ void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
             }
         }
         break;
+        case ID_MILITARY_WAREHOUSE:
+        {
+            if(GAMECLIENT.IsReplayModeOn())
+                return;
+            if(gcFactory.SetMilitaryWarehouse(wh->GetPos()))
+                UpdateMilitaryWarehouseButton();
+        }
+        break;
         default: // an Basis weiterleiten
         {
             iwWares::Msg_ButtonClick(ctrl_id);
@@ -311,6 +338,15 @@ void iwBaseWarehouse::UpdateOverlays()
     }
 }
 
+void iwBaseWarehouse::UpdateMilitaryWarehouseButton()
+{
+    const bool isMilitaryWarehouse = gwv.GetWorld().GetPlayer(wh->GetPlayer()).IsMilitaryWarehouse(*wh);
+    auto* button = GetCtrl<ctrlButton>(ID_MILITARY_WAREHOUSE);
+    button->SetChecked(isMilitaryWarehouse);
+    button->SetIlluminated(isMilitaryWarehouse);
+    button->SetTexture(isMilitaryWarehouse ? TextureColor::Green2 : TextureColor::Grey);
+}
+
 void iwBaseWarehouse::OnChange(unsigned changeId)
 {
     if(changeId == 0)
@@ -318,5 +354,8 @@ void iwBaseWarehouse::OnChange(unsigned changeId)
         wh = nullptr;
         Close();
     } else if(changeId == 1)
+    {
         UpdateOverlays();
+        UpdateMilitaryWarehouseButton();
+    }
 }

--- a/libs/s25main/ingameWindows/iwBaseWarehouse.h
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.h
@@ -32,6 +32,7 @@ protected:
     /// Update displayed overlay (e.g. stop symbol) for the item of the given type
     void UpdateOverlay(unsigned i, bool isWare);
     void UpdateOverlays();
+    void UpdateMilitaryWarehouseButton();
 
     void Msg_Group_ButtonClick(unsigned group_id, unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;

--- a/tests/s25Main/integration/testBaseWarehouse.cpp
+++ b/tests/s25Main/integration/testBaseWarehouse.cpp
@@ -4,10 +4,12 @@
 
 #include "GamePlayer.h"
 #include "RTTR_AssertError.h"
+#include "Ware.h"
 #include "buildings/nobBaseWarehouse.h"
 #include "factories/BuildingFactory.h"
 #include "figures/nofPassiveSoldier.h"
 #include "figures/nofScout_Free.h"
+#include "nodeObjs/noFlag.h"
 #include "worldFixtures/CreateEmptyWorld.h"
 #include "worldFixtures/WorldFixture.h"
 #include "worldFixtures/WorldWithGCExecution.h"
@@ -74,6 +76,7 @@ struct AddGoodsFixture : public WorldFixture<CreateEmptyWorld, 1>, public rttr::
 };
 
 using EmptyWorldFixture1P = WorldFixture<CreateEmptyWorld, 1>;
+using LogisticsWarehouseFixture = WorldWithGCExecution<1, 32, 16>;
 
 } // namespace
 
@@ -283,6 +286,32 @@ BOOST_FIXTURE_TEST_CASE(CollectGoodsAndFigures, WorldWithGCExecution1P)
         BOOST_TEST(wh2->GetNumVisualWares(good) == 1u);
         BOOST_TEST(wh2->GetNumRealWares(good) == 1u);
     }
+}
+
+BOOST_FIXTURE_TEST_CASE(MilitaryWarehouseAttractsRecruitmentGoods, LogisticsWarehouseFixture)
+{
+    GamePlayer& player = world.GetPlayer(curPlayer);
+    auto* hq = world.GetSpecObj<nobBaseWarehouse>(hqPos);
+    BOOST_TEST_REQUIRE(hq);
+
+    const MapPoint militaryWhPos = hqPos + MapPoint(4, 0);
+    auto* militaryWh = static_cast<nobBaseWarehouse*>(
+      BuildingFactory::CreateBuilding(world, BuildingType::Storehouse, militaryWhPos, curPlayer, Nation::Romans));
+    BOOST_TEST_REQUIRE(militaryWh);
+
+    this->BuildRoad(hq->GetFlagPos(), false, std::vector<Direction>(4, Direction::East));
+    this->SetMilitaryWarehouse(militaryWhPos);
+
+    player.IncreaseInventoryWare(GoodType::Beer, 1);
+    auto beer = std::make_unique<Ware>(GoodType::Beer, nullptr, hq->GetFlag());
+    noBaseBuilding* target = player.FindClientForWare(*beer);
+
+    BOOST_TEST_REQUIRE(target);
+    BOOST_TEST(target->GetPos().x == militaryWhPos.x);
+    BOOST_TEST(target->GetPos().y == militaryWhPos.y);
+
+    beer->WareLost(curPlayer);
+    beer->Destroy();
 }
 
 BOOST_FIXTURE_TEST_CASE(AddSoldierWithArmor, EmptyWorldFixture1P)

--- a/tests/s25Main/integration/testGameCommands.cpp
+++ b/tests/s25Main/integration/testGameCommands.cpp
@@ -892,6 +892,33 @@ BOOST_FIXTURE_TEST_CASE(SetInventorySettingTest, WorldWithGCExecution2P)
     this->SetInventorySetting(hqPos, Job::Woodcutter, InventorySetting());
 }
 
+BOOST_FIXTURE_TEST_CASE(SetMilitaryWarehouseTest, WorldWithGCExecution2P)
+{
+    GamePlayer& player = world.GetPlayer(curPlayer);
+    auto* hq = world.GetSpecObj<nobBaseWarehouse>(hqPos);
+    BOOST_TEST_REQUIRE(hq);
+
+    const MapPoint whPos = hqPos + MapPoint(3, 0);
+    auto* militaryWh = static_cast<nobBaseWarehouse*>(
+      BuildingFactory::CreateBuilding(world, BuildingType::Storehouse, whPos, curPlayer, Nation::Africans));
+    BOOST_TEST_REQUIRE(militaryWh);
+
+    BOOST_TEST(player.IsMilitaryWarehouse(*hq));
+
+    this->SetInventorySetting(hqPos, GoodType::Beer, EInventorySetting::Send);
+    this->SetMilitaryWarehouse(whPos);
+
+    BOOST_TEST(player.IsMilitaryWarehouse(*militaryWh));
+    BOOST_TEST(player.GetMilitaryWarehousePos() == whPos);
+
+    for(const GoodType good : {GoodType::Beer, GoodType::Sword, GoodType::ShieldRomans})
+    {
+        BOOST_TEST(militaryWh->IsInventorySetting(good, EInventorySetting::Collect));
+        BOOST_TEST(!hq->IsInventorySetting(good, EInventorySetting::Collect));
+    }
+    BOOST_TEST(hq->IsInventorySetting(GoodType::Beer, EInventorySetting::Send));
+}
+
 BOOST_FIXTURE_TEST_CASE(ChangeReserveTest, WorldWithGCExecution2P)
 {
     GamePlayer& player = world.GetPlayer(curPlayer);


### PR DESCRIPTION
## What changed

- Adds a player-level military warehouse focus that defaults to the HQ.
- Adds a warehouse window button with a soldier icon and tooltip to select the military warehouse.
- Routes beer, swords, and shields to the selected military warehouse so recruitment goods are concentrated in one place.
- Preserves existing non-collect warehouse settings when switching the focus.
- Stores the selected military warehouse in savegames and adds a replay-safe game command.

## Why

Soldier recruitment is warehouse-local: beer, swords, shields, and helpers must be present in the same warehouse. In larger economies these goods can become scattered across multiple warehouses, which makes recruitment unreliable unless the player manually blocks or redirects goods in every warehouse.

This change gives players one explicit recruitment warehouse target without adding a new transport system.

## Validation

- `cmake --build . --config Debug --target Test_integration --parallel`
- `Test_integration.exe --run_test=GameCommandSuite/SetMilitaryWarehouseTest --catch_system_errors=no`
- `Test_integration.exe --run_test=MilitaryWarehouseAttractsRecruitmentGoods --catch_system_errors=no`
- `ctest -R Test_integration --output-on-failure -C Debug`