### PR TITLE
Add recruitment goods collect shortcut

### DIFF
--- a/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
@@ -154,6 +154,28 @@ void iwBaseWarehouse::Msg_Group_ButtonClick(const unsigned group_id, const unsig
     }
 }
 
+
+void iwBaseWarehouse::CollectRecruitmentGoods()
+{
+    if(GAMECLIENT.IsReplayModeOn())
+        return;
+
+    for(const GoodType good : RECRUITMENT_GOODS)
+    {
+        InventorySetting state = wh->GetInventorySettingVisual(good);
+        if(state.IsSet(EInventorySetting::Collect))
+            continue;
+
+        state.Toggle(EInventorySetting::Collect);
+        if(gcFactory.SetInventorySetting(wh->GetPos(), good, state))
+        {
+            wh->SetInventorySettingVisual(good, state);
+            UpdateOverlay(rttr::enum_cast(good), true);
+        }
+    }
+}
+
+
 void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
 {
     switch(ctrl_id)
@@ -275,22 +297,7 @@ void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
         break;
         case ID_COLLECT_RECRUITMENT_GOODS:
         {
-            if(GAMECLIENT.IsReplayModeOn())
-                return;
-
-            for(const GoodType good : RECRUITMENT_GOODS)
-            {
-                InventorySetting state = wh->GetInventorySettingVisual(good);
-                if(state.IsSet(EInventorySetting::Collect))
-                    continue;
-
-                state.Toggle(EInventorySetting::Collect);
-                if(gcFactory.SetInventorySetting(wh->GetPos(), good, state))
-                {
-                    wh->SetInventorySettingVisual(good, state);
-                    UpdateOverlay(rttr::enum_cast(good), true);
-                }
-            }
+            CollectRecruitmentGoods();
         }
         break;
         default: // an Basis weiterleiten

--- a/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
@@ -154,7 +154,6 @@ void iwBaseWarehouse::Msg_Group_ButtonClick(const unsigned group_id, const unsig
     }
 }
 
-
 void iwBaseWarehouse::CollectRecruitmentGoods()
 {
     if(GAMECLIENT.IsReplayModeOn())
@@ -174,7 +173,6 @@ void iwBaseWarehouse::CollectRecruitmentGoods()
         }
     }
 }
-
 
 void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
 {

--- a/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.cpp
@@ -23,6 +23,7 @@
 #include "world/GameWorldView.h"
 #include "gameData/BuildingConsts.h"
 #include "gameData/const_gui_ids.h"
+#include <array>
 #include <stdexcept>
 
 namespace {
@@ -39,12 +40,20 @@ enum
     ID_SELECT_ALL,
     ID_GOTO,
     ID_GOTO_NEXT,
+    ID_COLLECT_RECRUITMENT_GOODS,
     ID_DEMOLISH
 };
+
+constexpr unsigned BUTTON_SIZE = 32;
+constexpr unsigned BUTTON_SPACING = 4;
+constexpr unsigned STORAGE_ROW_OFFSET = 115;
+constexpr unsigned WAREHOUSE_ACTION_ROW_OFFSET = 81;
+constexpr unsigned WINDOW_ACTION_ROW_OFFSET = 47;
+constexpr std::array<GoodType, 3> RECRUITMENT_GOODS = {GoodType::Beer, GoodType::Sword, GoodType::ShieldRomans};
 }
 
 iwBaseWarehouse::iwBaseWarehouse(GameWorldView& gwv, GameCommandFactory& gcFactory, nobBaseWarehouse* wh)
-    : iwWares(CGI_BUILDING + MapBase::CreateGUIID(wh->GetPos()), IngameWindow::posAtMouse, 40,
+    : iwWares(CGI_BUILDING + MapBase::CreateGUIID(wh->GetPos()), IngameWindow::posAtMouse, 74,
               _(BUILDING_NAMES[wh->GetBuildingType()]), true, NormalFont, wh->GetInventory(),
               gwv.GetWorld().GetPlayer(wh->GetPlayer())),
       gwv(gwv), gcFactory(gcFactory), wh(wh)
@@ -57,26 +66,36 @@ iwBaseWarehouse::iwBaseWarehouse(GameWorldView& gwv, GameCommandFactory& gcFacto
     // Auswahl für Auslagern/Einlagern Verbieten-Knöpfe
     ctrlOptionGroup* group = AddOptionGroup(ID_STORE_SETTINGS_GROUP, GroupSelectType::Check);
     // Einlagern
-    group->AddImageButton(ID_COLLECT, DrawPoint(16, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    group->AddImageButton(ID_COLLECT, DrawPoint(16, GetFullSize().y - STORAGE_ROW_OFFSET),
+                          Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                           LOADER.GetImageN("io_new", 4), _("Collect"));
     // Auslagern
-    group->AddImageButton(ID_TAKEOUT, DrawPoint(52, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    group->AddImageButton(ID_TAKEOUT, DrawPoint(52, GetFullSize().y - STORAGE_ROW_OFFSET),
+                          Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                           LOADER.GetImageN("io", 211), _("Take out of store"));
     // Einlagern verbieten
-    group->AddImageButton(ID_STOP, DrawPoint(86, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    group->AddImageButton(ID_STOP, DrawPoint(86, GetFullSize().y - STORAGE_ROW_OFFSET),
+                          Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                           LOADER.GetImageN("io", 212), _("Stop storage"));
     // nix tun auswählen
     group->SetSelection(ID_COLLECT);
     // Alle auswählen bzw setzen!
-    AddImageButton(ID_SELECT_ALL, DrawPoint(122, GetFullSize().y - 81), Extent(32, 32), TextureColor::Grey,
+    AddImageButton(ID_SELECT_ALL, DrawPoint(122, GetFullSize().y - STORAGE_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                    LOADER.GetImageN("io", 223), _("Select all"));
 
     // "Gehe Zu Ort"
-    AddImageButton(ID_GOTO, DrawPoint(122, GetFullSize().y - 47), Extent(15, 32), TextureColor::Grey,
+    AddImageButton(ID_GOTO, DrawPoint(52, GetFullSize().y - WAREHOUSE_ACTION_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                    LOADER.GetImageN("io_new", 10), _("Go to place"));
     // Go to next warehouse
-    AddImageButton(ID_GOTO_NEXT, DrawPoint(139, GetFullSize().y - 47), Extent(15, 32), TextureColor::Grey,
+    AddImageButton(ID_GOTO_NEXT, DrawPoint(52 + BUTTON_SIZE + BUTTON_SPACING,
+                                           GetFullSize().y - WAREHOUSE_ACTION_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                    LOADER.GetImageN("io_new", 13), _("Go to next warehouse"));
+    AddImageButton(ID_COLLECT_RECRUITMENT_GOODS, DrawPoint(122, GetFullSize().y - WAREHOUSE_ACTION_ROW_OFFSET),
+                   Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
+                   LOADER.GetJobTex(Job::Private), _("Collect recruitment goods here"));
 
     UpdateOverlays();
 
@@ -84,10 +103,11 @@ iwBaseWarehouse::iwBaseWarehouse(GameWorldView& gwv, GameCommandFactory& gcFacto
     if(wh->GetGOT() != GO_Type::NobHq)
     {
         // Make paginate button smaller and move to make space for demolish button
-        GetCtrl<ctrlButton>(ID_PAGINATE)->SetWidth(32);
-        GetCtrl<ctrlButton>(ID_PAGINATE)->SetPos(DrawPoint(86, GetFullSize().y - 47));
+        GetCtrl<ctrlButton>(ID_PAGINATE)->SetWidth(BUTTON_SIZE);
+        GetCtrl<ctrlButton>(ID_PAGINATE)->SetPos(DrawPoint(86, GetFullSize().y - WINDOW_ACTION_ROW_OFFSET));
 
-        AddImageButton(ID_DEMOLISH, DrawPoint(52, GetFullSize().y - 47), Extent(32, 32), TextureColor::Grey,
+        AddImageButton(ID_DEMOLISH, DrawPoint(52, GetFullSize().y - WINDOW_ACTION_ROW_OFFSET),
+                       Extent(BUTTON_SIZE, BUTTON_SIZE), TextureColor::Grey,
                        LOADER.GetImageN("io", 23), _("Demolish house"));
     }
 }
@@ -250,6 +270,26 @@ void iwBaseWarehouse::Msg_ButtonClick(const unsigned ctrl_id)
                       .SetPos(GetPos());
                 }
                 break;
+            }
+        }
+        break;
+        case ID_COLLECT_RECRUITMENT_GOODS:
+        {
+            if(GAMECLIENT.IsReplayModeOn())
+                return;
+
+            for(const GoodType good : RECRUITMENT_GOODS)
+            {
+                InventorySetting state = wh->GetInventorySettingVisual(good);
+                if(state.IsSet(EInventorySetting::Collect))
+                    continue;
+
+                state.Toggle(EInventorySetting::Collect);
+                if(gcFactory.SetInventorySetting(wh->GetPos(), good, state))
+                {
+                    wh->SetInventorySettingVisual(good, state);
+                    UpdateOverlay(rttr::enum_cast(good), true);
+                }
             }
         }
         break;

--- a/libs/s25main/ingameWindows/iwBaseWarehouse.h
+++ b/libs/s25main/ingameWindows/iwBaseWarehouse.h
@@ -32,6 +32,7 @@ protected:
     /// Update displayed overlay (e.g. stop symbol) for the item of the given type
     void UpdateOverlay(unsigned i, bool isWare);
     void UpdateOverlays();
+    void CollectRecruitmentGoods();
 
     void Msg_Group_ButtonClick(unsigned group_id, unsigned ctrl_id) override;
     void Msg_ButtonClick(unsigned ctrl_id) override;


### PR DESCRIPTION
## Summary

- add a warehouse window shortcut for collecting recruitment goods
- sets the existing `Collect` inventory setting for beer, swords, and shields on the selected warehouse
- keeps the existing warehouse collection, distribution, and routing mechanics unchanged

## Motivation

Recruitment depends on beer, swords, and shields being available in the same warehouse. This can already be configured manually through the existing inventory `Collect` setting, but it is easy to miss and repetitive to set up every time.

This is intentionally a small convenience feature. It may be unnecessary for players who already manage warehouse inventory settings directly. The goal is not to introduce a new military warehouse mode, but only to make an existing configuration easier to discover and apply.

## Scope / safety notes

This PR deliberately keeps the behavior narrow:

- no new warehouse state is added
- no new routing logic is added
- no special military warehouse behavior is added
- no recruitment rules are changed
- no ware distribution priorities are changed
- the shortcut only applies existing `Collect` settings for the selected warehouse

In other words, this is a UI shortcut for an existing mechanic, not a new economy system.

## Validation

- Built locally with Visual Studio 2022 Debug
- Ran the affected local build/test target successfully
