### PR TITLE
Send password rejection before kicking client

### DIFF
--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -938,10 +938,12 @@ bool GameServer::OnGameMessage(const GameMessage_Server_Password& msg)
     } else
         playerInfos[msg.senderPlayerID].isHost = false;
 
-    player->sendMsgAsync(new GameMessage_Server_Password(passwordok));
-
     if(passwordok == "false")
+    {
+        player->sendMsg(GameMessage_Server_Password(passwordok));
         KickPlayer(msg.senderPlayerID, KickReason::WrongPassword, __LINE__);
+    } else
+        player->sendMsgAsync(new GameMessage_Server_Password(passwordok));
     return true;
 }
 

--- a/tests/s25Main/network/testGameClient.cpp
+++ b/tests/s25Main/network/testGameClient.cpp
@@ -287,6 +287,34 @@ BOOST_AUTO_TEST_CASE(ClientDetectsMapBufferOverflow)
     BOOST_TEST(client.GetState() == ClientState::Stopped);
 }
 
+BOOST_AUTO_TEST_CASE(ClientReportsWrongPasswordResponse)
+{
+    GameClient client;
+    GameMessageInterface& clientMsgInterface = client;
+    MockClientInterface callbacks;
+    client.SetInterface(&callbacks);
+    TestServer server;
+    const auto serverPort = server.tryListen();
+    BOOST_TEST_REQUIRE(serverPort >= 0);
+    const auto serverType = rttr::test::randomEnum<ServerType>();
+    mock::sequence s;
+    MOCK_EXPECT(callbacks.CI_NextConnectState).in(s).with(ConnectState::Initiated).once();
+    MOCK_EXPECT(callbacks.CI_NextConnectState).in(s).with(ConnectState::VerifyServer).once();
+    MOCK_EXPECT(callbacks.CI_NextConnectState).in(s).with(ConnectState::QueryPw).once();
+    MOCK_EXPECT(callbacks.CI_Error).in(s).with(ClientError::WrongPassword).once();
+
+    BOOST_TEST_REQUIRE(client.Connect("localhost", rttr::test::randString(10), serverType, serverPort, false, false));
+    clientMsgInterface.OnGameMessage(GameMessage_Player_Id(1));
+    clientMsgInterface.OnGameMessage(GameMessage_Server_TypeOK(GameMessage_Server_TypeOK::StatusCode::Ok, ""));
+    BOOST_TEST_REQUIRE(boost::dynamic_pointer_cast<GameMessage_Server_Type>(client.GetMainPlayer().sendQueue.pop()));
+    BOOST_TEST_REQUIRE(
+      boost::dynamic_pointer_cast<GameMessage_Server_Password>(client.GetMainPlayer().sendQueue.pop()));
+
+    clientMsgInterface.OnGameMessage(GameMessage_Server_Password("false"));
+
+    BOOST_TEST(client.GetState() == ClientState::Stopped);
+}
+
 using namespace std::chrono_literals;
 
 BOOST_AUTO_TEST_CASE(CanSetNewSpeed)


### PR DESCRIPTION
## Summary

- send the password rejection response synchronously before kicking the client
- avoid reporting a generic connection-lost error when joining a password-protected direct-IP game with a wrong password
- keep the existing `WrongPassword` client error path unchanged
- add deterministic client-side regression coverage for the wrong-password response

## Root cause

The server queued the password response with `sendMsgAsync()` and immediately kicked the client afterwards. For wrong passwords this could close the connection before the queued `"false"` response was sent, so the client only observed a connection loss.

This PR sends the `"false"` password response synchronously before kicking the player. Successful password responses keep the existing async send path.

The regression test intentionally avoids asserting real socket delivery-vs-disconnect timing, because that would be brittle. Instead, it verifies that receiving `GameMessage_Server_Password("false")` triggers the existing `ClientError::WrongPassword` path and stops the client.

## Validation

- Built `Test_network` locally with Visual Studio 2022 / Debug
- Ran `Test_network.exe --run_test=GameClientTests/ClientReportsWrongPasswordResponse --report_level=short`
  - 1 test case passed
  - 9 assertions passed
- Ran `Test_network.exe --report_level=short`
  - 14 test cases passed
  - 228 assertions passed
- Ran `git diff --check`

Fixes #1057