### PR TITLE
Document print key screenshot shortcut

### DIFF
--- a/data/RTTR/texte/keyboardlayout.txt
+++ b/data/RTTR/texte/keyboardlayout.txt
@@ -31,6 +31,7 @@ F9:................... Readme
 F10:.................. Settings (UI, ...)
 F11:.................. Musicplayer
 F12:.................. Options window
+Print:................ Take screenshot
 
 Post office:
 


### PR DESCRIPTION
## Summary

- document the `Print` key in the in-game keyboard layout readme
- clarify that `Print` takes a screenshot
- leave the existing keyboard handling unchanged

## Motivation

The screenshot shortcut already exists in the game, but it was missing from `keyboardlayout.txt`.

This keeps the change intentionally limited to the user-facing keyboard layout documentation.

## Validation

- Ran `git diff --check`
- Docs-only change; no runtime test needed

Fixes #886