### PR TITLE
Keep restricted soldiers in military buildings

### DIFF
--- a/libs/s25main/buildings/nobMilitary.cpp
+++ b/libs/s25main/buildings/nobMilitary.cpp
@@ -566,21 +566,43 @@ void nobMilitary::RegulateTroops()
         // Weak ones first
         std::vector<nofPassiveSoldier*> notNeededSoldiers;
         GamePlayer& owner = world->GetPlayer(player);
+
+        std::array<bool, NUM_SOLDIER_RANKS> rankHasReturnWarehouse{};
+        for(unsigned rank = 0; rank < NUM_SOLDIER_RANKS; ++rank)
+        {
+            rankHasReturnWarehouse[rank] =
+              owner.FindWarehouse(*this, FW::AcceptsFigure(SOLDIER_JOBS[rank]), true, false) != nullptr;
+        }
+
+        auto canReturnHome = [&rankHasReturnWarehouse](const nofSoldier& soldier) {
+            return rankHasReturnWarehouse[soldier.GetRank()];
+        };
+
         if(owner.GetMilitarySetting(1) > MILITARY_SETTINGS_SCALE[1] / 2)
         {
-            for(auto it = ordered_troops.begin(); diff && !ordered_troops.empty(); ++diff)
+            for(auto it = ordered_troops.begin(); diff && it != ordered_troops.end();)
             {
-                notNeededSoldiers.push_back(*it);
-                it = ordered_troops.erase(it);
+                if(canReturnHome(**it))
+                {
+                    notNeededSoldiers.push_back(*it);
+                    it = ordered_troops.erase(it);
+                    ++diff;
+                } else
+                    ++it;
             }
         }
         // Strong ones first
         else
         {
-            for(auto it = ordered_troops.rbegin(); diff && !ordered_troops.empty(); ++diff)
+            for(auto it = ordered_troops.rbegin(); diff && it != ordered_troops.rend();)
             {
-                notNeededSoldiers.push_back(*it);
-                it = helpers::erase_reverse(ordered_troops, it);
+                if(canReturnHome(**it))
+                {
+                    notNeededSoldiers.push_back(*it);
+                    it = helpers::erase_reverse(ordered_troops, it);
+                    ++diff;
+                } else
+                    ++it;
             }
         }
 
@@ -590,32 +612,37 @@ void nobMilitary::RegulateTroops()
             notNeededSoldier->NotNeeded();
         }
 
-        // Nur rausschicken, wenn es einen Weg zu einem Lagerhaus gibt!
-        if(owner.FindWarehouse(*this, FW::NoCondition(), true, false))
+        // Dann den Rest (einer muss immer noch drinbleiben!)
+        // erst die schwachen Soldaten raus
+        if(owner.GetMilitarySetting(1) > MILITARY_SETTINGS_SCALE[1] / 2)
         {
-            // Dann den Rest (einer muss immer noch drinbleiben!)
-            // erst die schwachen Soldaten raus
-            if(owner.GetMilitarySetting(1) > MILITARY_SETTINGS_SCALE[1] / 2)
+            for(auto it = troops.begin(); diff && it != troops.end() && troops.size() > 1;)
             {
-                for(auto it = troops.begin(); diff && troops.size() > 1; ++diff)
+                if(canReturnHome(**it))
                 {
                     (*it)->LeaveBuilding();
                     AddLeavingFigure(std::move(*it));
                     it = troops.erase(it);
-                }
+                    ++diff;
+                } else
+                    ++it;
             }
-            // erst die starken Soldaten raus
-            else
+        }
+        // erst die starken Soldaten raus
+        else
+        {
+            for(auto it = troops.rbegin(); diff && it != troops.rend() && troops.size() > 1;)
             {
-                for(auto it = troops.rbegin(); diff && troops.size() > 1; ++diff)
+                if(canReturnHome(**it))
                 {
                     (*it)->LeaveBuilding();
                     AddLeavingFigure(std::move(*it));
                     it = helpers::erase_reverse(troops, it);
-                }
+                    ++diff;
+                } else
+                    ++it;
             }
         }
-
     } else if(diff > 0)
     {
         // Zu wenig Truppen

--- a/tests/s25Main/integration/testAttacking.cpp
+++ b/tests/s25Main/integration/testAttacking.cpp
@@ -23,6 +23,7 @@
 #include "world/GameWorldViewer.h"
 #include "nodeObjs/noFlag.h"
 #include "gameTypes/GameTypesOutput.h"
+#include "gameTypes/InventorySetting.h"
 #include "gameData/MilitaryConsts.h"
 #include "gameData/SettingTypeConv.h"
 #include "rttr/test/random.hpp"
@@ -541,6 +542,25 @@ BOOST_FIXTURE_TEST_CASE(ArmoredSoldierLosesArmorInFight, AttackFixture<>)
     BOOST_TEST(attackedPlInventory[jobEnumToAmoredSoldierEnum(Job::Private)] == numOldWeakSoldiersWithArmor - 1);
     BOOST_TEST(attackedPlInventory.people[Job::Private] == numOldWeakSoldiers);
     BOOST_TEST(milBld1->GetDefender()->GetHitpoints() == HITPOINTS[milBld1->GetDefender()->GetRank()]);
+}
+
+BOOST_FIXTURE_TEST_CASE(RestrictedSoldiersStayWhenNoWarehouseAcceptsRank, AttackFixture<>)
+{
+    BuildRoadForBlds(milBld0Pos, hqPos[0]);
+
+    AddSoldiers(milBld0Pos, 2, Job::General);
+    BOOST_TEST_REQUIRE(milBld0->GetNumTroops() == 2u);
+
+    this->SetInventorySetting(hqPos[0], Job::General, InventorySetting(EInventorySetting::Stop));
+
+    auto militarySettings = MILITARY_SETTINGS_SCALE;
+    militarySettings[4 + static_cast<unsigned>(milBld0->GetFrontierDistance())] = 0;
+    this->ChangeMilitary(militarySettings);
+
+    milBld0->RegulateTroops();
+
+    BOOST_TEST_REQUIRE(milBld0->GetNumTroops() == 2u);
+    BOOST_TEST_REQUIRE(milBld0->GetLeavingFigures().empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(ConquerBldCoinAddonEnable, AttackFixture<>)


### PR DESCRIPTION
## Summary

- avoid sending soldiers home from military buildings when no connected warehouse accepts their rank
- check return-home availability per soldier rank before removing surplus troops
- add regression coverage for restricted generals staying in their military building

## Root cause

When a military building had surplus troops due to military settings, `RegulateTroops()` only checked whether any warehouse was reachable. It did not check whether that warehouse accepted the rank of the soldier being sent home.

If that rank was restricted in all connected warehouses, the soldier could leave the building, fail to find a valid warehouse, start wandering, and eventually die.

## Validation

- Built `Test_integration` locally with Visual Studio 2022 / Debug
- Ran `Test_integration.exe --run_test=AttackSuite/RestrictedSoldiersStayWhenNoWarehouseAcceptsRank --report_level=short`
- Ran `Test_integration.exe --run_test=AttackSuite --report_level=short`

Fixes #1560