### PR TITLE
Remove empty replay recordings

### DIFF
--- a/libs/s25main/Replay.cpp
+++ b/libs/s25main/Replay.cpp
@@ -72,6 +72,15 @@ bool Replay::StopRecording()
     isRecording_ = false;
     file_.Close();
 
+    // Remove empty replay recordings. They are mostly produced when a game is aborted
+    // during startup, for example after an early script error.
+    if(lastGF_ == 0)
+    {
+        boost::system::error_code ec;
+        boost::filesystem::remove(filepath_, ec);
+        return !ec;
+    }
+
     BinaryFile file;
     if(!file.Open(filepath_, OpenFileMode::Read))
         return false;

--- a/tests/s25Main/integration/testSerialization.cpp
+++ b/tests/s25Main/integration/testSerialization.cpp
@@ -398,6 +398,26 @@ struct ReplayMapFixture
     }
 };
 
+BOOST_FIXTURE_TEST_CASE(EmptyReplayRecordingIsRemoved, ReplayMapFixture)
+{
+    Replay replay;
+    for(const BasePlayerInfo& player : players)
+        replay.AddPlayer(player);
+    replay.ggs.speed = GameSpeed::VeryFast;
+
+    TmpFile tmpFile(".rpl");
+    BOOST_TEST_REQUIRE(tmpFile.isValid());
+    tmpFile.close();
+    bfs::remove(tmpFile.filePath);
+
+    BOOST_TEST_REQUIRE(replay.StartRecording(tmpFile.filePath, map, 42));
+    BOOST_TEST_REQUIRE(replay.IsRecording());
+    BOOST_TEST(replay.GetLastGF() == 0u);
+
+    BOOST_TEST_REQUIRE(replay.StopRecording());
+    BOOST_TEST_REQUIRE(!replay.IsRecording());
+    BOOST_TEST(!bfs::exists(tmpFile.filePath));
+}
 BOOST_FIXTURE_TEST_CASE(ReplayWithMap, ReplayMapFixture)
 {
     Replay replay;


### PR DESCRIPTION
## Summary

- remove replay files when recording stops without any recorded game frame
- keep normal replay recording unchanged once the replay has a non-zero last game frame
- add regression coverage for empty replay recording cleanup

## Motivation

Starting a game and aborting during early setup, for example after a script error, can leave behind 0-GF replay files. These files are not useful as actual replays and clutter the replay folder.

This keeps completed/non-empty replay recordings unchanged, but removes empty recordings when recording is stopped cleanly.

Fixes #984

## Validation

- Built `Test_integration` locally with Visual Studio 2022 Debug
- Ran `Serialization/EmptyReplayRecordingIsRemoved`
- Ran `Serialization/ReplayWithMap`
- Ran `Serialization`