### PR TITLE
Draw Nubian mine fire only while working

### DIFF
--- a/libs/s25main/buildings/nobUsual.cpp
+++ b/libs/s25main/buildings/nobUsual.cpp
@@ -221,7 +221,7 @@ void nobUsual::Draw(DrawPoint drawPt)
         dynamic_cast<nofPigbreeder*>(worker)->MakePigSounds(); //-V522
     }
     // Bei nubischen Bergwerken das Feuer vor dem Bergwerk zeichnen
-    else if(BuildingProperties::IsMine(bldType_) && worker && nation == Nation::Africans)
+    else if(BuildingProperties::IsMine(bldType_) && worker && is_working && nation == Nation::Africans)
     {
         DrawPoint offset;
         switch(bldType_)


### PR DESCRIPTION
## Summary

- only draw the Nubian/African mine fire animation while the mine is actually working
- keep the existing worker and nation checks unchanged

## Motivation

Nubian mines currently draw their fire animation whenever a worker is assigned to the building. This can make occupied but idle mines look like they are actively working, for example while waiting for production input or after production has stopped.

Other production visuals such as smoke already depend on `is_working`. This applies the same working-state check to the Nubian mine fire.

Fixes #1513

## Validation

- Built `s25Main` locally with Visual Studio 2022 Debug
- Built `Test_integration` locally with Visual Studio 2022 Debug
- Ran `BuildingSuite`