### PR TITLE
Store received savegames in save folder

### DIFF
--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -928,7 +928,10 @@ bool GameClient::OnGameMessage(const GameMessage_Map_Info& msg)
         OnError(ClientError::InvalidMap);
         return true;
     }
-    mapinfo.filepath = RTTRCONFIG.ExpandPath(s25::folders::mapsPlayed) / portFilename;
+    const auto targetPath =
+      RTTRCONFIG.ExpandPath((msg.mt == MapType::Savegame) ? s25::folders::save : s25::folders::mapsPlayed);
+    bfs::create_directories(targetPath);
+    mapinfo.filepath = targetPath / portFilename;
     mapinfo.type = msg.mt;
 
     // lua script file path

--- a/tests/s25Main/network/testGameClient.cpp
+++ b/tests/s25Main/network/testGameClient.cpp
@@ -244,6 +244,36 @@ BOOST_DATA_TEST_CASE(ClientFollowsConnectProtocol, usesLuaScriptValues, usesLuaS
     }
 }
 
+BOOST_AUTO_TEST_CASE(ClientStoresReceivedSavegamesInSaveFolder)
+{
+    rttr::test::TmpFolder testUserData;
+    rttr::test::ConfigOverride userDataOverride("USERDATA", testUserData);
+
+    GameClient client;
+    GameMessageInterface& clientMsgInterface = client;
+    TestServer server;
+    const auto serverPort = server.tryListen();
+    BOOST_TEST_REQUIRE(serverPort >= 0);
+
+    BOOST_TEST_REQUIRE(client.Connect("localhost", rttr::test::randString(10), rttr::test::randomEnum<ServerType>(),
+                                      serverPort, false, false));
+    clientMsgInterface.OnGameMessage(GameMessage_Player_Id(1));
+    client.GetMainPlayer().sendQueue.clear();
+    clientMsgInterface.OnGameMessage(GameMessage_Server_TypeOK(GameMessage_Server_TypeOK::StatusCode::Ok, ""));
+    client.GetMainPlayer().sendQueue.clear();
+    clientMsgInterface.OnGameMessage(GameMessage_Server_Password("true"));
+    client.GetMainPlayer().sendQueue.clear();
+
+    const auto expectedSavePath = RTTRCONFIG.ExpandPath(s25::folders::save) / "received.sav";
+
+    clientMsgInterface.OnGameMessage(GameMessage_Map_Info("received.sav", MapType::Savegame, 1, 1, 0, 0));
+    const auto msg = boost::dynamic_pointer_cast<GameMessage_MapRequest>(client.GetMainPlayer().sendQueue.pop());
+    BOOST_TEST_REQUIRE(msg);
+    BOOST_TEST(!msg->requestInfo);
+    BOOST_TEST(client.GetMapType() == MapType::Savegame);
+    BOOST_TEST(client.GetMapPath() == expectedSavePath);
+}
+
 BOOST_AUTO_TEST_CASE(ClientDetectsMapBufferOverflow)
 {
     rttr::test::LogAccessor _suppressLogOutput;


### PR DESCRIPTION

## Summary

- store received savegame transfers in the savegame folder instead of the played-maps folder
- keep regular map and Lua transfers in the played-maps folder
- add focused regression coverage for received savegame path selection

## Motivation

Received map data is currently written to the played-maps folder unconditionally. This also affects `MapType::Savegame`, leaving `.sav` files in `MAPS`.

Savegame transfers should not be stored as played maps.

Fixes #1846

## Validation

- Built `Test_network` locally with VS2022 Debug
- Ran `GameClientTests/ClientStoresReceivedSavegamesInSaveFolder`
- Ran `GameClientTests`
