### PR TITLE
Document Lua SetAI name reset behavior

### DIFF
--- a/doc/lua/functions.md
+++ b/doc/lua/functions.md
@@ -238,6 +238,7 @@ Closes a spot kicking any player or AI there.
 
 **SetAI(level)**  
 Add an AI or change its difficulty.
+Switching a slot to an AI assigns the AI's default name. If a custom name should be kept, call `SetName(name)` after `SetAI(level)`.
 
 **SetName(name)**  
 Change the player's name.


### PR DESCRIPTION
## Summary

- document that Lua `SetAI(level)` assigns the AI's default name
- document that scripts should call `SetName(name)` after `SetAI(level)` when they want to keep a custom name

## Motivation

`SetAI(level)` intentionally resets the slot name to the AI default name. This behavior was clarified in #1467, but the Lua documentation currently only says that `SetAI(level)` adds or changes an AI.

Fixes #1467

## Validation

- Documentation-only change
- Ran `git diff --check`
