### PR TITLE
Hunter: Use GetPointsInRadius() instead of square

### DIFF
--- a/libs/s25main/Replay.cpp
+++ b/libs/s25main/Replay.cpp
@@ -41,7 +41,8 @@ uint8_t Replay::GetLatestMinorVersion() const
     // 8.2: Set correct initial distributions if replay starts without savegame for leather addon (see GameClient.cpp
     //      StartReplay function for detailed description)
     // 8.3  Remove invalid fish for replays started from start (i.e. map instead of savegame)
-    return 3;
+    // 8.4  Hunter/skinner/AI search for animals in a circle instead of a square (radius-based)
+    return 4;
 }
 
 uint8_t Replay::GetLatestMajorVersion() const

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -1965,51 +1965,26 @@ bool AIPlayerJH::HuntablesinRange(const MapPoint pt, unsigned min)
     // check first if no other hunter(or hunter buildingsite) is nearby
     if(aii.isBuildingNearby(BuildingType::Hunter, pt, 14))
         return false;
-    unsigned maxrange = 25;
-    unsigned short fx, fy, lx, ly;
-    const unsigned short SQUARE_SIZE = 19;
-    unsigned huntablecount = 0;
-    if(pt.x > SQUARE_SIZE)
-        fx = pt.x - SQUARE_SIZE;
-    else
-        fx = 0;
-    if(pt.y > SQUARE_SIZE)
-        fy = pt.y - SQUARE_SIZE;
-    else
-        fy = 0;
-    if(pt.x + SQUARE_SIZE < gwb.GetWidth())
-        lx = pt.x + SQUARE_SIZE;
-    else
-        lx = gwb.GetWidth() - 1;
-    if(pt.y + SQUARE_SIZE < gwb.GetHeight())
-        ly = pt.y + SQUARE_SIZE;
-    else
-        ly = gwb.GetHeight() - 1;
-    // Durchgehen und nach Tieren suchen
-    for(MapPoint p2(0, fy); p2.y <= ly; ++p2.y)
-    {
-        for(p2.x = fx; p2.x <= lx; ++p2.x)
+    const unsigned maxrange = 25;
+
+    const auto pointToAnimal = [this](const MapPoint pt, unsigned) -> const noAnimal* {
+        for(const noBase& fig : gwb.GetFigures(pt))
         {
-            // Search for animals
-            for(const noBase& fig : gwb.GetFigures(p2))
-            {
-                if(fig.GetType() == NodalObjectType::Animal)
-                {
-                    // Ist das Tier überhaupt zum Jagen geeignet?
-                    if(!static_cast<const noAnimal&>(fig).CanHunted())
-                        continue;
-                    // Und komme ich hin?
-                    if(gwb.FindHumanPath(pt, static_cast<const noAnimal&>(fig).GetPos(), maxrange))
-                    // Dann nehmen wir es
-                    {
-                        if(++huntablecount >= min)
-                            return true;
-                    }
-                }
-            }
+            if(fig.GetType() == NodalObjectType::Animal)
+                return static_cast<const noAnimal*>(&fig);
         }
-    }
-    return false;
+        return nullptr;
+    };
+
+    const auto canAnimalBeHunted = [this, pt, maxrange](const noAnimal* const animal) {
+        return animal && animal->CanHunted()
+               && gwb.FindHumanPath(pt, animal->GetPos(), maxrange);
+    };
+
+    const auto available_animals =
+      gwb.GetPointsInRadius(pt, ANIMAL_RADIUS, pointToAnimal, canAnimalBeHunted, true);
+
+    return available_animals.size() >= min;
 }
 
 void AIPlayerJH::InitStoreAndMilitarylists()

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -1705,7 +1705,7 @@ void AIPlayerJH::TrySeaAttack()
                     if(!testseaidswithattackers.empty())
                     {
                         undefendedTargets.push_back(milBld);
-                    }  // else - no attackers - do nothing
+                    } // else - no attackers - do nothing
                 } else // normal target - check is done after random shuffle so we dont have to check every possible
                        // target and instead only enough to get 1 good one
                 {

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -32,6 +32,7 @@
 #include "nodeObjs/noFlag.h"
 #include "nodeObjs/noShip.h"
 #include "nodeObjs/noTree.h"
+#include "figures/nofHunter.h"
 #include "gameData/BuildingConsts.h"
 #include "gameData/BuildingProperties.h"
 #include "gameData/GameConsts.h"
@@ -1965,24 +1966,10 @@ bool AIPlayerJH::HuntablesinRange(const MapPoint pt, unsigned min)
     // check first if no other hunter(or hunter buildingsite) is nearby
     if(aii.isBuildingNearby(BuildingType::Hunter, pt, 14))
         return false;
-    const unsigned maxrange = 25;
+    constexpr unsigned maxrange = 25;
 
-    const auto pointToAnimal = [this](const MapPoint pt, unsigned) -> const noAnimal* {
-        for(const noBase& fig : gwb.GetFigures(pt))
-        {
-            if(fig.GetType() == NodalObjectType::Animal)
-                return static_cast<const noAnimal*>(&fig);
-        }
-        return nullptr;
-    };
-
-    const auto canAnimalBeHunted = [this, pt, maxrange](const noAnimal* const animal) {
-        return animal && animal->CanHunted()
-               && gwb.FindHumanPath(pt, animal->GetPos(), maxrange);
-    };
-
-    const auto available_animals =
-      gwb.GetPointsInRadius(pt, ANIMAL_RADIUS, pointToAnimal, canAnimalBeHunted, true);
+    const auto available_animals = nofHunter::GetAnimalsInRange(gwb, pt, ANIMAL_RADIUS, maxrange,
+                                                               [](const noAnimal* a) { return a->CanHunted(); });
 
     return available_animals.size() >= min;
 }

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -17,6 +17,7 @@
 #include "buildings/nobHarborBuilding.h"
 #include "buildings/nobMilitary.h"
 #include "buildings/nobUsual.h"
+#include "figures/nofHunter.h"
 #include "helpers/IdRange.h"
 #include "helpers/MaxEnumValue.h"
 #include "helpers/containerUtils.h"
@@ -32,7 +33,6 @@
 #include "nodeObjs/noFlag.h"
 #include "nodeObjs/noShip.h"
 #include "nodeObjs/noTree.h"
-#include "figures/nofHunter.h"
 #include "gameData/BuildingConsts.h"
 #include "gameData/BuildingProperties.h"
 #include "gameData/GameConsts.h"
@@ -1968,8 +1968,8 @@ bool AIPlayerJH::HuntablesinRange(const MapPoint pt, unsigned min)
         return false;
     constexpr unsigned maxrange = 25;
 
-    const auto available_animals = nofHunter::GetAnimalsInRange(gwb, pt, ANIMAL_RADIUS, maxrange,
-                                                               [](const noAnimal* a) { return a->CanHunted(); });
+    const auto available_animals =
+      nofHunter::GetAnimalsInRange(gwb, pt, ANIMAL_RADIUS, maxrange, [](const noAnimal* a) { return a->CanHunted(); });
 
     return available_animals.size() >= min;
 }

--- a/libs/s25main/ai/aijh/AIPlayerJH.cpp
+++ b/libs/s25main/ai/aijh/AIPlayerJH.cpp
@@ -1968,10 +1968,55 @@ bool AIPlayerJH::HuntablesinRange(const MapPoint pt, unsigned min)
         return false;
     constexpr unsigned maxrange = 25;
 
-    const auto available_animals =
-      nofHunter::GetAnimalsInRange(gwb, pt, ANIMAL_RADIUS, maxrange, [](const noAnimal* a) { return a->CanHunted(); });
+    if(gwb.GetReplayMinorVersion() >= 4)
+    {
+        const auto available_animals =
+          nofHunter::GetAnimalsInRange(gwb, pt, ANIMAL_RADIUS, maxrange, [](const noAnimal* a) { return a->CanHunted(); });
 
-    return available_animals.size() >= min;
+        return available_animals.size() >= min;
+    } else
+    {
+        // Legacy square search for replays recorded with old code
+        unsigned short fx, fy, lx, ly;
+        const unsigned short SQUARE_SIZE = 19;
+        unsigned huntablecount = 0;
+        if(pt.x > SQUARE_SIZE)
+            fx = pt.x - SQUARE_SIZE;
+        else
+            fx = 0;
+        if(pt.y > SQUARE_SIZE)
+            fy = pt.y - SQUARE_SIZE;
+        else
+            fy = 0;
+        if(pt.x + SQUARE_SIZE < gwb.GetWidth())
+            lx = pt.x + SQUARE_SIZE;
+        else
+            lx = gwb.GetWidth() - 1;
+        if(pt.y + SQUARE_SIZE < gwb.GetHeight())
+            ly = pt.y + SQUARE_SIZE;
+        else
+            ly = gwb.GetHeight() - 1;
+        for(MapPoint p2(0, fy); p2.y <= ly; ++p2.y)
+        {
+            for(p2.x = fx; p2.x <= lx; ++p2.x)
+            {
+                for(const noBase& fig : gwb.GetFigures(p2))
+                {
+                    if(fig.GetType() == NodalObjectType::Animal)
+                    {
+                        if(!static_cast<const noAnimal&>(fig).CanHunted())
+                            continue;
+                        if(gwb.FindHumanPath(pt, static_cast<const noAnimal&>(fig).GetPos(), maxrange))
+                        {
+                            if(++huntablecount >= min)
+                                return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
 }
 
 void AIPlayerJH::InitStoreAndMilitarylists()

--- a/libs/s25main/figures/nofHunter.cpp
+++ b/libs/s25main/figures/nofHunter.cpp
@@ -129,26 +129,31 @@ void nofHunter::HandleDerivedEvent(unsigned /*id*/)
     }
 }
 
-void nofHunter::TryStartHunting()
+std::vector<noAnimal*> nofHunter::GetAnimalsInRange(const GameWorldBase& world, const MapPoint pos,
+                                                      unsigned radius, unsigned maxDistance,
+                                                      bool (*isValidAnimal)(const noAnimal*))
 {
-    // Find animals in a circle around building
-    const auto pointToAnimal = [world = this->world](const MapPoint pt, unsigned) -> noAnimal* {
-        for(auto& figure : world->GetFigures(pt))
+    const auto pointToAnimal = [&world](const MapPoint pt, unsigned) -> noAnimal* {
+        for(auto& figure : world.GetFigures(pt))
         {
-            if(figure.GetType() != NodalObjectType::Animal)
-                continue;
-            return static_cast<noAnimal*>(&figure);
+            if(figure.GetType() == NodalObjectType::Animal)
+                return static_cast<noAnimal*>(&figure);
         }
         return nullptr;
     };
 
-    const auto canAnimalBeHunted = [pos = this->pos](const noAnimal* const animal) {
-        return animal && animal->CanHunted()
-               && (pos == animal->GetPos() || world->FindHumanPath(pos, animal->GetPos(), MAX_HUNTING_DISTANCE));
+    const auto canAnimalBeUsed = [pos, maxDistance, &world, isValidAnimal](const noAnimal* const animal) {
+        return animal && isValidAnimal(animal)
+               && (pos == animal->GetPos() || world.FindHumanPath(pos, animal->GetPos(), maxDistance));
     };
 
-    const auto available_animals =
-      world->GetPointsInRadius(pos, ANIMAL_RADIUS, pointToAnimal, canAnimalBeHunted, true);
+    return world.GetPointsInRadius(pos, radius, pointToAnimal, canAnimalBeUsed, true);
+}
+
+void nofHunter::TryStartHunting()
+{
+    const auto available_animals = GetAnimalsInRange(*world, pos, ANIMAL_RADIUS, MAX_HUNTING_DISTANCE,
+                                                     [](const noAnimal* a) { return a->CanHunted(); });
 
     // Gibt es überhaupt ein Tier, das ich jagen kann?
     if(!available_animals.empty())

--- a/libs/s25main/figures/nofHunter.cpp
+++ b/libs/s25main/figures/nofHunter.cpp
@@ -129,9 +129,8 @@ void nofHunter::HandleDerivedEvent(unsigned /*id*/)
     }
 }
 
-std::vector<noAnimal*> nofHunter::GetAnimalsInRange(const GameWorldBase& world, const MapPoint pos,
-                                                      unsigned radius, unsigned maxDistance,
-                                                      bool (*isValidAnimal)(const noAnimal*))
+std::vector<noAnimal*> nofHunter::GetAnimalsInRange(const GameWorldBase& world, const MapPoint pos, unsigned radius,
+                                                    unsigned maxDistance, bool (*isValidAnimal)(const noAnimal*))
 {
     const auto pointToAnimal = [&world](const MapPoint pt, unsigned) -> noAnimal* {
         for(auto& figure : world.GetFigures(pt))

--- a/libs/s25main/figures/nofHunter.cpp
+++ b/libs/s25main/figures/nofHunter.cpp
@@ -151,8 +151,37 @@ std::vector<noAnimal*> nofHunter::GetAnimalsInRange(const GameWorldBase& world, 
 
 void nofHunter::TryStartHunting()
 {
-    const auto available_animals = GetAnimalsInRange(*world, pos, ANIMAL_RADIUS, MAX_HUNTING_DISTANCE,
-                                                     [](const noAnimal* a) { return a->CanHunted(); });
+    std::vector<noAnimal*> available_animals;
+
+    if(world->GetReplayMinorVersion() >= 4)
+    {
+        available_animals = GetAnimalsInRange(*world, pos, ANIMAL_RADIUS, MAX_HUNTING_DISTANCE,
+                                              [](const noAnimal* a) { return a->CanHunted(); });
+    } else
+    {
+        // Legacy square search for replays recorded with old code
+        const int SQUARE_SIZE = 19;
+        Position curPos;
+        for(curPos.y = pos.y - SQUARE_SIZE; curPos.y <= pos.y + SQUARE_SIZE; ++curPos.y)
+        {
+            for(curPos.x = pos.x - SQUARE_SIZE; curPos.x <= pos.x + SQUARE_SIZE; ++curPos.x)
+            {
+                MapPoint curMapPos = world->MakeMapPoint(curPos);
+                for(auto& figure : world->GetFigures(curMapPos))
+                {
+                    if(figure.GetType() != NodalObjectType::Animal)
+                        continue;
+                    auto& animal = static_cast<noAnimal&>(figure);
+                    if(!animal.CanHunted())
+                        continue;
+                    if(pos == animal.GetPos() || world->FindHumanPath(pos, animal.GetPos(), MAX_HUNTING_DISTANCE))
+                    {
+                        available_animals.push_back(&animal);
+                    }
+                }
+            }
+        }
+    }
 
     // Gibt es überhaupt ein Tier, das ich jagen kann?
     if(!available_animals.empty())

--- a/libs/s25main/figures/nofHunter.cpp
+++ b/libs/s25main/figures/nofHunter.cpp
@@ -131,39 +131,24 @@ void nofHunter::HandleDerivedEvent(unsigned /*id*/)
 
 void nofHunter::TryStartHunting()
 {
-    // Find animals in a square around building (actually should be circle, but animals are moving anyway)
-    const int SQUARE_SIZE = 19;
-
-    // Liste mit den gefundenen Tieren
-    std::vector<noAnimal*> available_animals;
-
-    // Durchgehen und nach Tieren suchen
-    Position curPos;
-    for(curPos.y = pos.y - SQUARE_SIZE; curPos.y <= pos.y + SQUARE_SIZE; ++curPos.y)
-    {
-        for(curPos.x = pos.x - SQUARE_SIZE; curPos.x <= pos.x + SQUARE_SIZE; ++curPos.x)
+    // Find animals in a circle around building
+    const auto pointToAnimal = [world = this->world](const MapPoint pt, unsigned) -> noAnimal* {
+        for(auto& figure : world->GetFigures(pt))
         {
-            MapPoint curMapPos = world->MakeMapPoint(curPos);
-
-            // nach Tieren suchen
-            for(auto& figure : world->GetFigures(curMapPos))
-            {
-                if(figure.GetType() != NodalObjectType::Animal)
-                    continue;
-                // Ist das Tier überhaupt zum Jagen geeignet?
-                auto& animal = static_cast<noAnimal&>(figure);
-                if(!animal.CanHunted())
-                    continue;
-
-                // Und komme ich hin?
-                if(pos == animal.GetPos() || world->FindHumanPath(pos, animal.GetPos(), MAX_HUNTING_DISTANCE))
-                {
-                    // Dann nehmen wir es
-                    available_animals.push_back(&animal);
-                }
-            }
+            if(figure.GetType() != NodalObjectType::Animal)
+                continue;
+            return static_cast<noAnimal*>(&figure);
         }
-    }
+        return nullptr;
+    };
+
+    const auto canAnimalBeHunted = [pos = this->pos](const noAnimal* const animal) {
+        return animal && animal->CanHunted()
+               && (pos == animal->GetPos() || world->FindHumanPath(pos, animal->GetPos(), MAX_HUNTING_DISTANCE));
+    };
+
+    const auto available_animals =
+      world->GetPointsInRadius(pos, ANIMAL_RADIUS, pointToAnimal, canAnimalBeHunted, true);
 
     // Gibt es überhaupt ein Tier, das ich jagen kann?
     if(!available_animals.empty())

--- a/libs/s25main/figures/nofHunter.h
+++ b/libs/s25main/figures/nofHunter.h
@@ -6,7 +6,9 @@
 
 #include "nofBuildingWorker.h"
 #include "gameTypes/Direction.h"
+#include <vector>
 
+class GameWorldBase;
 class noAnimal;
 class SerializedGameData;
 class nobUsual;
@@ -63,6 +65,11 @@ public:
     void HandleDerivedEvent(unsigned id) override;
 
     void TryStartHunting();
+
+    /// Find animals in a radius around a position that satisfy a predicate and are reachable
+    static std::vector<noAnimal*> GetAnimalsInRange(const GameWorldBase& world, const MapPoint pos,
+                                                     unsigned radius, unsigned maxDistance,
+                                                     bool (*isValidAnimal)(const noAnimal*));
 
     /// das Tier ist nicht mehr verfügbar (von selbst gestorben o.Ä.)
     void AnimalLost();

--- a/libs/s25main/figures/nofHunter.h
+++ b/libs/s25main/figures/nofHunter.h
@@ -67,9 +67,8 @@ public:
     void TryStartHunting();
 
     /// Find animals in a radius around a position that satisfy a predicate and are reachable
-    static std::vector<noAnimal*> GetAnimalsInRange(const GameWorldBase& world, const MapPoint pos,
-                                                     unsigned radius, unsigned maxDistance,
-                                                     bool (*isValidAnimal)(const noAnimal*));
+    static std::vector<noAnimal*> GetAnimalsInRange(const GameWorldBase& world, const MapPoint pos, unsigned radius,
+                                                    unsigned maxDistance, bool (*isValidAnimal)(const noAnimal*));
 
     /// das Tier ist nicht mehr verfügbar (von selbst gestorben o.Ä.)
     void AnimalLost();

--- a/libs/s25main/figures/nofHunter.h
+++ b/libs/s25main/figures/nofHunter.h
@@ -67,7 +67,7 @@ public:
     void TryStartHunting();
 
     /// Find animals in a radius around a position that satisfy a predicate and are reachable
-    static std::vector<noAnimal*> GetAnimalsInRange(const GameWorldBase& world, const MapPoint pos, unsigned radius,
+    static std::vector<noAnimal*> GetAnimalsInRange(const GameWorldBase& world, MapPoint pos, unsigned radius,
                                                     unsigned maxDistance, bool (*isValidAnimal)(const noAnimal*));
 
     /// das Tier ist nicht mehr verfügbar (von selbst gestorben o.Ä.)

--- a/libs/s25main/figures/nofSkinner.cpp
+++ b/libs/s25main/figures/nofSkinner.cpp
@@ -16,6 +16,7 @@
 #include "random/Random.h"
 #include "world/GameWorld.h"
 #include "nodeObjs/noAnimal.h"
+#include "figures/nofHunter.h"
 #include "gameData/GameConsts.h"
 #include "gameData/JobConsts.h"
 
@@ -188,23 +189,9 @@ void nofSkinner::TryStartSkinning()
         HandleStateWaiting1();
     else
     {
-        const auto pointToAnimal = [world = this->world](const MapPoint pt, unsigned) -> noAnimal* {
-            for(auto& figure : world->GetFigures(pt))
-            {
-                if(figure.GetType() != NodalObjectType::Animal)
-                    continue;
-                return checkedCast<noAnimal*>(&figure);
-            }
-            return nullptr;
-        };
-
-        const auto canAnimalBeSkinned = [pos = this->pos](const noAnimal* const animal) {
-            return animal && animal->CanBeSkinned()
-                   && (pos == animal->GetPos() || world->FindHumanPath(pos, animal->GetPos(), MAX_SKINNING_DISTANCE));
-        };
-
         const auto available_animals =
-          world->GetPointsInRadius(pos, ANIMAL_RADIUS, pointToAnimal, canAnimalBeSkinned, true);
+          nofHunter::GetAnimalsInRange(*world, pos, ANIMAL_RADIUS, MAX_SKINNING_DISTANCE,
+                                       [](const noAnimal* a) { return a->CanBeSkinned(); });
 
         if(!available_animals.empty())
         {

--- a/libs/s25main/figures/nofSkinner.cpp
+++ b/libs/s25main/figures/nofSkinner.cpp
@@ -16,6 +16,7 @@
 #include "random/Random.h"
 #include "world/GameWorld.h"
 #include "nodeObjs/noAnimal.h"
+#include "gameData/GameConsts.h"
 #include "gameData/JobConsts.h"
 
 using namespace leatheraddon;
@@ -187,7 +188,6 @@ void nofSkinner::TryStartSkinning()
         HandleStateWaiting1();
     else
     {
-        const int ANIMAL_RADIUS = 19;
         const auto pointToAnimal = [world = this->world](const MapPoint pt, unsigned) -> noAnimal* {
             for(auto& figure : world->GetFigures(pt))
             {

--- a/libs/s25main/figures/nofSkinner.cpp
+++ b/libs/s25main/figures/nofSkinner.cpp
@@ -10,13 +10,13 @@
 #include "SerializedGameData.h"
 #include "SoundManager.h"
 #include "buildings/nobUsual.h"
+#include "figures/nofHunter.h"
 #include "network/GameClient.h"
 #include "notifications/BuildingNote.h"
 #include "ogl/glArchivItem_Bitmap_Player.h"
 #include "random/Random.h"
 #include "world/GameWorld.h"
 #include "nodeObjs/noAnimal.h"
-#include "figures/nofHunter.h"
 #include "gameData/GameConsts.h"
 #include "gameData/JobConsts.h"
 
@@ -189,9 +189,8 @@ void nofSkinner::TryStartSkinning()
         HandleStateWaiting1();
     else
     {
-        const auto available_animals =
-          nofHunter::GetAnimalsInRange(*world, pos, ANIMAL_RADIUS, MAX_SKINNING_DISTANCE,
-                                       [](const noAnimal* a) { return a->CanBeSkinned(); });
+        const auto available_animals = nofHunter::GetAnimalsInRange(
+          *world, pos, ANIMAL_RADIUS, MAX_SKINNING_DISTANCE, [](const noAnimal* a) { return a->CanBeSkinned(); });
 
         if(!available_animals.empty())
         {

--- a/libs/s25main/gameData/GameConsts.h
+++ b/libs/s25main/gameData/GameConsts.h
@@ -41,7 +41,7 @@ constexpr auto gfs_to_duration(const unsigned gfs)
 /// Reichweite der Bergarbeiter
 constexpr unsigned MINER_RADIUS = 2;
 
-/// Suchradius für Tiere (Jäger, Gerber, KI)
+/// Search radius for animals (hunter, skinner, AI)
 constexpr unsigned ANIMAL_RADIUS = 19;
 
 /// Konstante für die Pfadrichtung bei einer Schiffsverbindung

--- a/libs/s25main/gameData/GameConsts.h
+++ b/libs/s25main/gameData/GameConsts.h
@@ -41,6 +41,9 @@ constexpr auto gfs_to_duration(const unsigned gfs)
 /// Reichweite der Bergarbeiter
 constexpr unsigned MINER_RADIUS = 2;
 
+/// Suchradius für Tiere (Jäger, Gerber, KI)
+constexpr unsigned ANIMAL_RADIUS = 19;
+
 /// Konstante für die Pfadrichtung bei einer Schiffsverbindung
 constexpr unsigned char SHIP_DIR = 100;
 constexpr unsigned char INVALID_DIR = 0xFF;

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -341,6 +341,8 @@ void GameClient::StartGame(const unsigned random_init)
         const bool fixFish = !GetReplay() || GetReplay()->GetMinorVersion() >= 3;
         MapLoader::SetupResources(gameWorld, fixFish);
     }
+    if(replayMode && replayinfo)
+        gameWorld.SetReplayMinorVersion(replayinfo->replay.GetMinorVersion());
     gameWorld.InitAfterLoad();
 
     // Update visual settings

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -67,6 +67,8 @@ protected:
     GameInterface* gi;
     std::unique_ptr<EconomyModeHandler> econHandler;
     std::unique_ptr<TradePathCache> tradePathCache;
+    /// Replay minor version when replaying. Set to current minor version for live games.
+    uint8_t replayMinorVersion_ = 255;
 
 public:
     GameWorldBase(std::vector<GamePlayer> players, const GlobalGameSettings& gameSettings, EventManager& em);
@@ -162,6 +164,11 @@ public:
     bool IsSinglePlayer() const;
     /// Return the game settings
     const GlobalGameSettings& GetGGS() const { return gameSettings; }
+    /// Get the replay minor version (used for backward compatibility)
+    uint8_t GetReplayMinorVersion() const { return replayMinorVersion_; }
+    /// Set the replay minor version (called when loading a replay)
+    void SetReplayMinorVersion(uint8_t version) { replayMinorVersion_ = version; }
+
     EventManager& GetEvMgr() { return em; }
     const EventManager& GetEvMgr() const { return em; }
     SoundManager& GetSoundMgr() { return *soundManager; }

--- a/tests/s25Main/autoplay/main.cpp
+++ b/tests/s25Main/autoplay/main.cpp
@@ -92,6 +92,7 @@ static void playReplay(const boost::filesystem::path& replayPath, const bool isS
             gameWorld.GetPlayer(i).MakeStartPacts();
     }
 
+    gameWorld.SetReplayMinorVersion(replay.GetMinorVersion());
     gameWorld.InitAfterLoad();
 
     bool endOfReplay = false;


### PR DESCRIPTION
Hunter currently uses square, comments says it should be circle.
Update it to use new [GetPointsInRadius() pattern from nofSkinner.cpp](https://github.com/morganchristiansson/s25client/blob/hunter-radius/libs/s25main/figures/nofSkinner.cpp#L207) to find animals.
Also extract ANIMAL_RADIUS to shared constant used by Hunter, AI Hunter builder and Skinner.

This supports #1946 which displays building radius as outline.
