### PR TITLE
Adjust save game window columns widths

### DIFF
--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -48,10 +48,10 @@ iwSaveLoad::iwSaveLoad(const std::string& window_title, ITexture* btImg, const u
 {
     using SRT = ctrlTable::SortType;
     AddTable(ID_tblSaveGames, DrawPoint(20, 30), Extent(560, 300), TextureColor::Green2, NormalFont,
-             ctrlTable::Columns{{_("Filename"), 270, SRT::String},
+             ctrlTable::Columns{{_("Filename"), 320, SRT::String},
                                 {_("Map"), 250, SRT::String},
                                 {_("Time"), 250, SRT::Date},
-                                {_("Game Time"), 2026, SRT::Time},
+                                {_("Game Time"), 180, SRT::Time},
                                 {}});
 
     AddText(ID_txtSaveFolder, DrawPoint(20, 333), RTTRCONFIG.ExpandPath(s25::folders::save).string(), COLOR_YELLOW,

--- a/libs/s25main/ingameWindows/iwSave.cpp
+++ b/libs/s25main/ingameWindows/iwSave.cpp
@@ -51,7 +51,7 @@ iwSaveLoad::iwSaveLoad(const std::string& window_title, ITexture* btImg, const u
              ctrlTable::Columns{{_("Filename"), 320, SRT::String},
                                 {_("Map"), 250, SRT::String},
                                 {_("Time"), 250, SRT::Date},
-                                {_("Game Time"), 180, SRT::Time},
+                                {_("Game Time"), 320, SRT::Time},
                                 {}});
 
     AddText(ID_txtSaveFolder, DrawPoint(20, 333), RTTRCONFIG.ExpandPath(s25::folders::save).string(), COLOR_YELLOW,


### PR DESCRIPTION
### Adjust save game window columns widths.

Looking at the file history, very wide "Game Time" column was most probably accidental. It made the window hard to use so I decided to do something about it :-).

Before:
<img width="602" height="55" alt="image" src="https://github.com/user-attachments/assets/f74d43c4-fdd2-40c7-bbb2-b7f2e93dc1e7" />

After:
<img width="602" height="55" alt="image" src="https://github.com/user-attachments/assets/688819ce-8306-4eeb-9d67-5f19488484b1" />
