### PR TITLE
ai-battle: support team assignment (--teams) and establish team start-pacts

### DIFF
--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -22,7 +22,7 @@
 #    include "Windows.h"
 #endif
 
-std::vector<PlayerInfo> GeneratePlayerInfo(const std::vector<AI::Info>& ais);
+std::vector<PlayerInfo> GeneratePlayerInfo(const std::vector<AI::Info>& ais, const std::vector<Team>& teams);
 std::string ToString(const std::chrono::milliseconds& time);
 std::string HumanReadableNumber(unsigned num);
 
@@ -44,8 +44,8 @@ void printConsole(const char* fmt, ...);
 #endif
 
 HeadlessGame::HeadlessGame(const GlobalGameSettings& ggs, const bfs::path& map, const std::vector<AI::Info>& ais,
-                           const bfs::path& luaPath)
-    : map_(map), game_(ggs, std::make_unique<EventManager>(0), GeneratePlayerInfo(ais)), world_(game_.world_),
+                           const bfs::path& luaPath, const std::vector<Team>& teams)
+    : map_(map), game_(ggs, std::make_unique<EventManager>(0), GeneratePlayerInfo(ais, teams)), world_(game_.world_),
       em_(*static_cast<EventManager*>(game_.em_.get()))
 {
     MapLoader loader(world_);
@@ -235,7 +235,7 @@ void HeadlessGame::PrintState()
     lastReportGf_ = em_.GetCurrentGF();
 }
 
-std::vector<PlayerInfo> GeneratePlayerInfo(const std::vector<AI::Info>& ais)
+std::vector<PlayerInfo> GeneratePlayerInfo(const std::vector<AI::Info>& ais, const std::vector<Team>& teams)
 {
     std::vector<PlayerInfo> ret;
     for(const AI::Info& ai : ais)
@@ -250,7 +250,7 @@ std::vector<PlayerInfo> GeneratePlayerInfo(const std::vector<AI::Info>& ais)
             default: pi.name = "Dummy " + std::to_string(ret.size()); break;
         }
         pi.nation = Nation::Romans;
-        pi.team = Team::None;
+        pi.team = (ret.size() < teams.size()) ? teams[ret.size()] : Team::None;
         pi.color = PLAYER_COLORS[ret.size() % PLAYER_COLORS.size()];
         ret.push_back(pi);
     }

--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -57,6 +57,7 @@ HeadlessGame::HeadlessGame(const GlobalGameSettings& ggs, const bfs::path& map, 
     {
         if(!loader.LoadLuaScript(game_, localState_, luaPath))
             throw std::runtime_error("Failed to load Lua script: " + luaPath.string());
+        world_.GetLua().setSuppressStdout(true);
         luaPath_ = luaPath;
         bnw::cout << "Lua script loaded: " << luaPath << '\n';
     }

--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -5,7 +5,6 @@
 #include "HeadlessGame.h"
 #include "EventManager.h"
 #include "GlobalGameSettings.h"
-#include "ILocalGameState.h"
 #include "PlayerInfo.h"
 #include "Savegame.h"
 #include "factories/AIFactory.h"
@@ -30,15 +29,6 @@ std::string HumanReadableNumber(unsigned num);
 namespace bfs = boost::filesystem;
 namespace bnw = boost::nowide;
 
-namespace {
-struct HeadlessLocalState : ILocalGameState
-{
-    unsigned GetPlayerId() const override { return 0; }
-    bool IsHost() const override { return true; }
-    std::string FormatGFTime(unsigned) const override { return ""; }
-    void SystemChat(const std::string& msg) override { bnw::cout << "[lua] " << msg << "\n"; }
-};
-} // namespace
 using bfs::canonical;
 
 #ifdef WIN32
@@ -166,9 +156,8 @@ void HeadlessGame::RecordReplay(const bfs::path& path, unsigned random_init)
 
 void HeadlessGame::LoadLuaScript(const bfs::path& luaPath)
 {
-    HeadlessLocalState state;
     MapLoader loader(world_);
-    if(!loader.LoadLuaScript(game_, state, luaPath))
+    if(!loader.LoadLuaScript(game_, localState_, luaPath))
         throw std::runtime_error("Failed to load Lua script: " + luaPath.string());
     luaPath_ = luaPath; // remember for embedding in the replay
     bnw::cout << "Lua script loaded: " << luaPath << '\n';

--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -4,6 +4,7 @@
 
 #include "HeadlessGame.h"
 #include "EventManager.h"
+#include "GamePlayer.h"
 #include "GlobalGameSettings.h"
 #include "PlayerInfo.h"
 #include "Savegame.h"
@@ -52,6 +53,14 @@ HeadlessGame::HeadlessGame(const GlobalGameSettings& ggs, const bfs::path& map, 
     if(!loader.Load(map))
         throw std::runtime_error("Could not load " + map.string());
     MapLoader::SetupResources(world_);
+
+    // Establish the team alliances (ally + non-aggression pacts) exactly like GameClient::StartGame does
+    // for a fresh map. Without this, teammates have no pacts and are mutually attackable, so the AIs attack
+    // their own team; on replay GameClient *does* set up the pacts, so those recorded attack commands are
+    // handled differently and the replay desyncs (object-count divergence). MakeStartPacts is a no-op for
+    // teamless players, so this is safe regardless of whether --teams was given.
+    for(unsigned i = 0; i < world_.GetNumPlayers(); ++i)
+        world_.GetPlayer(i).MakeStartPacts();
 
     if(!luaPath.empty())
     {

--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "HeadlessGame.h"
 #include "EventManager.h"
 #include "GlobalGameSettings.h"
+#include "ILocalGameState.h"
 #include "PlayerInfo.h"
 #include "Savegame.h"
 #include "factories/AIFactory.h"
@@ -13,6 +14,7 @@
 #include "world/MapLoader.h"
 #include "gameTypes/MapInfo.h"
 #include "gameData/GameConsts.h"
+#include "s25util/colors.h"
 #include <boost/nowide/iostream.hpp>
 #include <chrono>
 #include <cstdio>
@@ -27,6 +29,16 @@ std::string HumanReadableNumber(unsigned num);
 
 namespace bfs = boost::filesystem;
 namespace bnw = boost::nowide;
+
+namespace {
+struct HeadlessLocalState : ILocalGameState
+{
+    unsigned GetPlayerId() const override { return 0; }
+    bool IsHost() const override { return true; }
+    std::string FormatGFTime(unsigned) const override { return ""; }
+    void SystemChat(const std::string& msg) override { bnw::cout << "[lua] " << msg << "\n"; }
+};
+} // namespace
 using bfs::canonical;
 
 #ifdef WIN32
@@ -48,6 +60,7 @@ HeadlessGame::HeadlessGame(const GlobalGameSettings& ggs, const bfs::path& map, 
     MapLoader loader(world_);
     if(!loader.Load(map))
         throw std::runtime_error("Could not load " + map.string());
+    MapLoader::SetupResources(world_);
 
     players_.clear();
     for(unsigned playerId = 0; playerId < world_.GetNumPlayers(); ++playerId)
@@ -138,11 +151,27 @@ void HeadlessGame::RecordReplay(const bfs::path& path, unsigned random_init)
     mapInfo.mapData.CompressFromFile(mapInfo.filepath, &mapInfo.mapChecksum);
     mapInfo.type = MapType::OldMap;
 
+    if(!luaPath_.empty() && bfs::exists(luaPath_))
+    {
+        mapInfo.luaFilepath = luaPath_;
+        mapInfo.luaData.CompressFromFile(luaPath_, &mapInfo.luaChecksum);
+    }
+
     for(unsigned playerId = 0; playerId < world_.GetNumPlayers(); ++playerId)
         replay_.AddPlayer(world_.GetPlayer(playerId));
     replay_.ggs = game_.ggs_;
     if(!replay_.StartRecording(path, mapInfo, random_init))
         throw std::runtime_error("Replayfile could not be opened!");
+}
+
+void HeadlessGame::LoadLuaScript(const bfs::path& luaPath)
+{
+    HeadlessLocalState state;
+    MapLoader loader(world_);
+    if(!loader.LoadLuaScript(game_, state, luaPath))
+        throw std::runtime_error("Failed to load Lua script: " + luaPath.string());
+    luaPath_ = luaPath; // remember for embedding in the replay
+    bnw::cout << "Lua script loaded: " << luaPath << '\n';
 }
 
 void HeadlessGame::SaveGame(const bfs::path& path) const
@@ -232,6 +261,7 @@ std::vector<PlayerInfo> GeneratePlayerInfo(const std::vector<AI::Info>& ais)
         }
         pi.nation = Nation::Romans;
         pi.team = Team::None;
+        pi.color = PLAYER_COLORS[ret.size() % PLAYER_COLORS.size()];
         ret.push_back(pi);
     }
     return ret;

--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -43,7 +43,8 @@ void printConsole(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 void printConsole(const char* fmt, ...);
 #endif
 
-HeadlessGame::HeadlessGame(const GlobalGameSettings& ggs, const bfs::path& map, const std::vector<AI::Info>& ais)
+HeadlessGame::HeadlessGame(const GlobalGameSettings& ggs, const bfs::path& map, const std::vector<AI::Info>& ais,
+                           const bfs::path& luaPath)
     : map_(map), game_(ggs, std::make_unique<EventManager>(0), GeneratePlayerInfo(ais)), world_(game_.world_),
       em_(*static_cast<EventManager*>(game_.em_.get()))
 {
@@ -51,6 +52,14 @@ HeadlessGame::HeadlessGame(const GlobalGameSettings& ggs, const bfs::path& map, 
     if(!loader.Load(map))
         throw std::runtime_error("Could not load " + map.string());
     MapLoader::SetupResources(world_);
+
+    if(!luaPath.empty())
+    {
+        if(!loader.LoadLuaScript(game_, localState_, luaPath))
+            throw std::runtime_error("Failed to load Lua script: " + luaPath.string());
+        luaPath_ = luaPath;
+        bnw::cout << "Lua script loaded: " << luaPath << '\n';
+    }
 
     players_.clear();
     for(unsigned playerId = 0; playerId < world_.GetNumPlayers(); ++playerId)
@@ -152,15 +161,6 @@ void HeadlessGame::RecordReplay(const bfs::path& path, unsigned random_init)
     replay_.ggs = game_.ggs_;
     if(!replay_.StartRecording(path, mapInfo, random_init))
         throw std::runtime_error("Replayfile could not be opened!");
-}
-
-void HeadlessGame::LoadLuaScript(const bfs::path& luaPath)
-{
-    MapLoader loader(world_);
-    if(!loader.LoadLuaScript(game_, localState_, luaPath))
-        throw std::runtime_error("Failed to load Lua script: " + luaPath.string());
-    luaPath_ = luaPath; // remember for embedding in the replay
-    bnw::cout << "Lua script loaded: " << luaPath << '\n';
 }
 
 void HeadlessGame::SaveGame(const bfs::path& path) const

--- a/extras/ai-battle/HeadlessGame.h
+++ b/extras/ai-battle/HeadlessGame.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Game.h"
+#include "ILocalGameState.h"
 #include "Replay.h"
 #include "ai/AIPlayer.h"
 #include "gameTypes/AIInfo.h"
@@ -34,6 +35,15 @@ public:
 private:
     void PrintState();
 
+    struct LocalState : ILocalGameState
+    {
+        unsigned GetPlayerId() const override { return 0; }
+        bool IsHost() const override { return true; }
+        std::string FormatGFTime(unsigned) const override { return ""; }
+        void SystemChat(const std::string&) override {}
+    };
+
+    LocalState localState_;
     boost::filesystem::path map_;
     Game game_;
     GameWorld& world_;

--- a/extras/ai-battle/HeadlessGame.h
+++ b/extras/ai-battle/HeadlessGame.h
@@ -9,6 +9,7 @@
 #include "Replay.h"
 #include "ai/AIPlayer.h"
 #include "gameTypes/AIInfo.h"
+#include "gameTypes/TeamTypes.h"
 #include <boost/filesystem.hpp>
 #include <chrono>
 #include <limits>
@@ -22,8 +23,10 @@ class EventManager;
 class HeadlessGame
 {
 public:
+    /// teams: optional per-player team assignment (index -> Team). Players sharing a team get start
+    /// pacts (ally + non-aggression), so only opposing teams fight. Defaults to no teams.
     HeadlessGame(const GlobalGameSettings& ggs, const boost::filesystem::path& map, const std::vector<AI::Info>& ais,
-                 const boost::filesystem::path& luaPath = {});
+                 const boost::filesystem::path& luaPath = {}, const std::vector<Team>& teams = {});
     ~HeadlessGame();
 
     void Run(unsigned maxGF = std::numeric_limits<unsigned>::max());

--- a/extras/ai-battle/HeadlessGame.h
+++ b/extras/ai-battle/HeadlessGame.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -29,6 +29,7 @@ public:
 
     void RecordReplay(const boost::filesystem::path& path, unsigned random_init);
     void SaveGame(const boost::filesystem::path& path) const;
+    void LoadLuaScript(const boost::filesystem::path& luaPath);
 
 private:
     void PrintState();
@@ -41,6 +42,7 @@ private:
 
     Replay replay_;
     boost::filesystem::path replayPath_;
+    boost::filesystem::path luaPath_;
 
     unsigned lastReportGf_ = 0;
     std::chrono::steady_clock::time_point gameStartTime_;

--- a/extras/ai-battle/HeadlessGame.h
+++ b/extras/ai-battle/HeadlessGame.h
@@ -22,7 +22,8 @@ class EventManager;
 class HeadlessGame
 {
 public:
-    HeadlessGame(const GlobalGameSettings& ggs, const boost::filesystem::path& map, const std::vector<AI::Info>& ais);
+    HeadlessGame(const GlobalGameSettings& ggs, const boost::filesystem::path& map, const std::vector<AI::Info>& ais,
+                 const boost::filesystem::path& luaPath = {});
     ~HeadlessGame();
 
     void Run(unsigned maxGF = std::numeric_limits<unsigned>::max());
@@ -30,7 +31,6 @@ public:
 
     void RecordReplay(const boost::filesystem::path& path, unsigned random_init);
     void SaveGame(const boost::filesystem::path& path) const;
-    void LoadLuaScript(const boost::filesystem::path& luaPath);
 
 private:
     void PrintState();

--- a/extras/ai-battle/main.cpp
+++ b/extras/ai-battle/main.cpp
@@ -14,6 +14,7 @@
 #include "ai/random.h"
 #include "files.h"
 #include "random/Random.h"
+#include "s25util/StringConversion.h"
 #include "s25util/System.h"
 
 #include <boost/filesystem.hpp>
@@ -55,7 +56,7 @@ static void loadAddonsFromIni(GlobalGameSettings& ggs, const bfs::path& iniPath)
     {
         try
         {
-            const auto id = static_cast<AddonId>(std::stoul(entry.first));
+            const auto id = static_cast<AddonId>(s25util::fromStringClassic<unsigned>(entry.first));
             const auto v = entry.second.get_value<unsigned>();
             ggs.setSelection(id, v);
             ++loaded;

--- a/extras/ai-battle/main.cpp
+++ b/extras/ai-battle/main.cpp
@@ -29,35 +29,6 @@ namespace bnw = boost::nowide;
 namespace bfs = boost::filesystem;
 namespace po = boost::program_options;
 
-static void printBriefUsage(const char* prog)
-{
-    bnw::cerr << "Usage: " << prog
-              << " -m <map> --ai aijh|dummy [--ai ...] [options]\n"
-                 "Run with --help or -h for a full list of options and examples.\n";
-}
-
-static const char PATH_EXPANSION_HELP[] =
-  "\nPath expansion (all path options):\n"
-  "  All paths support <RTTR_X> placeholders and a leading ~.\n"
-  "  ~ is expanded by the application: %USERPROFILE%\\Saved Games on Windows,\n"
-  "  $HOME on Linux/macOS.\n"
-  "  Available placeholders:\n"
-  "    <RTTR_USERDATA>   user data dir\n"
-  "                        Windows : %USERPROFILE%\\Saved Games\\Return To The Roots\n"
-  "                        Linux   : $HOME/.s25rttr\n"
-  "                        macOS   : $HOME/Library/Application Support/Return To The Roots\n"
-  "    <RTTR_DATA>       RTTR data directory\n"
-  "    <RTTR_GAME>       directory containing S2 DATA/ and GFX/ folders\n"
-  "    <RTTR_RTTR>       <RTTR_DATA>/RTTR sub-directory\n"
-  "    <RTTR_BIN>        binary directory\n"
-  "    <RTTR_EXTRA_BIN>  extra binary directory\n"
-  "    <RTTR_LIB>        library directory\n"
-  "    <RTTR_DRIVER>     driver directory\n"
-  "  Each placeholder can be overridden with the RTTR_<ID>_DIR environment variable.\n"
-  "\nExample:\n"
-  "  ai-battle -m maps/Wal5.swd --ai 3 --ai 3 --wares alot"
-  " --settings \"<RTTR_USERDATA>/CONFIG.INI\"\n";
-
 static void loadAddonsFromIni(GlobalGameSettings& ggs, const bfs::path& iniPath)
 {
     if(!bfs::exists(iniPath))
@@ -105,41 +76,32 @@ int main(int argc, char** argv)
     po::options_description desc("Allowed options");
     // clang-format off
     desc.add_options()
-        ("help,h", "Show this detailed help and exit.")
-        ("map,m", po::value<std::string>()->required(),
-                        "Path to the map file (.swd/.wld).")
-        ("ai", po::value<std::vector<std::string>>()->required(),
-                        "AI player to add: aijh (the AIJH AI) | dummy (does nothing).\n"
-                        "Case-insensitive. Repeat the flag once per player (e.g. --ai aijh --ai aijh).")
-        ("objective", po::value<std::string>()->default_value("domination"),
-                        "Win condition: domination (default) | conquer")
-        ("wares", po::value<std::string>()->default_value("normal"),
-                        "Starting wares for all players: vlow | low | normal (default) | alot")
-        ("settings", po::value(&settings_path),
-                        "INI file with an [addons] section to configure addon settings (optional).\n"
-                        "Keys are numeric AddonId values; values are the option index to select.\n"
-                        "When omitted, all addons use their default values.")
-        ("replay", po::value(&replay_path),
-                        "File to write a replay to (optional). If a Lua script was loaded via --lua\n"
-                        "it is embedded into the replay automatically.")
-        ("save", po::value(&savegame_path),
-                        "File to write a savegame to after the run (optional).")
-        ("lua", po::value(&lua_path),
-                        "Lua script to execute during the game (optional). The script is also embedded\n"
-                        "into the replay when --replay is used.")
-        ("random_init", po::value(&random_init),
-                        "Seed for the main random number generator (optional, default: time-based).")
-        ("random_ai_init", po::value(&random_ai_init),
-                        "Seed for the AI random number generator (optional, defaults to random_init).")
-        ("maxGF", po::value<unsigned>()->default_value(std::numeric_limits<unsigned>::max()),
-                        "Maximum number of game frames to simulate before stopping (optional).")
-        ("version", "Show version information and exit.")
+        ("help,h", "Show help")
+        ("map,m", po::value<std::string>()->required(),"Map to load")
+        ("ai", po::value<std::vector<std::string>>()->required(),"AI player(s) to add (aijh | dummy)")
+        ("objective", po::value<std::string>()->default_value("domination"),"domination(default) | conquer")
+        ("wares", po::value<std::string>()->default_value("normal"),"Starting wares: vlow | low | normal (default) | alot")
+        ("settings", po::value(&settings_path),"INI file with an [addons] section to configure addon settings (optional)")
+        ("replay", po::value(&replay_path),"Filename to write replay to (optional)")
+        ("save", po::value(&savegame_path),"Filename to write savegame to (optional)")
+        ("lua", po::value(&lua_path),"Lua script to execute during the game (optional)")
+        ("random_init", po::value(&random_init),"Seed value for the random number generator (optional)")
+        ("random_ai_init", po::value(&random_ai_init),"Seed value for the AI random number generator (optional)")
+        ("maxGF", po::value<unsigned>()->default_value(std::numeric_limits<unsigned>::max()),"Maximum number of game frames to run (optional)")
+        ("version", "Show version information and exit")
         ;
     // clang-format on
 
+    const auto printHelp = [&](std::ostream& os) {
+        os << desc
+           << "\nNote: path arguments support the <RTTR_USERDATA> placeholder "
+              "(game data folder: SAVES, REPLAYS, MAPS, PRESETS)."
+           << std::endl;
+    };
+
     if(argc == 1)
     {
-        printBriefUsage(argv[0]);
+        printHelp(bnw::cerr);
         return 1;
     }
 
@@ -150,7 +112,7 @@ int main(int argc, char** argv)
 
         if(options.count("help"))
         {
-            bnw::cout << desc << PATH_EXPANSION_HELP << std::endl;
+            printHelp(bnw::cout);
             return 0;
         }
         if(options.count("version"))
@@ -165,7 +127,7 @@ int main(int argc, char** argv)
     } catch(const std::exception& e)
     {
         bnw::cerr << "Error: " << e.what() << std::endl;
-        printBriefUsage(argv[0]);
+        printHelp(bnw::cerr);
         return 1;
     }
 

--- a/extras/ai-battle/main.cpp
+++ b/extras/ai-battle/main.cpp
@@ -13,6 +13,7 @@
 #include "addons/const_addons.h"
 #include "ai/random.h"
 #include "files.h"
+#include "gameTypes/TeamTypes.h"
 #include "random/Random.h"
 #include "s25util/StringConversion.h"
 #include "s25util/System.h"
@@ -24,6 +25,7 @@
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <iomanip>
+#include <sstream>
 #if BOOST_VERSION >= 109000
 #    include <optional>
 using std::optional;
@@ -86,6 +88,7 @@ int main(int argc, char** argv)
         ("help,h", "Show help")
         ("map,m", po::value<std::string>()->required(),"Map to load")
         ("ai", po::value<std::vector<std::string>>()->required(),"AI player(s) to add (aijh | dummy)")
+        ("teams", po::value<std::string>(),"Team assignment, e.g. \"0,1;2,3\" for a 2v2 (groups separated by ';', player indices by ','). Allied players get start pacts.")
         ("objective", po::value<std::string>()->default_value("domination"),"domination(default) | conquer")
         ("wares", po::value<std::string>()->default_value("normal"),"Starting wares: vlow | low | normal (default) | alot")
         ("settings", po::value(&settings_path),"INI file with an [addons] section to configure addon settings (optional)")
@@ -207,7 +210,32 @@ int main(int argc, char** argv)
             }
         }
 
-        HeadlessGame game(ggs, mapPath, ais, lua_path ? RTTRCONFIG.ExpandPath(*lua_path) : bfs::path{});
+        // Team assignment, e.g. "0,1;2,3". Player index -> Team (Team1, Team2, ...).
+        std::vector<Team> teams;
+        if(options.count("teams"))
+        {
+            std::stringstream groups(options["teams"].as<std::string>());
+            std::string group;
+            unsigned teamIdx = 0;
+            while(std::getline(groups, group, ';'))
+            {
+                const Team team = static_cast<Team>(static_cast<uint8_t>(Team::Team1) + teamIdx);
+                std::stringstream members(group);
+                std::string idx;
+                while(std::getline(members, idx, ','))
+                {
+                    if(idx.empty())
+                        continue;
+                    const unsigned p = static_cast<unsigned>(std::stoul(idx));
+                    if(p >= teams.size())
+                        teams.resize(p + 1, Team::None);
+                    teams[p] = team;
+                }
+                ++teamIdx;
+            }
+        }
+
+        HeadlessGame game(ggs, mapPath, ais, lua_path ? RTTRCONFIG.ExpandPath(*lua_path) : bfs::path{}, teams);
         if(replay_path)
             game.RecordReplay(RTTRCONFIG.ExpandPath(*replay_path), random_init);
 

--- a/extras/ai-battle/main.cpp
+++ b/extras/ai-battle/main.cpp
@@ -50,7 +50,7 @@ static void loadAddonsFromIni(GlobalGameSettings& ggs, const bfs::path& iniPath)
         try
         {
             const auto id = static_cast<AddonId>(std::stoul(entry.first));
-            const unsigned v = entry.second.get_value<unsigned>();
+            const auto v = entry.second.get_value<unsigned>();
             ggs.setSelection(id, v);
             ++loaded;
         } catch(const std::exception&)

--- a/extras/ai-battle/main.cpp
+++ b/extras/ai-battle/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2024 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -7,6 +7,10 @@
 #include "QuickStartGame.h"
 #include "RTTR_Version.h"
 #include "RttrConfig.h"
+#include "addons/Addon.h"
+#include "addons/AddonBool.h"
+#include "addons/AddonList.h"
+#include "addons/const_addons.h"
 #include "ai/random.h"
 #include "files.h"
 #include "random/Random.h"
@@ -18,10 +22,73 @@
 #include <boost/nowide/iostream.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+#include <iomanip>
 
 namespace bnw = boost::nowide;
 namespace bfs = boost::filesystem;
 namespace po = boost::program_options;
+
+static void printBriefUsage(const char* prog)
+{
+    bnw::cerr << "Usage: " << prog
+              << " -m <map> --ai aijh|dummy [--ai ...] [options]\n"
+                 "Run with --help or -h for a full list of options and examples.\n";
+}
+
+static const char PATH_EXPANSION_HELP[] =
+  "\nPath expansion (all path options):\n"
+  "  All paths support <RTTR_X> placeholders and a leading ~.\n"
+  "  ~ is expanded by the application: %USERPROFILE%\\Saved Games on Windows,\n"
+  "  $HOME on Linux/macOS.\n"
+  "  Available placeholders:\n"
+  "    <RTTR_USERDATA>   user data dir\n"
+  "                        Windows : %USERPROFILE%\\Saved Games\\Return To The Roots\n"
+  "                        Linux   : $HOME/.s25rttr\n"
+  "                        macOS   : $HOME/Library/Application Support/Return To The Roots\n"
+  "    <RTTR_DATA>       RTTR data directory\n"
+  "    <RTTR_GAME>       directory containing S2 DATA/ and GFX/ folders\n"
+  "    <RTTR_RTTR>       <RTTR_DATA>/RTTR sub-directory\n"
+  "    <RTTR_BIN>        binary directory\n"
+  "    <RTTR_EXTRA_BIN>  extra binary directory\n"
+  "    <RTTR_LIB>        library directory\n"
+  "    <RTTR_DRIVER>     driver directory\n"
+  "  Each placeholder can be overridden with the RTTR_<ID>_DIR environment variable.\n"
+  "\nExample:\n"
+  "  ai-battle -m maps/Wal5.swd --ai 3 --ai 3 --wares alot"
+  " --settings \"<RTTR_USERDATA>/CONFIG.INI\"\n";
+
+static void loadAddonsFromIni(GlobalGameSettings& ggs, const bfs::path& iniPath)
+{
+    if(!bfs::exists(iniPath))
+        throw std::runtime_error("Settings file not found: " + iniPath.string());
+
+    boost::property_tree::ptree tree;
+    boost::property_tree::read_ini(iniPath.string(), tree);
+
+    const auto addons = tree.get_child_optional("addons");
+    if(!addons)
+    {
+        bnw::cout << "Note: no [addons] section in " << iniPath << ", using defaults.\n";
+        return;
+    }
+
+    unsigned loaded = 0;
+    for(const auto& entry : *addons)
+    {
+        try
+        {
+            const auto id = static_cast<AddonId>(std::stoul(entry.first));
+            const unsigned v = entry.second.get_value<unsigned>();
+            ggs.setSelection(id, v);
+            ++loaded;
+        } catch(const std::exception&)
+        {
+            // Unknown or invalid entry - skip silently
+        }
+    }
+    bnw::cout << "Loaded " << loaded << " addon settings from " << iniPath << '\n';
+}
 
 int main(int argc, char** argv)
 {
@@ -30,28 +97,49 @@ int main(int argc, char** argv)
 
     boost::optional<std::string> replay_path;
     boost::optional<std::string> savegame_path;
+    boost::optional<std::string> lua_path;
+    boost::optional<std::string> settings_path;
     unsigned random_init = static_cast<unsigned>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     unsigned random_ai_init = random_init;
 
     po::options_description desc("Allowed options");
     // clang-format off
     desc.add_options()
-        ("help,h", "Show help")
-        ("map,m", po::value<std::string>()->required(),"Map to load")
-        ("ai", po::value<std::vector<std::string>>()->required(),"AI player(s) to add")
-        ("objective", po::value<std::string>()->default_value("domination"),"domination(default)|conquer")
-        ("replay", po::value(&replay_path),"Filename to write replay to (optional)")
-        ("save", po::value(&savegame_path),"Filename to write savegame to (optional)")
-        ("random_init", po::value(&random_init),"Seed value for the random number generator (optional)")
-        ("random_ai_init", po::value(&random_ai_init),"Seed value for the AI random number generator (optional)")
-        ("maxGF", po::value<unsigned>()->default_value(std::numeric_limits<unsigned>::max()),"Maximum number of game frames to run (optional)")
-        ("version", "Show version information and exit")
+        ("help,h", "Show this detailed help and exit.")
+        ("map,m", po::value<std::string>()->required(),
+                        "Path to the map file (.swd/.wld).")
+        ("ai", po::value<std::vector<std::string>>()->required(),
+                        "AI player to add: aijh (the AIJH AI) | dummy (does nothing).\n"
+                        "Case-insensitive. Repeat the flag once per player (e.g. --ai aijh --ai aijh).")
+        ("objective", po::value<std::string>()->default_value("domination"),
+                        "Win condition: domination (default) | conquer")
+        ("wares", po::value<std::string>()->default_value("normal"),
+                        "Starting wares for all players: vlow | low | normal (default) | alot")
+        ("settings", po::value(&settings_path),
+                        "INI file with an [addons] section to configure addon settings (optional).\n"
+                        "Keys are numeric AddonId values; values are the option index to select.\n"
+                        "When omitted, all addons use their default values.")
+        ("replay", po::value(&replay_path),
+                        "File to write a replay to (optional). If a Lua script was loaded via --lua\n"
+                        "it is embedded into the replay automatically.")
+        ("save", po::value(&savegame_path),
+                        "File to write a savegame to after the run (optional).")
+        ("lua", po::value(&lua_path),
+                        "Lua script to execute during the game (optional). The script is also embedded\n"
+                        "into the replay when --replay is used.")
+        ("random_init", po::value(&random_init),
+                        "Seed for the main random number generator (optional, default: time-based).")
+        ("random_ai_init", po::value(&random_ai_init),
+                        "Seed for the AI random number generator (optional, defaults to random_init).")
+        ("maxGF", po::value<unsigned>()->default_value(std::numeric_limits<unsigned>::max()),
+                        "Maximum number of game frames to simulate before stopping (optional).")
+        ("version", "Show version information and exit.")
         ;
     // clang-format on
 
     if(argc == 1)
     {
-        bnw::cerr << desc << std::endl;
+        printBriefUsage(argv[0]);
         return 1;
     }
 
@@ -62,7 +150,7 @@ int main(int argc, char** argv)
 
         if(options.count("help"))
         {
-            bnw::cout << desc << std::endl;
+            bnw::cout << desc << PATH_EXPANSION_HELP << std::endl;
             return 0;
         }
         if(options.count("version"))
@@ -77,7 +165,7 @@ int main(int argc, char** argv)
     } catch(const std::exception& e)
     {
         bnw::cerr << "Error: " << e.what() << std::endl;
-        bnw::cerr << desc << std::endl;
+        printBriefUsage(argv[0]);
         return 1;
     }
 
@@ -110,15 +198,56 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        ggs.objective = GameObjective::TotalDomination;
+        const auto wares = options["wares"].as<std::string>();
+        if(wares == "vlow")
+            ggs.startWares = StartWares::VLow;
+        else if(wares == "low")
+            ggs.startWares = StartWares::Low;
+        else if(wares == "normal")
+            ggs.startWares = StartWares::Normal;
+        else if(wares == "alot")
+            ggs.startWares = StartWares::ALot;
+        else
+        {
+            bnw::cerr << "Unknown wares value: " << wares << std::endl;
+            return 1;
+        }
+
+        if(settings_path)
+        {
+            loadAddonsFromIni(ggs, RTTRCONFIG.ExpandPath(*settings_path));
+
+            bnw::cout << "settings: " << RTTRCONFIG.ExpandPath(*settings_path) << std::endl;
+            bnw::cout << "addon selections (non-default only):" << std::endl;
+            for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+            {
+                unsigned status = 0;
+                const Addon* addon = ggs.getAddon(i, status);
+                if(addon && status != addon->getDefaultStatus())
+                {
+                    bnw::cout << "  [0x" << std::hex << std::setw(8) << std::setfill('0')
+                              << static_cast<unsigned>(addon->getId()) << std::dec << "] " << addon->getName() << " = ";
+                    if(const auto* listAddon = dynamic_cast<const AddonList*>(addon))
+                        bnw::cout << listAddon->getOptionName(status);
+                    else if(dynamic_cast<const AddonBool*>(addon))
+                        bnw::cout << (status ? "True" : "False");
+                    else
+                        bnw::cout << status;
+                    bnw::cout << std::endl;
+                }
+            }
+        }
+
         HeadlessGame game(ggs, mapPath, ais);
+        if(lua_path)
+            game.LoadLuaScript(RTTRCONFIG.ExpandPath(*lua_path));
         if(replay_path)
-            game.RecordReplay(*replay_path, random_init);
+            game.RecordReplay(RTTRCONFIG.ExpandPath(*replay_path), random_init);
 
         game.Run(options["maxGF"].as<unsigned>());
         game.Close();
         if(savegame_path)
-            game.SaveGame(*savegame_path);
+            game.SaveGame(RTTRCONFIG.ExpandPath(*savegame_path));
     } catch(const std::exception& e)
     {
         bnw::cerr << e.what() << std::endl;

--- a/extras/ai-battle/main.cpp
+++ b/extras/ai-battle/main.cpp
@@ -200,9 +200,7 @@ int main(int argc, char** argv)
             }
         }
 
-        HeadlessGame game(ggs, mapPath, ais);
-        if(lua_path)
-            game.LoadLuaScript(RTTRCONFIG.ExpandPath(*lua_path));
+        HeadlessGame game(ggs, mapPath, ais, lua_path ? RTTRCONFIG.ExpandPath(*lua_path) : bfs::path{});
         if(replay_path)
             game.RecordReplay(RTTRCONFIG.ExpandPath(*replay_path), random_init);
 

--- a/extras/ai-battle/main.cpp
+++ b/extras/ai-battle/main.cpp
@@ -46,26 +46,32 @@ static void loadAddonsFromIni(GlobalGameSettings& ggs, const bfs::path& iniPath)
     boost::property_tree::ptree tree;
     boost::property_tree::read_ini(iniPath.string(), tree);
 
+    if(tree.empty()) // empty file -> nothing to configure, that's fine
+        return;
+
+    // Anything else is intentional configuration, so surface mistakes as hard errors instead of
+    // silently ignoring them (a mistyped section or key/value would otherwise go unnoticed).
     const auto addons = tree.get_child_optional("addons");
     if(!addons)
-    {
-        bnw::cout << "Note: no [addons] section in " << iniPath << ", using defaults.\n";
-        return;
-    }
+        throw std::runtime_error("No [addons] section in " + iniPath.string());
 
     unsigned loaded = 0;
     for(const auto& entry : *addons)
     {
+        AddonId id{};
+        unsigned value = 0;
         try
         {
-            const auto id = static_cast<AddonId>(s25util::fromStringClassic<unsigned>(entry.first));
-            const auto v = entry.second.get_value<unsigned>();
-            ggs.setSelection(id, v);
-            ++loaded;
+            id = static_cast<AddonId>(s25util::fromStringClassic<unsigned>(entry.first));
+            value = entry.second.get_value<unsigned>();
         } catch(const std::exception&)
         {
-            // Unknown or invalid entry - skip silently
+            throw std::runtime_error("Invalid addon entry '" + entry.first + "' in " + iniPath.string());
         }
+        if(!ggs.getAddon(id)) // unknown/unsupported addon id
+            throw std::runtime_error("Unknown addon id '" + entry.first + "' in " + iniPath.string());
+        ggs.setSelection(id, value);
+        ++loaded;
     }
     bnw::cout << "Loaded " << loaded << " addon settings from " << iniPath << '\n';
 }

--- a/libs/libGamedata/lua/LuaInterfaceBase.cpp
+++ b/libs/libGamedata/lua/LuaInterfaceBase.cpp
@@ -168,5 +168,5 @@ bool LuaInterfaceBase::validateUTF8(const std::string& scriptTxt)
 
 void LuaInterfaceBase::log(const std::string& msg)
 {
-    logger_.write("%s\n") % msg;
+    logger_.write("%s\n", suppressStdout_ ? LogTarget::File : LogTarget::FileAndStdout) % msg;
 }

--- a/libs/libGamedata/lua/LuaInterfaceBase.h
+++ b/libs/libGamedata/lua/LuaInterfaceBase.h
@@ -35,6 +35,7 @@ public:
     /// Disable or re-enable throwing an exception on error.
     /// Note: If error throwing is disabled you have to use HasErrorOccurred to detect an error situation
     void setThrowOnError(bool doThrow);
+    void setSuppressStdout(bool suppress) { suppressStdout_ = suppress; }
     bool hasErrorOccurred() const { return errorOccured_; }
     void clearErrorOccured() { errorOccured_ = false; }
 
@@ -60,6 +61,7 @@ protected:
 
 private:
     Log& logger_;
+    bool suppressStdout_ = false;
     /// Sticky flag to signal an occurred error during execution of lua code
     bool errorOccured_;
     std::map<std::string, std::string> translations_;

--- a/libs/s25main/addons/AddonList.cpp
+++ b/libs/s25main/addons/AddonList.cpp
@@ -26,6 +26,11 @@ unsigned AddonList::getNumOptions() const
     return options.size();
 }
 
+const std::string& AddonList::getOptionName(unsigned status) const
+{
+    return options.at(status);
+}
+
 AddonList::Gui::Gui(const AddonList& addon, Window& window, bool readonly) : AddonGui(addon, window, readonly)
 {
     DrawPoint cbPos(430, 0);

--- a/libs/s25main/addons/AddonList.h
+++ b/libs/s25main/addons/AddonList.h
@@ -25,6 +25,7 @@ public:
               std::vector<std::string> options, unsigned defaultStatus = 0);
 
     unsigned getNumOptions() const override;
+    const std::string& getOptionName(unsigned status) const;
 
     std::unique_ptr<AddonGui> createGui(Window& window, bool readonly) const override;
 


### PR DESCRIPTION
# ai-battle: support team assignment (`--teams`) and establish team start-pacts

Builds on #1949 (uses its `HeadlessGame`). Two commits:

### 1. `--teams` option for team assignment

Adds a `--teams` option to the headless ai-battle harness so the AI can be
verified under real team rules instead of a free-for-all:

```
ai-battle -m Map.swd --ai aijh --ai aijh --ai aijh --ai aijh --teams "0,1;2,3"
```

Groups are separated by `;`, player indices by `,`. The first group becomes
`Team1`, the second `Team2`, and so on; unlisted players stay teamless. The
assignment is threaded through `HeadlessGame` into `GeneratePlayerInfo`, which
sets `PlayerInfo::team`.

### 2. Establish team start-pacts in `HeadlessGame` to match `GameClient` (avoid desyncs in replays)

`GameClient::StartGame` calls `GamePlayer::MakeStartPacts()` for every player on
a fresh map, creating the ally + non-aggression pacts that bind a team together.
`HeadlessGame` never did this, so a recorded ai-battle with teams had no pacts:
`GamePlayer::IsAttackable()` returned `true` for teammates and the AIs attacked
their own team. On replay `GameClient` *does* set up the pacts, so the recorded
inter-team attack commands hit allied players and were resolved differently —
producing an object-count divergence (replay desync) **without** any RANDOM
divergence.

`MakeStartPacts()` early-returns for `Team::None`, so the call is a no-op until
players are actually assigned to teams via `--teams`. Together with the
`MapLoader::SetupResources()` call already in `HeadlessGame`, this makes the
headless world setup match the `GameClient` replay path.

### Note
- Depends on #1949 — best merged after it (or rebased onto master once #1949 lands).
