### PR TITLE
rttr:AddTerrain() for MyMap.lua

### DIFF
--- a/libs/libGamedata/lua/GameDataLoader.cpp
+++ b/libs/libGamedata/lua/GameDataLoader.cpp
@@ -96,19 +96,60 @@ void GameDataLoader::Include(const std::string& filepath)
     }
 }
 
+void addLandscape(WorldDescription& worldDesc, const kaguya::LuaTable& data)
+{
+    worldDesc.landscapes.add(LandscapeDesc(CheckedLuaTable(data), worldDesc));
+}
+
+void addTerrainEdge(WorldDescription& worldDesc, const kaguya::LuaTable& data)
+{
+    worldDesc.edges.add(EdgeDesc(CheckedLuaTable(data), worldDesc));
+}
+
+void addTerrain(WorldDescription& worldDesc, const kaguya::LuaTable& data)
+{
+    TerrainDesc terrain(CheckedLuaTable(data), worldDesc);
+
+    // Validate s2Id
+    if(terrain.s2Id != 0xFF)
+    {
+        // Bit 6 (0x40) is the harbour flag (libsiedler2::HARBOR_MASK) in the S2 map format.
+        // It is a per-node flag in the map file, not part of the terrain identity.
+        if(terrain.s2Id & 0x40)
+        {
+            throw GameDataLoadError(
+              helpers::format("Terrain '%1%' has s2Id 0x%2$x with the harbour bit (0x40) set. "
+                              "This bit is reserved for per-node map data (libsiedler2::HARBOR_MASK) "
+                              "and must not be used as part of the terrain ID.",
+                              terrain.name, terrain.s2Id));
+        }
+        // Check that no other terrain with the same s2Id + landscape combination exists.
+        if(worldDesc.terrain.find([s2Id = terrain.s2Id, landscape = terrain.landscape](const TerrainDesc& t) {
+               return t.s2Id == s2Id && t.landscape == landscape;
+           }))
+        {
+            throw GameDataLoadError(helpers::format("Duplicate s2Id 0x%1$x for landscape '%2%' in terrain '%3%'",
+                                                    terrain.s2Id, worldDesc.landscapes.get(terrain.landscape).name,
+                                                    terrain.name));
+        }
+    }
+
+    worldDesc.terrain.add(std::move(terrain));
+}
+
 void GameDataLoader::AddLandscape(const kaguya::LuaTable& data)
 {
-    worldDesc_.landscapes.add(LandscapeDesc(data, worldDesc_));
+    addLandscape(worldDesc_, data);
 }
 
 void GameDataLoader::AddTerrainEdge(const kaguya::LuaTable& data)
 {
-    worldDesc_.edges.add(EdgeDesc(data, worldDesc_));
+    addTerrainEdge(worldDesc_, data);
 }
 
 void GameDataLoader::AddTerrain(const kaguya::LuaTable& data)
 {
-    worldDesc_.terrain.add(TerrainDesc(data, worldDesc_));
+    addTerrain(worldDesc_, data);
 }
 
 void loadGameData(WorldDescription& worldDesc)

--- a/libs/libGamedata/lua/GameDataLoader.h
+++ b/libs/libGamedata/lua/GameDataLoader.h
@@ -35,4 +35,12 @@ private:
     int curIncludeDepth_;
 };
 
+/// @name Shared helpers for adding world description items from Lua tables
+/// These can be used by both GameDataLoader (game data init) and LuaInterfaceGame (companion scripts).
+/// \{
+void addTerrain(WorldDescription& worldDesc, const kaguya::LuaTable& data);
+void addLandscape(WorldDescription& worldDesc, const kaguya::LuaTable& data);
+void addTerrainEdge(WorldDescription& worldDesc, const kaguya::LuaTable& data);
+/// \}
+
 void loadGameData(WorldDescription& worldDesc);

--- a/libs/rttrConfig/src/RttrConfig.cpp
+++ b/libs/rttrConfig/src/RttrConfig.cpp
@@ -121,6 +121,11 @@ void RttrConfig::overridePathMapping(const std::string& id, const boost::filesys
     pathMappings[id] = path;
 }
 
+void RttrConfig::addPathMapping(const std::string& id, const boost::filesystem::path& path)
+{
+    pathMappings[id] = path;
+}
+
 bool RttrConfig::Init()
 {
     prefixPath_ = GetPrefixPath();

--- a/libs/rttrConfig/src/RttrConfig.h
+++ b/libs/rttrConfig/src/RttrConfig.h
@@ -27,6 +27,8 @@ public:
     boost::filesystem::path ExpandPath(const std::string& path) const;
     /// Overwrite a given path mapping
     void overridePathMapping(const std::string& id, const boost::filesystem::path& path);
+    /// Register a new path mapping (used for dynamic prefixes like <RTTR_MAP>)
+    void addPathMapping(const std::string& id, const boost::filesystem::path& path);
 };
 
 #define RTTRCONFIG RttrConfig::inst()

--- a/libs/s25main/lua/LuaInterfaceGame.cpp
+++ b/libs/s25main/lua/LuaInterfaceGame.cpp
@@ -5,10 +5,12 @@
 #include "LuaInterfaceGame.h"
 #include "EventManager.h"
 #include "Game.h"
+#include "RttrConfig.h"
 #include "WindowManager.h"
 #include "ai/AIInterface.h"
 #include "ai/AIPlayer.h"
 #include "ingameWindows/iwMissionStatement.h"
+#include "lua/GameDataLoader.h"
 #include "lua/LuaHelpers.h"
 #include "lua/LuaPlayer.h"
 #include "lua/LuaWorld.h"
@@ -206,6 +208,7 @@ KAGUYA_MEMBER_FUNCTION_OVERLOADS(SetMissionGoalWrapper, LuaInterfaceGame, SetMis
 void LuaInterfaceGame::Register(kaguya::State& state)
 {
     state["RTTRGame"].setClass(kaguya::UserdataMetatable<LuaInterfaceGame, LuaInterfaceGameBase>()
+                                 .addFunction("AddTerrain", &LuaInterfaceGame::AddTerrain)
                                  .addFunction("ClearResources", &LuaInterfaceGame::ClearResources)
                                  .addFunction("GetGF", &LuaInterfaceGame::GetGF)
                                  .addFunction("FormatNumGFs", &LuaInterfaceGame::FormatNumGFs)
@@ -257,6 +260,42 @@ bool LuaInterfaceGame::Deserialize(Serializer& luaSaveState)
         return load.call<bool>(kaguya::standard::ref(luaSaveState)) && !hasErrorOccurred();
     } else
         return true;
+}
+
+void LuaInterfaceGame::SetMapDir(const boost::filesystem::path& mapDir)
+{
+    mapDir_ = mapDir;
+    RTTRCONFIG.addPathMapping("MAP", mapDir);
+}
+
+void LuaInterfaceGame::AddTerrain(const kaguya::LuaTable& data)
+{
+    if(!mapDir_.empty())
+    {
+        // Resolve relative texture paths to <RTTR_MAP>/filename
+        kaguya::LuaRef texRef = data["texture"];
+        if(texRef.type() == LUA_TSTRING)
+        {
+            std::string texPath = texRef;
+            if(texPath.find("<RTTR_") != 0 && !texPath.empty())
+            {
+                boost::filesystem::path p(texPath);
+                if(p.is_absolute())
+                {
+                    throw LuaExecutionError("Absolute paths not allowed in AddTerrain texture path: " + texPath);
+                }
+                // Prevent directory traversal
+                if(texPath.find("..") != std::string::npos)
+                {
+                    throw LuaExecutionError("Invalid texture path '" + texPath + "': must not contain '..'");
+                }
+                // Use <RTTR_MAP> prefix so validatePath and ExpandPath handle it naturally
+                kaguya::LuaTable mutableData = data;
+                mutableData["texture"] = std::string("<RTTR_MAP>/") + texPath;
+            }
+        }
+    }
+    addTerrain(gw.GetDescriptionWriteable(), data);
 }
 
 void LuaInterfaceGame::ClearResources()

--- a/libs/s25main/lua/LuaInterfaceGame.h
+++ b/libs/s25main/lua/LuaInterfaceGame.h
@@ -7,6 +7,7 @@
 #include "LuaInterfaceGameBase.h"
 #include "gameTypes/MapCoordinates.h"
 #include "gameTypes/PactTypes.h"
+#include <boost/filesystem/path.hpp>
 #include <memory>
 #include <string>
 
@@ -45,7 +46,12 @@ public:
     // called if pact was created
     void EventPactCreated(PactType pt, unsigned char suggestedByPlayerId, unsigned char targetPlayerId,
                           unsigned duration);
+    /// Set the directory from which relative texture paths in AddTerrain are resolved.
+    /// Registers <RTTR_MAP> so that ExpandPath and validatePath can resolve it.
+    void SetMapDir(const boost::filesystem::path& mapDir);
+
     // Callable from Lua
+    void AddTerrain(const kaguya::LuaTable& data);
     void ClearResources();
     unsigned GetGF() const;
     std::string FormatNumGFs(unsigned numGFs) const;
@@ -63,6 +69,7 @@ private:
     ILocalGameState& localGameState;
     GameWorld& gw;
     Game& game;
+    boost::filesystem::path mapDir_; ///< Base dir for resolving relative texture paths in AddTerrain
     LuaPlayer GetPlayer(int playerIdx);
     LuaWorld GetWorld();
 };

--- a/libs/s25main/world/MapLoader.cpp
+++ b/libs/s25main/world/MapLoader.cpp
@@ -94,6 +94,7 @@ bool MapLoader::LoadLuaScript(Game& game, ILocalGameState& localgameState, const
     if(!bfs::exists(luaFilePath))
         return false;
     auto lua = std::make_unique<LuaInterfaceGame>(game, localgameState);
+    lua->SetMapDir(luaFilePath.parent_path());
     if(!lua->loadScript(luaFilePath) || !lua->CheckScriptVersion())
         return false;
     game.SetLua(std::move(lua));
@@ -254,8 +255,8 @@ bool MapLoader::InitNodes(const libsiedler2::ArchivItem_Map& map, Exploration ex
         // Will be set later
         node.harborId.reset();
 
-        node.t1 = getTerrainFromS2(t1 & 0x3F); // Only lower 6 bits
-        node.t2 = getTerrainFromS2(t2 & 0x3F); // Only lower 6 bits
+        node.t1 = getTerrainFromS2(t1 & ~0x40); // Clear harbour bit (bit 6)
+        node.t2 = getTerrainFromS2(t2 & ~0x40); // Clear harbour bit (bit 6)
         if(!node.t1 || !node.t2)
             return false;
 


### PR DESCRIPTION
It's incredible how quick it is to make a proof of concept PR with AI.
Not tested at all yet.

But if you have some early thoughts - all feedback is welcome.

The idea is to enable map creators to use custom textures, from S2 gamedata or externally provided.
So they could provide zip with:
```
MyMap.swd
MyMap.lua
MyMap.lbm
```
MyMap.lua calls `rttr.AddTerrain(filename = "MyMap.lbm")` with a bunch of parameters to define extra textures.

Changes:
- Expose rttr:AddTerrain() to MyMap lua in LuaInterfaceGame
- Disallow harbout bit 0x40
- Allow 7 bit s2Ids (all except harbour bit)
- Disallow replacing existing s2Ids (or maybe should be allowed idk)
- Support <RTTR_MAP> or relative path from MyMap.lua
- Existing path validations (only current dir and subfolders)

PR is really small really.

Open questions:
- Some way to embed textures/lua in maps would be nice. Maybe .swz that is a zip file? idk.
- need to consider API for map creators., rttr:AddTerrain() was added by Flamefire in 2017 so I guess it's feature complete and stable.
- Support more image formats than lbm/bbm/bmp. maybe add png?
- 32bit HD textures
- Also need rttr:AddTerrainEdge()?

Also reason for this PR is to get all pieces on the board while adding s25edit custom texture support. There is no rush at all to review & merge this, it's not ready.
As workaround data/RTTR/gamedata/world/greenland/wasteland/winterland.lua can be edited to support new textures without changes which should work for testing purposes, but is not ideal for distributing maps with custom textures if map creators start doing this.
My enthusiasm for this depends on enthusiasm of map creators to use custom textures.