### PR TITLE
fixed emergency protocol by removing sheduled wares requested before ...

### DIFF
--- a/extras/ai-battle/HeadlessGame.cpp
+++ b/extras/ai-battle/HeadlessGame.cpp
@@ -157,8 +157,8 @@ void HeadlessGame::RecordReplay(const bfs::path& path, unsigned random_init)
         mapInfo.luaData.CompressFromFile(luaPath_, &mapInfo.luaChecksum);
     }
 
-    for(unsigned playerId = 0; playerId < world_.GetNumPlayers(); ++playerId)
-        replay_.AddPlayer(world_.GetPlayer(playerId));
+    for(auto& player : world_.getPlayers())
+        replay_.AddPlayer(player);
     replay_.ggs = game_.ggs_;
     if(!replay_.StartRecording(path, mapInfo, random_init))
         throw std::runtime_error("Replayfile could not be opened!");
@@ -170,8 +170,8 @@ void HeadlessGame::SaveGame(const bfs::path& path) const
     bfs::remove(path);
 
     Savegame save;
-    for(unsigned playerId = 0; playerId < world_.GetNumPlayers(); ++playerId)
-        save.AddPlayer(world_.GetPlayer(playerId));
+    for(auto& player : world_.getPlayers())
+        save.AddPlayer(player);
     save.ggs = game_.ggs_;
     save.ggs.exploration = Exploration::Disabled; // no FOW
     save.start_gf = em_.GetCurrentGF();
@@ -220,9 +220,8 @@ void HeadlessGame::PrintState()
     printConsole("┌────────────────────────┬─────────────────┬─────────────┬───────────┬───────────┐\n");
     printConsole("│ Player                 │ Country         │ Buildings   │ Military  │ Gold      │\n");
     printConsole("├────────────────────────┼─────────────────┼─────────────┼───────────┼───────────┤\n");
-    for(unsigned playerId = 0; playerId < world_.GetNumPlayers(); ++playerId)
+    for(const auto& player : world_.getPlayers())
     {
-        const GamePlayer& player = world_.GetPlayer(playerId);
         printConsole("│ %s%-22s%s │ %15s │ %11s │ %9s │ %9s │\n", player.IsDefeated() ? "\x1b[9m" : "",
                      player.name.c_str(), player.IsDefeated() ? "\x1b[29m" : "",
                      HumanReadableNumber(player.GetStatisticCurrentValue(StatisticType::Country)).c_str(),

--- a/libs/s25main/Game.cpp
+++ b/libs/s25main/Game.cpp
@@ -61,9 +61,9 @@ namespace {
 unsigned getNumAlivePlayers(const GameWorldBase& world)
 {
     unsigned numPlayersAlive = 0;
-    for(unsigned i = 0; i < world.GetNumPlayers(); ++i)
+    for(const auto& player : world.getPlayers())
     {
-        if(!world.GetPlayer(i).IsDefeated())
+        if(!player.IsDefeated())
             ++numPlayersAlive;
     }
     return numPlayersAlive;
@@ -76,9 +76,8 @@ void Game::RunGF()
     //  EventManager Bescheid sagen
     em_->ExecuteNextGF();
     // Notfallprogramm durchlaufen lassen
-    for(unsigned i = 0; i < world_.GetNumPlayers(); ++i)
+    for(GamePlayer& player : world_.getPlayers())
     {
-        GamePlayer& player = world_.GetPlayer(i);
         if(player.isUsed())
         {
             // Auf Notfall testen (Wenige Bretter/Steine und keine Holzindustrie)
@@ -100,8 +99,8 @@ void Game::RunGF()
 
 void Game::StatisticStep()
 {
-    for(unsigned i = 0; i < world_.GetNumPlayers(); ++i)
-        world_.GetPlayer(i).StatisticStep();
+    for(auto& player : world_.getPlayers())
+        player.StatisticStep();
 
     CheckObjective();
 }

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -889,7 +889,7 @@ void GamePlayer::FindWarehouseForAllJobs(const Job job)
     }
 }
 
-bool GamePlayer::IsWareFineWithEmergencyProtocol(GoodType goodType, const noBaseBuilding& goal){
+static bool IsWareFineWithEmergencyProtocol(GoodType goodType, const noBaseBuilding& goal){
     return (goodType != GoodType::Boards && goodType != GoodType::Stones) || goal.GetBuildingType() == BuildingType::Woodcutter || goal.GetBuildingType() == BuildingType::Sawmill;
 }
 
@@ -2097,7 +2097,7 @@ void GamePlayer::CancelWaresForEmergencyProtocol()
     for(auto it = ware_list.begin(); it != ware_list.end();){
         Ware * ware = *it;
         // checks if this ware is
-        if(ware->IsWaitingInWarehouse() && !IsWareFineWithEmergencyProtocol(ware->type,*ware->GetGoal()))
+        if(ware->IsWaitingInWarehouse() && ware->GetGoal() != nullptr && !IsWareFineWithEmergencyProtocol(ware->type,*ware->GetGoal()))
         {
             ware->NotifyGoalAboutLostWare();
             static_cast<nobBaseWarehouse*>(ware->GetLocation())->CancelWare(ware);

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -2089,6 +2089,25 @@ bool GamePlayer::FindHarborForUnloading(noShip* ship, const MapPoint start, Harb
     return false;
 }
 
+void GamePlayer::CancelWaresForEmergencyProtocol()
+{
+    for(auto it = ware_list.begin(); it != ware_list.end();){
+        Ware * ware = *it;
+        if(ware->IsWaitingInWarehouse())
+        {
+            auto* goal = ware->GetGoal();
+            if(goal != nullptr && goal->GetBuildingType() != BuildingType::Sawmill && goal->GetBuildingType() != BuildingType::Woodcutter)
+            {
+                ware->NotifyGoalAboutLostWare();
+                static_cast<nobBaseWarehouse*>(ware->GetLocation())->CancelWare(ware);
+                it = ware_list.erase(it);
+                continue;
+            }
+        }
+        it++;
+    }
+}
+
 void GamePlayer::TestForEmergencyProgramm()
 {
     // we are already defeated, do not even think about an emergency program - it's too late :-(
@@ -2119,6 +2138,9 @@ void GamePlayer::TestForEmergencyProgramm()
             SendPostMessage(std::make_unique<PostMsg>(
               world.GetEvMgr().GetCurrentGF(), _("The emergency program has been activated."), PostCategory::Economy));
         }
+
+        //remove all existing ware deliveries to buildings not sawmill or woodcutter
+        CancelWaresForEmergencyProtocol();
     } else
     {
         // Sobald Notfall vorbei, Notfallprogramm beenden, evtl. Baustellen wieder mit Kram versorgen

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -2097,7 +2097,7 @@ void GamePlayer::CancelWaresForEmergencyProtocol()
     for(auto it = ware_list.begin(); it != ware_list.end();){
         Ware * ware = *it;
         // checks if this ware is
-        if(ware->IsWaitingInWarehouse() && ware->GetGoal() != nullptr && !IsWareFineWithEmergencyProtocol(ware->type,*ware->GetGoal()))
+        if(ware->IsWaitingInWarehouse() && ware->GetGoal() && !IsWareFineWithEmergencyProtocol(ware->type,*ware->GetGoal()))
         {
             ware->NotifyGoalAboutLostWare();
             static_cast<nobBaseWarehouse*>(ware->GetLocation())->CancelWare(ware);

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -889,6 +889,10 @@ void GamePlayer::FindWarehouseForAllJobs(const Job job)
     }
 }
 
+bool GamePlayer::IsWareFineWithEmergencyProtocol(GoodType goodType, const noBaseBuilding& goal){
+    return (goodType != GoodType::Boards && goodType != GoodType::Stones) || goal.GetBuildingType() == BuildingType::Woodcutter || goal.GetBuildingType() == BuildingType::Sawmill;
+}
+
 Ware* GamePlayer::OrderWare(const GoodType ware, noBaseBuilding& goal)
 {
     /// Gibt es ein Lagerhaus mit dieser Ware?
@@ -902,8 +906,7 @@ Ware* GamePlayer::OrderWare(const GoodType ware, noBaseBuilding& goal)
         else
         {
             // Wenn Notfallprogramm aktiv nur an Holzfäller und Sägewerke Bretter/Steine liefern
-            if((ware != GoodType::Boards && ware != GoodType::Stones)
-               || goal.GetBuildingType() == BuildingType::Woodcutter || goal.GetBuildingType() == BuildingType::Sawmill)
+            if(IsWareFineWithEmergencyProtocol(ware,goal))
                 return wh->OrderWare(ware, goal);
             else
                 return nullptr;
@@ -2093,16 +2096,13 @@ void GamePlayer::CancelWaresForEmergencyProtocol()
 {
     for(auto it = ware_list.begin(); it != ware_list.end();){
         Ware * ware = *it;
-        if(ware->type == GoodType::Boards && ware->IsWaitingInWarehouse())
+        // checks if this ware is
+        if(ware->IsWaitingInWarehouse() && !IsWareFineWithEmergencyProtocol(ware->type,*ware->GetGoal()))
         {
-            auto* goal = ware->GetGoal();
-            if(goal != nullptr && goal->GetBuildingType() != BuildingType::Sawmill && goal->GetBuildingType() != BuildingType::Woodcutter)
-            {
-                ware->NotifyGoalAboutLostWare();
-                static_cast<nobBaseWarehouse*>(ware->GetLocation())->CancelWare(ware);
-                it = ware_list.erase(it);
-                continue;
-            }
+            ware->NotifyGoalAboutLostWare();
+            static_cast<nobBaseWarehouse*>(ware->GetLocation())->CancelWare(ware);
+            it = ware_list.erase(it);
+            continue;
         }
         it++;
     }
@@ -2137,10 +2137,10 @@ void GamePlayer::TestForEmergencyProgramm()
             emergency = true;
             SendPostMessage(std::make_unique<PostMsg>(
               world.GetEvMgr().GetCurrentGF(), _("The emergency program has been activated."), PostCategory::Economy));
-        }
 
-        //remove all existing ware deliveries to buildings not sawmill or woodcutter
-        CancelWaresForEmergencyProtocol();
+            //Handle wares already ordered
+            CancelWaresForEmergencyProtocol();
+        }
     } else
     {
         // Sobald Notfall vorbei, Notfallprogramm beenden, evtl. Baustellen wieder mit Kram versorgen

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -889,8 +889,10 @@ void GamePlayer::FindWarehouseForAllJobs(const Job job)
     }
 }
 
-static bool IsWareFineWithEmergencyProtocol(GoodType goodType, const noBaseBuilding& goal){
-    return (goodType != GoodType::Boards && goodType != GoodType::Stones) || goal.GetBuildingType() == BuildingType::Woodcutter || goal.GetBuildingType() == BuildingType::Sawmill;
+static bool IsWareFineWithEmergencyProtocol(GoodType goodType, const noBaseBuilding& goal)
+{
+    return (goodType != GoodType::Boards && goodType != GoodType::Stones)
+           || goal.GetBuildingType() == BuildingType::Woodcutter || goal.GetBuildingType() == BuildingType::Sawmill;
 }
 
 Ware* GamePlayer::OrderWare(const GoodType ware, noBaseBuilding& goal)
@@ -906,7 +908,7 @@ Ware* GamePlayer::OrderWare(const GoodType ware, noBaseBuilding& goal)
         else
         {
             // Wenn Notfallprogramm aktiv nur an Holzfäller und Sägewerke Bretter/Steine liefern
-            if(IsWareFineWithEmergencyProtocol(ware,goal))
+            if(IsWareFineWithEmergencyProtocol(ware, goal))
                 return wh->OrderWare(ware, goal);
             else
                 return nullptr;
@@ -2094,10 +2096,12 @@ bool GamePlayer::FindHarborForUnloading(noShip* ship, const MapPoint start, Harb
 
 void GamePlayer::CancelWaresForEmergencyProtocol()
 {
-    for(auto it = ware_list.begin(); it != ware_list.end();){
-        Ware * ware = *it;
+    for(auto it = ware_list.begin(); it != ware_list.end();)
+    {
+        Ware* ware = *it;
         // checks if this ware is
-        if(ware->IsWaitingInWarehouse() && ware->GetGoal() && !IsWareFineWithEmergencyProtocol(ware->type,*ware->GetGoal()))
+        if(ware->IsWaitingInWarehouse() && ware->GetGoal()
+           && !IsWareFineWithEmergencyProtocol(ware->type, *ware->GetGoal()))
         {
             ware->NotifyGoalAboutLostWare();
             static_cast<nobBaseWarehouse*>(ware->GetLocation())->CancelWare(ware);
@@ -2138,7 +2142,7 @@ void GamePlayer::TestForEmergencyProgramm()
             SendPostMessage(std::make_unique<PostMsg>(
               world.GetEvMgr().GetCurrentGF(), _("The emergency program has been activated."), PostCategory::Economy));
 
-            //Handle wares already ordered
+            // Handle wares already ordered
             CancelWaresForEmergencyProtocol();
         }
     } else

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -2093,7 +2093,7 @@ void GamePlayer::CancelWaresForEmergencyProtocol()
 {
     for(auto it = ware_list.begin(); it != ware_list.end();){
         Ware * ware = *it;
-        if(ware->IsWaitingInWarehouse())
+        if(ware->type == GoodType::Boards && ware->IsWaitingInWarehouse())
         {
             auto* goal = ware->GetGoal();
             if(goal != nullptr && goal->GetBuildingType() != BuildingType::Sawmill && goal->GetBuildingType() != BuildingType::Woodcutter)

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -2099,7 +2099,6 @@ void GamePlayer::CancelWaresForEmergencyProtocol()
     for(auto it = ware_list.begin(); it != ware_list.end();)
     {
         Ware* ware = *it;
-        // checks if this ware is
         if(ware->IsWaitingInWarehouse() && ware->GetGoal()
            && !IsWareFineWithEmergencyProtocol(ware->type, *ware->GetGoal()))
         {

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -331,7 +331,7 @@ public:
     const Statistic& GetStatistic(StatisticTime time) const { return statistic[time]; };
     unsigned GetStatisticCurrentValue(StatisticType idx) const { return statisticCurrentData[idx]; }
 
-    // remove all wares that are already scheduled but ignoring emergency protocol
+    // Stop wares restricted in emergency mode that are waiting in warehouse to be transported already
     void CancelWaresForEmergencyProtocol();
     // Testet ob Notfallprogramm aktiviert werden muss und tut dies dann
     void TestForEmergencyProgramm();

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -331,7 +331,8 @@ public:
     const Statistic& GetStatistic(StatisticTime time) const { return statistic[time]; };
     unsigned GetStatisticCurrentValue(StatisticType idx) const { return statisticCurrentData[idx]; }
 
-    // Lösht alle waren die bereits zur Auslieferung vorbereitet sind aber dem Notfallprogramm wiedersprechen
+    bool IsWareFineWithEmergencyProtocol(GoodType goodType, const noBaseBuilding& goal);
+    // remove all wares that are already scheduled but ignoring emergency protocol
     void CancelWaresForEmergencyProtocol();
     // Testet ob Notfallprogramm aktiviert werden muss und tut dies dann
     void TestForEmergencyProgramm();

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -331,6 +331,8 @@ public:
     const Statistic& GetStatistic(StatisticTime time) const { return statistic[time]; };
     unsigned GetStatisticCurrentValue(StatisticType idx) const { return statisticCurrentData[idx]; }
 
+    // Lösht alle waren die bereits zur Auslieferung vorbereitet sind aber dem Notfallprogramm wiedersprechen
+    void CancelWaresForEmergencyProtocol();
     // Testet ob Notfallprogramm aktiviert werden muss und tut dies dann
     void TestForEmergencyProgramm();
     bool hasEmergency() const { return emergency; }

--- a/libs/s25main/GamePlayer.h
+++ b/libs/s25main/GamePlayer.h
@@ -331,7 +331,6 @@ public:
     const Statistic& GetStatistic(StatisticTime time) const { return statistic[time]; };
     unsigned GetStatisticCurrentValue(StatisticType idx) const { return statisticCurrentData[idx]; }
 
-    bool IsWareFineWithEmergencyProtocol(GoodType goodType, const noBaseBuilding& goal);
     // remove all wares that are already scheduled but ignoring emergency protocol
     void CancelWaresForEmergencyProtocol();
     // Testet ob Notfallprogramm aktiviert werden muss und tut dies dann

--- a/libs/s25main/SerializedGameData.cpp
+++ b/libs/s25main/SerializedGameData.cpp
@@ -258,13 +258,13 @@ void SerializedGameData::MakeSnapshot(const Game& game)
         PushObject(gw.getEconHandler(), true);
     }
     // Spieler serialisieren
-    for(unsigned i = 0; i < gw.GetNumPlayers(); ++i)
+    for(const auto& player : gw.getPlayers())
     {
         if(debugMode)
-            LOG.write("Start serializing player %1% at %2%\n") % i % GetLength();
-        gw.GetPlayer(i).Serialize(*this);
+            LOG.write("Start serializing player %1% at %2%\n") % player.GetPlayerId() % GetLength();
+        player.Serialize(*this);
         if(debugMode)
-            LOG.write("Done serializing player %1% at %2%\n") % i % GetLength();
+            LOG.write("Done serializing player %1% at %2%\n") % player.GetPlayerId() % GetLength();
     }
 
     if(writtenEventIds.size() != writeEm->GetNumActiveEvents())
@@ -301,8 +301,8 @@ void SerializedGameData::ReadSnapshot(Game& game, ILocalGameState& localGameStat
           std::unique_ptr<EconomyModeHandler>(PopObject<EconomyModeHandler>(GO_Type::Economymodehandler)));
     }
 
-    for(unsigned i = 0; i < gw.GetNumPlayers(); ++i)
-        gw.GetPlayer(i).Deserialize(*this);
+    for(auto& player : gw.getPlayers())
+        player.Deserialize(*this);
 
     // If this check fails, we did not serialize all objects or there was an async
     if(readEvents.size() != em->GetNumActiveEvents())

--- a/libs/s25main/ingameWindows/iwStatistics.cpp
+++ b/libs/s25main/ingameWindows/iwStatistics.cpp
@@ -82,9 +82,9 @@ iwStatistics::iwStatistics(const GameWorldViewer& gwv)
     // Count active players
     numPlayingPlayers = 0;
     const GameWorldBase& world = gwv.GetWorld();
-    for(const auto i : helpers::range(world.GetNumPlayers()))
+    for(const auto& player : world.getPlayers())
     {
-        if(world.GetPlayer(i).isUsed())
+        if(player.isUsed())
             numPlayingPlayers++;
     }
 

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -327,8 +327,8 @@ void GameClient::StartGame(const unsigned random_init)
     {
         RTTR_Assert(mapinfo.type != MapType::Savegame);
         /// Startbündnisse setzen
-        for(unsigned i = 0; i < gameWorld.GetNumPlayers(); ++i)
-            gameWorld.GetPlayer(i).MakeStartPacts();
+        for(auto& player : gameWorld.getPlayers())
+            player.MakeStartPacts();
 
         MapLoader loader(gameWorld);
         if(!loader.Load(mapinfo.filepath)
@@ -1580,8 +1580,8 @@ bool GameClient::StartReplay(const boost::filesystem::path& path)
             idx++;
         }
 
-        for(unsigned i = 0; i < game->world_.GetNumPlayers(); i++)
-            game->world_.GetPlayer(i).ChangeDistribution(newDistributions);
+        for(auto& player : game->world_.getPlayers())
+            player.ChangeDistribution(newDistributions);
     }
 
     replayinfo->next_gf = replayinfo->replay.ReadGF();

--- a/libs/s25main/world/GameWorldBase.cpp
+++ b/libs/s25main/world/GameWorldBase.cpp
@@ -66,6 +66,16 @@ unsigned GameWorldBase::GetNumPlayers() const
     return players.size();
 }
 
+s25util::span<GamePlayer> GameWorldBase::getPlayers()
+{
+    return players;
+}
+
+s25util::span<const GamePlayer> GameWorldBase::getPlayers() const
+{
+    return players;
+}
+
 bool GameWorldBase::IsSinglePlayer() const
 {
     bool foundPlayer = false;

--- a/libs/s25main/world/GameWorldBase.h
+++ b/libs/s25main/world/GameWorldBase.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -12,6 +12,7 @@
 #include "notifications/NotificationManager.h"
 #include "postSystem/PostManager.h"
 #include "world/World.h"
+#include "s25util/span.hpp"
 #include <memory>
 #include <set>
 #include <vector>
@@ -158,6 +159,8 @@ public:
     GamePlayer& GetPlayer(unsigned id);
     const GamePlayer& GetPlayer(unsigned id) const;
     unsigned GetNumPlayers() const;
+    s25util::span<GamePlayer> getPlayers();
+    s25util::span<const GamePlayer> getPlayers() const;
     bool IsSinglePlayer() const;
     /// Return the game settings
     const GlobalGameSettings& GetGGS() const { return gameSettings; }

--- a/tests/s25Main/autoplay/main.cpp
+++ b/tests/s25Main/autoplay/main.cpp
@@ -88,8 +88,8 @@ static void playReplay(const boost::filesystem::path& replayPath, const bool isS
         BOOST_TEST_REQUIRE(replay.GetMinorVersion() < 3u);
         MapLoader::SetupResources(gameWorld, false);
 
-        for(unsigned i = 0; i < gameWorld.GetNumPlayers(); ++i)
-            gameWorld.GetPlayer(i).MakeStartPacts();
+        for(auto& player : gameWorld.getPlayers())
+            player.MakeStartPacts();
     }
 
     gameWorld.InitAfterLoad();

--- a/tests/s25Main/integration/testArmor.cpp
+++ b/tests/s25Main/integration/testArmor.cpp
@@ -83,10 +83,10 @@ struct ArmorTradeFixture : public ArmoredSoldierFixture
 
     void testExpectedFiguresInGlobalInventoryMatchWithHQInventory() const
     {
-        for(unsigned i = 0; i < world.GetNumPlayers(); i++)
+        for(const auto& player : world.getPlayers())
         {
-            auto const& playerWh = world.GetSpecObj<nobBaseWarehouse>(players[i]->GetHQPos());
-            auto const& globalInventoryPlayer = world.GetPlayer(i).GetInventory();
+            auto const& playerWh = world.GetSpecObj<nobBaseWarehouse>(player.GetHQPos());
+            auto const& globalInventoryPlayer = player.GetInventory();
             for(unsigned i = 0; i < NUM_SOLDIER_RANKS; i++)
             {
                 BOOST_TEST(playerWh->GetNumRealArmoredFigures(jobEnumToAmoredSoldierEnum(SOLDIER_JOBS[i]))

--- a/tests/s25Main/integration/testEconomyMode.cpp
+++ b/tests/s25Main/integration/testEconomyMode.cpp
@@ -118,8 +118,8 @@ BOOST_FIXTURE_TEST_CASE(EconomyModeSerialization, EconModeFixture)
     world.getEconHandler()->UpdateAmounts();
 
     Savegame save;
-    for(unsigned i = 0; i < world.GetNumPlayers(); i++)
-        save.AddPlayer(world.GetPlayer(i));
+    for(const auto& player : world.getPlayers())
+        save.AddPlayer(player);
     save.ggs = ggs;
     save.start_gf = game->em_->GetCurrentGF();
     save.sgd.MakeSnapshot(*game);

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -20,7 +20,7 @@
 
 struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
 {
-    nobHQ* HQ = world.GetPlayer(0).GetHQ();
+    nobHQ* hq = world.GetPlayer(0).GetHQ();
     EmergencyFixture()
     {
         HQ->AddToInventory(HQ->getStartInventory(StartWares::VLow), true);
@@ -42,14 +42,13 @@ struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
         // activate program (with 10 boards it should trigger)
         world.GetPlayer(0).TestForEmergencyProgramm();
 
-        // wait for some more ticks to give time if not working to deliver more boards
+        // No more boards are carried out to the farms due to emergency protocol
         RTTR_SKIP_GFS(200);
-        // check boards are still fine and protocol working
-        BOOST_TEST_CHECK(world.GetPlayer(0).GetHQ()->GetInventory()[GoodType::Boards] == 10);
+        BOOST_TEST_CHECK(hq->GetInventory()[GoodType::Boards] == 10);
     }
 };
 
-BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveWoodcutterAndSawmillCanBuild, EmergencyFixture)
+BOOST_FIXTURE_TEST_CASE(EmergencyProtocolActiveWoodcutterAndSawmillCanBuild, EmergencyFixture)
 {
     initGameRNG();
 
@@ -66,7 +65,7 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveWoodcutterAndSawmillCanBuild, Emer
     // check if inventory boards are given out
     RTTR_EXEC_TILL(200, HQ->GetInventory()[GoodType::Boards] < 10);
 
-    // check if building where found
+    // check that buildings are built
     RTTR_EXEC_TILL(2000, world.GetNO(posWoodcutter)->GetType() == NodalObjectType::Building);
     RTTR_EXEC_TILL(2000, world.GetNO(posSawmill)->GetType() == NodalObjectType::Building);
 }
@@ -80,8 +79,7 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFi
     world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
                     std::vector<Direction>(2, Direction::NorthEast));
 
-    // wait for some more ticks to give time if not working to deliver more boards
+    // No boards are carried out to the farms or watchtower due to emergency protocol
     RTTR_SKIP_GFS(500);
-    // check boards are still fine and protocol working
-    BOOST_TEST_CHECK(world.GetPlayer(0).GetHQ()->GetInventory()[GoodType::Boards] == 10);
+    BOOST_TEST_CHECK(hq->GetInventory()[GoodType::Boards] == 10);
 }

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -18,26 +18,24 @@
 #include <buildings/nobHQ.h>
 #include <buildings/nobUsual.h>
 
-struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
+struct EmergencyFixture : public WorldWithGCExecution1P
 {
     nobHQ* hq = world.GetPlayer(0).GetHQ();
     EmergencyFixture()
     {
-        HQ->AddToInventory(HQ->getStartInventory(StartWares::VLow), true);
+        hq->AddToInventory(hq->getStartInventory(StartWares::VLow), true);
         MapPoint pos;
 
-        pos = world.GetPlayer(0).GetHQPos() + MapPoint(3, 0);
+        pos = hqPos + MapPoint(3, 0);
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
-        world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
-                        std::vector<Direction>(3, Direction::West));
+        BuildRoadForBlds(pos,hqPos);
 
-        pos = world.GetPlayer(0).GetHQPos() + MapPoint(-3, 0);
+        pos = hqPos + MapPoint(-3, 0);
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
-        world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
-                        std::vector<Direction>(3, Direction::East));
+        BuildRoadForBlds(pos,hqPos);
 
         // wait until emergency protocol should be activated
-        RTTR_EXEC_TILL(500, HQ->GetInventory()[GoodType::Boards] == 10);
+        RTTR_EXEC_TILL(500, hq->GetInventory()[GoodType::Boards] == 10);
 
         // activate program (with 10 boards it should trigger)
         world.GetPlayer(0).TestForEmergencyProgramm();
@@ -45,6 +43,8 @@ struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
         // No more boards are carried out to the farms due to emergency protocol
         RTTR_SKIP_GFS(200);
         BOOST_TEST_CHECK(hq->GetInventory()[GoodType::Boards] == 10);
+
+        initGameRNG();
     }
 };
 
@@ -52,18 +52,16 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtocolActiveWoodcutterAndSawmillCanBuild, Eme
 {
     initGameRNG();
 
-    MapPoint posWoodcutter = world.GetPlayer(0).GetHQPos() + MapPoint(-1, 2);
+    MapPoint posWoodcutter = hqPos + MapPoint(-1, 2);
     world.SetBuildingSite(BuildingType::Woodcutter, posWoodcutter, 0);
-    world.BuildRoad(0, false, world.GetNeighbour(posWoodcutter, Direction::SouthEast),
-                    std::vector<Direction>(2, Direction::NorthEast));
+    BuildRoadForBlds(posWoodcutter,hqPos);
 
-    MapPoint posSawmill = world.GetPlayer(0).GetHQPos() + MapPoint(-2, 4);
+    MapPoint posSawmill = hqPos + MapPoint(-2, 4);
     world.SetBuildingSite(BuildingType::Sawmill, posSawmill, 0);
-    world.BuildRoad(0, false, world.GetNeighbour(posSawmill, Direction::SouthEast),
-                    std::vector<Direction>(2, Direction::NorthEast));
+    BuildRoadForBlds(posSawmill,hqPos);
 
     // check if inventory boards are given out
-    RTTR_EXEC_TILL(200, HQ->GetInventory()[GoodType::Boards] < 10);
+    RTTR_EXEC_TILL(200, hq->GetInventory()[GoodType::Boards] < 10);
 
     // check that buildings are built
     RTTR_EXEC_TILL(2000, world.GetNO(posWoodcutter)->GetType() == NodalObjectType::Building);
@@ -72,12 +70,10 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtocolActiveWoodcutterAndSawmillCanBuild, Eme
 
 BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFixture)
 {
-    initGameRNG();
-
-    MapPoint pos = world.GetPlayer(0).GetHQPos() + MapPoint(-1, 2);
+    MapPoint pos = hqPos + MapPoint(-3, 0);
     world.SetBuildingSite(BuildingType::Watchtower, pos, 0);
-    world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
-                    std::vector<Direction>(2, Direction::NorthEast));
+
+    BuildRoadForBlds(pos,hqPos);
 
     // No boards are carried out to the farms or watchtower due to emergency protocol
     RTTR_SKIP_GFS(500);

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -30,13 +30,11 @@ struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
         world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
                         std::vector<Direction>(3, Direction::West));
-
-
+        
         pos = world.GetPlayer(0).GetHQPos() + MapPoint(-3, 0);
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
         world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
                         std::vector<Direction>(3, Direction::East));
-
 
         //wait until emergency protocol should be activated
         RTTR_EXEC_TILL(500,HQ->GetInventory()[GoodType::Boards] == 10);
@@ -66,11 +64,11 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveWoodcutterAndSawmillCanBuild, Emer
                     std::vector<Direction>(2, Direction::NorthEast));
 
     //check if inventory boards are given out
-    RTTR_EXEC_TILL(500,HQ->GetInventory()[GoodType::Boards] < 10);
+    RTTR_EXEC_TILL(200,HQ->GetInventory()[GoodType::Boards] < 10);
 
     //check if building where found
-    RTTR_EXEC_TILL(10000,world.GetNO(posWoodcutter)->GetType() == NodalObjectType::Building);
-    RTTR_EXEC_TILL(10000,world.GetNO(posSawmill)->GetType() == NodalObjectType::Building);
+    RTTR_EXEC_TILL(2000,world.GetNO(posWoodcutter)->GetType() == NodalObjectType::Building);
+    RTTR_EXEC_TILL(2000,world.GetNO(posSawmill)->GetType() == NodalObjectType::Building);
 }
 
 BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFixture)
@@ -83,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFi
                     std::vector<Direction>(2, Direction::NorthEast));
 
     //wait for some more ticks to give time if not working to deliver more boards
-    RTTR_SKIP_GFS(200);
+    RTTR_SKIP_GFS(500);
     //check boards are still fine and protocol working
     BOOST_TEST_CHECK(world.GetPlayer(0).GetHQ()->GetInventory()[GoodType::Boards] == 10);
 }

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -28,12 +28,11 @@ struct EmergencyFixture : public WorldWithGCExecution1P
         // wait until emergency protocol should be activated
         RTTR_EXEC_TILL(500, hq->GetInventory()[GoodType::Boards] == 10);
 
-        // activate program (with 10 boards it should trigger)
-        world.GetPlayer(0).TestForEmergencyProgramm();
+        BOOST_TEST_REQUIRE(world.GetPlayer(0).hasEmergency());
 
         // No more boards are carried out to the farms due to emergency protocol
         RTTR_SKIP_GFS(200);
-        BOOST_TEST_CHECK(hq->GetInventory()[GoodType::Boards] == 10);
+        BOOST_TEST(hq->GetInventory()[GoodType::Boards] == 10);
 
         initGameRNG();
     }
@@ -67,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE(CannotBuildOtherBuldings, EmergencyFixture)
 
     // No boards are carried out to the farms or watchtower due to emergency protocol
     RTTR_SKIP_GFS(500);
-    BOOST_TEST_CHECK(hq->GetInventory()[GoodType::Boards] == 10);
+    BOOST_TEST(hq->GetInventory()[GoodType::Boards] == 10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -28,11 +28,11 @@ struct EmergencyFixture : public WorldWithGCExecution1P
 
         pos = hqPos + MapPoint(3, 0);
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
-        BuildRoadForBlds(pos,hqPos);
+        BuildRoadForBlds(pos, hqPos);
 
         pos = hqPos + MapPoint(-3, 0);
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
-        BuildRoadForBlds(pos,hqPos);
+        BuildRoadForBlds(pos, hqPos);
 
         // wait until emergency protocol should be activated
         RTTR_EXEC_TILL(500, hq->GetInventory()[GoodType::Boards] == 10);
@@ -54,11 +54,11 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtocolActiveWoodcutterAndSawmillCanBuild, Eme
 
     MapPoint posWoodcutter = hqPos + MapPoint(-1, 2);
     world.SetBuildingSite(BuildingType::Woodcutter, posWoodcutter, 0);
-    BuildRoadForBlds(posWoodcutter,hqPos);
+    BuildRoadForBlds(posWoodcutter, hqPos);
 
     MapPoint posSawmill = hqPos + MapPoint(-2, 4);
     world.SetBuildingSite(BuildingType::Sawmill, posSawmill, 0);
-    BuildRoadForBlds(posSawmill,hqPos);
+    BuildRoadForBlds(posSawmill, hqPos);
 
     // check if inventory boards are given out
     RTTR_EXEC_TILL(200, hq->GetInventory()[GoodType::Boards] < 10);
@@ -73,7 +73,7 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFi
     MapPoint pos = hqPos + MapPoint(-3, 0);
     world.SetBuildingSite(BuildingType::Watchtower, pos, 0);
 
-    BuildRoadForBlds(pos,hqPos);
+    BuildRoadForBlds(pos, hqPos);
 
     // No boards are carried out to the farms or watchtower due to emergency protocol
     RTTR_SKIP_GFS(500);

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "EconomyModeHandler.h"
+#include "EventManager.h"
+#include "GamePlayer.h"
+#include "Savegame.h"
+#include "SerializedGameData.h"
+#include "addons/AddonEconomyModeGameLength.h"
+#include "factories/BuildingFactory.h"
+#include "worldFixtures/MockLocalGameState.h"
+#include "worldFixtures/WorldFixture.h"
+#include "worldFixtures/WorldWithGCExecution.h"
+#include "worldFixtures/initGameRNG.hpp"
+#include "gameTypes/GO_Type.h"
+#include <boost/test/unit_test.hpp>
+#include <buildings/nobUsual.h>
+#include <buildings/nobHQ.h>
+
+struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
+{
+    nobHQ * HQ = world.GetPlayer(0).GetHQ();
+    EmergencyFixture()
+    {
+        HQ->AddToInventory(HQ->getStartInventory(StartWares::VLow), true);
+        MapPoint pos;
+
+        pos = world.GetPlayer(0).GetHQPos() + MapPoint(3, 0);
+        world.SetBuildingSite(BuildingType::Farm, pos, 0);
+        world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
+                        std::vector<Direction>(3, Direction::West));
+
+
+        pos = world.GetPlayer(0).GetHQPos() + MapPoint(-3, 0);
+        world.SetBuildingSite(BuildingType::Farm, pos, 0);
+        world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
+                        std::vector<Direction>(3, Direction::East));
+
+
+        //wait until emergency protocol should be activated
+        RTTR_EXEC_TILL(500,HQ->GetInventory()[GoodType::Boards] == 10);
+
+        //activate program (with 10 boards it should trigger)
+        world.GetPlayer(0).TestForEmergencyProgramm();
+
+        //wait for some more ticks to give time if not working to deliver more boards
+        RTTR_SKIP_GFS(200);
+        //check boards are still fine and protocol working
+        BOOST_TEST_CHECK(world.GetPlayer(0).GetHQ()->GetInventory()[GoodType::Boards] == 10);
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveWoodcutterAndSawmillCanBuild, EmergencyFixture)
+{
+    initGameRNG();
+
+    MapPoint posWoodcutter = world.GetPlayer(0).GetHQPos() + MapPoint(-1, 2);
+    world.SetBuildingSite(BuildingType::Woodcutter, posWoodcutter, 0);
+    world.BuildRoad(0, false, world.GetNeighbour(posWoodcutter, Direction::SouthEast),
+                    std::vector<Direction>(2, Direction::NorthEast));
+
+    MapPoint posSawmill = world.GetPlayer(0).GetHQPos() + MapPoint(-2, 4);
+    world.SetBuildingSite(BuildingType::Sawmill, posSawmill, 0);
+    world.BuildRoad(0, false, world.GetNeighbour(posSawmill, Direction::SouthEast),
+                    std::vector<Direction>(2, Direction::NorthEast));
+
+    //check if inventory boards are given out
+    RTTR_EXEC_TILL(500,HQ->GetInventory()[GoodType::Boards] < 10);
+
+    //check if building where found
+    RTTR_EXEC_TILL(10000,world.GetNO(posWoodcutter)->GetType() == NodalObjectType::Building);
+    RTTR_EXEC_TILL(10000,world.GetNO(posSawmill)->GetType() == NodalObjectType::Building);
+}
+
+BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFixture)
+{
+    initGameRNG();
+
+    MapPoint pos = world.GetPlayer(0).GetHQPos() + MapPoint(-1, 2);
+    world.SetBuildingSite(BuildingType::Watchtower, pos, 0);
+    world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
+                    std::vector<Direction>(2, Direction::NorthEast));
+
+    //wait for some more ticks to give time if not working to deliver more boards
+    RTTR_SKIP_GFS(200);
+    //check boards are still fine and protocol working
+    BOOST_TEST_CHECK(world.GetPlayer(0).GetHQ()->GetInventory()[GoodType::Boards] == 10);
+}

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -2,22 +2,13 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "EconomyModeHandler.h"
-#include "EventManager.h"
-#include "GamePlayer.h"
-#include "Savegame.h"
-#include "SerializedGameData.h"
-#include "addons/AddonEconomyModeGameLength.h"
-#include "factories/BuildingFactory.h"
-#include "worldFixtures/MockLocalGameState.h"
-#include "worldFixtures/WorldFixture.h"
+#include "NodalObjectTypes.h"
+#include "buildings/nobHQ.h"
 #include "worldFixtures/WorldWithGCExecution.h"
 #include "worldFixtures/initGameRNG.hpp"
-#include "gameTypes/GO_Type.h"
 #include <boost/test/unit_test.hpp>
-#include <buildings/nobHQ.h>
-#include <buildings/nobUsual.h>
 
+/// Start with low wares and build 2 farms to trigger emergency protocol activation
 struct EmergencyFixture : public WorldWithGCExecution1P
 {
     nobHQ* hq = world.GetPlayer(0).GetHQ();
@@ -48,15 +39,14 @@ struct EmergencyFixture : public WorldWithGCExecution1P
     }
 };
 
-BOOST_FIXTURE_TEST_CASE(EmergencyProtocolActiveWoodcutterAndSawmillCanBuild, EmergencyFixture)
+BOOST_FIXTURE_TEST_SUITE(EmergencyProtocol, EmergencyFixture)
+BOOST_AUTO_TEST_CASE(CanBuildWoodcutterAndSawmill)
 {
-    initGameRNG();
-
-    MapPoint posWoodcutter = hqPos + MapPoint(-1, 2);
+    const MapPoint posWoodcutter = hqPos + MapPoint(-1, 2);
     world.SetBuildingSite(BuildingType::Woodcutter, posWoodcutter, 0);
     BuildRoadForBlds(posWoodcutter, hqPos);
 
-    MapPoint posSawmill = hqPos + MapPoint(-2, 4);
+    const MapPoint posSawmill = hqPos + MapPoint(-2, 4);
     world.SetBuildingSite(BuildingType::Sawmill, posSawmill, 0);
     BuildRoadForBlds(posSawmill, hqPos);
 
@@ -68,9 +58,9 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtocolActiveWoodcutterAndSawmillCanBuild, Eme
     RTTR_EXEC_TILL(2000, world.GetNO(posSawmill)->GetType() == NodalObjectType::Building);
 }
 
-BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFixture)
+BOOST_FIXTURE_TEST_CASE(CannotBuildOtherBuldings, EmergencyFixture)
 {
-    MapPoint pos = hqPos + MapPoint(-3, 0);
+    const MapPoint pos = hqPos + MapPoint(-3, 0);
     world.SetBuildingSite(BuildingType::Watchtower, pos, 0);
 
     BuildRoadForBlds(pos, hqPos);
@@ -79,3 +69,5 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFi
     RTTR_SKIP_GFS(500);
     BOOST_TEST_CHECK(hq->GetInventory()[GoodType::Boards] == 10);
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/s25Main/integration/testEmergencyProtocol.cpp
+++ b/tests/s25Main/integration/testEmergencyProtocol.cpp
@@ -15,12 +15,12 @@
 #include "worldFixtures/initGameRNG.hpp"
 #include "gameTypes/GO_Type.h"
 #include <boost/test/unit_test.hpp>
-#include <buildings/nobUsual.h>
 #include <buildings/nobHQ.h>
+#include <buildings/nobUsual.h>
 
 struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
 {
-    nobHQ * HQ = world.GetPlayer(0).GetHQ();
+    nobHQ* HQ = world.GetPlayer(0).GetHQ();
     EmergencyFixture()
     {
         HQ->AddToInventory(HQ->getStartInventory(StartWares::VLow), true);
@@ -30,21 +30,21 @@ struct EmergencyFixture : public WorldFixture<CreateEmptyWorld, 1>
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
         world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
                         std::vector<Direction>(3, Direction::West));
-        
+
         pos = world.GetPlayer(0).GetHQPos() + MapPoint(-3, 0);
         world.SetBuildingSite(BuildingType::Farm, pos, 0);
         world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
                         std::vector<Direction>(3, Direction::East));
 
-        //wait until emergency protocol should be activated
-        RTTR_EXEC_TILL(500,HQ->GetInventory()[GoodType::Boards] == 10);
+        // wait until emergency protocol should be activated
+        RTTR_EXEC_TILL(500, HQ->GetInventory()[GoodType::Boards] == 10);
 
-        //activate program (with 10 boards it should trigger)
+        // activate program (with 10 boards it should trigger)
         world.GetPlayer(0).TestForEmergencyProgramm();
 
-        //wait for some more ticks to give time if not working to deliver more boards
+        // wait for some more ticks to give time if not working to deliver more boards
         RTTR_SKIP_GFS(200);
-        //check boards are still fine and protocol working
+        // check boards are still fine and protocol working
         BOOST_TEST_CHECK(world.GetPlayer(0).GetHQ()->GetInventory()[GoodType::Boards] == 10);
     }
 };
@@ -63,12 +63,12 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveWoodcutterAndSawmillCanBuild, Emer
     world.BuildRoad(0, false, world.GetNeighbour(posSawmill, Direction::SouthEast),
                     std::vector<Direction>(2, Direction::NorthEast));
 
-    //check if inventory boards are given out
-    RTTR_EXEC_TILL(200,HQ->GetInventory()[GoodType::Boards] < 10);
+    // check if inventory boards are given out
+    RTTR_EXEC_TILL(200, HQ->GetInventory()[GoodType::Boards] < 10);
 
-    //check if building where found
-    RTTR_EXEC_TILL(2000,world.GetNO(posWoodcutter)->GetType() == NodalObjectType::Building);
-    RTTR_EXEC_TILL(2000,world.GetNO(posSawmill)->GetType() == NodalObjectType::Building);
+    // check if building where found
+    RTTR_EXEC_TILL(2000, world.GetNO(posWoodcutter)->GetType() == NodalObjectType::Building);
+    RTTR_EXEC_TILL(2000, world.GetNO(posSawmill)->GetType() == NodalObjectType::Building);
 }
 
 BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFixture)
@@ -80,8 +80,8 @@ BOOST_FIXTURE_TEST_CASE(EmergencyProtoclActiveOtherBuldingsnotBuild, EmergencyFi
     world.BuildRoad(0, false, world.GetNeighbour(pos, Direction::SouthEast),
                     std::vector<Direction>(2, Direction::NorthEast));
 
-    //wait for some more ticks to give time if not working to deliver more boards
+    // wait for some more ticks to give time if not working to deliver more boards
     RTTR_SKIP_GFS(500);
-    //check boards are still fine and protocol working
+    // check boards are still fine and protocol working
     BOOST_TEST_CHECK(world.GetPlayer(0).GetHQ()->GetInventory()[GoodType::Boards] == 10);
 }

--- a/tests/s25Main/integration/testGameCommands.cpp
+++ b/tests/s25Main/integration/testGameCommands.cpp
@@ -738,8 +738,8 @@ void InitPactsAndPost(GameWorldBase& world)
 BOOST_FIXTURE_TEST_CASE(NotifyAllies, WorldWithGCExecution3P)
 {
     // At first there are no teams
-    for(unsigned i = 0; i < world.GetNumPlayers(); i++)
-        BOOST_TEST_REQUIRE(world.GetPlayer(i).team == Team::None);
+    for(const auto& player : world.getPlayers())
+        BOOST_TEST_REQUIRE(player.team == Team::None);
     PostManager& postMgr = world.GetPostMgr();
     // Add postbox for each player
     for(unsigned i = 0; i < world.GetNumPlayers(); i++)

--- a/tests/s25Main/integration/testProduction.cpp
+++ b/tests/s25Main/integration/testProduction.cpp
@@ -74,7 +74,8 @@ BOOST_FIXTURE_TEST_CASE(MetalWorkerStopped, WorldWithGCExecution1P)
 BOOST_FIXTURE_TEST_CASE(MetalWorkerOrders, WorldWithGCExecution1P)
 {
     GoodsAndPeopleCounts inv;
-    inv[GoodType::Boards] = 10;
+    inv[GoodType::Boards] = 20;
+    inv[GoodType::Stones] = 20;
     inv[GoodType::Iron] = 10;
     inv[Job::Metalworker] = 1;
     world.GetSpecObj<nobBaseWarehouse>(hqPos)->AddToInventory(inv, true);

--- a/tests/s25Main/integration/testSerialization.cpp
+++ b/tests/s25Main/integration/testSerialization.cpp
@@ -250,8 +250,8 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
 
     Savegame save;
 
-    for(unsigned i = 0; i < world.GetNumPlayers(); i++)
-        save.AddPlayer(world.GetPlayer(i));
+    for(const auto& player : world.getPlayers())
+        save.AddPlayer(player);
 
     save.ggs = ggs;
     save.start_gf = em.GetCurrentGF();
@@ -563,8 +563,8 @@ BOOST_FIXTURE_TEST_CASE(ReplayWithSavegame, RandWorldFixture)
     map.filepath = "Map.swd";
     map.luaFilepath = "Map.lua";
     map.savegame = std::make_unique<Savegame>();
-    for(unsigned i = 0; i < world.GetNumPlayers(); i++)
-        map.savegame->AddPlayer(world.GetPlayer(i));
+    for(const auto& player : world.getPlayers())
+        map.savegame->AddPlayer(player);
     // We can change players
     std::vector<BasePlayerInfo> players(4);
     players[0].ps = PlayerState::AI;

--- a/tests/s25Main/integration/testWorld.cpp
+++ b/tests/s25Main/integration/testWorld.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(HQPlacement)
     // The loader stores the HQ positions read from the map
     BOOST_TEST(hqsShuffledMap == hqsOriginalMap, boost::test_tools::per_element());
     // When shuffled the positions should have changed
-    BOOST_TEST(hqsShuffledWorld != hqsOriginalWorld, boost::test_tools::per_element());
+    BOOST_TEST(hqsShuffledWorld != hqsOriginalWorld);
     helpers::sort(hqsOriginalMap, MapPointLess{});
     helpers::sort(hqsShuffledWorld, MapPointLess{});
     helpers::sort(hqsOriginalWorld, MapPointLess{});

--- a/tests/s25Main/worldFixtures/TestEventManager.cpp
+++ b/tests/s25Main/worldFixtures/TestEventManager.cpp
@@ -1,11 +1,13 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "TestEventManager.h"
 #include "GameEvent.h"
+#include "GamePlayer.h"
+#include "world/GameWorldBase.h"
 
-unsigned TestEventManager::ExecuteNextEvent(unsigned maxGF)
+unsigned TestEventManager::doExecuteNextEvent(unsigned maxGF)
 {
     if(GetCurrentGF() >= maxGF)
         return 0;
@@ -26,6 +28,23 @@ unsigned TestEventManager::ExecuteNextEvent(unsigned maxGF)
     currentGF = itEvents->first;
     ExecuteEvents(itEvents);
     DestroyCurrentObjects();
+    return numGFs;
+}
+
+unsigned TestEventManager::ExecuteNextEvent(unsigned maxGF)
+{
+    const auto numGFs = doExecuteNextEvent(maxGF);
+    if(numGFs > 0)
+    {
+        for(auto& player : world_->getPlayers())
+        {
+            if(player.isUsed())
+            {
+                player.TestForEmergencyProgramm();
+                player.TestPacts();
+            }
+        }
+    }
     return numGFs;
 }
 

--- a/tests/s25Main/worldFixtures/TestEventManager.h
+++ b/tests/s25Main/worldFixtures/TestEventManager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -7,8 +7,13 @@
 #include "EventManager.h"
 #include <limits>
 
+class GameWorldBase;
+
 class TestEventManager : public EventManager
 {
+    GameWorldBase* world_ = nullptr;
+    unsigned doExecuteNextEvent(unsigned maxGF);
+
 public:
     TestEventManager(unsigned startGF = 0) : EventManager(startGF) {}
     /// Execute the next event increasing the GF to the events GF
@@ -22,4 +27,5 @@ public:
     /// Remove the event and add a copy that is executed at the given GF
     const GameEvent* RescheduleEvent(const GameEvent* event, unsigned targetGF);
     std::vector<const GameEvent*> GetEvents() const;
+    void setWorld(GameWorldBase& world) { world_ = &world; }
 };

--- a/tests/s25Main/worldFixtures/WorldFixture.h
+++ b/tests/s25Main/worldFixtures/WorldFixture.h
@@ -97,7 +97,9 @@ struct WorldFixtureBase
                                       std::vector<PlayerInfo>(numPlayers, GetPlayer()))),
           em(static_cast<TestEventManager&>(*game->em_)), ggs(const_cast<GlobalGameSettings&>(game->ggs_)),
           world(game->world_)
-    { // Fast moving ships
+    {
+        em.setWorld(world);
+        // Fast moving ships
         ggs.setSelection(AddonId::SHIP_SPEED, 4);
         // Explored area stays explored. Avoids fow creation
         ggs.exploration = Exploration::Classic;


### PR DESCRIPTION
When emergency protocol is activated and many buildings are already planned, the wares already scheduled for delivery are ignoring the protocol.

So now when emergency protocol is activated, those wares get removed (if not for the sawmill or woodcutter).

This also solved the issue for AI enemies on very low resources where they're not able to start because the first sawmill never got built.