### PR TITLE
Fix double free for geologist sign

### DIFF
--- a/libs/s25main/nodeObjs/noDisappearingEnvObject.cpp
+++ b/libs/s25main/nodeObjs/noDisappearingEnvObject.cpp
@@ -67,6 +67,8 @@ void noDisappearingEnvObject::HandleEvent(const unsigned id)
 {
     if(id)
     {
+        RTTR_Assert(world->GetNode(pos).obj == this);
+        world->SetNO(pos, nullptr);
         // endgültig vernichten
         GetEvMgr().AddToKillList(this);
         dead_event = nullptr;
@@ -85,7 +87,8 @@ void noDisappearingEnvObject::HandleEvent(const unsigned id)
 void noDisappearingEnvObject::Destroy()
 {
     // Feld räumen, wenn ich sterbe
-    world->SetNO(pos, nullptr);
+    if(world->GetNode(pos).obj == this)
+        world->SetNO(pos, nullptr);
 
     // ggf Event abmelden
     if(dead_event)


### PR DESCRIPTION
A geologist replacing an old sign with a new one destroys and frees it immediately, leaving the kill list holding a dangling pointer and double-freeing it moments later.

Not sure if it impacts meaningfully replays. 