### PR TITLE
Fix underflow when trading

### DIFF
--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -2320,7 +2320,7 @@ void GamePlayer::Trade(nobBaseWarehouse* goalWh, const boost_variant2<GoodType, 
             tradePathCache.addEntry(tr.GetTradePath(), GetPlayerId());
 
             wh->StartTradeCaravane(what, actualCount, tr, goalWh);
-            count -= available;
+            count -= actualCount;
             if(count == 0)
                 return;
         }

--- a/libs/s25main/buildings/nobBaseWarehouse.cpp
+++ b/libs/s25main/buildings/nobBaseWarehouse.cpp
@@ -1451,7 +1451,7 @@ unsigned nobBaseWarehouse::GetAvailableFiguresForTrading(const Job job) const
     if(job == Job::Helper)
         return (inventory[Job::Helper] - 1) / 2; // need one as leader
     else
-        return std::min(inventory[job], inventory[Job::Helper] - 1);
+        return inventory[job];
 }
 
 void nobBaseWarehouse::StartTradeCaravane(const boost_variant2<GoodType, Job>& what, const unsigned count,

--- a/tests/s25Main/integration/testArmor.cpp
+++ b/tests/s25Main/integration/testArmor.cpp
@@ -79,6 +79,7 @@ struct ArmorTradeFixture : public ArmoredSoldierFixture
 
         // Enable trading
         this->ggs.setSelection(AddonId::TRADE, 1);
+        initGameRNG();
     }
 
     void testExpectedFiguresInGlobalInventoryMatchWithHQInventory() const
@@ -135,8 +136,6 @@ BOOST_FIXTURE_TEST_SUITE(GameCommandSuite, ArmorTradeFixture)
 
 BOOST_AUTO_TEST_CASE(TradeArmoredFigures)
 {
-    initGameRNG();
-
     // Disable trading
     this->ggs.setSelection(AddonId::TRADE, 0);
     this->TradeOverLand(players[0]->GetHQPos(), Job::Officer, 3);
@@ -184,8 +183,6 @@ BOOST_AUTO_TEST_CASE(TradeArmoredFigures)
 
 BOOST_AUTO_TEST_CASE(ArmorTradeFail)
 {
-    initGameRNG();
-
     const unsigned officerSoldiersTraded = 3;
     const unsigned officerSoldiersWithArmor = 2;
 
@@ -221,8 +218,6 @@ BOOST_AUTO_TEST_CASE(ArmorTradeFail)
 
 BOOST_AUTO_TEST_CASE(ArmorTradeFailDie)
 {
-    initGameRNG();
-
     const unsigned officerSoldiersTraded = 3;
     const unsigned officerSoldiersWithArmor = 2;
 

--- a/tests/s25Main/integration/testFarmer.cpp
+++ b/tests/s25Main/integration/testFarmer.cpp
@@ -31,13 +31,12 @@ struct FarmerFixture : public WorldFixture<CreateEmptyWorld, 1>
         RTTR_EXEC_TILL(7 * 20 + 60, farm->HasWorker());
         farmer = dynamic_cast<const nofFarmhand*>(farm->GetWorker());
         BOOST_TEST_REQUIRE(farmer);
+        initGameRNG();
     }
 };
 
 BOOST_FIXTURE_TEST_CASE(ForesterAvoidsPotentialFarmFieldSpots, FarmerFixture)
 {
-    initGameRNG();
-
     const auto isPointAvailable = [](const nofFarmhand& worker, const MapPoint pt) {
         return worker.GetPointQuality(pt) != nofFarmhand::PointQuality::NotPossible;
     };
@@ -60,7 +59,6 @@ BOOST_FIXTURE_TEST_CASE(ForesterAvoidsPotentialFarmFieldSpots, FarmerFixture)
 
 BOOST_FIXTURE_TEST_CASE(FarmFieldPlanting, FarmerFixture)
 {
-    initGameRNG();
     const auto isPointAvailable = [farmer = this->farmer](const MapPoint pt) {
         return farmer->GetPointQuality(pt) != nofFarmhand::PointQuality::NotPossible;
     };

--- a/tests/s25Main/integration/testTrading.cpp
+++ b/tests/s25Main/integration/testTrading.cpp
@@ -211,7 +211,6 @@ BOOST_AUTO_TEST_CASE(TradeLessFiguresThenInStoreHouse)
     initGameRNG();
 
     auto* const hqPlayer1 = world.GetSpecObj<nobBaseWarehouse>(players[1]->GetHQPos());
-    BOOST_TEST_REQUIRE(hqPlayer1->GetNumRealFigures(Job::Woodcutter) == 8);
 
     // Add second warehouse
     auto* wh1 = static_cast<nobBaseWarehouse*>(BuildingFactory::CreateBuilding(

--- a/tests/s25Main/integration/testTrading.cpp
+++ b/tests/s25Main/integration/testTrading.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(TradeToMuch)
     testAfterLeaving(20);
 }
 
-BOOST_AUTO_TEST_CASE(NoOverflowWhenTradingLessFiguresThenInStoreHouse)
+BOOST_AUTO_TEST_CASE(TradeLessFiguresThenInStoreHouse)
 {
     initGameRNG();
 

--- a/tests/s25Main/integration/testTrading.cpp
+++ b/tests/s25Main/integration/testTrading.cpp
@@ -14,6 +14,7 @@
 #include "gameData/JobConsts.h"
 #include <rttr/test/LogAccessor.hpp>
 #include <boost/test/unit_test.hpp>
+#include <factories/BuildingFactory.h>
 #include <variant.h>
 
 struct TradeFixture : public WorldWithGCExecution3P
@@ -203,6 +204,37 @@ BOOST_AUTO_TEST_CASE(TradeToMuch)
     // Recruited soldiers
     numHelpers -= numSwords;
     testAfterLeaving(20);
+}
+
+BOOST_AUTO_TEST_CASE(NoOverflowWhenTradingLessFiguresThenInStoreHouse)
+{
+    initGameRNG();
+
+    auto* const hqPlayer1 = world.GetSpecObj<nobBaseWarehouse>(players[1]->GetHQPos());
+    BOOST_TEST_REQUIRE(hqPlayer1->GetNumRealFigures(Job::Woodcutter) == 8);
+
+    // Add second warehouse
+    auto* wh1 = static_cast<nobBaseWarehouse*>(BuildingFactory::CreateBuilding(
+      world, BuildingType::Storehouse, players[1]->GetHQPos() + MapPoint(2, 0), 1, Nation::Romans));
+    world.BuildRoad(0, false, wh1->GetFlagPos(), {2, Direction::East});
+
+    PeopleCounts inv;
+    inv[Job::Woodcutter] = 2;
+    inv[Job::Helper] = 1;
+    wh1->AddToInventory(inv, true);
+
+    BOOST_TEST_REQUIRE(hqPlayer1->GetNumRealFigures(Job::Woodcutter) == 8);
+    BOOST_TEST_REQUIRE(wh1->GetNumRealFigures(Job::Woodcutter) == 2);
+
+    // Trade less figures then in nearest warehouse wh1
+    this->TradeOverLand(players[0]->GetHQPos(), Job::Woodcutter, 1);
+
+    // Trade less figures then in nearest warehouse wh1 should use only figures from that WH
+    // Run enough GFs so all trade caravans are out (~numTradeItems + 1 people need to leave taking 30GFs max each)
+    RTTR_EXEC_TILL(30 * (1 + 1), wh1->GetLeavingFigures().empty() && hqPlayer1->GetLeavingFigures().empty());
+
+    BOOST_TEST_REQUIRE(hqPlayer1->GetNumRealFigures(Job::Woodcutter) == 8);
+    BOOST_TEST_REQUIRE(wh1->GetNumRealFigures(Job::Woodcutter) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(TradeFail)

--- a/tests/s25Main/integration/testTrading.cpp
+++ b/tests/s25Main/integration/testTrading.cpp
@@ -53,6 +53,7 @@ struct TradeFixture : public WorldWithGCExecution3P
 
         // Enable trading
         this->ggs.setSelection(AddonId::TRADE, 1);
+        initGameRNG();
     }
 
     void testExpectedWares() const
@@ -86,8 +87,6 @@ BOOST_FIXTURE_TEST_SUITE(GameCommandSuite, TradeFixture)
 
 BOOST_AUTO_TEST_CASE(TradeWares)
 {
-    initGameRNG();
-
     // Disable trading
     this->ggs.setSelection(AddonId::TRADE, 0);
     this->TradeOverLand(players[0]->GetHQPos(), GoodType::Boards, 2);
@@ -136,8 +135,6 @@ BOOST_AUTO_TEST_CASE(TradeWares)
 
 BOOST_AUTO_TEST_CASE(TradeFigures)
 {
-    initGameRNG();
-
     // Disable trading
     this->ggs.setSelection(AddonId::TRADE, 0);
     this->TradeOverLand(players[0]->GetHQPos(), Job::Woodcutter, 2);
@@ -178,8 +175,6 @@ BOOST_AUTO_TEST_CASE(TradeFigures)
 
 BOOST_AUTO_TEST_CASE(TradeToMuch)
 {
-    initGameRNG();
-
     // Trade more wares than available (not limited by donkeys)
     BOOST_TEST_REQUIRE(numSaws < numDonkeys);
     this->TradeOverLand(players[0]->GetHQPos(), GoodType::Saw, numSaws * 2);
@@ -208,8 +203,6 @@ BOOST_AUTO_TEST_CASE(TradeToMuch)
 
 BOOST_AUTO_TEST_CASE(TradeLessFiguresThenInStoreHouse)
 {
-    initGameRNG();
-
     auto* const hqPlayer1 = world.GetSpecObj<nobBaseWarehouse>(players[1]->GetHQPos());
 
     // Add second warehouse
@@ -238,8 +231,6 @@ BOOST_AUTO_TEST_CASE(TradeLessFiguresThenInStoreHouse)
 
 BOOST_AUTO_TEST_CASE(TradeFail)
 {
-    initGameRNG();
-
     this->TradeOverLand(players[0]->GetHQPos(), GoodType::Boards, 2);
     // Each donkey carries a ware and we need a leader
     numBoards -= 2;
@@ -285,8 +276,6 @@ BOOST_AUTO_TEST_CASE(TradeFail)
 
 BOOST_AUTO_TEST_CASE(TradeFailDie)
 {
-    initGameRNG();
-
     this->TradeOverLand(players[0]->GetHQPos(), GoodType::Boards, 2);
     this->TradeOverLand(players[0]->GetHQPos(), Job::Woodcutter, 2);
     // Each donkey carries a ware and we need 2 leaders
@@ -314,7 +303,6 @@ BOOST_AUTO_TEST_CASE(TradeFailDie)
 
 BOOST_AUTO_TEST_CASE(TradeMessages)
 {
-    initGameRNG();
     const PostBox& postbox = world.GetPostMgr().AddPostBox(0);
 
     this->TradeOverLand(players[0]->GetHQPos(), Job::Woodcutter, 2);


### PR DESCRIPTION
Steps to reproduce:

- Build two storehouses
- Both storehouses have figures with one type, for example woodcutter
- Both storehouses have 2 woodcutters
- Send 1 woodcutter to ally storehouse
- Then 3 woodcutters are sent to the ally instead of 1

It sends the requested number from the first WH and then basically ALL from the other warehouses due to count - available underflowing