### PR TITLE
GHA CI adjustments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref }}
           name: Release ${{ github.ref }}
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Extract tag name
         id: get_tag
-        run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
       - name: Set filenames
         id: filenames
         run: |
-          echo "::set-output name=src::s25client_src_${{steps.get_tag.outputs.tag}}.tar.gz"
-          echo "::set-output name=devTools::s25client_dev-tools_${{steps.get_tag.outputs.tag}}.tar.gz"
+          echo src=s25client_src_${{steps.get_tag.outputs.tag}}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "devTools=s25client_dev-tools_${{steps.get_tag.outputs.tag}}.tar.gz" >> "$GITHUB_OUTPUT"
       - name: Create source distribution
         run: |
             set -x

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Lint markdown files
         uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb # v1.5.0
         with:
-          ignore: external data/RTTR/MAPS .
+          args: doc/
       - name: Check licensing
         run:
           pip install --user reuse

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   Windows:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { os: windows-2022, generator: Visual Studio 17 2022, type: Debug,   platform: Win32}
@@ -71,6 +72,7 @@ jobs:
 
   Linux:
     strategy:
+      fail-fast: false
       matrix:
         include:
           # MacOSX:


### PR DESCRIPTION
- `softprops/action-gh-release` doesn't support/need the token input
- Updated markdown-lint option requires the included files, not the excluded ones
- Use `$GITHUB_OUTPUT` to avoid deprecation
- Continue full matrix for tests - Useful when running into compiler-(version) specific issues to have other results available too to see if it is a general issue