### PR TITLE
Fix ambiguous clamp and switch to `std::chrono::milliseconds`

### DIFF
--- a/libs/common/include/commonDefines.h
+++ b/libs/common/include/commonDefines.h
@@ -12,7 +12,7 @@
 
 /// Deletes the ptr and sets it to nullptr
 template<typename T>
-inline void deletePtr(T*& ptr)
+void deletePtr(T*& ptr)
 {
     delete ptr;
     ptr = nullptr;
@@ -28,7 +28,7 @@ inline T absDiff(T a, T b)
 /// Same as static_cast<T> but assert the correct dynamic type (in debug mode)
 /// Use like: checkedCast<Derived*>(basePtr)
 template<typename T, typename T_Src>
-inline T checkedCast(T_Src* src)
+T checkedCast(T_Src* src)
 {
     static_assert(std::is_pointer_v<T>, "T must be a pointer type");
     RTTR_Assert(!src || dynamic_cast<T>(src));
@@ -38,11 +38,19 @@ inline T checkedCast(T_Src* src)
 /// Same as static_cast<T&> but assert the correct dynamic type (in debug mode)
 /// Use like: checkedCast<Derived>(baseRef)
 template<typename T, typename T_Src>
-inline T& checkedCast(T_Src& src)
+T& checkedCast(T_Src& src)
 {
     static_assert(std::is_class_v<T>, "T must be a plain type");
     RTTR_Assert(dynamic_cast<T*>(&src));
     return static_cast<T&>(src);
+}
+
+/// Return a reference to the pointed-to object, checking for NULL in debug mode
+template<typename T>
+T& assertNonNull(T* src)
+{
+    RTTR_Assert(src);
+    return *src;
 }
 
 // Fwd decl

--- a/libs/common/include/helpers/mathFuncs.h
+++ b/libs/common/include/helpers/mathFuncs.h
@@ -1,10 +1,11 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
 #include "RTTR_Assert.h"
+#include <algorithm>
 #include <cmath>
 #include <type_traits>
 
@@ -22,26 +23,15 @@ constexpr unsigned divCeil(unsigned dividend, unsigned divisor) noexcept
     return (dividend + divisor - 1) / divisor;
 }
 /// Clamp the value into [min, max]
-template<typename T>
-constexpr T clamp(T val, T min, T max) noexcept
-{
-    if(val <= min)
-        return min;
-    else if(val >= max)
-        return max;
-    else
-        return val;
-}
 template<typename T, typename U>
 constexpr U clamp(T val, U min, U max) noexcept
 {
-    using Common = std::common_type_t<T, U>;
-    if(std::is_signed_v<T> && !std::is_signed_v<U>)
+    if constexpr(std::is_signed_v<T> && !std::is_signed_v<U>)
     {
         // min/max is unsigned -> No negative values possible
         if(val < 0)
             return min;
-    } else if(!std::is_signed_v<T> && std::is_signed_v<U>)
+    } else if constexpr(!std::is_signed_v<T> && std::is_signed_v<U>)
     {
         // min/max is signed
         if(max < 0)
@@ -50,7 +40,8 @@ constexpr U clamp(T val, U min, U max) noexcept
             min = 0;
     }
     // Here all values are positive or have the same signedness
-    return static_cast<U>(clamp(static_cast<Common>(val), static_cast<Common>(min), static_cast<Common>(max)));
+    using Common = std::common_type_t<T, U>;
+    return static_cast<U>(std::clamp(static_cast<Common>(val), static_cast<Common>(min), static_cast<Common>(max)));
 }
 /// Linear interpolation between [startVal, endVal]. Difference between those 2 and elapsedTime should be smallish
 template<typename T, typename U, typename V>

--- a/libs/s25main/EventManager.cpp
+++ b/libs/s25main/EventManager.cpp
@@ -262,8 +262,7 @@ void EventManager::RemoveEventFromQueue(const GameEvent& event)
 
 void EventManager::AddToKillList(GameObject* obj)
 {
-    RTTR_Assert(obj);
-    RTTR_Assert(!IsObjectInKillList(*obj));
+    RTTR_Assert(!IsObjectInKillList(assertNonNull(obj)));
     killList.emplace_back(obj);
 }
 

--- a/libs/s25main/FramesInfo.cpp
+++ b/libs/s25main/FramesInfo.cpp
@@ -11,11 +11,12 @@ FramesInfo::FramesInfo()
 
 void FramesInfo::Clear()
 {
-    // Default GF len of 20
-    gf_length = milliseconds32_t(20);
+    using namespace std::chrono_literals;
+    // Default GF len
+    gf_length = 20ms;
     gfLengthReq = gf_length;
     nwf_length = 0;
-    frameTime = milliseconds32_t::zero();
+    frameTime = frameTime.zero();
     lastTime = UsedClock::time_point();
     isPaused = false;
 }
@@ -29,5 +30,5 @@ void FramesInfoClient::Clear()
 {
     FramesInfo::Clear();
     forcePauseStart = UsedClock::time_point();
-    forcePauseLen = milliseconds32_t::zero();
+    forcePauseLen = forcePauseLen.zero();
 }

--- a/libs/s25main/FramesInfo.h
+++ b/libs/s25main/FramesInfo.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -9,21 +9,19 @@
 /// Struct that stores information about the frames, like GF status...
 struct FramesInfo
 {
-    // No need for 64 bit std::millis
-    using milliseconds32_t = std::chrono::duration<uint32_t, std::milli>; //-V:milliseconds32_t:813
     using UsedClock = std::chrono::steady_clock;
 
     FramesInfo();
     void Clear();
 
     /// Length of one GF in ms (~ 1/speed of the game)
-    milliseconds32_t gf_length;
+    std::chrono::milliseconds gf_length;
     /// Requested length of GF (for multiple changes between a NWF)
-    milliseconds32_t gfLengthReq;
+    std::chrono::milliseconds gfLengthReq;
     /// Length of a NWF (network frame) in GFs
     unsigned nwf_length;
     /// Time since last GF in ms (valid range: [0, gfLength) )
-    milliseconds32_t frameTime;
+    std::chrono::milliseconds frameTime;
     /// Timestamp of the last processed GF (--> FrameTime = CurrentTime - LastTime (except for lags) )
     UsedClock::time_point lastTime;
     /// True if the game is paused (no processing of GFs)
@@ -38,5 +36,5 @@ struct FramesInfoClient : public FramesInfo
 
     /// Force pause the game (start TS and length) e.g. to compensate for lags
     UsedClock::time_point forcePauseStart;
-    milliseconds32_t forcePauseLen;
+    std::chrono::milliseconds forcePauseLen;
 };

--- a/libs/s25main/GamePlayer.cpp
+++ b/libs/s25main/GamePlayer.cpp
@@ -405,8 +405,7 @@ nobBaseWarehouse* GamePlayer::FindWarehouse(const noRoadNode& start, const T_IsW
     for(nobBaseWarehouse* wh : buildings.GetStorehouses())
     {
         // Lagerhaus geeignet?
-        RTTR_Assert(wh);
-        if(!isWarehouseGood(*wh))
+        if(!isWarehouseGood(assertNonNull(wh)))
             continue;
 
         if(start.GetPos() == wh->GetPos())

--- a/libs/s25main/NWFInfo.cpp
+++ b/libs/s25main/NWFInfo.cpp
@@ -116,7 +116,7 @@ void NWFInfo::execute(FramesInfo& info)
         player.commands.pop();
     }
 
-    info.gf_length = FramesInfo::milliseconds32_t(serverInfo.newGFLen);
+    info.gf_length = serverInfo.newGFLen;
     info.nwf_length = serverInfo.nextNWF - serverInfo.gf;
     nextNWF_ = serverInfo.nextNWF;
 }

--- a/libs/s25main/NWFInfo.h
+++ b/libs/s25main/NWFInfo.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "network/PlayerGameCommands.h"
+#include <chrono>
 #include <queue>
 #include <vector>
 
@@ -14,11 +15,13 @@ struct NWFServerInfo
 {
     /// GF at which this should be executed
     unsigned gf;
-    /// New GF length in ms
-    unsigned newGFLen;
+    /// New GF length
+    std::chrono::milliseconds newGFLen;
     /// GF at which the next NWF is to be executed
     unsigned nextNWF;
-    NWFServerInfo(unsigned gf, unsigned gfLen, unsigned nextNWF) : gf(gf), newGFLen(gfLen), nextNWF(nextNWF) {}
+    NWFServerInfo(unsigned gf, std::chrono::milliseconds gfLen, unsigned nextNWF)
+        : gf(gf), newGFLen(gfLen), nextNWF(nextNWF)
+    {}
 };
 
 struct NWFPlayerInfo

--- a/libs/s25main/Ware.cpp
+++ b/libs/s25main/Ware.cpp
@@ -351,9 +351,8 @@ unsigned Ware::CheckNewGoalForLostWare(const noBaseBuilding& newgoal) const
 
 Ware::RouteParams Ware::CalcPathToGoal(const noBaseBuilding& newgoal) const
 {
-    RTTR_Assert(location);
     unsigned length;
-    RoadPathDirection possibledir = world->FindPathForWareOnRoads(*location, newgoal, &length);
+    RoadPathDirection possibledir = world->FindPathForWareOnRoads(assertNonNull(location), newgoal, &length);
     if(possibledir != RoadPathDirection::None) // there is a valid path to the goal? -> ordered!
     {
         // in case the ware is right in front of the goal building the ware has to be moved away 1 flag and then back

--- a/libs/s25main/desktops/dskGameInterface.cpp
+++ b/libs/s25main/desktops/dskGameInterface.cpp
@@ -392,20 +392,21 @@ void dskGameInterface::Msg_PaintAfter()
     if(SETTINGS.global.showGFInfo)
     {
         std::array<char, 256> nwf_string;
+        const auto gfLenMs = static_cast<unsigned>(GAMECLIENT.GetGFLength() / 1ms);
+        const auto nwfLenMs = static_cast<unsigned>((GAMECLIENT.GetNWFLength() * GAMECLIENT.GetGFLength()) / 1ms);
         if(GAMECLIENT.IsReplayModeOn())
         {
             snprintf(nwf_string.data(), nwf_string.size(),
                      _("(Replay-Mode) Current GF: %u (End at: %u) / GF length: %u ms / NWF length: %u gf (%u ms)"),
-                     world.GetEvMgr().GetCurrentGF(), GAMECLIENT.GetLastReplayGF(),
-                     GAMECLIENT.GetGFLength() / FramesInfo::milliseconds32_t(1), GAMECLIENT.GetNWFLength(),
-                     GAMECLIENT.GetNWFLength() * GAMECLIENT.GetGFLength() / FramesInfo::milliseconds32_t(1));
+                     world.GetEvMgr().GetCurrentGF(), GAMECLIENT.GetLastReplayGF(), gfLenMs, GAMECLIENT.GetNWFLength(),
+                     nwfLenMs);
         } else
+        {
             snprintf(nwf_string.data(), nwf_string.size(),
                      _("Current GF: %u / GF length: %u ms / NWF length: %u gf (%u ms) /  Ping: %u ms"),
-                     world.GetEvMgr().GetCurrentGF(), GAMECLIENT.GetGFLength() / FramesInfo::milliseconds32_t(1),
-                     GAMECLIENT.GetNWFLength(),
-                     GAMECLIENT.GetNWFLength() * GAMECLIENT.GetGFLength() / FramesInfo::milliseconds32_t(1),
+                     world.GetEvMgr().GetCurrentGF(), gfLenMs, GAMECLIENT.GetNWFLength(), nwfLenMs,
                      worldViewer.GetPlayer().ping);
+        }
         NormalFont->Draw(DrawPoint(30, 1), nwf_string.data(), FontStyle{}, COLOR_YELLOW);
     }
 

--- a/libs/s25main/gameData/GameConsts.h
+++ b/libs/s25main/gameData/GameConsts.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2025 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -12,8 +12,8 @@
 
 using namespace std::chrono_literals;
 /// Length of GameFrames for each speed level
-constexpr helpers::EnumArray<std::chrono::duration<unsigned, std::milli>, GameSpeed> SUPPRESS_UNUSED
-  SPEED_GF_LENGTHS = {{80ms, 60ms, 50ms, 40ms, 30ms}};
+constexpr helpers::EnumArray<std::chrono::milliseconds, GameSpeed> SUPPRESS_UNUSED SPEED_GF_LENGTHS = {
+  {80ms, 60ms, 50ms, 40ms, 30ms}};
 constexpr auto MAX_SPEED = 10ms;
 constexpr auto MIN_SPEED = SPEED_GF_LENGTHS[GameSpeed::VerySlow];
 /// Max/Max speed for debug mode (includes replays)
@@ -24,12 +24,15 @@ constexpr auto SPEED_STEP = 10ms;
 
 /// Normal speed as reference speed for ingame time computations
 constexpr auto REFERENCE_SPEED = SPEED_GF_LENGTHS[GameSpeed::Normal];
+// When using unsigned as the type for number of GFs check that we can represent
+// game durations of at least a year in units of our chosen (reference) speed.
+static_assert(REFERENCE_SPEED * std::numeric_limits<unsigned>::max() >= 24h * 365);
 
 /// Get normalized number of game frames for the given duration
 template<class Rep, class Period>
 constexpr auto duration_to_gfs(const std::chrono::duration<Rep, Period> d)
 {
-    return d / REFERENCE_SPEED;
+    return static_cast<unsigned>(d / REFERENCE_SPEED);
 }
 
 /// Get normalized duration for the given number of game frames

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1199,7 +1199,7 @@ void GameClient::DecreaseSpeed()
         SetNewSpeed(framesinfo.gfLengthReq / SPEED_STEP * SPEED_STEP + SPEED_STEP);
 }
 
-void GameClient::SetNewSpeed(FramesInfo::milliseconds32_t gfLength)
+void GameClient::SetNewSpeed(std::chrono::milliseconds gfLength)
 {
     static_assert(MIN_SPEED >= SPEED_GF_LENGTHS[GameSpeed::VeryFast], "Not all speeds reachable");
     static_assert(MAX_SPEED <= SPEED_GF_LENGTHS[GameSpeed::VerySlow], "Not all speeds reachable");
@@ -1221,7 +1221,7 @@ bool GameClient::OnGameMessage(const GameMessage_Server_NWFDone& msg)
     if(!nwfInfo)
         return true;
 
-    if(!nwfInfo->addServerInfo(NWFServerInfo(msg.gf, msg.gf_length, msg.nextNWF)))
+    if(!nwfInfo->addServerInfo(NWFServerInfo(msg.gf, std::chrono::milliseconds(msg.gf_length), msg.nextNWF)))
     {
         RTTR_Assert(false);
         LOG.write("Failed to add server info. Invalid server?\n");
@@ -1293,7 +1293,7 @@ void GameClient::ExecuteGameFrame()
     if(framesinfo.forcePauseLen.count())
     {
         if(currentTime - framesinfo.forcePauseStart > framesinfo.forcePauseLen)
-            framesinfo.forcePauseLen = FramesInfo::milliseconds32_t::zero();
+            framesinfo.forcePauseLen = framesinfo.forcePauseLen.zero();
         else
             return; // Pause
     }
@@ -1342,7 +1342,7 @@ void GameClient::ExecuteGameFrame()
 
                     ExecuteNWF();
 
-                    FramesInfo::milliseconds32_t oldGFLen = framesinfo.gf_length;
+                    const auto oldGFLen = framesinfo.gf_length;
                     nwfInfo->execute(framesinfo);
                     if(oldGFLen != framesinfo.gf_length)
                     {
@@ -1369,7 +1369,8 @@ void GameClient::ExecuteGameFrame()
         if(skiptogf == GetGFNumber())
             skiptogf = 0;
     }
-    framesinfo.frameTime = std::chrono::duration_cast<FramesInfo::milliseconds32_t>(currentTime - framesinfo.lastTime);
+    framesinfo.frameTime =
+      std::chrono::duration_cast<decltype(framesinfo.frameTime)>(currentTime - framesinfo.lastTime);
     // Check remaining time until next GF
     if(framesinfo.frameTime >= framesinfo.gf_length)
     {
@@ -1604,9 +1605,8 @@ unsigned GameClient::GetGlobalAnimation(const unsigned short max, const unsigned
     // every frame of an 8-part animation anymore.
     // An animation runs fully in (factor_numerator / factor_denumerator) multiples of 630ms
     const unsigned unit = 630 /*ms*/ * factor_numerator / factor_denumerator;
-    const unsigned currenttime = std::chrono::duration_cast<FramesInfo::milliseconds32_t>(
-                                   (framesinfo.lastTime + framesinfo.frameTime).time_since_epoch())
-                                   .count();
+    const auto currenttime =
+      static_cast<unsigned>((framesinfo.lastTime + framesinfo.frameTime).time_since_epoch() / 1ms);
     return ((currenttime % unit) * max / unit + offset) % max;
 }
 
@@ -1614,24 +1614,24 @@ unsigned GameClient::Interpolate(unsigned max_val, const GameEvent* ev)
 {
     RTTR_Assert(ev);
     // TODO: Move to some animation system that is part of game
-    FramesInfo::milliseconds32_t elapsedTime;
+    std::chrono::milliseconds elapsedTime;
     if(state == ClientState::Game)
         elapsedTime = (GetGFNumber() - ev->startGF) * framesinfo.gf_length + framesinfo.frameTime;
     else
-        elapsedTime = FramesInfo::milliseconds32_t::zero();
-    FramesInfo::milliseconds32_t duration = ev->length * framesinfo.gf_length;
+        elapsedTime = 0ms;
+    const auto duration = ev->length * framesinfo.gf_length;
     return helpers::interpolate(0u, max_val, elapsedTime, duration);
 }
 
 int GameClient::Interpolate(int x1, int x2, const GameEvent* ev)
 {
     RTTR_Assert(ev);
-    FramesInfo::milliseconds32_t elapsedTime;
+    std::chrono::milliseconds elapsedTime;
     if(state == ClientState::Game)
         elapsedTime = (GetGFNumber() - ev->startGF) * framesinfo.gf_length + framesinfo.frameTime;
     else
-        elapsedTime = FramesInfo::milliseconds32_t::zero();
-    FramesInfo::milliseconds32_t duration = ev->length * framesinfo.gf_length;
+        elapsedTime = 0ms;
+    const auto duration = ev->length * framesinfo.gf_length;
     return helpers::interpolate(x1, x2, elapsedTime, duration);
 }
 
@@ -1759,12 +1759,12 @@ void GameClient::SetPause(bool pause)
         if(!pause)
             return;
         framesinfo.isPaused = true;
-        framesinfo.frameTime = FramesInfo::milliseconds32_t::zero();
+        framesinfo.frameTime = 0ms;
     } else if(replayMode)
     {
         // Pause instantly
         framesinfo.isPaused = pause;
-        framesinfo.frameTime = FramesInfo::milliseconds32_t::zero();
+        framesinfo.frameTime = 0ms;
     } else if(IsHost())
     {
         auto* msg = new GameMessage_Pause(pause);

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1610,29 +1610,27 @@ unsigned GameClient::GetGlobalAnimation(const unsigned short max, const unsigned
     return ((currenttime % unit) * max / unit + offset) % max;
 }
 
-unsigned GameClient::Interpolate(unsigned max_val, const GameEvent* ev)
+template<typename T>
+T GameClient::do_interpolate(const T x1, const T x2, const GameEvent& ev) const
 {
-    RTTR_Assert(ev);
     // TODO: Move to some animation system that is part of game
-    std::chrono::milliseconds elapsedTime;
+    std::chrono::milliseconds elapsedTime{};
     if(state == ClientState::Game)
-        elapsedTime = (GetGFNumber() - ev->startGF) * framesinfo.gf_length + framesinfo.frameTime;
-    else
-        elapsedTime = 0ms;
-    const auto duration = ev->length * framesinfo.gf_length;
-    return helpers::interpolate(0u, max_val, elapsedTime, duration);
+        elapsedTime = (GetGFNumber() - ev.startGF) * framesinfo.gf_length + framesinfo.frameTime;
+    const auto duration = ev.length * framesinfo.gf_length;
+    return helpers::interpolate(x1, x2, elapsedTime, duration);
 }
 
-int GameClient::Interpolate(int x1, int x2, const GameEvent* ev)
+unsigned GameClient::Interpolate(const unsigned maxVal, const GameEvent* ev) const
 {
     RTTR_Assert(ev);
-    std::chrono::milliseconds elapsedTime;
-    if(state == ClientState::Game)
-        elapsedTime = (GetGFNumber() - ev->startGF) * framesinfo.gf_length + framesinfo.frameTime;
-    else
-        elapsedTime = 0ms;
-    const auto duration = ev->length * framesinfo.gf_length;
-    return helpers::interpolate(x1, x2, elapsedTime, duration);
+    return do_interpolate(0u, maxVal, *ev);
+}
+
+int GameClient::Interpolate(const int x1, const int x2, const GameEvent* ev) const
+{
+    RTTR_Assert(ev);
+    return do_interpolate(x1, x2, *ev);
 }
 
 void GameClient::ServerLost()

--- a/libs/s25main/network/GameClient.cpp
+++ b/libs/s25main/network/GameClient.cpp
@@ -1623,14 +1623,12 @@ T GameClient::do_interpolate(const T x1, const T x2, const GameEvent& ev) const
 
 unsigned GameClient::Interpolate(const unsigned maxVal, const GameEvent* ev) const
 {
-    RTTR_Assert(ev);
-    return do_interpolate(0u, maxVal, *ev);
+    return do_interpolate(0u, maxVal, assertNonNull(ev));
 }
 
 int GameClient::Interpolate(const int x1, const int x2, const GameEvent* ev) const
 {
-    RTTR_Assert(ev);
-    return do_interpolate(x1, x2, *ev);
+    return do_interpolate(x1, x2, assertNonNull(ev));
 }
 
 void GameClient::ServerLost()

--- a/libs/s25main/network/GameClient.h
+++ b/libs/s25main/network/GameClient.h
@@ -109,9 +109,9 @@ public:
     const AIPlayer* GetAIPlayer(unsigned id) const;
 
     unsigned GetGFNumber() const;
-    FramesInfo::milliseconds32_t GetGFLength() const { return framesinfo.gf_length; }
+    std::chrono::milliseconds GetGFLength() const { return framesinfo.gf_length; }
     unsigned GetNWFLength() const { return framesinfo.nwf_length; }
-    FramesInfo::milliseconds32_t GetFrameTime() const { return framesinfo.frameTime; }
+    std::chrono::milliseconds GetFrameTime() const { return framesinfo.frameTime; }
     unsigned GetGlobalAnimation(unsigned short max, unsigned char factor_numerator, unsigned char factor_denumerator,
                                 unsigned offset);
     unsigned Interpolate(unsigned max_val, const GameEvent* ev);
@@ -130,9 +130,9 @@ public:
 
     void IncreaseSpeed(bool wraparound = false);
     void DecreaseSpeed();
-    void SetNewSpeed(FramesInfo::milliseconds32_t gfLength);
+    void SetNewSpeed(std::chrono::milliseconds gfLength);
     // Used by tests (stinks, but what to do?)
-    FramesInfo::milliseconds32_t GetGFLengthReq() { return framesinfo.gfLengthReq; }
+    std::chrono::milliseconds GetGFLengthReq() { return framesinfo.gfLengthReq; }
 
     /// Lädt ein Replay und startet dementsprechend das Spiel
     bool StartReplay(const boost::filesystem::path& path);

--- a/libs/s25main/network/GameClient.h
+++ b/libs/s25main/network/GameClient.h
@@ -114,8 +114,8 @@ public:
     std::chrono::milliseconds GetFrameTime() const { return framesinfo.frameTime; }
     unsigned GetGlobalAnimation(unsigned short max, unsigned char factor_numerator, unsigned char factor_denumerator,
                                 unsigned offset);
-    unsigned Interpolate(unsigned max_val, const GameEvent* ev);
-    int Interpolate(int x1, int x2, const GameEvent* ev);
+    unsigned Interpolate(unsigned maxVal, const GameEvent* ev) const;
+    int Interpolate(int x1, int x2, const GameEvent* ev) const;
 
     void Command_Chat(const std::string& text, ChatDestination cd);
     void Command_SetNation(Nation newNation);
@@ -207,6 +207,11 @@ private:
     void NextGF(bool wasNWF);
     /// Checks if its time for autosaving (if enabled) and does it
     void HandleAutosave();
+
+    /// Interpolate implementation for generic types
+    /// Returns x in [x1, x2] according to the current time in the range of the events duration.
+    template<typename T>
+    T do_interpolate(T x1, T x2, const GameEvent& ev) const;
 
     //  Netzwerknachrichten
     RTTR_IGNORE_OVERLOADED_VIRTUAL

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -367,7 +367,8 @@ void GameServer::RunStateLoading()
     // Send cmdDelay NWFDone messages
     // First send the OK for NWF 0 which is also the game ready command
     // Note: Do not store. It already is in NWFInfo
-    SendToAll(GameMessage_Server_NWFDone(serverInfo.gf, serverInfo.newGFLen, serverInfo.nextNWF));
+    SendToAll(
+      GameMessage_Server_NWFDone(serverInfo.gf, static_cast<unsigned>(serverInfo.newGFLen / 1ms), serverInfo.nextNWF));
     RTTR_Assert(framesinfo.nwf_length > 0);
     // Then the remaining OKs for the commands sent above
     for(unsigned i = 1; i < nwfInfo.getCmdDelay(); i++)
@@ -558,7 +559,7 @@ bool GameServer::StartGame()
     framesinfo.gfLengthReq = framesinfo.gf_length = SPEED_GF_LENGTHS[ggs_.speed];
 
     // NetworkFrame-Länge bestimmen, je schlechter (also höher) die Pings, desto länger auch die Framelänge
-    framesinfo.nwf_length = CalcNWFLenght(FramesInfo::milliseconds32_t(highest_ping));
+    framesinfo.nwf_length = CalcNWFLenght(std::chrono::milliseconds(highest_ping));
 
     LOG.write("SERVER: Using gameframe length of %1%\n") % helpers::withUnit(framesinfo.gf_length);
     LOG.write("SERVER: Using networkframe length of %1% GFs (%2%)\n") % framesinfo.nwf_length
@@ -572,8 +573,7 @@ bool GameServer::StartGame()
 
     // Add server info so nwfInfo can be ready but do NOT send it yet, as we wait for the player commands before sending
     // the done msg
-    nwfInfo.addServerInfo(NWFServerInfo(currentGF, framesinfo.gf_length / FramesInfo::milliseconds32_t(1),
-                                        currentGF + framesinfo.nwf_length));
+    nwfInfo.addServerInfo(NWFServerInfo(currentGF, framesinfo.gf_length, currentGF + framesinfo.nwf_length));
 
     state = ServerState::Loading;
     loadStartTime = SteadyClock::now();
@@ -581,7 +581,7 @@ bool GameServer::StartGame()
     return true;
 }
 
-unsigned GameServer::CalcNWFLenght(FramesInfo::milliseconds32_t minDuration) const
+unsigned GameServer::CalcNWFLenght(std::chrono::milliseconds minDuration) const
 {
     constexpr unsigned maxNumGF = 20;
     for(unsigned i = 1; i < maxNumGF; ++i)
@@ -595,7 +595,7 @@ unsigned GameServer::CalcNWFLenght(FramesInfo::milliseconds32_t minDuration) con
 void GameServer::SendNWFDone(const NWFServerInfo& info)
 {
     nwfInfo.addServerInfo(info);
-    SendToAll(GameMessage_Server_NWFDone(info.gf, info.newGFLen, info.nextNWF));
+    SendToAll(GameMessage_Server_NWFDone(info.gf, static_cast<unsigned>(info.newGFLen / 1ms), info.nextNWF));
 }
 
 void GameServer::SendToAll(const GameMessage& msg)
@@ -675,8 +675,7 @@ void GameServer::ExecuteGameFrame()
     RTTR_Assert(state == ServerState::Game);
 
     FramesInfo::UsedClock::time_point currentTime = FramesInfo::UsedClock::now();
-    FramesInfo::milliseconds32_t passedTime =
-      std::chrono::duration_cast<FramesInfo::milliseconds32_t>(currentTime - framesinfo.lastTime);
+    auto passedTime = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - framesinfo.lastTime);
 
     // prüfen ob GF vergangen
     if(passedTime >= framesinfo.gf_length || skiptogf > currentGF)
@@ -740,15 +739,14 @@ void GameServer::ExecuteNWF()
     RTTR_Assert(serverInfo.nextNWF > currentGF);
     // First save old values
     unsigned lastNWF = nwfInfo.getLastNWF();
-    FramesInfo::milliseconds32_t oldGFLen = framesinfo.gf_length;
+    const auto oldGFLen = framesinfo.gf_length;
     nwfInfo.execute(framesinfo);
     if(oldGFLen != framesinfo.gf_length)
     {
         LOG.write(_("SERVER: At GF %1%: Speed changed from %2% to %3%. NWF %4%\n")) % currentGF
           % helpers::withUnit(oldGFLen) % helpers::withUnit(framesinfo.gf_length) % framesinfo.nwf_length;
     }
-    NWFServerInfo newInfo(lastNWF, framesinfo.gfLengthReq / FramesInfo::milliseconds32_t(1),
-                          lastNWF + framesinfo.nwf_length);
+    NWFServerInfo newInfo(lastNWF, framesinfo.gfLengthReq, lastNWF + framesinfo.nwf_length);
     if(framesinfo.gfLengthReq != framesinfo.gf_length)
     {
         // Speed will change, adjust nwf length so the time will stay constant
@@ -1253,7 +1251,7 @@ bool GameServer::OnGameMessage(const GameMessage_Speed& msg)
         KickPlayer(msg.senderPlayerID, KickReason::InvalidMsg, __LINE__);
         return true;
     }
-    framesinfo.gfLengthReq = FramesInfo::milliseconds32_t(msg.gf_length);
+    framesinfo.gfLengthReq = msg.gf_length;
     return true;
 }
 

--- a/libs/s25main/network/GameServer.cpp
+++ b/libs/s25main/network/GameServer.cpp
@@ -559,7 +559,7 @@ bool GameServer::StartGame()
     framesinfo.gfLengthReq = framesinfo.gf_length = SPEED_GF_LENGTHS[ggs_.speed];
 
     // NetworkFrame-Länge bestimmen, je schlechter (also höher) die Pings, desto länger auch die Framelänge
-    framesinfo.nwf_length = CalcNWFLenght(std::chrono::milliseconds(highest_ping));
+    framesinfo.nwf_length = CalcNWFLength(std::chrono::milliseconds(highest_ping));
 
     LOG.write("SERVER: Using gameframe length of %1%\n") % helpers::withUnit(framesinfo.gf_length);
     LOG.write("SERVER: Using networkframe length of %1% GFs (%2%)\n") % framesinfo.nwf_length
@@ -581,7 +581,7 @@ bool GameServer::StartGame()
     return true;
 }
 
-unsigned GameServer::CalcNWFLenght(std::chrono::milliseconds minDuration) const
+unsigned GameServer::CalcNWFLength(std::chrono::milliseconds minDuration) const
 {
     constexpr unsigned maxNumGF = 20;
     for(unsigned i = 1; i < maxNumGF; ++i)

--- a/libs/s25main/network/GameServer.h
+++ b/libs/s25main/network/GameServer.h
@@ -55,7 +55,7 @@ public:
 private:
     bool StartGame();
 
-    unsigned CalcNWFLenght(FramesInfo::milliseconds32_t minDuration) const;
+    unsigned CalcNWFLenght(std::chrono::milliseconds minDuration) const;
 
     GameServerPlayer* GetNetworkPlayer(unsigned playerId);
     /// Swap players ingame or during config

--- a/libs/s25main/network/GameServer.h
+++ b/libs/s25main/network/GameServer.h
@@ -55,7 +55,7 @@ public:
 private:
     bool StartGame();
 
-    unsigned CalcNWFLenght(std::chrono::milliseconds minDuration) const;
+    unsigned CalcNWFLength(std::chrono::milliseconds minDuration) const;
 
     GameServerPlayer* GetNetworkPlayer(unsigned playerId);
     /// Swap players ingame or during config

--- a/tests/testHelpers/rttr/test/TmpFolder.hpp
+++ b/tests/testHelpers/rttr/test/TmpFolder.hpp
@@ -24,6 +24,8 @@ public:
     ~TmpFolder() { boost::filesystem::remove_all(folder); }
     const boost::filesystem::path& get() const { return folder; }
     boost::filesystem::path operator/(const boost::filesystem::path& rhs) const { return folder / rhs; }
-    operator const boost::filesystem::path &() const { return folder; }
+    // clang-format off
+    operator const boost::filesystem::path&() const { return folder; }
+    // clang-format on
 };
 } // namespace rttr::test


### PR DESCRIPTION
C++17 introduced `std::clamp` which makes passing a type from std namespace (such as chrono-types) ambiguous in the semi-recursive call. Use constexpr-ifs and `std::clamp` in the final path.