### PR TITLE
Fix `absDiff`

### DIFF
--- a/libs/common/include/commonDefines.h
+++ b/libs/common/include/commonDefines.h
@@ -20,8 +20,9 @@ void deletePtr(T*& ptr)
 
 /// Calculate |a-b| of 2 unsigned values
 template<typename T>
-inline T absDiff(T a, T b)
+T absDiff(T a, T b)
 {
+    static_assert(std::is_unsigned_v<T>);
     return (a > b) ? a - b : b - a;
 }
 

--- a/libs/s25main/world/MapBase.cpp
+++ b/libs/s25main/world/MapBase.cpp
@@ -121,20 +121,16 @@ helpers::EnumArray<MapPoint, Direction> MapBase::GetNeighbours(const MapPoint pt
 unsigned MapBase::CalcDistance(const Position& p1, const Position& p2) const
 {
     int dx = ((p1.x - p2.x) * 2) + (p1.y & 1) - (p2.y & 1);
-    int dy = absDiff(p1.y, p2.y) * 2;
+    int dy = std::abs(p1.y - p2.y) * 2;
+
+    if(dy > size_.y)
+        dy = (size_.y * 2) - dy;
 
     if(dx < 0)
         dx = -dx;
 
-    if(dy > size_.y)
-    {
-        dy = (size_.y * 2) - dy;
-    }
-
     if(dx > size_.x)
-    {
         dx = (size_.x * 2) - dx;
-    }
 
     dx -= dy / 2;
 


### PR DESCRIPTION
Assert that it is indeed called with unsigned values.
Fix the violation.

Also reordered the calculations in `CalcDistance` such that each `dx` and `dy` parts are closer together