### PR TITLE
Take nonNull argument to `Ware::Carry` etc. by reference

### DIFF
--- a/libs/common/include/commonDefines.h
+++ b/libs/common/include/commonDefines.h
@@ -46,11 +46,17 @@ T& checkedCast(T_Src& src)
 }
 
 /// Return a reference to the pointed-to object, checking for NULL in debug mode
-template<typename T>
-T& assertNonNull(T* src)
+template<class T>
+T& assertNonNull(T* pointer)
 {
-    RTTR_Assert(src);
-    return *src;
+    RTTR_Assert(pointer);
+    return *pointer;
+}
+/// Additionally assert dynamic type (if T & U are different)
+template<class T, class U>
+T& assertNonNull(U* pointer)
+{
+    return assertNonNull(checkedCast<T*>(pointer));
 }
 
 // Fwd decl

--- a/libs/s25main/Ware.cpp
+++ b/libs/s25main/Ware.cpp
@@ -240,25 +240,22 @@ void Ware::GoalDestroyed()
     }
 }
 
-void Ware::WaitAtFlag(noFlag* flag)
+void Ware::WaitAtFlag(noFlag& flag)
 {
-    RTTR_Assert(flag);
     state = State::WaitAtFlag;
-    location = flag;
+    location = &flag;
 }
 
-void Ware::WaitInWarehouse(nobBaseWarehouse* wh)
+void Ware::WaitInWarehouse(nobBaseWarehouse& wh)
 {
-    RTTR_Assert(wh);
     state = State::WaitInWarehouse;
-    location = wh;
+    location = &wh;
 }
 
-void Ware::Carry(noRoadNode* nextGoal)
+void Ware::Carry(noRoadNode& nextGoal)
 {
-    RTTR_Assert(nextGoal);
     state = State::Carried;
-    location = nextGoal;
+    location = &nextGoal;
 }
 
 /// Gibt dem Ziel der Ware bekannt, dass diese nicht mehr kommen kann

--- a/libs/s25main/Ware.h
+++ b/libs/s25main/Ware.h
@@ -72,9 +72,9 @@ public:
     /// Wird aufgerufen, wenn es das Ziel der Ware nicht mehr gibt und sie wieder "nach Hause" getragen werden muss
     void GoalDestroyed();
     /// Changes the state of the ware
-    void WaitAtFlag(noFlag* flag);
-    void WaitInWarehouse(nobBaseWarehouse* wh);
-    void Carry(noRoadNode* nextGoal);
+    void WaitAtFlag(noFlag& flag);
+    void WaitInWarehouse(nobBaseWarehouse& wh);
+    void Carry(noRoadNode& nextGoal);
     /// Gibt dem Ziel der Ware bekannt, dass diese nicht mehr kommen kann
     void NotifyGoalAboutLostWare();
     /// Wenn die Ware vernichtet werden muss

--- a/libs/s25main/buildings/noBaseBuilding.cpp
+++ b/libs/s25main/buildings/noBaseBuilding.cpp
@@ -126,7 +126,7 @@ void noBaseBuilding::Destroy()
                 {
                     // Ware erzeugen
                     auto ware = std::make_unique<Ware>(goods[which], nullptr, flag);
-                    ware->WaitAtFlag(flag);
+                    ware->WaitAtFlag(*flag);
                     // Inventur anpassen
                     world->GetPlayer(player).IncreaseInventoryWare(goods[which], 1);
                     // Abnehmer für Ware finden

--- a/libs/s25main/buildings/nobBaseWarehouse.cpp
+++ b/libs/s25main/buildings/nobBaseWarehouse.cpp
@@ -653,7 +653,7 @@ void nobBaseWarehouse::HandleLeaveEvent()
             auto ware = std::move(waiting_wares.front());
             waiting_wares.pop_front();
             inventory.visual.Remove(ConvertShields(ware->type));
-            ware->Carry(GetFlag());
+            ware->Carry(*GetFlag());
             world->AddFigure(pos, std::make_unique<nofWarehouseWorker>(pos, player, std::move(ware), false))
               .WalkToGoal();
         } else
@@ -717,7 +717,7 @@ Ware* nobBaseWarehouse::OrderWare(const GoodType good, noBaseBuilding& goal)
 void nobBaseWarehouse::AddWaitingWare(std::unique_ptr<Ware> ware)
 {
     inventory.visual.Add(ConvertShields(ware->type));
-    ware->WaitInWarehouse(this);
+    ware->WaitInWarehouse(*this);
     waiting_wares.push_back(std::move(ware));
     AddLeavingEvent();
 }

--- a/libs/s25main/buildings/nobHarborBuilding.cpp
+++ b/libs/s25main/buildings/nobHarborBuilding.cpp
@@ -1295,7 +1295,7 @@ void nobHarborBuilding::WareDontWantToTravelByShip(Ware* ware)
 
     // Move to waiting_wares
     waiting_wares.push_back(helpers::extractPtr(wares_for_ships, ware));
-    ware->WaitInWarehouse(this);
+    ware->WaitInWarehouse(*this);
     // Carry out. If it would want to go back to this building, then this will be handled by the carrier
     AddLeavingEvent();
 }

--- a/libs/s25main/figures/nofBuildingWorker.cpp
+++ b/libs/s25main/figures/nofBuildingWorker.cpp
@@ -149,7 +149,7 @@ void nofBuildingWorker::WorkingReady()
         {
             // Ware erzeugen
             auto real_ware = std::make_unique<Ware>(*ware, nullptr, flag);
-            real_ware->WaitAtFlag(flag);
+            real_ware->WaitAtFlag(*flag);
             // Inventur entsprechend erhöhen, dabei Schilder unterscheiden!
             GoodType ware_type = ConvertShields(real_ware->type);
             world->GetPlayer(player).IncreaseInventoryWare(ware_type, 1);

--- a/libs/s25main/figures/nofCarrier.cpp
+++ b/libs/s25main/figures/nofCarrier.cpp
@@ -379,7 +379,7 @@ void nofCarrier::Walked()
             if(rs_pos == cur_rs->GetLength())
             {
                 // Flag just reached
-                auto* this_flag = static_cast<noFlag*>(((rs_dir) ? workplace->GetF1() : workplace->GetF2()));
+                auto& this_flag = assertNonNull<noFlag>(((rs_dir) ? workplace->GetF1() : workplace->GetF2()));
 
                 bool calculated = false;
 
@@ -389,14 +389,15 @@ void nofCarrier::Walked()
                     // Walk to building or building site
                     state = CarrierState::CarryWareToBuilding;
                     StartWalking(Direction::NorthWest);
-                    cur_rs = this_flag->GetRoute(Direction::NorthWest);
+                    cur_rs = this_flag.GetRoute(Direction::NorthWest);
                     // Set location to next road node, i.e. building
-                    carried_ware->Carry((cur_rs->GetF1() == this_flag) ? cur_rs->GetF2() : cur_rs->GetF1());
+                    carried_ware->Carry(
+                      assertNonNull((cur_rs->GetF1() == &this_flag) ? cur_rs->GetF2() : cur_rs->GetF1()));
                 } else
                 {
                     // Put ware at flag if there is space.
                     // If not try swapping it with another ware at that flag
-                    if(this_flag->HasSpaceForWare())
+                    if(this_flag.HasSpaceForWare())
                     {
                         carried_ware->WaitAtFlag(this_flag);
 
@@ -405,7 +406,7 @@ void nofCarrier::Walked()
                             carried_ware->RecalcRoute();
 
                         // Put down ware
-                        this_flag->AddWare(std::move(carried_ware));
+                        this_flag.AddWare(std::move(carried_ware));
                         RTTR_Assert(carried_ware == nullptr);
                         // Check if we can pick up another ware at this flag, else go back to middle of road
                         LookForWares();
@@ -421,7 +422,7 @@ void nofCarrier::Walked()
                         tmp_ware->WaitAtFlag(this_flag);
                         if(!calculated)
                             tmp_ware->RecalcRoute();
-                        this_flag->AddWare(std::move(tmp_ware));
+                        this_flag.AddWare(std::move(tmp_ware));
                     } else
                     {
                         // No space at flag, go back and try again later
@@ -540,7 +541,7 @@ void nofCarrier::GoalReached()
 
                 if(carried_ware)
                 {
-                    carried_ware->Carry((rs_dir ? workplace->GetF1() : workplace->GetF2()));
+                    carried_ware->Carry(assertNonNull(rs_dir ? workplace->GetF1() : workplace->GetF2()));
                     state = CarrierState::CarryWare;
                 }
             }
@@ -829,7 +830,7 @@ void nofCarrier::FetchWare(const bool swap_wares)
 
     if(carried_ware)
     {
-        carried_ware->Carry((rs_dir) ? workplace->GetF2() : workplace->GetF1());
+        carried_ware->Carry(assertNonNull(rs_dir ? workplace->GetF2() : workplace->GetF1()));
         // Und zum anderen Ende laufen
         state = CarrierState::CarryWare;
         rs_dir = !rs_dir;
@@ -899,9 +900,9 @@ void nofCarrier::CorrectSplitData_Derived()
     {
         // Dann die Location von der Ware aktualisieren
         if(!rs_dir)
-            carried_ware->Carry(cur_rs->GetF2());
+            carried_ware->Carry(assertNonNull(cur_rs->GetF2()));
         else
-            carried_ware->Carry(cur_rs->GetF1());
+            carried_ware->Carry(assertNonNull(cur_rs->GetF1()));
     }
 }
 

--- a/libs/s25main/figures/nofWarehouseWorker.cpp
+++ b/libs/s25main/figures/nofWarehouseWorker.cpp
@@ -59,22 +59,21 @@ void nofWarehouseWorker::Draw(DrawPoint drawPt)
 
 void nofWarehouseWorker::GoalReached()
 {
-    auto* wh = world->GetSpecObj<nobBaseWarehouse>(world->GetNeighbour(pos, Direction::NorthWest));
-    RTTR_Assert(wh); // When worker is still working, the warehouse (and its flag) exists
-    auto* flag = wh->GetFlag();
-    RTTR_Assert(flag);
+    // When worker is still working, the warehouse (and its flag) exists
+    auto& wh = assertNonNull(world->GetSpecObj<nobBaseWarehouse>(world->GetNeighbour(pos, Direction::NorthWest)));
+    auto& flag = assertNonNull(wh.GetFlag());
     if(!shouldBringWareIn)
     {
         // Put ware down at flag if enough space.
         // Might need to take it back in if goal was destroyed or changed to the warehouse
-        if(flag->HasSpaceForWare() && carried_ware->GetGoal() && carried_ware->GetGoal() != wh)
+        if(flag.HasSpaceForWare() && carried_ware->GetGoal() && carried_ware->GetGoal() != &wh)
         {
             // TODO: Remove assert. Was added to verify prior condition
             RTTR_Assert(carried_ware->GetGoal() != carried_ware->GetLocation());
 
             carried_ware->WaitAtFlag(flag);
             carried_ware->RecalcRoute();
-            flag->AddWare(std::move(carried_ware));
+            flag.AddWare(std::move(carried_ware));
         } else
         {
             // Bring back in
@@ -83,14 +82,14 @@ void nofWarehouseWorker::GoalReached()
     } else
     {
         // Take ware if any
-        carried_ware = flag->SelectWare(Direction::NorthWest, false, this);
+        carried_ware = flag.SelectWare(Direction::NorthWest, false, this);
         if(carried_ware)
             carried_ware->Carry(wh);
     }
 
     // Start walking back
     StartWalking(Direction::NorthWest);
-    InitializeRoadWalking(wh->GetRoute(Direction::SouthEast), 0, false);
+    InitializeRoadWalking(wh.GetRoute(Direction::SouthEast), 0, false);
 }
 
 void nofWarehouseWorker::Walked()

--- a/tests/s25Main/integration/testAttacking.cpp
+++ b/tests/s25Main/integration/testAttacking.cpp
@@ -696,7 +696,7 @@ BOOST_FIXTURE_TEST_CASE(ConquerWithMultipleWalkingIn, AttackFixture4P)
 
     AddSoldiers(milBld0Pos, 0, 6);
     AddSoldiers(milBld1Pos, 1, Job::Private);
-    MapPoint milBld1FlagPos = world.GetNeighbour(milBld1Pos, Direction::SouthEast);
+    const MapPoint milBld1FlagPos = milBld1->GetFlagPos();
 
     // Scenario 1: Attack with one soldier.
     // Once enemy is defeated we walk in with another soldier of the enemy who wants to occupy its building.
@@ -844,34 +844,33 @@ BOOST_FIXTURE_TEST_CASE(ConquerWithCarriersWalkingIn, AttackFixture<2>)
     // 2. Carrier with coin walking out of the building
     AddSoldiers(milBld0Pos, 0, 6);
     AddSoldiers(milBld1Pos, 1, Job::Private);
-    MapPoint milBld1FlagPos = world.GetNeighbour(milBld1Pos, Direction::SouthEast);
+    const MapPoint milBld1FlagPos = milBld1->GetFlagPos();
 
     curPlayer = 1;
-    MapPoint flagPos = world.MakeMapPoint(milBld1FlagPos - Position(2, 0));
+    const MapPoint flagPos = world.MakeMapPoint(milBld1FlagPos - Position(2, 0));
     this->BuildRoad(milBld1FlagPos, false, std::vector<Direction>(2, Direction::West));
-    auto* flag = world.GetSpecObj<noFlag>(flagPos);
-    BOOST_TEST_REQUIRE(flag);
-    RoadSegment* rs = flag->GetRoute(Direction::East);
+    auto& flag = ensureNonNull(world.GetSpecObj<noFlag>(flagPos));
+    RoadSegment* rs = flag.GetRoute(Direction::East);
     BOOST_TEST_REQUIRE(rs);
     auto& carrierIn =
-      world.AddFigure(flagPos, std::make_unique<nofCarrier>(CarrierType::Normal, flagPos, curPlayer, rs, flag));
+      world.AddFigure(flagPos, std::make_unique<nofCarrier>(CarrierType::Normal, flagPos, curPlayer, rs, &flag));
     auto& carrierOut =
-      world.AddFigure(flagPos, std::make_unique<nofCarrier>(CarrierType::Donkey, flagPos, curPlayer, rs, flag));
+      world.AddFigure(flagPos, std::make_unique<nofCarrier>(CarrierType::Donkey, flagPos, curPlayer, rs, &flag));
     rs->setCarrier(0, &carrierIn);
     rs->setCarrier(1, &carrierOut);
     // Add 2 coins for the bld
     for(unsigned i = 0; i < 2; i++)
     {
-        auto coin = std::make_unique<Ware>(GoodType::Coins, milBld1, flag);
+        auto coin = std::make_unique<Ware>(GoodType::Coins, milBld1, &flag);
         coin->WaitAtFlag(flag);
         coin->RecalcRoute();
-        flag->AddWare(std::move(coin));
+        flag.AddWare(std::move(coin));
     }
     world.GetPlayer(1).IncreaseInventoryWare(GoodType::Coins, 2);
     carrierIn.ActAtFirst();
     carrierOut.ActAtFirst();
     // Both picked up
-    BOOST_TEST_REQUIRE(flag->GetNumWares() == 0u);
+    BOOST_TEST_REQUIRE(flag.GetNumWares() == 0u);
     // Move carriers to flag
     for(unsigned i = 0; i < 2; i++)
     {
@@ -891,22 +890,20 @@ BOOST_FIXTURE_TEST_CASE(ConquerWithCarriersWalkingIn, AttackFixture<2>)
     // Add another for later
     MapPoint flagPosE = world.MakeMapPoint(milBld1FlagPos + Position(2, 0));
     this->BuildRoad(milBld1FlagPos, false, std::vector<Direction>(2, Direction::East));
-    auto* flagE = world.GetSpecObj<noFlag>(flagPosE);
-    BOOST_TEST_REQUIRE(flagE);
-    RoadSegment* rsE = flagE->GetRoute(Direction::West);
-    BOOST_TEST_REQUIRE(rsE);
+    auto& flagE = ensureNonNull(world.GetSpecObj<noFlag>(flagPosE));
+    RoadSegment& rsE = ensureNonNull(flagE.GetRoute(Direction::West));
     auto& carrierInE =
-      world.AddFigure(flagPosE, std::make_unique<nofCarrier>(CarrierType::Normal, flagPosE, curPlayer, rsE, flagE));
-    rsE->setCarrier(0, &carrierInE);
+      world.AddFigure(flagPosE, std::make_unique<nofCarrier>(CarrierType::Normal, flagPosE, curPlayer, &rsE, &flagE));
+    rsE.setCarrier(0, &carrierInE);
     // He also gets 1 coin
-    auto coin = std::make_unique<Ware>(GoodType::Coins, milBld1, flagE);
+    auto coin = std::make_unique<Ware>(GoodType::Coins, milBld1, &flagE);
     coin->WaitAtFlag(flagE);
     coin->RecalcRoute();
-    flagE->AddWare(std::move(coin));
+    flagE.AddWare(std::move(coin));
     world.GetPlayer(1).IncreaseInventoryWare(GoodType::Coins, 1);
     carrierInE.ActAtFirst();
     // Picked up
-    BOOST_TEST_REQUIRE(flagE->GetNumWares() == 0u);
+    BOOST_TEST_REQUIRE(flagE.GetNumWares() == 0u);
     // And pause him
     rescheduleWalkEvent(em, carrierInE, 10000);
 

--- a/tests/s25Main/integration/testSeafaring.cpp
+++ b/tests/s25Main/integration/testSeafaring.cpp
@@ -842,7 +842,7 @@ BOOST_FIXTURE_TEST_CASE(AddWareWithUnreachableGoalToHarbor, ShipAndHarborsReadyF
     // Sanity check: Move from harbor1 to wh (over harbor2)
     auto ware = std::make_unique<MockWare>(goodType, wh, &harbor1);
     auto* warePtr = ware.get();
-    ware->Carry(&harbor1);
+    ware->Carry(harbor1);
     auto numVisWaresBefore = harbor1.GetNumVisualWares(goodType);
     auto numRealWaresBefore = harbor1.GetNumRealWares(goodType);
     harbor1.AddWare(std::move(ware));
@@ -861,7 +861,7 @@ BOOST_FIXTURE_TEST_CASE(AddWareWithUnreachableGoalToHarbor, ShipAndHarborsReadyF
             DestroyRoad(harbor2.GetFlagPos(), d);
     }
     ware = std::make_unique<MockWare>(goodType, wh, &harbor1);
-    ware->Carry(&harbor1);
+    ware->Carry(harbor1);
     numVisWaresBefore = harbor1.GetNumVisualWares(goodType);
     numRealWaresBefore = harbor1.GetNumRealWares(goodType);
     harbor1.AddWare(std::move(ware));
@@ -872,7 +872,7 @@ BOOST_FIXTURE_TEST_CASE(AddWareWithUnreachableGoalToHarbor, ShipAndHarborsReadyF
     // Same but disallow harbor as goal -> Find another storehouse
     SetInventorySetting(harbor1.GetPos(), goodType, EInventorySetting::Stop);
     ware = std::make_unique<MockWare>(goodType, wh, &harbor1);
-    ware->Carry(&harbor1);
+    ware->Carry(harbor1);
     warePtr = ware.get();
     numVisWaresBefore = harbor1.GetNumVisualWares(goodType);
     numRealWaresBefore = harbor1.GetNumRealWares(goodType);
@@ -885,7 +885,7 @@ BOOST_FIXTURE_TEST_CASE(AddWareWithUnreachableGoalToHarbor, ShipAndHarborsReadyF
     // If no other storehouse is available take it anyway
     SetInventorySetting(harbor2.GetPos(), goodType, EInventorySetting::Stop);
     ware = std::make_unique<MockWare>(goodType, wh, &harbor1);
-    ware->Carry(&harbor1);
+    ware->Carry(harbor1);
     numVisWaresBefore = harbor1.GetNumVisualWares(goodType);
     numRealWaresBefore = harbor1.GetNumRealWares(goodType);
     harbor1.AddWare(std::move(ware));

--- a/tests/s25Main/integration/testSerialization.cpp
+++ b/tests/s25Main/integration/testSerialization.cpp
@@ -217,13 +217,13 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
     }
 
     const MapPoint hqPos = world.GetPlayer(0).GetHQPos();
-    auto* hq = world.GetSpecObj<nobBaseWarehouse>(hqPos);
-    auto* hqFlag = hq->GetFlag();
+    auto& hq = ensureNonNull(world.GetSpecObj<nobBaseWarehouse>(hqPos));
+    auto& hqFlag = ensureNonNull(hq.GetFlag());
     const MapPoint usualBldPos = world.MakeMapPoint(hqPos + Position(3, 0));
     auto* usualBld = static_cast<nobUsual*>(
       BuildingFactory::CreateBuilding(world, BuildingType::Bakery, usualBldPos, 0, Nation::Vikings));
     world.RecalcBQAroundPointBig(usualBldPos);
-    world.BuildRoad(0, false, hqFlag->GetPos(), std::vector<Direction>(3, Direction::East));
+    world.BuildRoad(0, false, hqFlag.GetPos(), std::vector<Direction>(3, Direction::East));
     usualBld->is_working = true;
 
     // Add 3 fires with first between the others to have a mixed event order in the same GF
@@ -240,13 +240,13 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
 
     // Do this after running GFs to keep the state
     // Add ware to flag
-    auto ware = std::make_unique<Ware>(GoodType::Flour, usualBld, hqFlag);
+    auto ware = std::make_unique<Ware>(GoodType::Flour, usualBld, &hqFlag);
     ware->WaitAtFlag(hqFlag);
     ware->RecalcRoute();
-    hqFlag->AddWare(std::move(ware));
+    hqFlag.AddWare(std::move(ware));
     // Add a ware waiting in a warehouse. See https://github.com/Return-To-The-Roots/s25client/issues/1293
-    ware = std::make_unique<Ware>(GoodType::Flour, usualBld, hq);
-    hq->AddWaitingWare(std::move(ware));
+    ware = std::make_unique<Ware>(GoodType::Flour, usualBld, &hq);
+    hq.AddWaitingWare(std::move(ware));
 
     Savegame save;
 
@@ -353,11 +353,11 @@ BOOST_FIXTURE_TEST_CASE(BaseSaveLoad, RandWorldFixture)
             BOOST_TEST(newUsual->HasWorker() == usualBld->HasWorker());
             BOOST_TEST(newUsual->GetProductivity() == usualBld->GetProductivity());
 
-            hq = world.GetSpecObj<nobBaseWarehouse>(hqPos);
-            BOOST_TEST_REQUIRE(hq);
-            hqFlag = hq->GetFlag();
-            BOOST_TEST_REQUIRE(hqFlag);
-            BOOST_TEST(hqFlag->GetNumWares() == 1u);
+            auto* hqLoaded = world.GetSpecObj<nobBaseWarehouse>(hqPos);
+            BOOST_TEST_REQUIRE(hqLoaded);
+            auto* hqFlagLoaded = hqLoaded->GetFlag();
+            BOOST_TEST_REQUIRE(hqFlagLoaded);
+            BOOST_TEST(hqFlagLoaded->GetNumWares() == 1u);
 
             BOOST_TEST_REQUIRE(world.HasLua());
             BOOST_TEST(world.GetLua().getScript() == luaScript);


### PR DESCRIPTION
Transitioning further to reference as non-null pointers

Enhances the `assertNonNull` util to also check the type if required.