### PR TITLE
Store the addon in AddonGui and iterate the GUIs directly

### DIFF
--- a/libs/s25main/addons/Addon.cpp
+++ b/libs/s25main/addons/Addon.cpp
@@ -7,7 +7,7 @@
 #include "Window.h"
 #include "s25util/colors.h"
 
-AddonGui::AddonGui(const Addon& addon, Window& window, bool /*readonly*/) : window_(window)
+AddonGui::AddonGui(const Addon& addon, Window& window, bool /*readonly*/) : addon_(addon), window_(window)
 {
     DrawPoint btPos(20, 0), txtPos(52, 4);
     window.AddText(0, txtPos, addon.getName(), COLOR_YELLOW, FontStyle{}, NormalFont);

--- a/libs/s25main/addons/Addon.h
+++ b/libs/s25main/addons/Addon.h
@@ -18,11 +18,13 @@ public:
     virtual ~AddonGui() = default;
     virtual void setStatus(unsigned status) = 0;
     virtual unsigned getStatus() const = 0;
+    const Addon& getAddon() const { return addon_; }
     /// Return the parent-window that contains the controls of this Addon
     Window& getWindow() { return window_; }
     const Window& getWindow() const { return window_; }
 
 private:
+    const Addon& addon_;
     Window& window_;
 };
 

--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -114,11 +114,8 @@ void iwAddons::Msg_ButtonClick(const unsigned ctrl_id)
         {
             if(policy_ != AddonChangeAllowed::None)
             {
-                // Einstellungen in ADDONMANAGER übertragen
-                for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
-                {
-                    ggs.setSelection(ggs.getAddon(i)->getId(), addonGuis_[i]->getStatus());
-                }
+                for(const auto& gui : addonGuis_)
+                    ggs.setSelection(gui->getAddon().getId(), gui->getStatus());
 
                 switch(policy_)
                 {
@@ -142,10 +139,8 @@ void iwAddons::Msg_ButtonClick(const unsigned ctrl_id)
         case ID_btSavePreset:
         {
             std::map<unsigned, unsigned> states;
-            for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
-            {
-                states[static_cast<unsigned>(ggs.getAddon(i)->getId())] = addonGuis_[i]->getStatus();
-            }
+            for(const auto& gui : addonGuis_)
+                states[static_cast<unsigned>(gui->getAddon().getId())] = gui->getStatus();
             WINDOWMANAGER.Show(std::make_unique<iwSaveAddonPreset>(std::move(states)));
         }
         break;
@@ -156,12 +151,11 @@ void iwAddons::Msg_ButtonClick(const unsigned ctrl_id)
             break;
 
         case ID_btS2Defaults: // Load S2 Defaults
-            // Standardeinstellungen aufs Fenster übertragen
-            for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+            for(const auto& gui : addonGuis_)
             {
-                const Addon* addon = ggs.getAddon(i);
-                if(!isReadOnly(addon->getId()))
-                    addonGuis_[i]->setStatus(addon->getDefaultStatus());
+                const Addon& addon = gui->getAddon();
+                if(!isReadOnly(addon.getId()))
+                    gui->setStatus(addon.getDefaultStatus());
             }
             break;
     }
@@ -174,11 +168,10 @@ void iwAddons::UpdateView(const AddonGroup selection)
     const unsigned scrollPosEnd = scrollPos + scrollbar->GetPageSize();
     unsigned short y = 90;
     unsigned short numAddonsInCurCategory = 0;
-    for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+    for(const auto& gui : addonGuis_)
     {
-        const Addon* addon = ggs.getAddon(i);
-        const bool isVisible = bitset::any(addon->getGroups(), selection);
-        Window& group = addonGuis_[i]->getWindow();
+        const bool isVisible = bitset::any(gui->getAddon().getGroups(), selection);
+        Window& group = gui->getWindow();
 
         // Don't show addon's gui if addon is beyond selected group or is beyond current page scope
         if(isVisible && numAddonsInCurCategory >= scrollPos && numAddonsInCurCategory < scrollPosEnd)
@@ -196,15 +189,15 @@ void iwAddons::UpdateView(const AddonGroup selection)
 
 void iwAddons::applyAddonStates(const std::map<unsigned, unsigned>& states)
 {
-    for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+    for(const auto& gui : addonGuis_)
     {
-        const Addon* addon = ggs.getAddon(i);
-        if(!isReadOnly(addon->getId()))
+        const Addon& addon = gui->getAddon();
+        if(!isReadOnly(addon.getId()))
         {
-            const auto it = states.find(static_cast<unsigned>(addon->getId()));
-            const unsigned rawStatus = (it != states.end()) ? it->second : addon->getDefaultStatus();
-            const unsigned status = (rawStatus < addon->getNumOptions()) ? rawStatus : addon->getDefaultStatus();
-            addonGuis_[i]->setStatus(status);
+            const auto it = states.find(static_cast<unsigned>(addon.getId()));
+            const unsigned rawStatus = (it != states.end()) ? it->second : addon.getDefaultStatus();
+            const unsigned status = (rawStatus < addon.getNumOptions()) ? rawStatus : addon.getDefaultStatus();
+            gui->setStatus(status);
         }
     }
 }


### PR DESCRIPTION
Follow-up to [73aafa2db](https://github.com/Return-To-The-Roots/s25client/commit/73aafa2db35babed5da0d791b3b4d17c29ccba81)

Five loops in `iwAddons` walked `addonGuis_` and `ggs.getAddon(i)` by the same
index, with nothing enforcing that the two stay aligned, and dereferenced the
returned `const Addon*` unchecked - while the constructor guards that same call
with `assertNonNull`. `AddonGui` already receives the addon to build its label
and description button, so it now keeps it and exposes `getAddon()` alongside
`getWindow()`.

Drops two German comments on rewritten lines: one naming `ADDONMANAGER`,
which no longer exists, and one redundant.