### PR TITLE
Act on the selected addon preset, not a typed name

### DIFF
--- a/libs/s25main/ingameWindows/iwAddonPresets.cpp
+++ b/libs/s25main/ingameWindows/iwAddonPresets.cpp
@@ -7,6 +7,8 @@
 #include "Loader.h"
 #include "RttrConfig.h"
 #include "WindowManager.h"
+#include "commonDefines.h"
+#include "controls/ctrlButton.h"
 #include "controls/ctrlEdit.h"
 #include "controls/ctrlTable.h"
 #include "controls/ctrlText.h"
@@ -65,8 +67,8 @@ static std::optional<std::map<unsigned, unsigned>> LoadPresetsFromFile(const bfs
 }
 
 // iwAddonPresetsBase
-iwAddonPresetsBase::iwAddonPresetsBase(const std::string& title, const std::string& actionLabel)
-    : IngameWindow(CGI_ADDON_PRESETS, IngameWindow::posLastOrCenter, Extent(440, 330), title,
+iwAddonPresetsBase::iwAddonPresetsBase(const std::string& title, const unsigned height)
+    : IngameWindow(CGI_ADDON_PRESETS, IngameWindow::posLastOrCenter, Extent(440, height), title,
                    LOADER.GetImageN("resource", 41), true)
 {
     const bfs::path presetsDir = GetPresetsDir();
@@ -91,20 +93,12 @@ iwAddonPresetsBase::iwAddonPresetsBase(const std::string& title, const std::stri
     AddText(ID_txtFolder, DrawPoint(20, 236), presetsDir.string(), COLOR_YELLOW, FontStyle::TOP, SmallFont)
       ->setMaxWidth(400);
 
-    // maxLength 251 = 255 filename limit - 4 chars for ".ini"; just discourages absurdly long
-    // input, isValidFileName() may still reject it since it counts bytes, not codepoints.
-    AddEdit(ID_edtName, DrawPoint(20, 254), Extent(400, 22), TextureColor::Green2, NormalFont, 251);
-    GetCtrl<ctrlEdit>(ID_edtName)->SetType(EditType::Filename);
-
-    AddTextButton(ID_btAction, DrawPoint(20, 284), Extent(185, 22), TextureColor::Green2, actionLabel, NormalFont);
-    AddTextButton(ID_btDelete, DrawPoint(235, 284), Extent(185, 22), TextureColor::Red1, _("Delete"), NormalFont);
-
     RefreshTable();
 }
 
 void iwAddonPresetsBase::RefreshTable()
 {
-    auto& table = *GetCtrl<ctrlTable>(ID_tblPresets);
+    auto& table = assertNonNull(GetCtrl<ctrlTable>(ID_tblPresets));
     table.DeleteAllItems();
 
     for(const auto& file : ListDir(GetPresetsDir(), "ini"))
@@ -113,56 +107,10 @@ void iwAddonPresetsBase::RefreshTable()
     table.SortRows(0, TableSortDir::Ascending);
 }
 
-bfs::path iwAddonPresetsBase::GetTargetFilePath() const
-{
-    const std::string name = GetCtrl<ctrlEdit>(ID_edtName)->GetText();
-    if(name.empty())
-        return {};
-
-    const auto& table = *GetCtrl<ctrlTable>(ID_tblPresets);
-    for(unsigned short i = 0; i < table.GetNumRows(); ++i)
-    {
-        if(table.GetItemText(i, 0) == name)
-            return table.GetItemText(i, 1);
-    }
-    return {};
-}
-
-bfs::path iwAddonPresetsBase::GetTargetFileOrNotify() const
-{
-    bfs::path path = GetTargetFilePath();
-    if(!path.empty())
-        return path;
-
-    const std::string name = GetCtrl<ctrlEdit>(ID_edtName)->GetText();
-    if(name.empty())
-        return {};
-
-    WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Preset Not Found"),
-                                                  helpers::format(_("Preset '%1%' was not found."), name), nullptr,
-                                                  MsgboxButton::Ok, MsgboxIcon::ExclamationRed));
-    return {};
-}
-
-void iwAddonPresetsBase::Msg_EditEnter(const unsigned /*ctrl_id*/)
-{
-    DoAction();
-}
-
 void iwAddonPresetsBase::Msg_ButtonClick(const unsigned ctrl_id)
 {
-    switch(ctrl_id)
-    {
-        case ID_btAction: DoAction(); break;
-        case ID_btDelete: ConfirmDelete(); break;
-        default: break;
-    }
-}
-
-void iwAddonPresetsBase::Msg_TableSelectItem(const unsigned /*ctrl_id*/, const std::optional<unsigned>& selection)
-{
-    const auto& table = *GetCtrl<ctrlTable>(ID_tblPresets);
-    GetCtrl<ctrlEdit>(ID_edtName)->SetText(selection ? table.GetItemText(*selection, 0) : "");
+    RTTR_Assert(ctrl_id == ID_btAction);
+    DoAction();
 }
 
 void iwAddonPresetsBase::Msg_TableChooseItem(const unsigned /*ctrl_id*/, const unsigned /*selection*/)
@@ -170,43 +118,31 @@ void iwAddonPresetsBase::Msg_TableChooseItem(const unsigned /*ctrl_id*/, const u
     DoAction();
 }
 
-void iwAddonPresetsBase::ConfirmDelete()
-{
-    const bfs::path filePath = GetTargetFileOrNotify();
-    if(filePath.empty())
-        return;
-    WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
-      _("Delete Preset"), helpers::format(_("Are you sure you want to delete preset '%1%'?"), filePath.stem().string()),
-      this, MsgboxButton::YesNo, MsgboxIcon::QuestionRed, ID_mbDelete));
-}
-
-void iwAddonPresetsBase::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult mbr)
-{
-    if(msgbox_id != ID_mbDelete || mbr != MsgboxResult::Yes)
-        return;
-
-    const bfs::path filePath = GetTargetFilePath();
-    if(filePath.empty())
-        return;
-
-    boost::system::error_code ec;
-    bfs::remove(filePath, ec);
-    if(ec)
-    {
-        LOG.write("Failed to delete addon preset %1%: %2%\n") % filePath % ec.message();
-        WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Delete Failed"), _("Failed to delete the selected preset."),
-                                                      this, MsgboxButton::Ok, MsgboxIcon::ExclamationRed));
-    }
-    // Refresh in both cases so the list reflects the actual filesystem state
-    // (e.g. the file became a directory or was removed out from under us).
-    RefreshTable();
-    GetCtrl<ctrlEdit>(ID_edtName)->SetText("");
-}
-
 // iwSaveAddonPreset
 iwSaveAddonPreset::iwSaveAddonPreset(std::map<unsigned, unsigned> states)
-    : iwAddonPresetsBase(_("Save Addon Preset"), _("Save")), states_(std::move(states))
-{}
+    : iwAddonPresetsBase(_("Save Addon Preset"), 330), states_(std::move(states))
+{
+    if(ShouldBeClosed())
+        return;
+
+    // maxLength 251 = 255 filename limit - 4 chars for ".ini"; just discourages absurdly long
+    // input, isValidFileName() may still reject it since it counts bytes, not codepoints.
+    AddEdit(ID_edtName, DrawPoint(20, 254), Extent(400, 22), TextureColor::Green2, NormalFont, 251)
+      ->SetType(EditType::Filename);
+
+    AddTextButton(ID_btAction, DrawPoint(20, 284), Extent(400, 22), TextureColor::Green2, _("Save"), NormalFont);
+}
+
+void iwSaveAddonPreset::Msg_EditEnter(const unsigned /*ctrl_id*/)
+{
+    DoAction();
+}
+
+void iwSaveAddonPreset::Msg_TableSelectItem(const unsigned /*ctrl_id*/, const std::optional<unsigned>& selection)
+{
+    const auto& table = assertNonNull(GetCtrl<ctrlTable>(ID_tblPresets));
+    GetCtrl<ctrlEdit>(ID_edtName)->SetText(selection ? table.GetItemText(*selection, 0) : "");
+}
 
 void iwSaveAddonPreset::DoAction()
 {
@@ -262,26 +198,54 @@ void iwSaveAddonPreset::SaveToPath(const bfs::path& filePath)
 
 void iwSaveAddonPreset::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult mbr)
 {
-    if(msgbox_id == ID_mbOverwrite)
-    {
-        if(mbr == MsgboxResult::Yes)
-        {
-            const auto fileNameResult = GetCtrl<ctrlEdit>(ID_edtName)->GetFileName(".ini");
-            if(fileNameResult.status == FileNameStatus::Valid)
-                SaveToPath(GetPresetsDir() / fileNameResult.name);
-        }
-    } else
-        iwAddonPresetsBase::Msg_MsgBoxResult(msgbox_id, mbr);
+    if(msgbox_id != ID_mbOverwrite || mbr != MsgboxResult::Yes)
+        return;
+
+    const auto fileNameResult = GetCtrl<ctrlEdit>(ID_edtName)->GetFileName(".ini");
+    if(fileNameResult.status == FileNameStatus::Valid)
+        SaveToPath(GetPresetsDir() / fileNameResult.name);
 }
 
 // iwLoadAddonPreset
 iwLoadAddonPreset::iwLoadAddonPreset(std::function<void(const std::map<unsigned, unsigned>&)> onLoad)
-    : iwAddonPresetsBase(_("Load Addon Preset"), _("Load")), onLoad_(std::move(onLoad))
-{}
+    : iwAddonPresetsBase(_("Load Addon Preset"), 300), onLoad_(std::move(onLoad))
+{
+    if(ShouldBeClosed())
+        return;
+
+    // Both act on the preset selected in the list, so they stay disabled until one is picked
+    AddTextButton(ID_btAction, DrawPoint(20, 254), Extent(185, 22), TextureColor::Green2, _("Load"), NormalFont)
+      ->SetEnabled(false);
+    AddTextButton(ID_btDelete, DrawPoint(235, 254), Extent(185, 22), TextureColor::Red1, _("Delete"), NormalFont)
+      ->SetEnabled(false);
+}
+
+bfs::path iwLoadAddonPreset::GetSelectedFilePath() const
+{
+    const auto& table = assertNonNull(GetCtrl<ctrlTable>(ID_tblPresets));
+    const auto& selection = table.GetSelection();
+    if(!selection)
+        return {};
+    return table.GetItemText(*selection, 1);
+}
+
+void iwLoadAddonPreset::Msg_ButtonClick(const unsigned ctrl_id)
+{
+    if(ctrl_id == ID_btDelete)
+        ConfirmDelete();
+    else
+        iwAddonPresetsBase::Msg_ButtonClick(ctrl_id);
+}
+
+void iwLoadAddonPreset::Msg_TableSelectItem(const unsigned /*ctrl_id*/, const std::optional<unsigned>& selection)
+{
+    GetCtrl<ctrlButton>(ID_btAction)->SetEnabled(selection.has_value());
+    GetCtrl<ctrlButton>(ID_btDelete)->SetEnabled(selection.has_value());
+}
 
 void iwLoadAddonPreset::DoAction()
 {
-    const bfs::path filePath = GetTargetFileOrNotify();
+    const bfs::path filePath = GetSelectedFilePath();
     if(filePath.empty())
         return;
 
@@ -297,4 +261,36 @@ void iwLoadAddonPreset::DoAction()
 
     onLoad_(*states);
     Close();
+}
+
+void iwLoadAddonPreset::ConfirmDelete()
+{
+    const bfs::path filePath = GetSelectedFilePath();
+    if(filePath.empty())
+        return;
+    WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
+      _("Delete Preset"), helpers::format(_("Are you sure you want to delete preset '%1%'?"), filePath.stem().string()),
+      this, MsgboxButton::YesNo, MsgboxIcon::QuestionRed, ID_mbDelete));
+}
+
+void iwLoadAddonPreset::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxResult mbr)
+{
+    if(msgbox_id != ID_mbDelete || mbr != MsgboxResult::Yes)
+        return;
+
+    const bfs::path filePath = GetSelectedFilePath();
+    if(filePath.empty())
+        return;
+
+    boost::system::error_code ec;
+    bfs::remove(filePath, ec);
+    if(ec)
+    {
+        LOG.write("Failed to delete addon preset %1%: %2%\n") % filePath % ec.message();
+        WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(_("Delete Failed"), _("Failed to delete the selected preset."),
+                                                      this, MsgboxButton::Ok, MsgboxIcon::ExclamationRed));
+    }
+    // Refresh in both cases so the list reflects the actual filesystem state
+    // (e.g. the file became a directory or was removed out from under us).
+    RefreshTable();
 }

--- a/libs/s25main/ingameWindows/iwAddonPresets.cpp
+++ b/libs/s25main/ingameWindows/iwAddonPresets.cpp
@@ -66,31 +66,31 @@ static std::optional<std::map<unsigned, unsigned>> LoadPresetsFromFile(const bfs
     return states;
 }
 
-// iwAddonPresetsBase
-iwAddonPresetsBase::iwAddonPresetsBase(const std::string& title, const unsigned height)
-    : IngameWindow(CGI_ADDON_PRESETS, IngameWindow::posLastOrCenter, Extent(440, height), title,
-                   LOADER.GetImageN("resource", 41), true)
+bool iwAddonPresetsBase::EnsurePresetsFolder()
 {
     const bfs::path presetsDir = GetPresetsDir();
     boost::system::error_code ec;
     bfs::create_directories(presetsDir, ec);
-    if(ec)
-    {
-        LOG.write("Failed to create addon preset folder %1%: %2%\n") % presetsDir % ec.message();
-        // Without the folder, saving/loading/deleting presets can't work.
-        WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
-          _("Addon Presets Unavailable"),
-          _("The addon presets folder could not be created. Saving and loading addon presets is unavailable."), nullptr,
-          MsgboxButton::Ok, MsgboxIcon::ExclamationRed));
-        Close();
-        return;
-    }
+    if(!ec)
+        return true;
 
+    LOG.write("Failed to create addon preset folder %1%: %2%\n") % presetsDir % ec.message();
+    WINDOWMANAGER.Show(std::make_unique<iwMsgbox>(
+      _("Addon Presets Unavailable"),
+      _("The addon presets folder could not be created. Saving and loading addon presets is unavailable."), nullptr,
+      MsgboxButton::Ok, MsgboxIcon::ExclamationRed));
+    return false;
+}
+
+iwAddonPresetsBase::iwAddonPresetsBase(const std::string& title, const unsigned height)
+    : IngameWindow(CGI_ADDON_PRESETS, IngameWindow::posLastOrCenter, Extent(440, height), title,
+                   LOADER.GetImageN("resource", 41), true)
+{
     using SRT = ctrlTable::SortType;
     AddTable(ID_tblPresets, DrawPoint(20, 30), Extent(400, 200), TextureColor::Green2, NormalFont,
              ctrlTable::Columns{{_("Preset Name"), 400, SRT::String}, {}});
 
-    AddText(ID_txtFolder, DrawPoint(20, 236), presetsDir.string(), COLOR_YELLOW, FontStyle::TOP, SmallFont)
+    AddText(ID_txtFolder, DrawPoint(20, 236), GetPresetsDir().string(), COLOR_YELLOW, FontStyle::TOP, SmallFont)
       ->setMaxWidth(400);
 
     RefreshTable();
@@ -118,13 +118,9 @@ void iwAddonPresetsBase::Msg_TableChooseItem(const unsigned /*ctrl_id*/, const u
     DoAction();
 }
 
-// iwSaveAddonPreset
 iwSaveAddonPreset::iwSaveAddonPreset(std::map<unsigned, unsigned> states)
     : iwAddonPresetsBase(_("Save Addon Preset"), 330), states_(std::move(states))
 {
-    if(ShouldBeClosed())
-        return;
-
     // maxLength 251 = 255 filename limit - 4 chars for ".ini"; just discourages absurdly long
     // input, isValidFileName() may still reject it since it counts bytes, not codepoints.
     AddEdit(ID_edtName, DrawPoint(20, 254), Extent(400, 22), TextureColor::Green2, NormalFont, 251)
@@ -206,13 +202,9 @@ void iwSaveAddonPreset::Msg_MsgBoxResult(const unsigned msgbox_id, const MsgboxR
         SaveToPath(GetPresetsDir() / fileNameResult.name);
 }
 
-// iwLoadAddonPreset
 iwLoadAddonPreset::iwLoadAddonPreset(std::function<void(const std::map<unsigned, unsigned>&)> onLoad)
     : iwAddonPresetsBase(_("Load Addon Preset"), 300), onLoad_(std::move(onLoad))
 {
-    if(ShouldBeClosed())
-        return;
-
     // Both act on the preset selected in the list, so they stay disabled until one is picked
     AddTextButton(ID_btAction, DrawPoint(20, 254), Extent(185, 22), TextureColor::Green2, _("Load"), NormalFont)
       ->SetEnabled(false);

--- a/libs/s25main/ingameWindows/iwAddonPresets.h
+++ b/libs/s25main/ingameWindows/iwAddonPresets.h
@@ -26,6 +26,8 @@ public:
         ID_mbOverwrite,
     };
 
+    static bool EnsurePresetsFolder();
+
 protected:
     iwAddonPresetsBase(const std::string& title, unsigned height);
 

--- a/libs/s25main/ingameWindows/iwAddonPresets.h
+++ b/libs/s25main/ingameWindows/iwAddonPresets.h
@@ -15,8 +15,6 @@
 class iwAddonPresetsBase : public IngameWindow
 {
 public:
-    explicit iwAddonPresetsBase(const std::string& title, const std::string& actionLabel);
-
     enum
     {
         ID_tblPresets,
@@ -29,23 +27,15 @@ public:
     };
 
 protected:
-    void RefreshTable();
-    /// Resolves the preset file whose display name matches the currently entered name, or empty if
-    /// the name field is empty or no such preset exists.
-    boost::filesystem::path GetTargetFilePath() const;
-    /// Like GetTargetFilePath(), but if a name was entered that doesn't match any preset, informs the
-    /// user before returning empty. An empty name stays a silent no-op.
-    boost::filesystem::path GetTargetFileOrNotify() const;
+    iwAddonPresetsBase(const std::string& title, unsigned height);
 
-    void Msg_EditEnter(unsigned ctrl_id) override;
+    void RefreshTable();
+
     void Msg_ButtonClick(unsigned ctrl_id) override;
-    void Msg_TableSelectItem(unsigned ctrl_id, const std::optional<unsigned>& selection) override;
     void Msg_TableChooseItem(unsigned ctrl_id, unsigned selection) override;
-    void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
 
 private:
     virtual void DoAction() = 0;
-    void ConfirmDelete();
 };
 
 class iwSaveAddonPreset : public iwAddonPresetsBase
@@ -57,6 +47,8 @@ private:
     const std::map<unsigned, unsigned> states_;
     void SaveToPath(const boost::filesystem::path& filePath);
     void DoAction() override;
+    void Msg_EditEnter(unsigned ctrl_id) override;
+    void Msg_TableSelectItem(unsigned ctrl_id, const std::optional<unsigned>& selection) override;
     void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
 };
 
@@ -67,5 +59,11 @@ public:
 
 private:
     std::function<void(const std::map<unsigned, unsigned>&)> onLoad_;
+    /// Empty if no preset is selected
+    boost::filesystem::path GetSelectedFilePath() const;
+    void ConfirmDelete();
     void DoAction() override;
+    void Msg_ButtonClick(unsigned ctrl_id) override;
+    void Msg_TableSelectItem(unsigned ctrl_id, const std::optional<unsigned>& selection) override;
+    void Msg_MsgBoxResult(unsigned msgbox_id, MsgboxResult mbr) override;
 };

--- a/libs/s25main/ingameWindows/iwAddons.cpp
+++ b/libs/s25main/ingameWindows/iwAddons.cpp
@@ -140,19 +140,23 @@ void iwAddons::Msg_ButtonClick(const unsigned ctrl_id)
             break;
 
         case ID_btSavePreset:
-        {
-            std::map<unsigned, unsigned> states;
-            for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+            if(iwAddonPresetsBase::EnsurePresetsFolder())
             {
-                states[static_cast<unsigned>(ggs.getAddon(i)->getId())] = addonGuis_[i]->getStatus();
+                std::map<unsigned, unsigned> states;
+                for(unsigned i = 0; i < ggs.getNumAddons(); ++i)
+                {
+                    states[static_cast<unsigned>(ggs.getAddon(i)->getId())] = addonGuis_[i]->getStatus();
+                }
+                WINDOWMANAGER.Show(std::make_unique<iwSaveAddonPreset>(std::move(states)));
             }
-            WINDOWMANAGER.Show(std::make_unique<iwSaveAddonPreset>(std::move(states)));
-        }
-        break;
+            break;
 
         case ID_btLoadPreset:
-            WINDOWMANAGER.Show(std::make_unique<iwLoadAddonPreset>(
-              [this](const std::map<unsigned, unsigned>& states) { applyAddonStates(states); }));
+            if(iwAddonPresetsBase::EnsurePresetsFolder())
+            {
+                WINDOWMANAGER.Show(std::make_unique<iwLoadAddonPreset>(
+                  [this](const std::map<unsigned, unsigned>& states) { applyAddonStates(states); }));
+            }
             break;
 
         case ID_btS2Defaults: // Load S2 Defaults

--- a/tests/s25Main/UI/testWindows.cpp
+++ b/tests/s25Main/UI/testWindows.cpp
@@ -117,12 +117,27 @@ struct AddonPresetFixture : uiHelper::Fixture
     rttr::test::TmpFolder tmp;
     rttr::test::ConfigOverride userDataOverride{"USERDATA", tmp};
 
+    // Selects the named preset, false if there is no such preset
+    static bool select(Window& wnd, const std::string& name)
+    {
+        auto& table = *wnd.GetCtrls<ctrlTable>().at(0);
+        for(unsigned short i = 0; i < table.GetNumRows(); ++i)
+        {
+            if(table.GetItemText(i, 0) == name)
+            {
+                table.SetSelection(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
     void save(const std::map<unsigned, unsigned>& states, const std::string& name)
     {
         iwSaveAddonPreset wnd(states);
         Window& base = wnd;
         base.GetCtrls<ctrlEdit>().at(0)->SetText(name);
-        base.Msg_EditEnter(0);
+        base.Msg_ButtonClick(iwAddonPresetsBase::ID_btAction);
     }
 
     // Returns the given preset's settings, or empty if the preset is missing or corrupt.
@@ -131,8 +146,8 @@ struct AddonPresetFixture : uiHelper::Fixture
         std::map<unsigned, unsigned> out;
         iwLoadAddonPreset wnd([&](const std::map<unsigned, unsigned>& s) { out = s; });
         Window& base = wnd;
-        base.GetCtrls<ctrlEdit>().at(0)->SetText(name);
-        base.Msg_EditEnter(0);
+        if(select(base, name))
+            base.Msg_ButtonClick(iwAddonPresetsBase::ID_btAction);
         return out;
     }
 
@@ -189,7 +204,7 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetSaveLoadAndOverwrite, AddonPresetFixture)
     BOOST_TEST(load("myPreset") == states2); // updated
 }
 
-// A name already ending in the extension is a distinct preset, independently loadable and deletable.
+// Saving a name that already ends in the extension yields a second preset instead of overwriting.
 BOOST_FIXTURE_TEST_CASE(AddonPresetExtensionInNameIsDistinct, AddonPresetFixture)
 {
     const std::map<unsigned, unsigned> states{{1, 2}};
@@ -200,44 +215,52 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetExtensionInNameIsDistinct, AddonPresetFixture
 
     BOOST_TEST(load("myPreset") == states);
     BOOST_TEST(load("myPreset.ini") == statesDoubled);
-
-    iwLoadAddonPreset wnd([](const std::map<unsigned, unsigned>&) noexcept {});
-    Window& base = wnd;
-    base.GetCtrls<ctrlEdit>().at(0)->SetText("myPreset.ini");
-    base.Msg_MsgBoxResult(iwAddonPresetsBase::ID_mbDelete, MsgboxResult::Yes);
-    BOOST_TEST(numPresets() == 1u);
-    BOOST_TEST(load("myPreset.ini").empty()); // doubled file gone
-    BOOST_TEST(load("myPreset") == states);   // sibling preset untouched
 }
 
-// The edit box is the source of truth: after selecting a preset, editing the name and acting
-// must target the edited name, not the stale table selection.
-BOOST_FIXTURE_TEST_CASE(AddonPresetEditOverridesSelection, AddonPresetFixture)
+BOOST_FIXTURE_TEST_CASE(AddonPresetDoubleClickLoads, AddonPresetFixture)
 {
-    const std::map<unsigned, unsigned> statesA{{1, 2}};
-    const std::map<unsigned, unsigned> statesB{{3, 4}};
-    save(statesA, "presetA");
-    save(statesB, "presetB");
+    const std::map<unsigned, unsigned> states{{1, 2}};
+    save(states, "myPreset");
 
     std::optional<std::map<unsigned, unsigned>> loaded;
     iwLoadAddonPreset wnd([&](const std::map<unsigned, unsigned>& s) { loaded = s; });
     Window& base = wnd;
+    BOOST_TEST_REQUIRE(select(base, "myPreset"));
+    base.Msg_TableChooseItem(iwAddonPresetsBase::ID_tblPresets, 0u);
+
+    BOOST_TEST_REQUIRE(loaded.has_value());
+    BOOST_TEST(*loaded == states);
+}
+
+// In the save window the selection only prefills the name: saving uses what is in the edit box.
+BOOST_FIXTURE_TEST_CASE(AddonPresetSaveNameFollowsSelection, AddonPresetFixture)
+{
+    const std::map<unsigned, unsigned> statesA{{1, 2}};
+    const std::map<unsigned, unsigned> statesB{{3, 4}};
+    const std::map<unsigned, unsigned> statesNew{{5, 6}};
+    save(statesA, "presetA");
+    save(statesB, "presetB");
+
+    iwSaveAddonPreset wnd(statesNew);
+    Window& base = wnd;
+    BOOST_TEST(!wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btDelete)); // saving cannot delete
     auto& edit = *wnd.GetCtrls<ctrlEdit>().at(0);
     auto& table = *wnd.GetCtrls<ctrlTable>().at(0);
-    // Selection drives the edit: each selected row's name lands in the edit (rows sorted ascending)
+    // Rows are sorted ascending, so row 0 is presetA
     table.SetSelection(0u);
     BOOST_TEST_REQUIRE(edit.GetText() == "presetA");
     table.SetSelection(1u);
     BOOST_TEST(edit.GetText() == "presetB"); // correct name for a non-first row
-    table.SetSelection(std::nullopt);        // deselect
+    table.SetSelection(std::nullopt);
     BOOST_TEST(edit.GetText() == "");
+    // User now types a new name after having selected a preset
     table.SetSelection(0u);
-    BOOST_TEST_REQUIRE(edit.GetText() == "presetA");
-    // User now retypes a different existing preset
-    edit.SetText("presetB");
+    edit.SetText("presetC");
     base.Msg_EditEnter(0);
-    BOOST_TEST_REQUIRE(loaded.has_value());
-    BOOST_TEST(*loaded == statesB);
+
+    BOOST_TEST(numPresets() == 3u);
+    BOOST_TEST(load("presetC") == statesNew); // saved under the typed name
+    BOOST_TEST(load("presetA") == statesA);   // selected preset untouched
 }
 
 BOOST_FIXTURE_TEST_CASE(AddonPresetDelete, AddonPresetFixture)
@@ -247,11 +270,13 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetDelete, AddonPresetFixture)
 
     iwLoadAddonPreset wnd([](const std::map<unsigned, unsigned>&) noexcept {});
     Window& base = wnd;
-    base.GetCtrls<ctrlEdit>().at(0)->SetText("toDelete");
+    BOOST_TEST_REQUIRE(select(base, "toDelete"));
     base.Msg_MsgBoxResult(iwAddonPresetsBase::ID_mbDelete, MsgboxResult::Yes);
 
-    BOOST_TEST(base.GetCtrls<ctrlEdit>().at(0)->GetText() == ""); // edit cleared after delete
-    BOOST_TEST(numPresets() == 0u);                               // file removed
+    BOOST_TEST(numPresets() == 0u); // file removed
+    // Deleting drops the selection, so both actions are unavailable again
+    BOOST_TEST(!wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btAction)->GetEnabled());
+    BOOST_TEST(!wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btDelete)->GetEnabled());
 }
 
 BOOST_FIXTURE_TEST_CASE(AddonPresetDeleteConfirmationNamesPreset, AddonPresetFixture)
@@ -260,7 +285,7 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetDeleteConfirmationNamesPreset, AddonPresetFix
 
     iwLoadAddonPreset wnd([](const std::map<unsigned, unsigned>&) noexcept {});
     Window& base = wnd;
-    base.GetCtrls<ctrlEdit>().at(0)->SetText("toDelete");
+    BOOST_TEST_REQUIRE(select(base, "toDelete"));
     base.Msg_ButtonClick(iwAddonPresetsBase::ID_btDelete);
 
     const auto* msgbox = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
@@ -276,62 +301,20 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetDeleteConfirmationNamesPreset, AddonPresetFix
     WINDOWMANAGER.CloseNow(const_cast<iwMsgbox*>(msgbox));
 }
 
-// Loading/deleting a name that doesn't exist informs the user and changes nothing.
-BOOST_FIXTURE_TEST_CASE(AddonPresetTargetNotFound, AddonPresetFixture)
+// Loading and deleting act on the list selection, so both stay unavailable until one is picked.
+BOOST_FIXTURE_TEST_CASE(AddonPresetActionsRequireSelection, AddonPresetFixture)
 {
     save({{1, 2}}, "exists");
 
-    // Load a missing name -> callback not invoked, "Preset Not Found" shown
-    {
-        bool called = false;
-        iwLoadAddonPreset wnd([&](const std::map<unsigned, unsigned>&) noexcept { called = true; });
-        Window& base = wnd;
-        base.GetCtrls<ctrlEdit>().at(0)->SetText("missing");
-        base.Msg_EditEnter(0);
-        BOOST_TEST(!called);
-        const auto* msgbox = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
-        BOOST_TEST_REQUIRE(msgbox);
-        BOOST_TEST(msgbox->GetTitle() == _("Preset Not Found"));
-        WINDOWMANAGER.CloseNow(const_cast<iwMsgbox*>(msgbox));
-    }
+    iwLoadAddonPreset wnd([](const std::map<unsigned, unsigned>&) noexcept {});
+    Window& base = wnd;
+    BOOST_TEST(wnd.GetCtrls<ctrlEdit>().empty()); // no name field, the list is the only target
+    BOOST_TEST(!wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btAction)->GetEnabled());
+    BOOST_TEST(!wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btDelete)->GetEnabled());
 
-    // Delete a missing name -> "Preset Not Found" shown (not the delete confirmation)
-    {
-        iwLoadAddonPreset wnd([](const std::map<unsigned, unsigned>&) noexcept {});
-        Window& base = wnd;
-        base.GetCtrls<ctrlEdit>().at(0)->SetText("missing");
-        base.Msg_ButtonClick(iwAddonPresetsBase::ID_btDelete);
-        const auto* msgbox = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
-        BOOST_TEST_REQUIRE(msgbox);
-        BOOST_TEST(msgbox->GetTitle() == _("Preset Not Found"));
-        WINDOWMANAGER.CloseNow(const_cast<iwMsgbox*>(msgbox));
-    }
-
-    BOOST_TEST(numPresets() == 1u); // "exists" untouched
-}
-
-BOOST_FIXTURE_TEST_CASE(AddonPresetEmptyNameNoOp, AddonPresetFixture)
-{
-    save({{1, 2}}, "exists");
-
-    // Load with empty edit -> callback not invoked, no message
-    {
-        bool called = false;
-        iwLoadAddonPreset wnd([&](const std::map<unsigned, unsigned>&) noexcept { called = true; });
-        Window& base = wnd;
-        base.Msg_EditEnter(0);
-        BOOST_TEST(!called);
-        BOOST_TEST(!dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow()));
-    }
-    // Delete with empty edit -> no message
-    {
-        iwLoadAddonPreset wnd([](const std::map<unsigned, unsigned>&) noexcept {});
-        Window& base = wnd;
-        base.Msg_ButtonClick(iwAddonPresetsBase::ID_btDelete);
-        BOOST_TEST(!dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow()));
-    }
-
-    BOOST_TEST(numPresets() == 1u); // nothing deleted
+    BOOST_TEST_REQUIRE(select(base, "exists"));
+    BOOST_TEST(wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btAction)->GetEnabled());
+    BOOST_TEST(wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btDelete)->GetEnabled());
 }
 
 // When the presets folder can't be created, the window informs the user and closes itself.
@@ -347,8 +330,11 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetFolderUnavailable, AddonPresetFixture)
     BOOST_TEST_REQUIRE(!boost::filesystem::is_directory(presetsDir));
 
     iwSaveAddonPreset wnd(std::map<unsigned, unsigned>{{1, 2}});
-    BOOST_TEST(wnd.ShouldBeClosed());              // window marked itself for closing
-    BOOST_TEST(wnd.GetCtrls<ctrlTable>().empty()); // no controls were built
+    BOOST_TEST(wnd.ShouldBeClosed()); // window marked itself for closing
+    // No controls were built, neither by the base window nor by the save window
+    BOOST_TEST(wnd.GetCtrls<ctrlTable>().empty());
+    BOOST_TEST(wnd.GetCtrls<ctrlEdit>().empty());
+    BOOST_TEST(wnd.GetCtrls<ctrlButton>().empty());
 
     const auto* msgbox = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(msgbox);

--- a/tests/s25Main/UI/testWindows.cpp
+++ b/tests/s25Main/UI/testWindows.cpp
@@ -112,10 +112,16 @@ BOOST_FIXTURE_TEST_CASE(JumpWindow, SmallWorldFixture)
 }
 
 namespace {
-struct AddonPresetFixture : uiHelper::Fixture
+struct AddonPresetTmpUserData : uiHelper::Fixture
 {
     rttr::test::TmpFolder tmp;
     rttr::test::ConfigOverride userDataOverride{"USERDATA", tmp};
+};
+
+struct AddonPresetFixture : AddonPresetTmpUserData
+{
+    // The windows expect the folder to exist, just like when iwAddons opens them
+    AddonPresetFixture() { BOOST_TEST_REQUIRE(iwAddonPresetsBase::EnsurePresetsFolder()); }
 
     // Selects the named preset, false if there is no such preset
     static bool select(Window& wnd, const std::string& name)
@@ -312,13 +318,14 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetActionsRequireSelection, AddonPresetFixture)
     BOOST_TEST(!wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btAction)->GetEnabled());
     BOOST_TEST(!wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btDelete)->GetEnabled());
 
+    BOOST_TEST(!select(base, "notSaved"));
     BOOST_TEST_REQUIRE(select(base, "exists"));
     BOOST_TEST(wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btAction)->GetEnabled());
     BOOST_TEST(wnd.GetCtrl<ctrlButton>(iwAddonPresetsBase::ID_btDelete)->GetEnabled());
 }
 
-// When the presets folder can't be created, the window informs the user and closes itself.
-BOOST_FIXTURE_TEST_CASE(AddonPresetFolderUnavailable, AddonPresetFixture)
+// When the presets folder can't be created, the user is told and no preset window is opened.
+BOOST_FIXTURE_TEST_CASE(AddonPresetFolderUnavailable, AddonPresetTmpUserData)
 {
     // Plant a file where the presets folder should be so create_directories() fails
     const auto presetsDir = RTTRCONFIG.ExpandPath(s25::folders::addonPresets);
@@ -329,12 +336,7 @@ BOOST_FIXTURE_TEST_CASE(AddonPresetFolderUnavailable, AddonPresetFixture)
     BOOST_TEST_REQUIRE(boost::filesystem::exists(presetsDir));
     BOOST_TEST_REQUIRE(!boost::filesystem::is_directory(presetsDir));
 
-    iwSaveAddonPreset wnd(std::map<unsigned, unsigned>{{1, 2}});
-    BOOST_TEST(wnd.ShouldBeClosed()); // window marked itself for closing
-    // No controls were built, neither by the base window nor by the save window
-    BOOST_TEST(wnd.GetCtrls<ctrlTable>().empty());
-    BOOST_TEST(wnd.GetCtrls<ctrlEdit>().empty());
-    BOOST_TEST(wnd.GetCtrls<ctrlButton>().empty());
+    BOOST_TEST(!iwAddonPresetsBase::EnsurePresetsFolder());
 
     const auto* msgbox = dynamic_cast<iwMsgbox*>(WINDOWMANAGER.GetTopMostWindow());
     BOOST_TEST_REQUIRE(msgbox);


### PR DESCRIPTION
Follow-up to [#1951](https://github.com/Return-To-The-Roots/s25client/pull/1951)

Removed **Delete** button from **Save Addon Preset** window
Removed name field from **Load Addon Preset** window

Load and Delete resolved their target from the name field, with the list
selection only prefilling it. So editing the name after picking a preset
silently retargeted the action, an unmatched name raised "Preset Not Found",
and an empty one did nothing.

Both now act on the list selection and are disabled until a preset is picked.
That makes those states unrepresentable, so `GetTargetFilePath()`,
`GetTargetFileOrNotify()` and the "Preset Not Found" strings are gone.

A typed name is only needed for saving, and deleting belongs with browsing
presets rather than with saving one.

<img width="442" height="332" alt="image" src="https://github.com/user-attachments/assets/e37c1bfd-af8e-46d3-911c-d4f29302d859" />
<img width="442" height="302" alt="image" src="https://github.com/user-attachments/assets/1af907bc-51db-4f3e-a64c-0a16ce8435b9" />
